### PR TITLE
docs: add PostgreSQL port-conflict troubleshooting in setup guide

### DIFF
--- a/apps/docs/docs/appendix/troubleshooting.mdx
+++ b/apps/docs/docs/appendix/troubleshooting.mdx
@@ -38,3 +38,33 @@ DB_POOL_ACQUIRE_TIMEOUT=30000
 ```
 
 If you continue to hit connection limits, verify that background workers and migrations use the same pool settings, and confirm that your database `max_connections` value comfortably exceeds the aggregate pool size across all applications connecting to it.
+
+## PostgreSQL auth errors on local setup
+
+If local commands such as `yarn generate`, `yarn db:generate`, or app startup fail with errors like:
+
+- `password authentication failed for user "postgres"`
+- `role "postgres" does not exist`
+- `could not connect to server`
+
+you may be connecting to a different PostgreSQL instance already bound to `localhost:5432` (for example, a host-installed Postgres), not the Docker one started for Open Mercato.
+
+### Fix
+
+Start Docker PostgreSQL on a different host port and use the same port in `DATABASE_URL`:
+
+```bash
+POSTGRES_PORT=55432 docker compose up -d postgres
+```
+
+```env
+DATABASE_URL=postgresql://postgres:postgres@localhost:55432/open-mercato
+```
+
+### Verify
+
+```bash
+psql "postgresql://postgres:postgres@localhost:55432/open-mercato" -c "select 1;"
+```
+
+If this succeeds but `:5432` still fails, keep using the alternate port (or stop the other local PostgreSQL service that occupies `5432`).

--- a/apps/docs/docs/installation/setup.mdx
+++ b/apps/docs/docs/installation/setup.mdx
@@ -215,6 +215,13 @@ Key variables you may want to override:
 
 **Port conflicts:**
 - If port 3000 is already in use, override it: `APP_PORT=3001 docker compose -f docker-compose.fullapp.dev.yml up`
+- If Postgres auth/connect errors appear during local commands (`yarn generate`, `yarn db:generate`) and `localhost:5432` is occupied by another local PostgreSQL instance, start Docker Postgres on another port and use the same port in `DATABASE_URL`:
+  ```bash
+  POSTGRES_PORT=55432 docker compose up -d postgres
+  ```
+  ```env
+  DATABASE_URL=postgresql://postgres:postgres@localhost:55432/open-mercato
+  ```
 
 **Slow file watching on Windows/WSL 2:**
 - Store the repository inside the WSL 2 filesystem (`\\wsl$\Ubuntu\home\...`) rather than on the Windows filesystem (`/mnt/c/...`) for significantly better I/O performance.


### PR DESCRIPTION
## Summary
- Adds troubleshooting guidance in the local setup docs for PostgreSQL auth/connection errors caused by `localhost:5432` port conflicts.
- Documents how to start Docker PostgreSQL on an alternate host port using `POSTGRES_PORT=55432`.
- Adds a matching `DATABASE_URL` example using `localhost:55432`.

## Why
When another local PostgreSQL instance already uses port `5432`, Open Mercato commands (e.g. `yarn generate`, `yarn db:generate`) may connect to the wrong DB and fail with auth errors. This update provides a clear workaround.

## Test plan
- [x] Run docs locally (`yarn docs:dev`)
- [x] Open `/installation/setup#troubleshooting-1`
- [x] Confirm new troubleshooting note renders correctly
- [x] Verify command and `DATABASE_URL` examples are copy-paste ready