### PR TITLE
fix: docker compose

### DIFF
--- a/docker/opencode/Dockerfile
+++ b/docker/opencode/Dockerfile
@@ -1,12 +1,7 @@
-FROM ubuntu:24.04
+FROM alpine:3.20
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install dependencies
-RUN apt-get update && apt-get install -y \
-    curl \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+# Install dependencies (Alpine uses apk, not affected by Debian mirror issues)
+RUN apk add --no-cache curl ca-certificates bash shadow
 
 # Install OpenCode and move to system path
 RUN curl -fsSL https://opencode.ai/install | bash && \


### PR DESCRIPTION
This pull request updates the Dockerfiles to use Alpine Linux instead of Debian/Ubuntu-based images, resulting in smaller image sizes and faster builds. The changes also update system dependency installation commands and user creation steps to be compatible with Alpine. These improvements help avoid issues with Debian mirrors and streamline the build process.

**Base image and package manager migration:**

* Updated the base images in both `Dockerfile` and `docker/opencode/Dockerfile` from Debian/Ubuntu (`bookworm-slim`, `ubuntu:24.04`) to Alpine (`node:24-alpine`, `alpine:3.20`), reducing image size and improving build speed. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R9) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L45-R51) [[3]](diffhunk://#diff-f1db8c821e921287dab5ca5a70b14343ef56f7b41150d80e45be8af77285516fL1-R4)
* Replaced `apt-get` commands with `apk add` for installing system dependencies, ensuring compatibility with Alpine and removing reliance on Debian mirrors. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R9) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L45-R51) [[3]](diffhunk://#diff-f1db8c821e921287dab5ca5a70b14343ef56f7b41150d80e45be8af77285516fL1-R4)

**User management adjustments:**

* Changed user creation from `useradd` (Debian/Ubuntu) to `adduser` (Alpine) in the Dockerfiles for dropping root privileges.

**Additional dependency updates:**

* Added `bash` and `shadow` to the installed dependencies in `docker/opencode/Dockerfile` to support scripts and user management on Alpine.