### PR TITLE
feat(search): prevent auto-reindex feedback loops in search indexing …

### DIFF
--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -215,7 +215,9 @@ export class HybridQueryEngine implements QueryEngine {
               : { scope: null })
           )
           if (gap) {
-            this.scheduleAutoReindex(entity, opts, gap.stats, coverageScope?.organizationId ?? null)
+            if (!opts.skipAutoReindex) {
+              this.scheduleAutoReindex(entity, opts, gap.stats, coverageScope?.organizationId ?? null)
+            }
             const force = this.isForcePartialIndexEnabled()
             if (!force) {
               if (gap.stats) {
@@ -437,7 +439,9 @@ export class HybridQueryEngine implements QueryEngine {
               : { entity: targetEntity, scope: null })
           )
           if (!gap) continue
-          this.scheduleAutoReindex(targetEntity, opts, gap.stats, coverageScope?.organizationId ?? null)
+          if (!opts.skipAutoReindex) {
+            this.scheduleAutoReindex(targetEntity, opts, gap.stats, coverageScope?.organizationId ?? null)
+          }
           partialIndexWarning = {
             entity: targetEntity,
             entityLabel: this.resolveEntityLabel(targetEntity),
@@ -1417,6 +1421,7 @@ export class HybridQueryEngine implements QueryEngine {
     organizationIdOverride?: string | null
   ) {
     if (!this.isAutoReindexEnabled()) return
+
     const bus = this.resolveEventBus()
     if (!bus) return
     const payload = {

--- a/packages/search/src/vector/services/vector-index.service.ts
+++ b/packages/search/src/vector/services/vector-index.service.ts
@@ -329,6 +329,7 @@ export class VectorIndexService {
       filters,
       includeCustomFields: true,
       fields: this.getEnrichmentFields(entityId),
+      skipAutoReindex: true,
     })
     const byId = new Map<string, Record<string, any>>()
     for (const item of result.items) {
@@ -902,6 +903,7 @@ export class VectorIndexService {
         page: { page, pageSize },
         includeCustomFields: true,
         fields: this.getEnrichmentFields(args.entityId),
+        skipAutoReindex: true,
       })
       if (!result.items.length) break
       for (const raw of result.items) {

--- a/packages/shared/src/lib/query/types.ts
+++ b/packages/shared/src/lib/query/types.ts
@@ -94,6 +94,10 @@ export type QueryOptions = {
   customFieldSources?: QueryCustomFieldSource[]
   joins?: QueryJoinEdge[]
   profiler?: Profiler
+  // When true, suppress automatic reindex scheduling triggered by coverage gap detection.
+  // Used by the search indexing pipeline to prevent feedback loops where indexing triggers
+  // re-indexing indefinitely.
+  skipAutoReindex?: boolean
 }
 
 export type PartialIndexWarning = {


### PR DESCRIPTION
## Summary

Search indexing operations that query the `HybridQueryEngine` to hydrate entity data can trigger coverage gap detection, which schedules auto-reindex events, which trigger more indexing — creating an infinite feedback loop. This change introduces a `skipAutoReindex` query option that the search indexing pipeline uses to suppress reindex scheduling during its own queries, breaking the cycle.

## Problem

When browsing pages with entities that have vector search enabled (e.g., /backend/customers/people), an infinite loop occurs where vector-indexing and events queue jobs grow indefinitely — observed reaching 1500+ jobs and climbing without bound.

The root cause is a feedback loop in the search indexing pipeline:
1. A user page load queries HybridQueryEngine, which detects a coverage gap (baseCount: 6, indexedCount: 11) and calls scheduleAutoReindex()
2. scheduleAutoReindex() emits a persistent query_index.reindex event
3. The reindex subscriber calls reindexEntity() with emitVectorizeEvents: true
4. This emits query_index.vectorize_one for every record (6 events)
5. Each vectorize_one event enqueues a vector-indexing job
6. The vector-indexing worker calls searchIndexer.indexRecordById(), which calls indexRecord() → buildSource(ctx)
7. buildSource() callbacks in module search configs (e.g., customers/search.ts) call ctx.queryEngine.query() to hydrate related entities — without skipAutoReindex
8. Those queries hit the coverage gap check again → back to step 1, creating an amplification loop (1 job → N jobs per cycle)

## Changes

- Added `skipAutoReindex?: boolean` to `QueryOptions` in `packages/shared/src/lib/query/types.ts`
- Guarded both `scheduleAutoReindex` call sites in `HybridQueryEngine` (`engine.ts`) behind `!opts.skipAutoReindex`
- Created `noReindexQueryEngine` getter in `SearchIndexer` that wraps the query engine to force `skipAutoReindex: true` on all queries made by `buildSource`/`formatResult` callbacks
- Added `skipAutoReindex: true` to all direct `queryEngine.query()` calls in `SearchIndexer` (record lookup, fulltext reindex, vector reindex batches)
- Added `skipAutoReindex: true` to `VectorIndexService` queries in `fetchRecord` and vector reindex batch loop

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)
**Spec file path:**
N/A — targeted bugfix, no spec required.
## Testing
- Verified that search indexing operations no longer trigger cascading auto-reindex events
- Confirmed normal query engine behavior (without `skipAutoReindex`) still schedules reindex on coverage gaps as expected
 

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Discovered after testing but not caused by #493 
