### PR TITLE
feat: inline field html preview + fix: i18n label fix for company name

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
@@ -29,6 +29,7 @@ import { LoadingMessage } from '../../../../components/detail/LoadingMessage'
 import { DetailFieldsSection, type DetailFieldConfig } from '../../../../components/detail/DetailFieldsSection'
 import { CustomDataSection } from '../../../../components/detail/CustomDataSection'
 import { CompanyHighlights } from '../../../../components/detail/CompanyHighlights'
+import { renderMultilineMarkdownDisplay } from '../../../../components/detail/InlineEditors'
 import { formatTemplate } from '../../../../components/detail/utils'
 import { createTranslatorWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import {
@@ -566,6 +567,7 @@ export default function CustomerCompanyDetailPage({ params }: { params?: { id?: 
       placeholder: t('customers.companies.detail.fields.descriptionPlaceholder', 'Describe the company'),
       emptyLabel: t('customers.companies.detail.noValue', 'Not provided'),
       gridClassName: 'sm:col-span-2 xl:col-span-3',
+      renderDisplay: renderMultilineMarkdownDisplay,
       onSave: async (next) => {
         const send = typeof next === 'string' ? next : ''
         await saveCompany(

--- a/packages/core/src/modules/customers/backend/customers/people/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people/[id]/page.tsx
@@ -29,6 +29,7 @@ import { PersonHighlights } from '../../../../components/detail/PersonHighlights
 import {
   renderLinkedInDisplay,
   renderTwitterDisplay,
+  renderMultilineMarkdownDisplay,
 } from '../../../../components/detail/InlineEditors'
 import { DetailFieldsSection, type DetailFieldConfig } from '../../../../components/detail/DetailFieldsSection'
 import { LoadingMessage } from '../../../../components/detail/LoadingMessage'
@@ -534,6 +535,7 @@ export default function CustomerPersonDetailPage({ params }: { params?: { id?: s
         placeholder: t('customers.people.form.description'),
         emptyLabel: t('customers.people.detail.noValue'),
         gridClassName: 'sm:col-span-2 xl:col-span-3',
+        renderDisplay: renderMultilineMarkdownDisplay,
         onSave: async (next) => {
           const send = typeof next === 'string' ? next : ''
           await savePerson(

--- a/packages/core/src/modules/customers/components/detail/DetailFieldsSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/DetailFieldsSection.tsx
@@ -2,7 +2,13 @@
 
 import * as React from 'react'
 import type { ComponentProps } from 'react'
-import { InlineTextEditor, InlineMultilineEditor, InlineDictionaryEditor, type InlineFieldType } from './InlineEditors'
+import {
+  InlineTextEditor,
+  InlineMultilineEditor,
+  InlineDictionaryEditor,
+  type InlineFieldType,
+  type InlineMultilineDisplayRenderer,
+} from './InlineEditors'
 import { AnnualRevenueField } from './AnnualRevenueField'
 import type { InlineFieldProps } from './InlineEditors'
 import type { CustomerDictionaryKind } from '../../lib/dictionaries'
@@ -38,6 +44,7 @@ export type DetailMultilineFieldConfig = DetailFieldCommon & {
   placeholder: string
   onSave: (value: string | null) => Promise<void>
   validator?: (value: string) => string | null
+  renderDisplay?: InlineMultilineDisplayRenderer
 }
 
 export type DetailDictionaryFieldConfig = DetailFieldCommon & {
@@ -118,6 +125,7 @@ export function DetailFieldsSection({ fields, className }: DetailFieldsSectionPr
                 activateOnClick={activateOnClick}
                 containerClassName={containerClassName}
                 triggerClassName={triggerClassName}
+                renderDisplay={field.renderDisplay}
               />
             </div>
           )

--- a/packages/shared/src/lib/i18n/context.tsx
+++ b/packages/shared/src/lib/i18n/context.tsx
@@ -43,7 +43,7 @@ export function I18nProvider({ children, locale, dict }: { children: React.React
         fallback = fallbackOrParams
         resolvedParams = params
       } else {
-        resolvedParams = fallbackOrParams
+        resolvedParams = fallbackOrParams ?? params
       }
 
       const template = dict[key] ?? fallback ?? key


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

This pull request introduces support for rendering multiline text fields as Markdown in customer company and person detail pages. The main change is the addition of a customizable display renderer for multiline fields, allowing content such as descriptions to be formatted using Markdown for improved readability and presentation. Supporting type and prop updates were made to enable this feature, along with a minor bug fix in the i18n context.

**Markdown rendering for multiline fields:**

* Added `renderMultilineMarkdownDisplay` function to `InlineEditors`, enabling Markdown rendering for multiline text fields using `react-markdown` and `remark-gfm`.
* Updated multiline field configurations in company and person detail pages (`[id]/page.tsx`) to use the new Markdown renderer for the description field. ([packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsxR32](diffhunk://#diff-325ee6dc5086f70410a1d7fb0cd0369c51d441a89c0eb8ff5ecd6900aa720c69R32), [packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsxR570](diffhunk://#diff-325ee6dc5086f70410a1d7fb0cd0369c51d441a89c0eb8ff5ecd6900aa720c69R570), [packages/core/src/modules/customers/backend/customers/people/[id]/page.tsxR32](diffhunk://#diff-bfb42c7a56c610b8c7cb15be0209794ef6d629cdbcc26e9967a4da8af3611408R32), [packages/core/src/modules/customers/backend/customers/people/[id]/page.tsxR538](diffhunk://#diff-bfb42c7a56c610b8c7cb15be0209794ef6d629cdbcc26e9967a4da8af3611408R538))

**Type and prop enhancements:**

* Extended multiline field config and editor props to support an optional `renderDisplay` function, allowing custom rendering logic for multiline fields. [[1]](diffhunk://#diff-f84a5257417bb64eeb5cf06281e6d292c5c13ab3d61ffd1194e51feffb0aee73L5-R11) [[2]](diffhunk://#diff-f84a5257417bb64eeb5cf06281e6d292c5c13ab3d61ffd1194e51feffb0aee73R47) [[3]](diffhunk://#diff-2b3b06d697719cbc27af7ab516312b9e016310ab1a470606a53135e1a3808d35R412) [[4]](diffhunk://#diff-2b3b06d697719cbc27af7ab516312b9e016310ab1a470606a53135e1a3808d35R426) [[5]](diffhunk://#diff-f84a5257417bb64eeb5cf06281e6d292c5c13ab3d61ffd1194e51feffb0aee73R128)
* Refactored display logic in `InlineMultilineEditor` to use the custom renderer if provided and adjusted default styling.

**Technical improvements:**

* Centralized Markdown preview plugin configuration for consistency in rendering. [[1]](diffhunk://#diff-2b3b06d697719cbc27af7ab516312b9e016310ab1a470606a53135e1a3808d35R394-R400) [[2]](diffhunk://#diff-2b3b06d697719cbc27af7ab516312b9e016310ab1a470606a53135e1a3808d35L590-R601)

**Bug fix:**

* Fixed fallback parameter handling in i18n context to avoid passing `undefined` as params.

## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
