### PR TITLE
ai-improvement/add-socrtatic-questions-skills: modified skills and sp…

### DIFF
--- a/.ai/skills/spec-writing/SKILL.md
+++ b/.ai/skills/spec-writing/SKILL.md
@@ -14,7 +14,10 @@ Design and review specifications (SPECs) against Open Mercato's architecture, na
     - OSS scope: `SPEC-{number}-{date}-{title}.md` in `.ai/specs/`
     - Enterprise scope: `SPEC-ENT-{number}-{date}-{title}.md` in `.ai/specs/enterprise/`
 3.  **Start Minimal**: Write a **Skeleton Spec** first (TLDR + 2-3 key sections). Do NOT write the full spec in one pass.
-4.  **Iterate**: Iterate with the user to refine the scope and requirements.
+    - Before writing the skeleton, scan the brief for **critical unknowns** — decisions that block architecture, data model, or scope. These are questions where a wrong assumption would require rewriting large parts of the spec.
+    - If critical unknowns exist, add a numbered **Open Questions** block (`Q1`, `Q2`, …) directly in the skeleton, immediately after the TLDR. One question per line. Keep each question short and answerable (binary or multiple-choice where possible).
+    - **STOP after presenting the skeleton.** Do not proceed to Step 5 (Research) or beyond until the user has answered all questions. This is a hard gate.
+4.  **Iterate**: Apply answers from the Open Questions gate to fill in the skeleton. Remove the Open Questions block once all are resolved. If new unknowns surface during research or design, repeat the gate for those questions only.
 5.  **Research**: Challenge requirements against open-source market leaders in the domain.
 6.  **Design**: Create the spec design and architecture.
 7.  **Implementation Breakdown**: Create implementation details broken down into **Phases** (stories) and **Steps** (testable tasks). Each step should result in a working application.

--- a/.ai/skills/spec-writing/references/spec-template.md
+++ b/.ai/skills/spec-writing/references/spec-template.md
@@ -27,6 +27,16 @@ Every non-trivial spec must include these sections:
 9. Final Compliance Report
 10. Changelog
 
+## Open Questions *(remove before finalizing)*
+
+> **When to include**: Add this section to the skeleton when critical architectural decisions — data model shape, scope boundaries, integration points, or technology choices — cannot be inferred from the brief. List as `Q1`, `Q2`, … Keep each question short and answerable. **STOP and wait for answers before proceeding to Research/Design.**
+> Once all questions are answered, fill in the spec and delete this section.
+
+- **Q1**: [Critical unknown — e.g. "Should this store data per-tenant or globally?"]
+- **Q2**: [Critical unknown — e.g. "Does this replace X or coexist with it?"]
+
+---
+
 ## Overview
 [What this module/feature does and why it is being implemented. Mention target audience and key benefits.]
 
@@ -100,9 +110,6 @@ Every non-trivial spec must include these sections:
 ### Testing Strategy (Optional)
 - [Unit tests for ...]
 - [Integration tests for ...]
-
-### Open Questions (Optional)
-- [Unresolved question 1]
 
 ## Risks & Impact Review
 Document concrete risks across the categories below. For each feature, answer "what can go wrong," then record mitigations and residual risk.


### PR DESCRIPTION
  Summary

  Adds Socratic Prompting pattern to the spec-writing skill — when a spec brief has critical unknowns, the LLM now stops and asks clarifying questions before proceeding to design,
  instead of making assumptions.

  Changes

  - Extend Step 3 and Step 4 in .claude/skills/spec-writing/SKILL.md with a hard STOP gate: scan for critical unknowns, list them as Q1/Q2/… in the skeleton, wait for answers before
  proceeding to Research/Design
  - Add ## Open Questions section to .claude/skills/spec-writing/references/spec-template.md as an early blocking section immediately after TLDR — replaces the buried optional entry
  at the bottom of Implementation Plan

  Specification

  Does a spec exist for this feature/module?
  - N/A (minor change, no spec needed)

  Testing

 Manually validated during SPEC-037 (GeoMap component - not yet pushed) authoring session — Q1–Q8 pattern used to resolve 8 architectural unknowns before spec design.

  Checklist

  - This pull request targets develop.
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
  - I updated documentation, locales, or generators if the change requires it.
  - I added or adjusted tests that cover the change.
  - I added or updated integration tests in .ai/qa/tests/ (or documented why integration coverage is not required).
  - I created or updated the spec in .ai/specs/ with a changelog entry (if applicable).

  Linked issues

  N/A