### PR TITLE
#700 - DI container - defensive changes to prevent DI failures in case of missing npm package

### DIFF
--- a/apps/mercato/src/di.ts
+++ b/apps/mercato/src/di.ts
@@ -55,7 +55,10 @@ export async function register(container: AppContainer) {
   try {
     // Call core bootstrap to setup eventBus and auto-register subscribers.
     // Guard against duplicate bootstrap when core bootstrap already ran in createRequestContainer.
-    if (!container.registrations?.eventBus) {
+    // Check the resolved value (not just registration existence) because container.ts
+    // pre-registers eventBus as null for Awilix CLASSIC mode compatibility.
+    const existingBus = (() => { try { return container.resolve('eventBus') } catch { return null } })()
+    if (!existingBus) {
       await bootstrap(container)
     }
   } catch (error) {

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -84,7 +84,15 @@ async function runModuleCommand(
     }
     throw new Error(`Command "${commandName}" not found in module "${moduleName}"`)
   }
-  await cmd.run(args)
+  if (options.optional) {
+    try {
+      await cmd.run(args)
+    } catch (err) {
+      console.warn(`⚠️  Optional command "${moduleName}:${commandName}" failed:`, (err as Error)?.message || err)
+    }
+  } else {
+    await cmd.run(args)
+  }
 }
 
 // Build all CLI modules (registered + built-in)

--- a/packages/create-app/template/src/di.ts
+++ b/packages/create-app/template/src/di.ts
@@ -55,7 +55,10 @@ export async function register(container: AppContainer) {
   try {
     // Call core bootstrap to setup eventBus and auto-register subscribers.
     // Guard against duplicate bootstrap when core bootstrap already ran in createRequestContainer.
-    if (!container.registrations?.eventBus) {
+    // Check the resolved value (not just registration existence) because container.ts
+    // pre-registers eventBus as null for Awilix CLASSIC mode compatibility.
+    const existingBus = (() => { try { return container.resolve('eventBus') } catch { return null } })()
+    if (!existingBus) {
       await bootstrap(container)
     }
   } catch (error) {

--- a/packages/search/src/modules/search/cli.ts
+++ b/packages/search/src/modules/search/cli.ts
@@ -518,7 +518,14 @@ async function reindexCommand(rest: string[]): Promise<void> {
   }
 
   try {
-    const searchIndexer = container.resolve<SearchIndexer>('searchIndexer')
+    let searchIndexer: SearchIndexer
+    try {
+      searchIndexer = container.resolve<SearchIndexer>('searchIndexer')
+    } catch {
+      console.error('[search.cli] SearchIndexer not available in DI container. Search module may not be configured.')
+      await disposeContainer()
+      return
+    }
     const enabledEntities = new Set(searchIndexer.listEnabledEntities())
     const baseEventBus = (() => {
       try {


### PR DESCRIPTION
## Summary

I faced an issue with initialization script that failed with error -> Initialization failed: Could not resolve 'eventBus' (details in issue #700 ). The actual problem was missing npm package (to resolved that finally I have run `yarn install`) 

But during the process Opus 4.6 proposed several **defensive changes** in DI container.

Please **carefully review this PR** as it touches DI container and accept / reject based on whether you think this is valueable. 

## Changes

1. **`container.ts` — pre-register `eventBus: asValue(null)`** — Still valuable. If any future dependency issue or bootstrap failure occurs, module DI factories (sales, catalog, notifications) won't crash with a cryptic Awilix error. They'll gracefully get a null event bus instead.

2. **`container.ts` — replace silent `catch {}` with `console.warn`** — **This is the most important change we made.** Without it, you would have spent hours debugging "Could not resolve 'eventBus'" with zero indication that the real problem was a missing npm package. This warning is what finally surfaced the root cause.

3. **`apps/mercato/src/di.ts` and template `di.ts` — check resolved value instead of registration existence** — Necessary companion to change #1. Without this, the null pre-registration would trick the bootstrap guard into thinking bootstrap already ran.

4. **`bootstrap.ts` — wrap `createCacheService` fallback and `createKmsService`** — Defensive hardening. Prevents one section of bootstrap from killing all subsequent sections. Not triggered today, but prevents future issues.

5. **`search/cli.ts` — handle missing `searchIndexer` gracefully** — Defensive. The reindex command now exits cleanly instead of throwing an unhandled error.

6. **`mercato.ts` — catch errors for optional `runModuleCommand`** — Defensive. Optional init steps (search reindex, dashboard seeding) no longer abort the entire initialization if they fail.

**Summary:** The root cause was a missing package. The defensive changes were not *necessary* to fix today's bug, but they are genuinely valuable improvements — especially the `console.warn` (#2) which is what diagnosed the actual problem. I'd keep them all.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- `yarn dev:greenfield` started to run properly

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #700 
