### PR TITLE
Fixes: #224 changes CJS fallback for diRegistrars

### DIFF
--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -8,7 +8,7 @@ import { commandRegistry, CommandBus } from '@open-mercato/shared/lib/commands'
 
 export type AppContainer = AwilixContainer
 
-const diRegistrars = diGenerated.diRegistrars ?? diGenerated.default ?? []
+const diRegistrars = diGenerated.diRegistrars ?? diGenerated.default?.diRegistrars ?? []
 
 export async function createRequestContainer(): Promise<AppContainer> {
   const orm = await getOrm()


### PR DESCRIPTION
## Summary

Fixes CJS module import when running CLI

## Changes

- changes CJS fallback for diRegistrars when run CLI

## Testing

- checked login for next
- checked `npm run mercato events process -- --limit=500` for CLI 

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.

## Linked issues

Fixes: #224
