### PR TITLE
feat(db): add DB_SCHEMA environment variable support

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -126,6 +126,10 @@ DB_POOL_MAX=20
 DB_POOL_IDLE_TIMEOUT=30000
 DB_POOL_ACQUIRE_TIMEOUT=60000
 
+# Database schema (optional, defaults to 'public')
+# Use this to isolate tables in a specific PostgreSQL schema
+# DB_SCHEMA=my_schema
+
 # Audit log retention windows
 # Core resources (users, roles) keep access history longer to support investigations.
 AUDIT_LOGS_CORE_RETENTION_DAYS=7

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -122,6 +122,10 @@ DB_POOL_MAX=20
 DB_POOL_IDLE_TIMEOUT=30000
 DB_POOL_ACQUIRE_TIMEOUT=60000
 
+# Database schema (optional, defaults to 'public')
+# Use this to isolate tables in a specific PostgreSQL schema
+# DB_SCHEMA=my_schema
+
 # Audit log retention windows
 # Core resources (users, roles) keep access history longer to support investigations.
 AUDIT_LOGS_CORE_RETENTION_DAYS=7

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -30,6 +30,7 @@ export async function getOrm() {
   const entities = getOrmEntities()
   const clientUrl = process.env.DATABASE_URL
   if (!clientUrl) throw new Error('DATABASE_URL is not set')
+  const schema = process.env.DB_SCHEMA || undefined
   
   // Parse connection pool settings from environment
   const poolMin = parseInt(process.env.DB_POOL_MIN || '2')
@@ -58,6 +59,7 @@ export async function getOrm() {
   ormInstance = await MikroORM.init<PostgreSqlDriver>({
     driver: PostgreSqlDriver,
     clientUrl,
+    schema,
     entities,
     debug: false,
     // Connection pooling configuration


### PR DESCRIPTION
Currently it seems like only `public` db schema name is supported.

In order to parallelize development and save resources, it may be useful to allow devs/envs to use any custom schema name. So that for example:

- I can run two open-mercato apps at once using a single postgres instance, or
- I can run multiple preview envs of open-mercato, each using a single postgres instance, but a separate database (schema).

This PR aims to make it possible.

## Summary
- Add `DB_SCHEMA` environment variable to specify a custom PostgreSQL schema
- Tables are created in the specified schema instead of default `public`
- Affects runtime ORM, migrations (`db:generate`, `db:migrate`), and greenfield commands

## Test plan
- [x] Verify existing behavior unchanged when `DB_SCHEMA` is not set
- [ ] Set `DB_SCHEMA=test_schema`, create schema manually, run migrations
- [ ] Verify tables created in custom schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)