### PR TITLE
fix: rebuild packages after generate in dev:greenfield script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "dev": "yarn build:packages && yarn watch:packages & sleep 3 && yarn dev:app",
-    "dev:greenfield": "yarn build:packages && yarn generate && yarn initialize -- --reinstall && yarn dev",
+    "dev:greenfield": "yarn build:packages && yarn generate && yarn build:packages && yarn initialize -- --reinstall && yarn dev",
     "dev:app": "turbo run dev --filter=@open-mercato/app",
     "watch:packages": "turbo run watch --filter='./packages/*' --parallel",
     "build": "yarn build:packages && yarn generate && yarn build:packages && yarn build:app",


### PR DESCRIPTION
## Summary

Minor fix, first PR here :)

The dev:greenfield script was missing a second build:packages step after generate, causing initialize to fail when trying to import generated files (e.g. entities.ids.generated.js) that had not yet been compiled into dist/.
  
Same as build command that runs it twice, so i guess it can be accepted as valid solution.

It will be easier for new people to setup project for first time if this command works.

## Changes

-- dev:greenfiled command execution chain

## Testing

yarn dev:greenfield
