### PR TITLE
feat(ci): add GitHub Actions annotations for test and lint errors

### DIFF
--- a/.ai/qa/tests/playwright.config.ts
+++ b/.ai/qa/tests/playwright.config.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { discoverIntegrationSpecFiles } from '../../../packages/cli/src/lib/testing/integration-discovery';
 
 const captureScreenshots = process.env.PW_CAPTURE_SCREENSHOTS === '1';
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
 const projectRoot = path.resolve(__dirname, '..', '..', '..');
 const STATIC_TEST_IGNORES = [
   '.claude/**',
@@ -29,10 +30,17 @@ export default defineConfig({
     screenshot: captureScreenshots ? 'on' : 'only-on-failure',
     trace: 'on-first-retry',
   },
-  reporter: [
-    ['list'],
-    ['json', { outputFile: '.ai/qa/test-results/results.json' }],
-    ['html', { outputFolder: '.ai/qa/test-results/html', open: 'never' }],
-  ],
+  reporter: isGitHubActions
+    ? [
+        ['github'],
+        ['list'],
+        ['json', { outputFile: '.ai/qa/test-results/results.json' }],
+        ['html', { outputFolder: '.ai/qa/test-results/html', open: 'never' }],
+      ]
+    : [
+        ['list'],
+        ['json', { outputFile: '.ai/qa/test-results/results.json' }],
+        ['html', { outputFolder: '.ai/qa/test-results/html', open: 'never' }],
+      ],
   outputDir: '.ai/qa/test-results/artifacts',
 });

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,6 @@
 /** @type {import('jest').Config} */
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
@@ -45,4 +47,7 @@ module.exports = {
   setupFiles: ['<rootDir>/jest.setup.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.dom.setup.ts'],
   collectCoverageFrom: ['src/**/*.(ts|tsx)', '!src/modules/**/migrations/**'],
+  reporters: isGitHubActions
+    ? [['github-actions', { silent: false }], 'summary']
+    : ['default'],
 }


### PR DESCRIPTION
## Summary

Adds GitHub Actions annotations for test failures that appear inline on PR diffs:

- **Jest** - conditional `github-actions` reporter
- **Playwright** - conditional `github` reporter

Uses `GITHUB_ACTIONS` environment variable (more specific than `CI`) to detect GitHub Actions environment.

## Example

This is how annotations appear on PR diffs:

![GitHub Actions annotations example](https://user-images.githubusercontent.com/2842920/181088099-38a7c67a-1102-4045-bc6d-b081e8d9c594.png)

## Implementation

**Zero new dependencies** - uses built-in Jest and Playwright reporters that emit GitHub Actions workflow commands (`::error::`, `::warning::`).

## Test plan

- [ ] Verify Jest test failures show annotations on PR diff
- [ ] Verify Playwright test failures show annotations on PR diff
- [ ] Verify local dev behavior unchanged (no annotations in terminal)

🤖 Generated with [Claude Code](https://claude.ai/code)