### PR TITLE
fix: remove duplicated header in custom field translation dialog

### DIFF
--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -591,6 +591,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
           {translateDef && (
             <TranslationManager
               mode="embedded"
+              compact
               entityType="entities:custom_field_def"
               recordId={`${translateDef.entityId}:${translateDef.def.key}`}
               baseValues={translateBaseValues}


### PR DESCRIPTION
## Summary
- Fixed duplicated header in the custom field label translation dialog on `/backend/entities/system|user/{entityId}` page
- The `TranslationManager` was rendered with `mode="embedded"` but without `compact` prop, causing it to render its own `<h2>Translations</h2>` inside a dialog that already had a `<DialogTitle>`
- Adding `compact` suppresses the component's built-in heading

## Files Changed
- `packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx` — added `compact` prop to `TranslationManager`

## Test plan
- [x] `yarn build:packages` passes
- [ ] Go to `/backend/entities/system` → select any entity → click "Translate" on a field → verify single header in dialog

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)