### PR TITLE
fix: fix for #176

### DIFF
--- a/docs/docs/customization/custom-fields-overview.mdx
+++ b/docs/docs/customization/custom-fields-overview.mdx
@@ -67,4 +67,4 @@ curl -X POST "$BASE_URL/entities/definitions.batch" \
   }"
 ```
 
-This request updates both the definitions and the curated list of fieldsets so CRUD forms immediately expose the new tab/dropdown. See [Entities API → Field definitions](/docs/api/entities#field-definitions--entitiesdefinitions) for more parameters and scopes.
+This request updates both the definitions and the curated list of fieldsets so CRUD forms immediately expose the new tab/dropdown. See [Entities API → Field definitions](/api/entities#field-definitions--entitiesdefinitions) for more parameters and scopes.

--- a/packages/core/src/modules/catalog/commands/__tests__/shared.test.ts
+++ b/packages/core/src/modules/catalog/commands/__tests__/shared.test.ts
@@ -96,7 +96,11 @@ describe('catalog command shared helpers', () => {
     expectedArgs: any
   }> = [
     { label: 'requireProduct', fn: (em) => requireProduct(em, 'prod'), expectedArgs: [{ id: 'prod', deletedAt: null }] },
-    { label: 'requireVariant', fn: (em) => requireVariant(em, 'variant'), expectedArgs: [{ id: 'variant', deletedAt: null }] },
+    {
+      label: 'requireVariant',
+      fn: (em) => requireVariant(em, 'variant'),
+      expectedArgs: [{ id: 'variant', deletedAt: null }, { populate: ['product'] }],
+    },
     { label: 'requireOffer', fn: (em) => requireOffer(em, 'offer'), expectedArgs: [{ id: 'offer' }] },
     {
       label: 'requireOptionSchemaTemplate',
@@ -112,7 +116,11 @@ describe('catalog command shared helpers', () => {
       const em = { findOne }
 
       await expect(fn(em)).resolves.toBe(entity)
-      expect(findOne).toHaveBeenCalledWith(expect.any(Function), expectedArgs[0])
+      if (expectedArgs[1]) {
+        expect(findOne).toHaveBeenCalledWith(expect.any(Function), expectedArgs[0], expectedArgs[1])
+      } else {
+        expect(findOne).toHaveBeenCalledWith(expect.any(Function), expectedArgs[0])
+      }
 
       findOne.mockResolvedValue(null)
       await expect(fn(em)).rejects.toBeInstanceOf(CrudHttpError)

--- a/packages/core/src/modules/catalog/commands/prices.ts
+++ b/packages/core/src/modules/catalog/commands/prices.ts
@@ -439,6 +439,10 @@ const updatePriceCommand: CommandHandler<PriceUpdateInput, { priceId: string }> 
       }
     }
 
+    if (targetVariant && (targetVariant as CatalogProductVariant | null)?.product === undefined) {
+      targetVariant = await requireVariant(em, targetVariant.id)
+    }
+
     if (parsed.productId !== undefined) {
       if (!parsed.productId) {
         targetProduct = null

--- a/packages/core/src/modules/catalog/commands/shared.ts
+++ b/packages/core/src/modules/catalog/commands/shared.ts
@@ -175,7 +175,7 @@ export async function requireVariant(
   id: string,
   message = 'Catalog variant not found'
 ): Promise<CatalogProductVariant> {
-  const variant = await em.findOne(CatalogProductVariant, { id, deletedAt: null })
+  const variant = await em.findOne(CatalogProductVariant, { id, deletedAt: null }, { populate: ['product'] })
   if (!variant) throw new CrudHttpError(404, { error: message })
   return variant
 }


### PR DESCRIPTION
This pull request focuses on improving how product variants are loaded and tested in the catalog module. The main changes ensure that when fetching a product variant, its associated product is always loaded, preventing potential issues with missing data. Additionally, the related tests and documentation have been updated for accuracy and completeness.

**Catalog Variant Loading Improvements:**

* Updated `requireVariant` in `shared.ts` to always populate the associated `product` when fetching a `CatalogProductVariant`, ensuring the product relationship is available.
* Modified the `updatePriceCommand` in `prices.ts` to re-fetch the target variant with its product if the product is missing, preventing downstream errors.

**Test Enhancements:**

* Updated the `requireVariant` test in `shared.test.ts` to expect the `populate: ['product']` option, aligning the test with the new implementation.
* Improved test assertions to check for the optional third argument in `findOne` calls, increasing test robustness.

**Documentation Fix:**

* Fixed a broken link in the custom fields overview documentation to point to the correct API reference.