### PR TITLE
feat: TranslationsAction button + CrudForm integration (#618)

### DIFF
--- a/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resources/[id]/page.tsx
@@ -17,6 +17,7 @@ import { RESOURCES_RESOURCE_FIELDSET_DEFAULT } from '@open-mercato/core/modules/
 import type { AvailabilityScheduleItemBuilder } from '@open-mercato/core/modules/planner/components/AvailabilityRulesEditor'
 import { AvailabilityRulesEditor } from '@open-mercato/core/modules/planner/components/AvailabilityRulesEditor'
 import { ResourcesResourceForm, useResourcesResourceFormConfig } from '@open-mercato/core/modules/resources/components/ResourceCrudForm'
+import { TranslationsAction } from '@open-mercato/core/modules/translations/components/TranslationsAction'
 import { renderDictionaryColor, renderDictionaryIcon, ICON_SUGGESTIONS } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import { createResourceNotesAdapter } from '@open-mercato/core/modules/resources/components/detail/notesAdapter'
 import { createResourceActivitiesAdapter } from '@open-mercato/core/modules/resources/components/detail/activitiesAdapter'
@@ -594,6 +595,11 @@ export default function ResourcesResourceDetailPage({ params }: { params?: { id?
                   onDelete={handleDelete}
                   isLoading={!initialValues}
                   loadingMessage={t('resources.resources.form.loading', 'Loading resource...')}
+                  extraActions={
+                    <TranslationsAction
+                      config={resourceId ? { entityType: 'resources:resources_resource', recordId: resourceId, baseValues: initialValues ?? undefined } : null}
+                    />
+                  }
                 />
               </div>
             </>

--- a/packages/core/src/modules/resources/components/ResourceCrudForm.tsx
+++ b/packages/core/src/modules/resources/components/ResourceCrudForm.tsx
@@ -312,6 +312,7 @@ export type ResourcesResourceFormProps = {
   isLoading?: boolean
   loadingMessage?: string
   formConfig: ResourcesResourceFormConfig
+  extraActions?: React.ReactNode
 }
 
 export function ResourcesResourceForm(props: ResourcesResourceFormProps) {
@@ -328,6 +329,7 @@ export function ResourcesResourceForm(props: ResourcesResourceFormProps) {
     isLoading,
     loadingMessage,
     formConfig,
+    extraActions,
   } = props
   const t = useT()
   const recordId = typeof initialValues?.id === 'string' ? initialValues.id : null
@@ -365,6 +367,7 @@ export function ResourcesResourceForm(props: ResourcesResourceFormProps) {
       onDelete={onDelete}
       isLoading={isLoading}
       loadingMessage={loadingMessage}
+      extraActions={extraActions}
     />
   )
 }

--- a/packages/core/src/modules/resources/translations.ts
+++ b/packages/core/src/modules/resources/translations.ts
@@ -1,0 +1,5 @@
+export const translatableFields: Record<string, string[]> = {
+  'resources:resources_resource': ['name', 'description'],
+}
+
+export default translatableFields

--- a/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/team-members/[id]/page.tsx
@@ -15,6 +15,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { createTranslatorWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import { AvailabilityRulesEditor } from '@open-mercato/core/modules/planner/components/AvailabilityRulesEditor'
 import { buildMemberScheduleItems } from '@open-mercato/core/modules/staff/lib/memberSchedule'
+import { TranslationsAction } from '@open-mercato/core/modules/translations/components/TranslationsAction'
 import { TeamMemberForm, buildTeamMemberPayload, type TeamMemberFormValues } from '@open-mercato/core/modules/staff/components/TeamMemberForm'
 import { NotesSection } from '@open-mercato/ui/backend/detail'
 import { ActivitiesSection, type SectionAction } from '@open-mercato/ui/backend/detail'
@@ -352,6 +353,9 @@ export default function StaffTeamMemberDetailPage({ params }: { params?: { id?: 
                 </p>
               </div>
             </div>
+            <TranslationsAction
+              config={memberId ? { entityType: 'staff:staff_team_member', recordId: memberId, baseValues: memberRecord ?? undefined } : null}
+            />
           </div>
 
           <div className="border-b">

--- a/packages/core/src/modules/staff/translations.ts
+++ b/packages/core/src/modules/staff/translations.ts
@@ -1,0 +1,5 @@
+export const translatableFields: Record<string, string[]> = {
+  'staff:staff_team_member': ['display_name', 'description'],
+}
+
+export default translatableFields

--- a/packages/core/src/modules/translations/components/TranslationsAction.tsx
+++ b/packages/core/src/modules/translations/components/TranslationsAction.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import * as React from 'react'
+import { Languages } from 'lucide-react'
+import { Button } from '@open-mercato/ui/primitives/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@open-mercato/ui/primitives/dialog'
+import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { TranslationManager } from './TranslationManager'
+
+export type TranslationsActionConfig = {
+  entityType: string
+  recordId: string
+  baseValues?: Record<string, unknown>
+}
+
+export type TranslationsActionProps = {
+  config: TranslationsActionConfig | null
+}
+
+export function TranslationsAction({ config }: TranslationsActionProps) {
+  const t = useT()
+  const [open, setOpen] = React.useState(false)
+
+  const enabled = Boolean(
+    config?.entityType
+      && config?.recordId
+      && String(config.recordId).trim().length > 0,
+  )
+
+  if (!enabled) return null
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={() => setOpen(true)}
+        aria-label={t('translations.action.title', 'Translations')}
+        title={t('translations.action.title', 'Translations')}
+      >
+        <Languages className="size-4" />
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>
+              {t('translations.action.dialogTitle', 'Manage translations')}
+            </DialogTitle>
+            <DialogDescription>
+              {t('translations.manager.description', 'Manage translations for entity records across supported locales.')}
+            </DialogDescription>
+          </DialogHeader>
+          <TranslationManager
+            mode="embedded"
+            entityType={config!.entityType}
+            recordId={config!.recordId}
+            baseValues={config!.baseValues}
+          />
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/packages/core/src/modules/translations/i18n/de.json
+++ b/packages/core/src/modules/translations/i18n/de.json
@@ -1,4 +1,6 @@
 {
+  "translations.action.dialogTitle": "Übersetzungen verwalten",
+  "translations.action.title": "Übersetzungen",
   "translations.config.nav.title": "Übersetzungen",
   "translations.locales.add": "Hinzufügen",
   "translations.locales.addPlaceholder": "z.B. fr, it, ja...",

--- a/packages/core/src/modules/translations/i18n/en.json
+++ b/packages/core/src/modules/translations/i18n/en.json
@@ -1,4 +1,6 @@
 {
+  "translations.action.dialogTitle": "Manage translations",
+  "translations.action.title": "Translations",
   "translations.config.nav.title": "Translations",
   "translations.locales.add": "Add",
   "translations.locales.addPlaceholder": "e.g. fr, it, ja...",

--- a/packages/core/src/modules/translations/i18n/es.json
+++ b/packages/core/src/modules/translations/i18n/es.json
@@ -1,4 +1,6 @@
 {
+  "translations.action.dialogTitle": "Gestionar traducciones",
+  "translations.action.title": "Traducciones",
   "translations.config.nav.title": "Traducciones",
   "translations.locales.add": "Añadir",
   "translations.locales.addPlaceholder": "p. ej. fr, it, ja...",

--- a/packages/core/src/modules/translations/i18n/pl.json
+++ b/packages/core/src/modules/translations/i18n/pl.json
@@ -1,4 +1,6 @@
 {
+  "translations.action.dialogTitle": "Zarządzaj tłumaczeniami",
+  "translations.action.title": "Tłumaczenia",
   "translations.config.nav.title": "Tłumaczenia",
   "translations.locales.add": "Dodaj",
   "translations.locales.addPlaceholder": "np. fr, it, ja...",

--- a/packages/core/src/modules/translations/lib/__tests__/resolve-field-list.test.ts
+++ b/packages/core/src/modules/translations/lib/__tests__/resolve-field-list.test.ts
@@ -112,10 +112,10 @@ describe('resolveFieldList', () => {
     })
   })
 
-  describe('custom field defs augmentation', () => {
-    it('appends text custom fields', () => {
-      registerTranslatableFields({ 'test:with_cf': ['title'] })
-      const result = resolveFieldList('test:with_cf', undefined, [
+  describe('custom field defs augmentation (auto-detect path only)', () => {
+    it('appends text custom fields when no registered fields', () => {
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_text', undefined, [
         { key: 'custom_note', kind: 'text', label: 'Custom Note' },
       ])
       expect(result).toHaveLength(2)
@@ -123,24 +123,24 @@ describe('resolveFieldList', () => {
     })
 
     it('appends multiline custom fields as multiline', () => {
-      registerTranslatableFields({ 'test:with_multiline_cf': ['title'] })
-      const result = resolveFieldList('test:with_multiline_cf', undefined, [
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_multiline', undefined, [
         { key: 'long_text', kind: 'multiline' },
       ])
       expect(result[1].multiline).toBe(true)
     })
 
     it('appends richtext custom fields as multiline', () => {
-      registerTranslatableFields({ 'test:with_richtext_cf': ['title'] })
-      const result = resolveFieldList('test:with_richtext_cf', undefined, [
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_richtext', undefined, [
         { key: 'rich_content', kind: 'richtext' },
       ])
       expect(result[1].multiline).toBe(true)
     })
 
     it('skips non-text kinds (number, boolean, etc.)', () => {
-      registerTranslatableFields({ 'test:skip_cf': ['title'] })
-      const result = resolveFieldList('test:skip_cf', undefined, [
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_skip', undefined, [
         { key: 'quantity', kind: 'number' },
         { key: 'is_active', kind: 'boolean' },
         { key: 'created_at', kind: 'date' },
@@ -149,28 +149,37 @@ describe('resolveFieldList', () => {
     })
 
     it('does not duplicate fields already in the list', () => {
-      registerTranslatableFields({ 'test:no_dup_cf': ['title'] })
-      const result = resolveFieldList('test:no_dup_cf', undefined, [
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_nodup', undefined, [
         { key: 'title', kind: 'text' },
       ])
       expect(result).toHaveLength(1)
     })
 
     it('uses formatFieldLabel when custom field has no label', () => {
-      registerTranslatableFields({ 'test:cf_no_label': ['title'] })
-      const result = resolveFieldList('test:cf_no_label', undefined, [
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_nolabel', undefined, [
         { key: 'product_note', kind: 'text' },
       ])
       expect(result[1].label).toBe('Product Note')
     })
 
     it('skips custom fields with empty key', () => {
-      registerTranslatableFields({ 'test:cf_empty_key': ['title'] })
-      const result = resolveFieldList('test:cf_empty_key', undefined, [
+      mockedGetEntityFields.mockReturnValue({ field1: 'title' })
+      const result = resolveFieldList('unknown:cf_emptykey', undefined, [
         { key: '', kind: 'text' },
         { key: '  ', kind: 'text' },
       ])
       expect(result).toHaveLength(1)
+    })
+
+    it('does NOT append custom fields when registered fields exist', () => {
+      registerTranslatableFields({ 'test:cf_registered': ['title'] })
+      const result = resolveFieldList('test:cf_registered', undefined, [
+        { key: 'custom_note', kind: 'text', label: 'Custom Note' },
+      ])
+      expect(result).toHaveLength(1)
+      expect(result[0].key).toBe('title')
     })
   })
 })

--- a/packages/core/src/modules/translations/lib/resolve-field-list.ts
+++ b/packages/core/src/modules/translations/lib/resolve-field-list.ts
@@ -24,8 +24,10 @@ export function resolveFieldList(
 
   const registered = getTranslatableFields(entityType)
   const fields: ResolvedField[] = []
+  let hasExplicitList = false
 
   if (registered) {
+    hasExplicitList = true
     for (const key of registered) {
       fields.push({
         key,
@@ -54,13 +56,15 @@ export function resolveFieldList(
     }
   }
 
-  for (const def of customFieldDefs) {
-    const key = typeof def.key === 'string' ? def.key.trim() : ''
-    if (!key) continue
-    if (def.kind !== 'text' && def.kind !== 'multiline' && def.kind !== 'richtext') continue
-    if (fields.some((f) => f.key === key)) continue
-    const label = typeof def.label === 'string' && def.label.trim().length ? def.label : formatFieldLabel(key)
-    fields.push({ key, label, multiline: def.kind === 'multiline' || def.kind === 'richtext' })
+  if (!hasExplicitList) {
+    for (const def of customFieldDefs) {
+      const key = typeof def.key === 'string' ? def.key.trim() : ''
+      if (!key) continue
+      if (def.kind !== 'text' && def.kind !== 'multiline' && def.kind !== 'richtext') continue
+      if (fields.some((f) => f.key === key)) continue
+      const label = typeof def.label === 'string' && def.label.trim().length ? def.label : formatFieldLabel(key)
+      fields.push({ key, label, multiline: def.kind === 'multiline' || def.kind === 'richtext' })
+    }
   }
 
   return fields


### PR DESCRIPTION
## Summary
- Add reusable `TranslationsAction` component (Languages icon button + dialog) following the `VersionHistoryAction` pattern
- Wire it into staff team member and resource detail pages via `extraActions`
- Create `translations.ts` field declarations for staff and resources modules so only relevant fields (not custom fields like Focus Areas) appear in the translation dialog
- Fix `resolveFieldList` to skip custom field augmentation when explicit translatable fields are registered

## Test plan
- [x] `yarn build:packages` passes
- [x] Unit tests pass (19/19 resolve-field-list tests)
- [x] Integration tests: TC-INT-006, TC-TRANS-001/002/003 all pass
- [ ] Manual: navigate to staff team member detail → Languages icon visible → click → dialog opens with TranslationManager showing only `display_name` and `description` fields
- [ ] Manual: navigate to resource detail → same behavior with `name` and `description` fields
- [ ] Manual: base values column is visible in the dialog (not compact mode)

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)