### PR TITLE
chore: update docs for db migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ At minimum, set `DATABASE_URL`, `JWT_SECRET`, and `REDIS_URL` (or `EVENTS_REDIS_
 
 Yarn 4 is now required. Ensure you have Yarn 4+ installed before proceeding.
 
-
 ## Getting Started
 
 
@@ -245,6 +244,14 @@ yarn generate
 yarn initialize # or yarn reinstall
 yarn dev
 ```
+
+After upgrading to a newer version, apply any new module migrations:
+
+```bash
+yarn db:migrate
+```
+
+Note: `yarn initialize` seeds demo data and may abort if users already exist. For upgrades on an existing database, use `yarn db:migrate` instead.
 
 For a fresh greenfield boot (build packages, generate registries, reinstall modules, then start dev), run:
 

--- a/apps/docs/docs/cli/db-migrate.mdx
+++ b/apps/docs/docs/cli/db-migrate.mdx
@@ -31,8 +31,10 @@ The command relies on `DATABASE_URL` for database connectivity.
 ## When to Run
 
 - After pulling new migrations from version control.
+- After upgrading to a newer Open Mercato version.
 - Immediately after `yarn db:generate` to apply fresh diffs.
 - During CI to guarantee the schema is aligned before running tests or seeding fixtures.
+- If you already have data and users, prefer `yarn db:migrate` over `yarn initialize` (which seeds data and may abort when users exist).
 
 ## Output
 

--- a/apps/docs/docs/customization/standalone-app.mdx
+++ b/apps/docs/docs/customization/standalone-app.mdx
@@ -63,7 +63,7 @@ yarn dev
 ```
 
 :::info
-`yarn initialize` handles code generation (`yarn generate`) and database migrations (`yarn db:migrate`) internally — you do not need to run them separately.
+`yarn initialize` handles code generation (`yarn generate`) and database migrations (`yarn db:migrate`) internally — you do not need to run them separately. It also seeds default data and will abort if existing users are found. For upgrades on an existing database, run `yarn db:migrate` instead of `yarn initialize`.
 :::
 
 Navigate to `http://localhost:3000/backend` and sign in with the credentials printed by `yarn initialize`.


### PR DESCRIPTION
## Summary
- Clarify that `yarn initialize` is a bootstrap/seed step and may abort on existing users.
- Add guidance to use `yarn db:migrate` for upgrades on existing databases.
- Update README and docs pages to reflect upgrade-safe migration flow.

## Docs Updated
- `README.md`
- `apps/docs/docs/customization/standalone-app.mdx`
- `apps/docs/docs/cli/db-migrate.mdx`

## Testing
- Not run (docs-only changes).
