### PR TITLE
bug: create form allows submission while "All organizations" is selected for products

### DIFF
--- a/.ai/qa/findings/BUG-CAT-002-product-create-all-organizations-context.md
+++ b/.ai/qa/findings/BUG-CAT-002-product-create-all-organizations-context.md
@@ -27,13 +27,12 @@ Catalog / Products / Organization Scope
 - `POST /api/catalog/products` should not be sent from global scope.
 
 ## Evidence
-- Failing test: `packages/core/src/modules/catalog/__integration__/TC-CAT-019.spec.ts`
+- Failing test: `packages/core/src/modules/catalog/__integration__/TC-CAT-014.spec.ts`
 - Assertion failure: expected `productCreatePostCount` = `0`, got `1`
 - Screenshot: `.ai/qa/tests/.ai/qa/test-results/artifacts/packages-core-src-modules--2351d--scope-is-All-organizations/test-failed-1.png`
 - Error context: `.ai/qa/tests/.ai/qa/test-results/artifacts/packages-core-src-modules--2351d--scope-is-All-organizations/error-context.md`
 
 ## Triage Classification
 - Type: Product bug
-- Proposed owner: User/Product team
-- Regression test: `packages/core/src/modules/catalog/__integration__/TC-CAT-019.spec.ts`
+- Regression test: `packages/core/src/modules/catalog/__integration__/TC-CAT-014.spec.ts`
 

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-014.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-014.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from '@playwright/test';
 import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
 
 /**
- * TC-CAT-019: Product Create Requires Specific Organization Context
+ * TC-CAT-014: Product Create Requires Specific Organization Context
  */
-test.describe('TC-CAT-019: Product Create Requires Specific Organization Context', () => {
+test.describe('TC-CAT-014: Product Create Requires Specific Organization Context', () => {
   test('should block submit while organization scope is All organizations', async ({ page }) => {
     await login(page, 'admin');
     await page.goto('/backend/catalog/products');
@@ -15,12 +15,12 @@ test.describe('TC-CAT-019: Product Create Requires Specific Organization Context
     await expect(organizationSelect).toHaveValue('');
 
     await page.goto('/backend/catalog/products/create');
-    await page.getByRole('textbox', { name: 'e.g., Summer sneaker' }).fill(`QA TC-CAT-019 ${Date.now()}`);
+    await page.getByRole('textbox', { name: 'e.g., Summer sneaker' }).fill(`QA TC-CAT-014 ${Date.now()}`);
     await page.getByRole('textbox', { name: 'Describe the product...' }).fill(
-      'QA TC-CAT-019 exploratory regression check for organization scope.',
+      'QA TC-CAT-014 exploratory regression check for organization scope.',
     );
     await page.getByRole('button', { name: 'Variants' }).click();
-    await page.getByRole('textbox', { name: 'e.g., SKU-001' }).fill(`QA-CAT-019-${Date.now()}`);
+    await page.getByRole('textbox', { name: 'e.g., SKU-001' }).fill(`QA-CAT-014-${Date.now()}`);
 
     let productCreatePostCount = 0;
     await page.route('**/api/catalog/products**', async (route) => {


### PR DESCRIPTION
## Summary
On `/backend/catalog/products`, the organization selector can stay on `All organizations`. In that state, user can open product creation and submit the form, which still sends create request instead of being blocked by UI.


https://github.com/user-attachments/assets/d70cead8-2ee9-4111-b0b3-602445acaa83



## Severity
Major

## Area
Catalog / Products / Organization Scope

## Reproducible Steps
1. Log in as user with product management permissions.
2. Go to `/backend/catalog/products`.
3. In the header organization dropdown, select `All organizations` (empty value).
4. Open `/backend/catalog/products/create`.
5. Fill required fields (`Name`, `Description`, `SKU`).
6. Click `Create product`.

## Actual Result
- Submit sends `POST /api/catalog/products`.
- Flow runs in invalid global org scope.

## Expected Result
- User should not be able to submit product create while context is `All organizations`.
- UI should require selecting a specific organization first.
- `POST /api/catalog/products` should not be sent from global scope.

## Evidence
- Failing test: `packages/core/src/modules/catalog/__integration__/TC-CAT-014.spec.ts`
- Assertion failure: expected `productCreatePostCount` = `0`, got `1`
- Screenshot: `.ai/qa/tests/.ai/qa/test-results/artifacts/packages-core-src-modules--2351d--scope-is-All-organizations/test-failed-1.png`
- Error context: `.ai/qa/tests/.ai/qa/test-results/artifacts/packages-core-src-modules--2351d--scope-is-All-organizations/error-context.md`

## Triage Classification
- Type: Product bug
- Regression test: `packages/core/src/modules/catalog/__integration__/TC-CAT-014.spec.ts`