### PR TITLE
feat(db): Support custom PostgreSQL schema via DATABASE_URL (Vibe Kanban)

### DIFF
--- a/packages/cli/src/lib/db/commands.ts
+++ b/packages/cli/src/lib/db/commands.ts
@@ -420,7 +420,7 @@ export async function dbGreenfield(resolver: PackageResolver, options: Greenfiel
     const client = new Client({ connectionString: getClientUrl(), ssl: getSslConfig() })
     await client.connect()
     try {
-      const res = await client.query(`SELECT tablename FROM pg_tables WHERE schemaname = 'public'`)
+      const res = await client.query(`SELECT tablename FROM pg_tables WHERE schemaname = current_schema()`)
       const tables: string[] = (res.rows || []).map((r: any) => String(r.tablename))
       if (tables.length) {
         await client.query('BEGIN')

--- a/packages/core/src/modules/catalog/migrations/Migration20251116191744.ts
+++ b/packages/core/src/modules/catalog/migrations/Migration20251116191744.ts
@@ -22,7 +22,7 @@ export class Migration20251116191744 extends Migration {
         if not exists (
           select 1
           from information_schema.columns
-          where table_schema = 'public'
+          where table_schema = current_schema()
             and table_name = 'catalog_product_variant_relations'
             and column_name = 'child_product_id'
         ) then
@@ -32,7 +32,7 @@ export class Migration20251116191744 extends Migration {
         if exists (
           select 1
           from information_schema.columns
-          where table_schema = 'public'
+          where table_schema = current_schema()
             and table_name = 'catalog_product_variant_relations'
             and column_name = 'child_variant_id'
         ) then
@@ -88,7 +88,7 @@ export class Migration20251116191744 extends Migration {
         if exists (
           select 1
           from information_schema.columns
-          where table_schema = 'public'
+          where table_schema = current_schema()
             and table_name = 'catalog_product_variant_relations'
             and column_name = 'child_product_id'
         ) then
@@ -98,7 +98,7 @@ export class Migration20251116191744 extends Migration {
         if exists (
           select 1
           from information_schema.columns
-          where table_schema = 'public'
+          where table_schema = current_schema()
             and table_name = 'catalog_product_variant_relations'
             and column_name = 'child_variant_id'
         ) then

--- a/packages/core/src/modules/customers/cli.ts
+++ b/packages/core/src/modules/customers/cli.ts
@@ -2644,7 +2644,8 @@ async function warnIfStressTestSchemaChanged(knex: any) {
     for (const [table, requiredColumns] of Object.entries(STRESS_TEST_REQUIRED_COLUMNS)) {
       const rows = await knex('information_schema.columns')
         .select('column_name')
-        .where({ table_schema: 'public', table_name: table })
+        .whereRaw('table_schema = current_schema()')
+        .where({ table_name: table })
       const existing = new Set(rows.map((row: { column_name: string }) => row.column_name))
       const missing = requiredColumns.filter((column) => !existing.has(column))
       if (missing.length) warnings.push(`${table}: missing ${missing.join(', ')}`)

--- a/packages/core/src/modules/query_index/lib/coverage.ts
+++ b/packages/core/src/modules/query_index/lib/coverage.ts
@@ -203,7 +203,8 @@ async function tableHasColumn(knex: Knex, table: string, column: string): Promis
   const key = `${table}.${column}`
   if (COLUMN_CACHE.has(key)) return COLUMN_CACHE.get(key)!
   const exists = await knex('information_schema.columns')
-    .where({ table_schema: 'public', table_name: table, column_name: column })
+    .whereRaw('table_schema = current_schema()')
+    .where({ table_name: table, column_name: column })
     .first()
   const present = !!exists
   COLUMN_CACHE.set(key, present)


### PR DESCRIPTION
## Summary

This PR adds support for custom PostgreSQL schemas specified via the `DATABASE_URL` query parameter:

```
postgresql://user:password@localhost:5432/dbname?options=-c%20search_path=custom_schema
```

## Changes Made

### Problem
The codebase had 8 hardcoded references to the `'public'` schema across 5 files, preventing deployment to databases with custom schemas.

### Solution
Use PostgreSQL's built-in `current_schema()` function everywhere. The database connection's `search_path` (set via `DATABASE_URL`) becomes the single source of truth.

### Files Modified

| File | Change |
|------|--------|
| `packages/cli/src/lib/db/commands.ts` | Use `current_schema()` in raw SQL query |
| `packages/cli/src/mercato.ts` | Use `current_schema()` for table listing and `to_regclass()` |
| `packages/core/src/modules/catalog/migrations/Migration20251116191744.ts` | Replace 4x `table_schema = 'public'` with `current_schema()` |
| `packages/core/src/modules/customers/cli.ts` | Use `.whereRaw('table_schema = current_schema()')` |
| `packages/core/src/modules/query_index/lib/coverage.ts` | Use `.whereRaw('table_schema = current_schema()')` |

## Why This Approach

1. **Single source of truth**: The database connection's `search_path` determines the schema
2. **No new dependencies**: Uses PostgreSQL's built-in function (available since v7.3)
3. **No extra env vars**: Leverages existing `DATABASE_URL` format
4. **Cleaner code**: No custom utility needed - just native PostgreSQL

## Related Discussion

See [PR #685 discussion](https://github.com/open-mercato/open-mercato/pull/685#issuecomment-3949846019) for context.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)