### PR TITLE
fix(#704): Fix seo widgets headers invisible in the dark mode

### DIFF
--- a/apps/mercato/src/modules/example/widgets/injection/catalog-seo-report/widget.client.tsx
+++ b/apps/mercato/src/modules/example/widgets/injection/catalog-seo-report/widget.client.tsx
@@ -51,7 +51,7 @@ async function fetchProductsNeedingSeo(): Promise<ProductSeoIssue[]> {
   return issues.slice(0, 5)
 }
 
-export default function CatalogSeoReportWidget({}: InjectionWidgetComponentProps) {
+export default function CatalogSeoReportWidget({ }: InjectionWidgetComponentProps) {
   const t = useT()
   const [issues, setIssues] = React.useState<ProductSeoIssue[]>([])
   const [loading, setLoading] = React.useState(true)
@@ -100,11 +100,11 @@ export default function CatalogSeoReportWidget({}: InjectionWidgetComponentProps
       ) : (
         <ul className="mt-3 space-y-2">
           {issues.map((issue) => (
-            <li key={issue.id} className="rounded border border-amber-200 bg-amber-50 px-3 py-2">
+            <li key={issue.id} className="rounded border border-amber-200 dark:border-amber-900/70 bg-amber-50 dark:bg-amber-950/40 px-3 py-2">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-sm font-medium text-foreground">{issue.title}</div>
-                  <div className="text-[11px] text-amber-800">{issue.issue}</div>
+                  <div className="text-sm font-medium text-foreground dark:text-amber-50">{issue.title}</div>
+                  <div className="text-[11px] text-amber-800 dark:text-amber-300">{issue.issue}</div>
                 </div>
                 <Button asChild size="sm" variant="outline">
                   <a href={`/backend/catalog/products/${issue.id}`} className="text-xs">


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

SEO widget headers and issue text in the catalog SEO report widget were invisible in dark mode. The widget used hardcoded light-only colors (`bg-amber-50`, `text-foreground`, `text-amber-800`) without dark mode variants, causing poor contrast against dark backgrounds. 

The fix adds dark mode Tailwind classes following the same amber color pattern used in `GlobalNoticeBars.tsx`.

## Changes

- Added `dark:border-amber-900/70` to the issue list item border
- Added `dark:bg-amber-950/40` to the issue list item background
- Replaced `text-foreground` with `text-amber-900 dark:text-amber-50` for the product title
- Added `dark:text-amber-300` to the issue description text

Dark theme
<img width="1692" height="888" alt="Screenshot 2026-02-25 at 10 24 23" src="https://github.com/user-attachments/assets/508a03f1-66fb-4b3f-909c-3a193a75c0d9" />

Light Theme
<img width="1703" height="895" alt="Screenshot 2026-02-25 at 10 26 04" src="https://github.com/user-attachments/assets/3abdc060-dfa6-402c-ab03-e218c05334f0" />

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Opened the catalog SEO report widget in dark mode and confirmed all headers and issue text are visible with proper contrast
- Verified light mode appearance is unchanged

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
 
## Linked issues

Fixes #704
