### PR TITLE
RFC: POS Module Specification (Issue #391)

### DIFF
--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -51,6 +51,7 @@ Files like `AGENTS.md` and `CLAUDE.md` use UPPERCASE names and are not numberedâ
 | [SPEC-014](SPEC-014-2026-01-28-onboarding-activation-login.md) | 2026-01-28 | Onboarding Activation Login | Duplicate-activation guard and tenant-aware login flow |
 | [SPEC-015](SPEC-015-2026-01-29-module-registry-scanner-dedup.md) | 2026-01-29 | Module Registry Scanner Dedup | Deduplicate widget scanner logic in module registry generation |
 | [SPEC-016](SPEC-016-2026-02-07-pos-module.md) | 2026-02-07 | POS Module | Point of Sale module for in-store retail operations |
+| [SPEC-016a](SPEC-016a-2026-02-09-pos-tile-browsing.md) | 2026-02-09 | POS Tile Browsing | Tile-based product browsing UI for POS checkout |
 
 ## Specification Structure
 


### PR DESCRIPTION
## Summary
This PR proposes a detailed specification for the POS Module as outlined in #391.

## Specification Highlights
- **7 core entities**: PosRegister, PosSession, PosCart, PosCartLine, PosPayment, PosReceipt, PosCashMovement
- **7 functional requirements** scoped to Phase 1
- **13 API endpoints** with OpenAPI patterns
- **UI design** leveraging existing Sales module components
- **Module integration analysis** identifying ready integrations (sales, catalog, customers) and deferred ones (WMS, promotions)

## Phase 1 Scope
- Registers + sessions
- Cart + payment + receipt  
- SalesOrder integration
- Minimal UI for checkout

## Open Questions
The spec includes 7 open questions for core team input (see Section 10).

I'm volunteering to implement this feature and would appreciate feedback on the specification before starting development.

Fixes #391