### PR TITLE
bug: values in `Organize` step are rendered as UUIDs instead of human-readable labels

### DIFF
--- a/.ai/qa/findings/BUG-CAT-003-product-organize-labels-regress-to-uuid-after-step-navigation.md
+++ b/.ai/qa/findings/BUG-CAT-003-product-organize-labels-regress-to-uuid-after-step-navigation.md
@@ -37,3 +37,9 @@ Catalog / Products / Create Form / Organize Step
 ## Triage Classification
 - Type: Product bug
 - Regression test: `packages/core/src/modules/catalog/__integration__/TC-CAT-015.spec.ts`
+
+## Status
+Fixed. `categoryOptionsMap` / `channelOptionsMap` lifted to `ProductBuilder` via
+`onCategoryOptionsResolved` / `onChannelOptionsResolved` callbacks with upsert merge.
+Remount seeded via `initialCategoryOptions` / `initialChannelOptions` props + lazy `useState`
+initializer in `ProductCategorizeSection`. TC-CAT-015 passes.

--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-015.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-015.spec.ts
@@ -86,10 +86,7 @@ test.describe('TC-CAT-015: Organize Step Keeps Human-Readable Labels After Step 
       await expect(categoriesSection).toContainText(categoryName);
       await expect(channelsSection).toContainText(channelName);
 
-      await page.getByRole('button', { name: 'Continue' }).click();
-      if (await page.getByPlaceholder('Search categories').isVisible()) {
-        await page.getByRole('button', { name: 'Variants' }).click();
-      }
+      await page.getByRole('button', { name: 'Variants' }).click();
       await expect(page.getByRole('columnheader', { name: 'Default option' })).toBeVisible();
       await page.getByRole('button', { name: 'Previous' }).click();
       await expect(page.getByPlaceholder('Search categories')).toBeVisible();

--- a/packages/core/src/modules/catalog/backend/catalog/products/create/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/create/page.tsx
@@ -19,7 +19,7 @@ import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/ap
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { E } from '#generated/entities.ids.generated'
 import { ProductMediaManager, type ProductMediaItem } from '@open-mercato/core/modules/catalog/components/products/ProductMediaManager'
-import { ProductCategorizeSection } from '@open-mercato/core/modules/catalog/components/products/ProductCategorizeSection'
+import { ProductCategorizeSection, type ProductCategorizePickerOption } from '@open-mercato/core/modules/catalog/components/products/ProductCategorizeSection'
 import {
   PRODUCT_FORM_STEPS,
   type PriceKindSummary,
@@ -653,6 +653,29 @@ function ProductBuilder({ values, setValue, errors, priceKinds, taxRates }: Prod
 
   const currentStepKey = steps[currentStep] ?? steps[0]
 
+  const [savedCategoryOptions, setSavedCategoryOptions] = React.useState<ProductCategorizePickerOption[]>([])
+  const [savedChannelOptions, setSavedChannelOptions] = React.useState<ProductCategorizePickerOption[]>([])
+
+  const handleCategoryOptionsResolved = React.useCallback((options: ProductCategorizePickerOption[]) => {
+    if (!options.length) return
+    setSavedCategoryOptions((prev) => {
+      const map: Record<string, ProductCategorizePickerOption> = {}
+      prev.forEach((opt) => { if (opt.value) map[opt.value] = opt })
+      options.forEach((opt) => { if (opt.value) map[opt.value] = opt })
+      return Object.values(map)
+    })
+  }, [])
+
+  const handleChannelOptionsResolved = React.useCallback((options: ProductCategorizePickerOption[]) => {
+    if (!options.length) return
+    setSavedChannelOptions((prev) => {
+      const map: Record<string, ProductCategorizePickerOption> = {}
+      prev.forEach((opt) => { if (opt.value) map[opt.value] = opt })
+      options.forEach((opt) => { if (opt.value) map[opt.value] = opt })
+      return Object.values(map)
+    })
+  }, [])
+
   const mediaItems = Array.isArray(values.mediaItems) ? values.mediaItems : []
 
 
@@ -932,6 +955,10 @@ function ProductBuilder({ values, setValue, errors, priceKinds, taxRates }: Prod
           values={values as ProductFormValues}
           setValue={setValue}
           errors={errors}
+          initialCategoryOptions={savedCategoryOptions}
+          initialChannelOptions={savedChannelOptions}
+          onCategoryOptionsResolved={handleCategoryOptionsResolved}
+          onChannelOptionsResolved={handleChannelOptionsResolved}
         />
       ) : null}
 

--- a/packages/core/src/modules/catalog/components/products/ProductCategorizeSection.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductCategorizeSection.tsx
@@ -24,6 +24,8 @@ type ProductCategorizeSectionProps = {
   initialCategoryOptions?: ProductCategorizePickerOption[]
   initialChannelOptions?: ProductCategorizePickerOption[]
   initialTagOptions?: ProductCategorizePickerOption[]
+  onCategoryOptionsResolved?: (options: ProductCategorizePickerOption[]) => void
+  onChannelOptionsResolved?: (options: ProductCategorizePickerOption[]) => void
 }
 
 export function ProductCategorizeSection({
@@ -33,10 +35,20 @@ export function ProductCategorizeSection({
   initialCategoryOptions,
   initialChannelOptions,
   initialTagOptions,
+  onCategoryOptionsResolved,
+  onChannelOptionsResolved,
 }: ProductCategorizeSectionProps) {
   const t = useT()
-  const [categoryOptionsMap, setCategoryOptionsMap] = React.useState<Record<string, ProductCategorizePickerOption>>({})
-  const [channelOptionsMap, setChannelOptionsMap] = React.useState<Record<string, ProductCategorizePickerOption>>({})
+  const [categoryOptionsMap, setCategoryOptionsMap] = React.useState<Record<string, ProductCategorizePickerOption>>(() => {
+    const map: Record<string, ProductCategorizePickerOption> = {}
+    initialCategoryOptions?.forEach((opt) => { if (opt.value) map[opt.value] = opt })
+    return map
+  })
+  const [channelOptionsMap, setChannelOptionsMap] = React.useState<Record<string, ProductCategorizePickerOption>>(() => {
+    const map: Record<string, ProductCategorizePickerOption> = {}
+    initialChannelOptions?.forEach((opt) => { if (opt.value) map[opt.value] = opt })
+    return map
+  })
   const [tagOptionsMap, setTagOptionsMap] = React.useState<Record<string, ProductCategorizePickerOption>>({})
 
   const registerPickerOptions = React.useCallback(
@@ -127,12 +139,13 @@ export function ProductCategorizeSection({
             ): option is { value: string; label: string; description: string | null } => !!option,
           )
         registerPickerOptions(setCategoryOptionsMap, options)
+        onCategoryOptionsResolved?.(options)
         return options
       } catch {
         return []
       }
     },
-    [registerPickerOptions, t],
+    [registerPickerOptions, onCategoryOptionsResolved, t],
   )
 
   const loadChannelSuggestions = React.useCallback(
@@ -165,12 +178,13 @@ export function ProductCategorizeSection({
             ): option is { value: string; label: string; description: string | null } => !!option,
           )
         registerPickerOptions(setChannelOptionsMap, options)
+        onChannelOptionsResolved?.(options)
         return options
       } catch {
         return []
       }
     },
-    [registerPickerOptions, t],
+    [registerPickerOptions, onChannelOptionsResolved, t],
   )
 
   const loadTagSuggestions = React.useCallback(


### PR DESCRIPTION
## Summary
In product create flow, selected values in `Organize` step are rendered as UUIDs instead of human-readable labels after navigating away and back (`Continue` to next step, then `Previous`).

Before 

https://github.com/user-attachments/assets/7ad15475-c5c4-45db-89a9-f6af22f44b56

After 

https://github.com/user-attachments/assets/072033a9-8ad3-4413-84db-e58f3dadf80f

## Reproducible Steps
1. Open `/backend/catalog/products/create`.
2. Fill `General data` fields and go to `Organize`.
3. Select category from categories picker.
4. Select sales channel from channels picker.
5. Move to next step (`Continue` / `Variants`).
6. Return to `Organize` with `Previous`