### PR TITLE
Surface create-mercato-app in docs and homepage

### DIFF
--- a/apps/docs/docs/installation/prerequisites.mdx
+++ b/apps/docs/docs/installation/prerequisites.mdx
@@ -5,11 +5,15 @@ description: Tools and services required before installing Open Mercato locally.
 
 Before cloning the repository make sure the following tools are installed:
 
+:::tip Standalone app
+If you want to build on Open Mercato without cloning the monorepo, use [`create-mercato-app`](/customization/standalone-app) to scaffold a standalone project. It has its own lighter prerequisites — see the [standalone app guide](/customization/standalone-app) for details.
+:::
+
 :::tip Docker-only setup (Windows recommended)
 If you plan to use the [Docker development setup](./setup#docker-development-setup), you only need **Docker Desktop** and **Git**. Node.js, Yarn, and the other tools below are not required — everything runs inside containers. This is the recommended path for **Windows** users.
 :::
 
-- **Node.js 20.18+** – aligns with the runtime requirements. Use `nvm`/`fnm` to switch versions if needed.
+- **Node.js 24+** – aligns with the runtime requirements. Use `nvm`/`fnm` to switch versions if needed.
 - **Yarn (via Corepack)** – enable it once per machine:
   ```bash
   corepack enable

--- a/apps/docs/docs/installation/setup.mdx
+++ b/apps/docs/docs/installation/setup.mdx
@@ -5,7 +5,7 @@ description: Step-by-step checklist to run Open Mercato locally.
 
 ## Getting started tracks
 
-**Recommended: follow the develop branch track.** It contains the latest monorepo setup and is the default path for active development.
+**Product teams** looking to build on Open Mercato should start with the [standalone app](#standalone-app-recommended-for-product-teams) — it gives you a clean project without cloning the full monorepo. **Core contributors** should follow the [develop branch](#develop-branch-recommended) track instead.
 
 :::tip Standalone app
 If you want to build a production app without cloning the monorepo, use [`create-mercato-app`](../customization/standalone-app) instead.
@@ -16,6 +16,17 @@ If you are on **Windows**, skip the native setup and jump straight to the [Docke
 :::
 
 [![Watch on YouTube](https://img.youtube.com/vi/OsalmbiWQ-I/maxresdefault.jpg)](https://youtu.be/OsalmbiWQ-I)
+
+### Standalone app (recommended for product teams)
+
+Scaffold a standalone project with a single command — no need to clone the monorepo:
+
+```bash
+npx create-mercato-app my-app
+cd my-app
+```
+
+Then follow the post-install steps in the [full standalone app guide](/customization/standalone-app).
 
 ### Develop branch (recommended)
 

--- a/apps/docs/docs/introduction/overview.mdx
+++ b/apps/docs/docs/introduction/overview.mdx
@@ -22,4 +22,4 @@ Open Mercato is an extensible commerce framework that blends a modular backend, 
 3. **Customization tutorials** – step-by-step guides for adding modules, APIs, forms, grids, and dashboards.
 4. **Framework reference** – deep dives into IoC, routing, database entities, and event-driven workflows.
 
-If you are in a rush: [Create a standalone app](../customization/standalone-app) to build on top of Open Mercato, or [Build your first app](../customization/build-first-app) to explore the monorepo. Come back for the reference sections later.
+If you are in a rush, scaffold a standalone project with `npx create-mercato-app my-app` ([guide](/customization/standalone-app)) or jump to [Build your first Open Mercato app](../customization/build-first-app) if you're working inside the monorepo.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -11,7 +11,15 @@ const sidebars: SidebarsConfig = {
     {
       type: "category",
       label: "Installation",
-      items: ["installation/prerequisites", "installation/setup"],
+      items: [
+        "installation/prerequisites",
+        "installation/setup",
+        {
+          type: "link",
+          label: "Standalone App (create-mercato-app)",
+          href: "/customization/standalone-app",
+        },
+      ],
     },
     {
       type: "category",

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -95,6 +95,11 @@ const screenshots = [
 
 const gettingStartedLinks = [
   {
+    title: 'Create a Standalone App',
+    description: 'Scaffold a new project with npx create-mercato-app — the fastest way to start building.',
+    to: '/customization/standalone-app',
+  },
+  {
     title: 'Install Locally',
     description: 'Spin up the platform in minutes with the guided setup.',
     to: '/installation/setup',

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -83,7 +83,7 @@ npx create-mercato-app my-store --registry http://localhost:4873
 
 ## Requirements
 
-- Node.js 18 or later
+- Node.js 24 or later
 - PostgreSQL database
 - Yarn (recommended) or npm
 


### PR DESCRIPTION
## Summary

- **Sidebar**: Added "Standalone App (create-mercato-app)" link to the Installation category so it's visible alongside prerequisites and setup
- **Setup page**: Updated intro paragraph to recommend standalone apps for product teams; added a new "Standalone app" track section with `npx create-mercato-app` snippet
- **Prerequisites page**: Added a tip admonition pointing to the standalone app guide; fixed Node.js version from 20.18+ to 24+
- **Overview page**: Updated the closing "start here" paragraph to lead with `create-mercato-app`
- **Homepage**: Added "Create a Standalone App" as the first Getting Started card
- **create-app README**: Fixed Node.js version from 18 to 24

## Test plan

- [x] `yarn --cwd apps/docs build` passes with no errors
- [ ] Verify homepage shows "Create a Standalone App" card in Getting Started
- [ ] Verify sidebar shows standalone app link under Installation
- [ ] Verify installation setup page shows the standalone track section
- [ ] Verify prerequisites page shows the standalone tip and correct Node 24+ version
- [ ] Verify introduction overview mentions create-mercato-app
- [ ] Verify all internal links resolve (no broken links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)