### PR TITLE
fix horizontal scrolls, truncation, add tooltips

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/people/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people/page.tsx
@@ -535,6 +535,14 @@ export default function CustomersPeoplePage() {
       {
         accessorKey: 'nextInteractionAt',
         header: t('customers.people.list.columns.nextInteraction'),
+        meta: {
+          tooltipContent: (row: PersonRow) => {
+            if (!row.nextInteractionAt) return undefined
+            const date = formatDate(row.nextInteractionAt, '')
+            const name = row.nextInteractionName || ''
+            return [date, name].filter(Boolean).join(' - ')
+          },
+        },
         cell: ({ row }) =>
           row.original.nextInteractionAt
             ? (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,5 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./*": "./src/*"
+  },
+  "dependencies": {
+    "@radix-ui/react-tooltip": "^1.2.8"
   }
 }

--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -887,7 +887,7 @@ export function AppShell({ productName, email, groups, rightHeaderSlot, children
       {/* Desktop sidebar */}
       <aside className={`${asideClassesBase} ${effectiveCollapsed ? 'px-2' : 'px-3'} hidden lg:block`} style={{ width: asideWidth }}>{renderSidebar(effectiveCollapsed)}</aside>
 
-      <div className="flex min-h-svh flex-col">
+      <div className="flex min-h-svh flex-col min-w-0">
         <header className="border-b bg-background/60 px-3 lg:px-4 py-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-2 flex-wrap">
             {/* Mobile menu button */}

--- a/packages/ui/src/backend/TruncatedCell.tsx
+++ b/packages/ui/src/backend/TruncatedCell.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import * as React from 'react'
+import { SimpleTooltip } from '../primitives/tooltip'
+import { cn } from '@/lib/utils'
+
+export type TruncatedCellProps = {
+  children: React.ReactNode
+  /** Maximum width for the cell content. Can be a Tailwind class (e.g., 'max-w-[200px]') or CSS value */
+  maxWidth?: string
+  /** Custom class name for the wrapper */
+  className?: string
+  /** Tooltip content - if not provided, will try to extract text from children */
+  tooltipContent?: React.ReactNode
+  /** Disable truncation and tooltip */
+  disabled?: boolean
+}
+
+/**
+ * Extracts text content from React nodes for tooltip display
+ */
+function extractTextContent(node: React.ReactNode): string {
+  if (node == null) return ''
+  if (typeof node === 'string') return node
+  if (typeof node === 'number') return String(node)
+  if (typeof node === 'boolean') return ''
+  if (Array.isArray(node)) {
+    return node.map(extractTextContent).join('')
+  }
+  if (React.isValidElement(node)) {
+    // Handle React elements - extract text from props.children
+    const props = node.props as Record<string, unknown>
+    if (props) {
+      // First try children
+      if (props.children != null) {
+        const childText = extractTextContent(props.children as React.ReactNode)
+        if (childText) return childText
+      }
+      // Try common text props
+      if (typeof props.value === 'string') return props.value
+      if (typeof props.label === 'string') return props.label
+      if (typeof props.title === 'string') return props.title
+    }
+  }
+  // Try to convert to string as last resort
+  if (node && typeof node === 'object' && 'toString' in node) {
+    const str = String(node)
+    if (str !== '[object Object]') return str
+  }
+  return ''
+}
+
+/**
+ * A cell wrapper that truncates content and shows a tooltip on hover
+ * only when the content is wider than the available space.
+ *
+ * @example
+ * <TruncatedCell maxWidth="max-w-[200px]">
+ *   <span>This is a very long text that will be truncated</span>
+ * </TruncatedCell>
+ */
+export function TruncatedCell({
+  children,
+  maxWidth = 'max-w-[150px]',
+  className,
+  tooltipContent,
+  disabled = false,
+}: TruncatedCellProps) {
+  const contentRef = React.useRef<HTMLDivElement>(null)
+  const [isTruncated, setIsTruncated] = React.useState(false)
+
+  // Get tooltip content - prefer explicit tooltipContent, fall back to extracting from children
+  const resolvedTooltipContent = tooltipContent ?? extractTextContent(children)
+
+  // Check if content is truncated after render and on resize
+  React.useEffect(() => {
+    const checkTruncation = () => {
+      const el = contentRef.current
+      if (el) {
+        setIsTruncated(el.scrollWidth > el.clientWidth)
+      }
+    }
+
+    // Check on mount
+    checkTruncation()
+
+    // Use ResizeObserver to detect size changes
+    const el = contentRef.current
+    if (el) {
+      const observer = new ResizeObserver(checkTruncation)
+      observer.observe(el)
+      return () => observer.disconnect()
+    }
+  }, [children, maxWidth])
+
+  if (disabled) {
+    return <>{children}</>
+  }
+
+  // Determine if maxWidth is a Tailwind class or a CSS value
+  const isTailwindClass = maxWidth.startsWith('max-w-')
+  const styleMaxWidth = isTailwindClass ? undefined : maxWidth
+  const classMaxWidth = isTailwindClass ? maxWidth : ''
+
+  const content = (
+    <div
+      ref={contentRef}
+      className={cn(
+        'overflow-hidden text-ellipsis whitespace-nowrap',
+        classMaxWidth,
+        className
+      )}
+      style={styleMaxWidth ? { maxWidth: styleMaxWidth } : undefined}
+    >
+      {children}
+    </div>
+  )
+
+  // Only show tooltip when content is actually truncated
+  if (!resolvedTooltipContent || !isTruncated) {
+    return content
+  }
+
+  return (
+    <SimpleTooltip
+      content={resolvedTooltipContent}
+      side="top"
+      delayDuration={300}
+    >
+      {content}
+    </SimpleTooltip>
+  )
+}

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import * as React from 'react'
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import { cn } from '@/lib/utils'
+
+export const TooltipProvider = TooltipPrimitive.Provider
+
+export const Tooltip = TooltipPrimitive.Root
+
+export const TooltipTrigger = TooltipPrimitive.Trigger
+
+export const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-slate-900 px-3 py-1.5 text-xs text-slate-50 animate-in fade-in-0 zoom-in-95',
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'max-w-xs break-words',
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export type TooltipProps = {
+  content: React.ReactNode
+  children: React.ReactNode
+  delayDuration?: number
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  align?: 'start' | 'center' | 'end'
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  disabled?: boolean
+}
+
+/**
+ * Simple tooltip wrapper component for common use cases.
+ *
+ * @example
+ * <SimpleTooltip content="Full text here">
+ *   <span>Truncated...</span>
+ * </SimpleTooltip>
+ */
+export function SimpleTooltip({
+  content,
+  children,
+  delayDuration = 300,
+  side = 'top',
+  align = 'center',
+  open,
+  onOpenChange,
+  disabled = false,
+}: TooltipProps) {
+  // If disabled or no content, just render children without tooltip
+  const isDisabled = disabled || !content
+
+  if (isDisabled) {
+    return <>{children}</>
+  }
+
+  return (
+    <Tooltip
+      open={open}
+      onOpenChange={onOpenChange}
+      delayDuration={delayDuration}
+    >
+      <TooltipTrigger asChild>
+        {children}
+      </TooltipTrigger>
+      <TooltipContent side={side} align={align}>
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -566,6 +566,33 @@
     "@eslint/core" "^0.15.2"
     levn "^0.4.1"
 
+"@floating-ui/core@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.7.3.tgz#462d722f001e23e46d86fd2bd0d21b7693ccb8b7"
+  integrity sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==
+  dependencies:
+    "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/dom@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.7.4.tgz#ee667549998745c9c3e3e84683b909c31d6c9a77"
+  integrity sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==
+  dependencies:
+    "@floating-ui/core" "^1.7.3"
+    "@floating-ui/utils" "^0.2.10"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.6.tgz#189f681043c1400561f62972f461b93f01bf2231"
+  integrity sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==
+  dependencies:
+    "@floating-ui/dom" "^1.7.4"
+
+"@floating-ui/utils@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
+  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz"
@@ -1426,6 +1453,13 @@
   resolved "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz"
   integrity sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==
 
+"@radix-ui/react-arrow@1.1.7":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz#e14a2657c81d961598c5e72b73dd6098acc04f09"
+  integrity sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+
 "@radix-ui/react-checkbox@^1.3.3":
   version "1.3.3"
   resolved "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz"
@@ -1509,6 +1543,22 @@
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
+"@radix-ui/react-popper@1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.8.tgz#a79f39cdd2b09ab9fb50bf95250918422c4d9602"
+  integrity sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-rect" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+    "@radix-ui/rect" "1.1.1"
+
 "@radix-ui/react-portal@1.1.9":
   version "1.1.9"
   resolved "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz"
@@ -1538,6 +1588,24 @@
   integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-tooltip@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz#3f50267e25bccfc9e20bb3036bfd9ab4c2c30c2c"
+  integrity sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.8"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-visually-hidden" "1.2.3"
 
 "@radix-ui/react-use-callback-ref@1.1.1":
   version "1.1.1"
@@ -1576,12 +1644,31 @@
   resolved "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz"
   integrity sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==
 
+"@radix-ui/react-use-rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz#01443ca8ed071d33023c1113e5173b5ed8769152"
+  integrity sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==
+  dependencies:
+    "@radix-ui/rect" "1.1.1"
+
 "@radix-ui/react-use-size@1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz"
   integrity sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
+
+"@radix-ui/react-visually-hidden@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz#a8c38c8607735dc9f05c32f87ab0f9c2b109efbf"
+  integrity sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.3"
+
+"@radix-ui/rect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.1.1.tgz#78244efe12930c56fd255d7923865857c41ac8cb"
+  integrity sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==
 
 "@react-email/body@0.1.0":
   version "0.1.0"


### PR DESCRIPTION
This pull request introduces a comprehensive solution for truncating long table cell content and displaying tooltips on hover in the UI data tables. The main changes include a new `TruncatedCell` component that wraps cell content, logic for determining truncation and tooltip display based on column type and metadata, and integration of the Radix UI tooltip library. These improvements enhance readability and usability of tables with dense or lengthy data.

**Table cell truncation and tooltip enhancements:**

* Added the new `TruncatedCell` component (`TruncatedCell.tsx`) that automatically truncates overflowing cell content and shows a tooltip with the full value on hover. The tooltip only appears if the content is actually truncated.
* Implemented logic in `DataTable.tsx` to determine truncation and maximum width per column using the new `getColumnTruncateConfig` and `shouldSkipTruncation` functions, with support for custom tooltip content via column metadata. [[1]](diffhunk://#diff-c39800fc27497d21a2ccac1b42a1a496598cbc04c1dec18c8f95989af0003beeR350-R390) [[2]](diffhunk://#diff-c39800fc27497d21a2ccac1b42a1a496598cbc04c1dec18c8f95989af0003beeR1600-R1628)

**Tooltip system integration:**

* Added Radix UI tooltip library as a dependency in `packages/ui/package.json` and created primitives for tooltips (`TooltipProvider`, `SimpleTooltip`, etc.) in `primitives/tooltip.tsx`. [[1]](diffhunk://#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51dR9-R11) [[2]](diffhunk://#diff-9f1fbda076bebb39b2c68130f3da87cf5971e43d63dac871a3eabfc5460ddc92R1-R85)
* Wrapped the entire data table in a `TooltipProvider` to enable consistent tooltip behavior across all cells. [[1]](diffhunk://#diff-c39800fc27497d21a2ccac1b42a1a496598cbc04c1dec18c8f95989af0003beeR1448) [[2]](diffhunk://#diff-c39800fc27497d21a2ccac1b42a1a496598cbc04c1dec18c8f95989af0003beeR1675)

**Custom tooltip support for specific columns:**

* Enabled custom tooltip content for the `nextInteractionAt` column in the customers people page, showing both date and interaction name in the tooltip when available.

**Minor UI improvements:**

* Ensured table containers have `min-w-0` to prevent layout issues with truncated content.## Summary

Provide a concise description of the problem and the proposed solution.

## Changes
<img width="1184" height="692" alt="Screenshot 2025-12-01 at 21 05 10" src="https://github.com/user-attachments/assets/cd767d8d-c088-49cc-937b-cee9fae4ef60" />



## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.

