### PR TITLE
feat: docs - note on un-encrypted embeddings

### DIFF
--- a/docs/docs/framework/database/vector-search.mdx
+++ b/docs/docs/framework/database/vector-search.mdx
@@ -10,7 +10,8 @@ The `vector` module centralises embeddings and similarity search for enabled ent
 - The JSONB query index (`entity_indexes.doc`) is stored encrypted at rest (same ciphertext values as base tables/custom fields).
 - `VectorIndexService` fetches records via the Query Engine, which decrypts entity fields and `cf:*` custom fields on read before embeddings/checksums are computed.
 - Vector result metadata stored in `vector_search` (`result_title`, `result_subtitle`, `result_icon`) is encrypted at rest by default and decrypted only when returning hits/list entries to the UI.
-- This keeps encryption/decryption logic centralized and avoids leaking plaintext into the query index table or vector index storage.
+- **Embeddings themselves are not encrypted**: the pgvector driver stores the raw numeric vector in `vector_search.embedding` exactly as returned by the embedding model. This means a database leak could expose information indirectly encoded in the vector (reconstruction/inference attacks are non-trivial, but possible in some settings).
+- This keeps encryption/decryption logic centralized and avoids storing plaintext chunks in the query index table or vector index storage; treat embeddings as sensitive and prefer redacting/transforming inputs in `buildSource` for high-sensitivity data.
 
 ## Module anatomy
 

--- a/docs/docs/user-guide/encryption.mdx
+++ b/docs/docs/user-guide/encryption.mdx
@@ -15,6 +15,15 @@ Use tenant data encryption to protect sensitive columns with per-tenant DEKs, ke
 
 Note: changing encryption maps or toggling the **Encrypted** flag on a custom field only applies to data written after the change; previously stored values stay as they were unless you re-save or migrate them.
 
+## Vector search embeddings (important)
+
+When using the `vector` module (vector search / embeddings), be aware that **embeddings are stored unencrypted** (for example, in Postgres pgvector the raw vector is stored in `vector_search.embedding`). Even though the source text is decrypted only transiently to compute the embedding and result metadata is encrypted by default, embeddings can still indirectly encode information about the underlying text.
+
+In practice, reconstructing the original text from embeddings is difficult, but treat embeddings as sensitive data:
+
+- Avoid embedding raw PII/high-sensitivity text; redact or transform inputs in your module’s `buildSource`.
+- Limit database access to the vector store and rely on disk-level / managed database encryption-at-rest where possible.
+
 ## Vault setup (KMS)
 
 1. Enable KV v2 and pick a mount, e.g. `secret/`:


### PR DESCRIPTION
This pull request adds important documentation clarifications regarding the security and encryption of vector search embeddings. It emphasizes that, unlike other sensitive data, embeddings are stored unencrypted and may indirectly reveal information about the original text. The changes advise treating embeddings as sensitive and provide recommendations for handling high-sensitivity data.

Security and encryption documentation updates:

* Added a new section in the user guide (`encryption.mdx`) explaining that vector search embeddings are stored unencrypted, with guidance on treating embeddings as sensitive data and recommendations for redacting or transforming high-sensitivity inputs.
* Updated the vector search framework documentation (`vector-search.mdx`) to clarify that embeddings are not encrypted, discuss the risks, and advise best practices for handling sensitive data in embeddings.