### PR TITLE
fix: initialize useOrganizationScope with current state

### DIFF
--- a/packages/shared/src/lib/frontend/organizationEvents.ts
+++ b/packages/shared/src/lib/frontend/organizationEvents.ts
@@ -5,8 +5,38 @@ export type OrganizationScopeChangedDetail = {
   tenantId: string | null
 }
 
+// Module-level state to track current scope and version
+let currentScope: OrganizationScopeChangedDetail = { 
+  organizationId: null, 
+  tenantId: null 
+}
+let currentVersion = 0
+
+export function getCurrentOrganizationScope(): OrganizationScopeChangedDetail {
+  return { ...currentScope }
+}
+
+export function getCurrentOrganizationScopeVersion(): number {
+  return currentVersion
+}
+
 export function emitOrganizationScopeChanged(detail: OrganizationScopeChangedDetail): void {
   if (typeof window === 'undefined' || typeof CustomEvent === 'undefined') return
+  
+  // Detect actual changes
+  const hasChanged = 
+    currentScope.organizationId !== detail.organizationId ||
+    currentScope.tenantId !== detail.tenantId
+  
+  // Update module-level state
+  currentScope = { ...detail }
+  
+  // Increment version only if actual change detected
+  if (hasChanged) {
+    currentVersion++
+  }
+  
+  // Emit event
   window.dispatchEvent(new CustomEvent<OrganizationScopeChangedDetail>(ORGANIZATION_SCOPE_CHANGED_EVENT, { detail }))
 }
 

--- a/packages/shared/src/lib/frontend/useOrganizationScope.ts
+++ b/packages/shared/src/lib/frontend/useOrganizationScope.ts
@@ -1,19 +1,26 @@
 "use client"
 import * as React from 'react'
-import { subscribeOrganizationScopeChanged, type OrganizationScopeChangedDetail } from './organizationEvents'
+import { 
+  subscribeOrganizationScopeChanged, 
+  getCurrentOrganizationScope,
+  getCurrentOrganizationScopeVersion,
+  type OrganizationScopeChangedDetail 
+} from './organizationEvents'
 
 export function useOrganizationScopeVersion(): number {
-  const [version, setVersion] = React.useState(0)
+  const [version, setVersion] = React.useState(getCurrentOrganizationScopeVersion)
   React.useEffect(() => {
     return subscribeOrganizationScopeChanged(() => {
-      setVersion((prev) => prev + 1)
+      setVersion(getCurrentOrganizationScopeVersion())
     })
   }, [])
   return version
 }
 
 export function useOrganizationScopeDetail(): OrganizationScopeChangedDetail {
-  const [detail, setDetail] = React.useState<OrganizationScopeChangedDetail>({ organizationId: null, tenantId: null })
+  const [detail, setDetail] = React.useState<OrganizationScopeChangedDetail>(
+    getCurrentOrganizationScope
+  )
   React.useEffect(() => {
     return subscribeOrganizationScopeChanged((next) => {
       setDetail(next)


### PR DESCRIPTION
## Summary

Add module-level state tracking and getters to ensure hooks start with the current organization scope instead of null, preventing null values on client side navigation

## Changes

- bullet the key code or documentation updates

## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [-] I updated documentation, locales, or generators if the change requires it.
- [-] I added or adjusted tests that cover the change.

## Linked issues

Fixes #292 
