### PR TITLE
fix: Fix yarn lint and add lint step to CI (Vibe Kanban)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Checking types
         run: yarn typecheck
 
+      - name: Lint
+        run: yarn lint
+
       - name: Test
         run: yarn test
 

--- a/apps/mercato/package.json
+++ b/apps/mercato/package.json
@@ -7,7 +7,7 @@
     "dev": "mercato server dev",
     "build": "next build",
     "start": "NODE_OPTIONS='-r newrelic' mercato server start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.cjs",
     "generate": "mercato generate",

--- a/apps/mercato/src/app/api/events/route.ts
+++ b/apps/mercato/src/app/api/events/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
 
   // Optional filters
   const category = searchParams.get('category')
-  const module = searchParams.get('module')
+  const moduleFilter = searchParams.get('module')
   const excludeTriggerExcluded = searchParams.get('excludeTriggerExcluded') !== 'false'
 
   // Get events from the global registry (populated during bootstrap)
@@ -26,8 +26,8 @@ export async function GET(request: NextRequest) {
     filteredEvents = filteredEvents.filter(e => e.category === category)
   }
 
-  if (module) {
-    filteredEvents = filteredEvents.filter(e => e.module === module)
+  if (moduleFilter) {
+    filteredEvents = filteredEvents.filter(e => e.module === moduleFilter)
   }
 
   return NextResponse.json({

--- a/apps/mercato/src/modules/example/api/todos/route.ts
+++ b/apps/mercato/src/modules/example/api/todos/route.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from 'zod'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { Todo } from '../../data/entities'

--- a/apps/mercato/src/modules/example/cli.ts
+++ b/apps/mercato/src/modules/example/cli.ts
@@ -196,5 +196,6 @@ const seedTodos: ModuleCli = {
   },
 }
 
-export default [hello, seedTodos]
+const commands = [hello, seedTodos]
+export default commands
 export type { TodoSeedArgs as ExampleTodoSeedArgs }

--- a/apps/mercato/src/modules/example/components/TodosTable.tsx
+++ b/apps/mercato/src/modules/example/components/TodosTable.tsx
@@ -137,7 +137,7 @@ export default function TodosTable() {
     const base = buildBaseColumns(t, severityPreset)
     if (!cfDefs.length) return base
     return applyCustomFieldVisibility(base, cfDefs)
-  }, [cfDefs, t])
+  }, [cfDefs, t, severityPreset])
 
   React.useEffect(() => {
     setColumns(computedColumns)

--- a/apps/mercato/src/modules/example/subscribers/example-event.ts
+++ b/apps/mercato/src/modules/example/subscribers/example-event.ts
@@ -7,7 +7,6 @@ export default async function onExamplePing(payload: any, ctx: { resolve: <T=any
   // demo subscriber; keep side-effects minimal
   const _em = ctx.resolve('em')
   if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line no-console
     console.log('[example.ping] payload:', payload)
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,7 @@
       "outputs": []
     },
     "lint": {
+      "cache": false,
       "outputs": []
     },
     "generate": {


### PR DESCRIPTION
## Summary

This PR fixes the broken `yarn lint` command and adds a lint step to the CI workflow.

## Changes Made

### 1. Fix `yarn lint` command
- **Problem**: `next lint` was removed in Next.js 16, causing `yarn lint` to fail with "Invalid project directory" error
- **Solution**: Updated `apps/mercato/package.json` to use `eslint .` directly instead of `next lint`
- Updated `turbo.json` to disable caching for the lint task

### 2. Fix ESLint errors/warnings
Fixed 5 lint issues across the codebase:

| File | Issue | Fix |
|------|-------|-----|
| `src/app/api/events/route.ts` | `@next/next/no-assign-module-variable` - variable named `module` conflicts with ESM | Renamed to `moduleFilter` |
| `src/modules/example/api/todos/route.ts` | Unused eslint-disable directive | Removed the directive |
| `src/modules/example/cli.ts` | `import/no-anonymous-default-export` | Named the exported array |
| `src/modules/example/components/TodosTable.tsx` | `react-hooks/exhaustive-deps` missing dependency | Added `severityPreset` to deps |
| `src/modules/example/subscribers/example-event.ts` | Unused eslint-disable directive | Removed the directive |

### 3. Add lint step to CI
- Added `yarn lint` step to `.github/workflows/ci.yml` after typecheck, before tests
- Ensures lint errors are caught in CI for all PRs

## Verification

```bash
yarn lint  # Now passes with exit code 0
```

---

This PR was written using [Vibe Kanban](https://vibekanban.com)