### PR TITLE
fix: CMD+K shortcut opens both Search and AI Assistant dialogs simultaneously bug Something isn't working

### DIFF
--- a/packages/ai-assistant/src/frontend/constants.ts
+++ b/packages/ai-assistant/src/frontend/constants.ts
@@ -1,8 +1,16 @@
+/**
+ * @deprecated Cmd+K is now reserved for Global Search.
+ * Use AI_CHAT_SHORTCUT (Cmd+J) to open the AI Assistant.
+ * Kept for backwards compatibility with external consumers.
+ */
 export const COMMAND_PALETTE_SHORTCUT = {
   key: 'k',
   meta: true, // Cmd on Mac, Ctrl on Windows/Linux
 } as const
 
+/**
+ * Keyboard shortcut to open the AI Chat/Assistant (Cmd+J on Mac, Ctrl+J on Windows/Linux)
+ */
 export const AI_CHAT_SHORTCUT = {
   key: 'j',
   meta: true, // Cmd on Mac, Ctrl on Windows/Linux

--- a/packages/ai-assistant/src/frontend/hooks/useCommandPalette.ts
+++ b/packages/ai-assistant/src/frontend/hooks/useCommandPalette.ts
@@ -267,7 +267,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
       // Open/close with Cmd+K or Ctrl+K
       if (
         (event.metaKey || event.ctrlKey) &&
-        event.key.toLowerCase() === COMMAND_PALETTE_SHORTCUT.key
+        event.key.toLowerCase() === AI_CHAT_SHORTCUT.key
       ) {
         event.preventDefault()
         setState((prev) => {

--- a/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
+++ b/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
@@ -313,7 +313,7 @@ export function GlobalSearchDialog({
           <span id="global-search-description" className="sr-only">
             {t('search.dialog.instructions')}
           </span>
-          <div className="flex flex-col gap-3 border-b px-4 pb-3 pt-4">
+          <div className="flex flex-col gap-3 border-b px-4 pb-3 pt-12">
             <div className="flex items-center gap-2 rounded border bg-background px-3 py-2 focus-within:ring-2 focus-within:ring-ring">
               <Search className="h-4 w-4 text-muted-foreground" />
               <TypedInput


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Both the AI Assistant and Global Search dialog were bound to the same keyboard shortcut (Cmd+K / Ctrl+K), causing a conflict where only one dialog could be opened.

## Changes

- Reassigned AI Assistant shortcut from Cmd+K to Cmd+J (Ctrl+J on Windows/Linux)
- Reserved Cmd+K exclusively for Global Search, which is the standard convention in most applications
- Added deprecation notice to COMMAND_PALETTE_SHORTCUT constant for backwards compatibility with external consumers
- Minor UI fix: adjusted Global Search dialog top padding for better visual alignment

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [X] N/A (minor change, no spec needed)

## Testing

Tested on Mac OS (MacBook and iPhone). 

## Checklist

- [X] This pull request targets `develop`.
- [X] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #505 
