### PR TITLE
#383 - fix mikro ORM config to support sslmode=require

### DIFF
--- a/packages/cli/src/lib/db/commands.ts
+++ b/packages/cli/src/lib/db/commands.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url'
 import { MikroORM, type Logger } from '@mikro-orm/core'
 import { Migrator } from '@mikro-orm/migrations'
 import { PostgreSqlDriver } from '@mikro-orm/postgresql'
+import { getSslConfig } from '@open-mercato/shared/lib/db/ssl'
 import type { PackageResolver, ModuleEntry } from '../resolver'
 
 const QUIET_MODE = process.env.OM_CLI_QUIET === '1' || process.env.MERCATO_QUIET === '1'
@@ -41,21 +42,6 @@ function getClientUrl(): string {
   const url = process.env.DATABASE_URL
   if (!url) throw new Error('DATABASE_URL is not set')
   return url
-}
-
-function getSslConfig() {
-  const clientUrl = process.env.DATABASE_URL || ''
-  const requireSsl = clientUrl.includes('sslmode=require') ||
-                     clientUrl.includes('ssl=true') ||
-                     process.env.DB_SSL === 'true'
-
-  if (!requireSsl) {
-    return undefined
-  }
-
-  return {
-    rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false',
-  }
 }
 
 function sortModules(mods: ModuleEntry[]): ModuleEntry[] {

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -8,6 +8,7 @@ import type { Module } from '@open-mercato/shared/modules/registry'
 import { getCliModules, hasCliModules, registerCliModules } from './registry'
 export { getCliModules, hasCliModules, registerCliModules }
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { getSslConfig } from '@open-mercato/shared/lib/db/ssl'
 import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import { resolveInitDerivedSecrets } from './lib/init-secrets'
 import {
@@ -49,15 +50,6 @@ async function ensureEnvLoaded() {
   try {
     await import('dotenv/config')
   } catch {}
-}
-
-function getSslConfig() {
-  const clientUrl = process.env.DATABASE_URL || ''
-  const requireSsl = clientUrl.includes('sslmode=require') ||
-                     clientUrl.includes('ssl=true') ||
-                     process.env.DB_SSL === 'true'
-  if (!requireSsl) return undefined
-  return { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' }
 }
 
 // Helper to run a CLI command directly (without spawning a process)

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -2,6 +2,7 @@ import 'dotenv/config'
 import 'reflect-metadata'
 import { MikroORM } from '@mikro-orm/core'
 import { PostgreSqlDriver } from '@mikro-orm/postgresql'
+import { getSslConfig } from './ssl'
 
 let ormInstance: MikroORM<PostgreSqlDriver> | null = null
 
@@ -52,13 +53,7 @@ export async function getOrm() {
       ? `-c idle_session_timeout=${idleSessionTimeoutMs}`
       : undefined
 
-  const requireSsl = clientUrl.includes('sslmode=require') ||
-                     clientUrl.includes('ssl=true') ||
-                     process.env.DB_SSL === 'true'
-
-  const sslConfig = requireSsl ? {
-    rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false',
-  } : undefined
+  const sslConfig = getSslConfig()
 
   ormInstance = await MikroORM.init<PostgreSqlDriver>({
     driver: PostgreSqlDriver,

--- a/packages/shared/src/lib/db/ssl.ts
+++ b/packages/shared/src/lib/db/ssl.ts
@@ -1,0 +1,18 @@
+/**
+ * Auto-detect SSL requirement from DATABASE_URL or explicit DB_SSL env var.
+ * Returns a pg-compatible SSL config object, or undefined when SSL is not needed.
+ */
+export function getSslConfig(): { rejectUnauthorized: boolean } | undefined {
+  const clientUrl = process.env.DATABASE_URL || ''
+  const requireSsl = clientUrl.includes('sslmode=require') ||
+                     clientUrl.includes('ssl=true') ||
+                     process.env.DB_SSL === 'true'
+
+  if (!requireSsl) {
+    return undefined
+  }
+
+  return {
+    rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false',
+  }
+}


### PR DESCRIPTION
## Summary

Fix for issue #383 - bug: mikroORM config to support ssl

_Note: this is my first PR from fork against open source project, hope it's ok_

## Changes

- minor mikroORM config changes to respect `sslmode=require` in `DATABASE_URL`

## Specification

In order to use 3rd party cloud-based database providers (like neon, supabase) - we need to respect sslmode in mikroORM config.

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Run open mercato in dev mode with default config (local postgres in docker) `DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato`
- Run the same with `DATABASE_URL=postgresql://neondb_owner:****@ep-dry-frost-ah34k6u1.c-3.us-east-1.aws.neon.tech/neondb?sslmode=require`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
