### PR TITLE
fix(ui): expose TruncatedCell for reuse

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './backend/utils/nav'
 export * from './backend/CrudForm'
 export * from './backend/JsonBuilder'
 export * from './backend/detail'
+export * from './backend/TruncatedCell'
 export * from './backend/schedule'
 
 export * from './backend/inputs'


### PR DESCRIPTION
Exposes TruncatedCell component from @open-mercato/ui in packages/ui/src/index.ts to allow reuse in other modules (e.g., POS). Also removes a duplicate export.