### PR TITLE
fix: specs sorting

### DIFF
--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -80,7 +80,7 @@ Files like `AGENTS.md` and `CLAUDE.md` use UPPERCASE names and are not numberedâ
 | [SPEC-028](SPEC-028-2026-02-16-multiple-sales-pipelines.md) | 2026-02-16 | Multiple Sales Pipelines | Multiple CRM pipelines with configurable stages + deal assignment |
 | [SPEC-029](SPEC-029-2026-02-17-ecommerce-storefront-module.md) | 2026-02-17 | Ecommerce Storefront Module | Dedicated `ecommerce` core module + `apps/storefront` starter: org-scoped stores, per-store configurable branding (CSS variables), localized catalog APIs, server-side faceted filters with cross-facet exclusion, multi-variant selection algorithm, WCAG 2.2 AA compliance, RWD-first component spec, and workflow-driven checkout (Phase 3) |
 | [SPEC-030](SPEC-030-2026-02-09-rate-limiting.md) | 2026-02-09 | Rate Limiting Utility | Strategy-based rate limiting for auth endpoints using rate-limiter-flexible |
-| [SPEC-032](SPEC-030-2026-02-19-notification-templates-db-only.md) | 2026-02-19 | Notification Templates (DB-Only) | DB-only architecture for versioned email/slack notification templates with publish flow, mapping resolver, and tenant-safe runtime fallback policy |
+| [SPEC-032](SPEC-032-2026-02-19-notification-templates-db-only.md) | 2026-02-19 | Notification Templates (DB-Only) | DB-only architecture for versioned email/slack notification templates with publish flow, mapping resolver, and tenant-safe runtime fallback policy |
 
 ## Specification Structure
 

--- a/.ai/specs/SPEC-031-2026-02-18-decrypt-database-cli.md
+++ b/.ai/specs/SPEC-031-2026-02-18-decrypt-database-cli.md
@@ -1,4 +1,4 @@
-# SPEC-030: Decrypt Database CLI Command
+# SPEC-031: Decrypt Database CLI Command
 
 ## TLDR
 

--- a/.ai/specs/SPEC-032-2026-02-19-notification-templates-db-only.md
+++ b/.ai/specs/SPEC-032-2026-02-19-notification-templates-db-only.md
@@ -1,3 +1,7 @@
+# SPEC-032: Notification Templates (DB-Only)
+
+## TLDR
+
 **Key Points:**
 - We introduce a unified template model for multiple channels, without hardcoding a specific channel in the core.
 - Data is stored in two tables: `notification_templates` (header/template metadata) and `notification_templates_blocks` (block tree).


### PR DESCRIPTION
This pull request updates the specification files to correct numbering and improve consistency in our documentation. The main changes involve renaming two spec files to align with their intended spec numbers and updating their headers accordingly. Additionally, a minor formatting fix was made in the spec list.

Specification file renaming and header updates:

* Renamed `.ai/specs/SPEC-030-2026-02-18-decrypt-database-cli.md` to `.ai/specs/SPEC-031-2026-02-18-decrypt-database-cli.md` and updated the header from `# SPEC-030` to `# SPEC-031` to match the correct spec number.
* Renamed `.ai/specs/SPEC-031-2026-02-19-notification-templates-db-only.md` to `.ai/specs/SPEC-032-2026-02-19-notification-templates-db-only.md` and updated the header from `# SPEC-031` to `# SPEC-032`.

Documentation consistency:

* Fixed a minor formatting issue in `.ai/specs/README.md` to ensure the spec list is accurate and consistent.