### PR TITLE
fix(queue): parse Redis URL before passing to BullMQ

### DIFF
--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -3,7 +3,7 @@ import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/conne
 
 // BullMQ interface types - we define the shape we use to maintain type safety
 // while keeping bullmq as an optional peer dependency
-type ConnectionOptions = { host?: string; port?: number; password?: string; db?: number } | string
+type ConnectionOptions = { host?: string; port?: number; password?: string; db?: number }
 
 interface BullQueueInterface<T> {
   add: (name: string, data: T, opts?: { removeOnComplete?: boolean; removeOnFail?: number }) => Promise<{ id?: string }>
@@ -28,11 +28,14 @@ interface BullMQModule {
 
 /**
  * Resolves Redis connection options from various sources.
+ *
+ * BullMQ requires connection options as `{ host, port, password, db }` object.
+ * It does NOT accept raw URL strings in `{ connection: string }` format.
  */
 function resolveConnection(options?: AsyncQueueOptions['connection']): ConnectionOptions {
   // Priority: explicit options > shared env helper
   if (options?.url) {
-    return options.url
+    return parseRedisUrl(options.url)
   }
 
   if (options?.host) {

--- a/packages/scheduler/src/modules/scheduler/api/jobs/[id]/executions/route.ts
+++ b/packages/scheduler/src/modules/scheduler/api/jobs/[id]/executions/route.ts
@@ -5,7 +5,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/core'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { ScheduledJob } from '../../../../data/entities.js'
-import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
 
@@ -77,7 +77,7 @@ export async function GET(
 
     // Fetch jobs from BullMQ scheduler-execution queue
     const { Queue } = await import('bullmq')
-    const queue = new Queue('scheduler-execution', { connection: { url: getRedisUrl('QUEUE') } })
+    const queue = new Queue('scheduler-execution', { connection: parseRedisUrl(getRedisUrl('QUEUE')) })
 
     try {
       // Validate query params with Zod schema

--- a/packages/scheduler/src/modules/scheduler/api/queue-jobs/[jobId]/route.ts
+++ b/packages/scheduler/src/modules/scheduler/api/queue-jobs/[jobId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import { getModules } from '@open-mercato/shared/lib/modules/registry'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
@@ -69,7 +69,7 @@ export async function GET(
 
     // Fetch job from BullMQ
     const { Queue } = await import('bullmq')
-    const queue = new Queue(queueName, { connection: { url: getRedisUrl('QUEUE') } })
+    const queue = new Queue(queueName, { connection: parseRedisUrl(getRedisUrl('QUEUE')) })
 
     const job = await queue.getJob(jobId)
 

--- a/packages/scheduler/src/modules/scheduler/services/bullmqSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/bullmqSchedulerService.ts
@@ -3,7 +3,7 @@ import { ScheduledJob } from '../data/entities.js'
 import { recalculateNextRun } from '../lib/nextRunCalculator'
 import { parseCronExpression } from '../lib/cronParser'
 import { parseInterval } from '../lib/intervalParser'
-import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 
 interface BullRepeatableJob {
   key: string
@@ -55,7 +55,7 @@ export class BullMQSchedulerService {
     if (!this.queue) {
       try {
         const { Queue } = await import('bullmq')
-        this.queue = new Queue('scheduler-execution', { connection: { url: getRedisUrl('QUEUE') } })
+        this.queue = new Queue('scheduler-execution', { connection: parseRedisUrl(getRedisUrl('QUEUE')) })
       } catch {
         throw new Error('BullMQ is required for async scheduler. Install it with: npm install bullmq')
       }

--- a/packages/shared/src/lib/redis/connection.ts
+++ b/packages/shared/src/lib/redis/connection.ts
@@ -47,6 +47,8 @@ export function parseRedisUrl(url: string): ParsedRedisConnection {
       db,
     }
   } catch {
+    const safeUrl = url.replace(/\/\/[^:]*:[^@]*@/, '//<redacted>@')
+    console.warn(`[redis] Failed to parse URL "${safeUrl}", falling back to localhost:6379`)
     return { host: 'localhost', port: 6379 }
   }
 }


### PR DESCRIPTION
## Problem

When setting `REDIS_URL` or `QUEUE_REDIS_URL`, workers would still connect to `localhost:6379` instead of the configured Redis instance.

**Root cause:** When a string is passed to BullMQ's connection option, `Object.assign({}, string)` spreads characters as indexed properties instead of creating a `url` property, causing BullMQ to fall back to defaults.

## Solution

- Fix Redis URL environment variable not being respected when `QUEUE_STRATEGY=async`
- BullMQ does not accept raw URL strings in `{ connection: string }` format
- Parse URLs into `{ host, port, password, db }` objects before passing to BullMQ

## Changes

- `packages/queue/src/strategies/async.ts`: Parse URL in `resolveConnection()` when `options.url` is provided
- `packages/scheduler/.../bullmqSchedulerService.ts`: Use `parseRedisUrl()` for direct BullMQ usage
- `packages/scheduler/.../executions/route.ts`: Use `parseRedisUrl()` for direct BullMQ usage  
- `packages/scheduler/.../queue-jobs/[jobId]/route.ts`: Use `parseRedisUrl()` for direct BullMQ usage
- `packages/shared/src/lib/redis/connection.ts`: Add warning log when URL parsing fails

## Test plan

- [ ] Set `REDIS_URL=redis://localhost:6380` and `QUEUE_STRATEGY=async`
- [ ] Verify queue commands connect to port 6380, not 6379
- [ ] Verify scheduler jobs execute against correct Redis instance
