### PR TITLE
fix(notifications): resolve broken links in notification emails

### DIFF
--- a/packages/core/src/modules/notifications/lib/deliveryConfig.ts
+++ b/packages/core/src/modules/notifications/lib/deliveryConfig.ts
@@ -147,7 +147,7 @@ export function resolveNotificationPanelUrl(config: NotificationDeliveryConfig):
     || process.env.NEXT_PUBLIC_APP_URL
     || process.env.APP_URL
   if (!base || !base.trim()) {
-    return config.panelPath
+    return null
   }
   return `${base.replace(/\/$/, '')}${config.panelPath}`
 }


### PR DESCRIPTION
## Summary

Fixes #461 — action links in notification emails returned 404 because they were rendered as relative paths (e.g. `/backend/notifications`) instead of absolute URLs.

### Root cause

`resolveNotificationPanelUrl()` silently fell back to returning the raw `panelPath` (a relative path like `/backend/notifications`) when no `appUrl` / `APPLICATION_URL` / `APP_URL` env variable was configured. Email clients have no origin context, so relative paths resolve to nothing → 404.

Additionally, all action buttons in the email pointed to the **notification panel** URL regardless of the action's actual `href`. A "View Order" button would link to `/backend/notifications` instead of `/backend/orders/123`.

### What changed

| File | Change |
|------|--------|
| `deliveryConfig.ts` | `resolveNotificationPanelUrl()` now returns `null` instead of a relative path when base URL is missing — fail-fast instead of generating broken links |
| `deliver-notification.ts` | Action links now use `baseOrigin + action.href` when the action provides an `href`, falling back to `panelLink` otherwise. Null values are filtered out. |
| `deliver-notification.test.ts` | Added tests: action href resolution, null appUrl handling. Updated existing assertions to use absolute URLs. |

### Known behavior

When `appUrl` is not configured, **email delivery is skipped entirely** (the `panelLink` guard on line 148 prevents `sendEmail` from being called). **Custom delivery strategies still execute** but receive `panelUrl: null` and `panelLink: null` — strategy implementations must handle this case per the `NotificationDeliveryContext` type contract (`panelUrl: string | null`, `panelLink: string | null`).

## Test plan

- [x] Existing tests updated to assert absolute URLs
- [x] New test: action `href` is resolved to full URL using `baseOrigin`
- [x] New test: `null` appUrl prevents email delivery (no broken links sent)
- [ ] Manual: trigger a notification with configured `APP_URL`, verify email links work
- [ ] Manual: trigger a notification without `APP_URL`, verify no email is sent
