### PR TITLE
feat: upgrade actions  - disabled for open source edition by default

### DIFF
--- a/packages/core/src/modules/configs/api/upgrade-actions/route.ts
+++ b/packages/core/src/modules/configs/api/upgrade-actions/route.ts
@@ -4,7 +4,7 @@ import { createRequestContainer } from '@/lib/di/container'
 import { getAuthFromRequest } from '@/lib/auth/server'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveFeatureCheckContext } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { executeUpgradeAction, getCurrentVersion, listPendingUpgradeActions } from '../../services/upgradeActionsService'
+import { executeUpgradeAction, getCurrentVersion, isUpgradeActionsEnabled, listPendingUpgradeActions } from '../../services/upgradeActionsService'
 import type { EntityManager } from '@mikro-orm/postgresql'
 
 export const metadata = {
@@ -44,6 +44,9 @@ async function resolveScope(
 }
 
 export async function GET(req: Request) {
+  if (!isUpgradeActionsEnabled()) {
+    return NextResponse.json({ version: getCurrentVersion(), actions: [] })
+  }
   const { translate } = await resolveTranslations()
   const scopedTranslate = (key: string, fallback?: string, params?: Record<string, unknown>) =>
     translate(key, fallback, params as any)
@@ -83,6 +86,9 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
+  if (!isUpgradeActionsEnabled()) {
+    return NextResponse.json({ error: 'Upgrade actions are disabled' }, { status: 404 })
+  }
   const { translate } = await resolveTranslations()
   const scopedTranslate = (key: string, fallback?: string, params?: Record<string, unknown>) =>
     translate(key, fallback, params as any)

--- a/packages/ui/src/backend/upgrades/UpgradeActionBanner.tsx
+++ b/packages/ui/src/backend/upgrades/UpgradeActionBanner.tsx
@@ -6,6 +6,10 @@ import { apiCall } from '../utils/apiCall'
 import { flash } from '../FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 
+const upgradeActionsEnabled =
+  process.env.NEXT_PUBLIC_UPGRADE_ACTIONS_ENABLED === 'true' ||
+  process.env.UPGRADE_ACTIONS_ENABLED === 'true'
+
 type UpgradeActionPayload = {
   id: string
   version: string
@@ -33,6 +37,7 @@ export function UpgradeActionBanner() {
   const [loading, setLoading] = React.useState(false)
 
   React.useEffect(() => {
+    if (!upgradeActionsEnabled) return
     if (typeof window === 'undefined' || typeof fetch === 'undefined') return
     let cancelled = false
     const load = async () => {
@@ -51,10 +56,10 @@ export function UpgradeActionBanner() {
     }
   }, [])
 
-  if (!action) return null
+  if (!upgradeActionsEnabled || !action) return null
 
   async function handleRun() {
-    if (!action || loading) return
+    if (!upgradeActionsEnabled || !action || loading) return
     setLoading(true)
     try {
       const response = await apiCall<RunActionResponse>('/api/configs/upgrade-actions', {


### PR DESCRIPTION
This pull request introduces a feature flag to enable or disable upgrade actions throughout the backend and frontend. The changes ensure that upgrade actions are only available when explicitly enabled via environment variables, and gracefully handle cases when the feature is disabled.

Backend enforcement of upgrade actions feature flag:

* Added an `isUpgradeActionsEnabled` function in `upgradeActionsService.ts` to check the `UPGRADE_ACTIONS_ENABLED` environment variable and used it to short-circuit or throw errors in `listPendingUpgradeActions` and `executeUpgradeAction`. [[1]](diffhunk://#diff-fb1a6a2f4520a090c7ad97b5c6c725bda25541ae443e86487dfee3d71ba7293aR10-R13) [[2]](diffhunk://#diff-fb1a6a2f4520a090c7ad97b5c6c725bda25541ae443e86487dfee3d71ba7293aR26) [[3]](diffhunk://#diff-fb1a6a2f4520a090c7ad97b5c6c725bda25541ae443e86487dfee3d71ba7293aR47-R49)
* Updated the API route in `route.ts` to return empty results or error responses in `GET` and `POST` handlers if upgrade actions are disabled. [[1]](diffhunk://#diff-f632b3c5a94f13679dcb1eb8ea2862aa05e421bce9a4f81072ba6248538a9718L7-R7) [[2]](diffhunk://#diff-f632b3c5a94f13679dcb1eb8ea2862aa05e421bce9a4f81072ba6248538a9718R47-R49) [[3]](diffhunk://#diff-f632b3c5a94f13679dcb1eb8ea2862aa05e421bce9a4f81072ba6248538a9718R89-R91)

Frontend awareness of upgrade actions feature flag:

* Introduced a `upgradeActionsEnabled` constant in `UpgradeActionBanner.tsx` to check the environment variable and prevent UI rendering or API calls related to upgrade actions if the feature is disabled. [[1]](diffhunk://#diff-01115e4067df47ee506fe3ea8ef602423ca6f1a92ba03d2ee317be4c95638789R9-R12) [[2]](diffhunk://#diff-01115e4067df47ee506fe3ea8ef602423ca6f1a92ba03d2ee317be4c95638789R40) [[3]](diffhunk://#diff-01115e4067df47ee506fe3ea8ef602423ca6f1a92ba03d2ee317be4c95638789L54-R62)