### PR TITLE
bug: Populate variant product before resolving tax rate

### DIFF
--- a/packages/core/src/modules/catalog/commands/variants.ts
+++ b/packages/core/src/modules/catalog/commands/variants.ts
@@ -664,8 +664,8 @@ const updateVariantCommand: CommandHandler<VariantUpdateInput, { variantId: stri
     if (!record) throw new CrudHttpError(404, { error: 'Catalog variant not found' })
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
-    const product =
-      typeof record.product === 'string' ? await requireProduct(em, record.product) : record.product
+    const product = await requireProduct(em, record.product.id)
+
     if (!product) throw new CrudHttpError(400, { error: 'Variant product missing' })
 
     const taxRateProvided = parsed.taxRateId !== undefined || parsed.taxRate !== undefined


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary
Editing a variant failed with `Tax class not found` because the update path was using a lazy/uninitialized product relation that lacked `organizationId` and `tenantId`, so tax-rate lookup could not be scoped correctly. Hydrating the product before resolving tax rates ensures those fields are present and the lookup succeeds.

## Changes
- Populate or re-fetch the product in the variant update flow before calling `resolveVariantTaxRate` so `tenantId`/`organizationId` are available.
- Keep tax-rate resolution and scopes unchanged; only ensure the product relation is hydrated.

## Testing
- Manual: edit an existing variant and save; confirm no `Tax class not found` error and the variant updates successfully.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.

## Linked issues

N/A
