### PR TITLE
fix/742-transform-form-data-apply-to-form: fixed the issue

### DIFF
--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -123,8 +123,12 @@ Files like `AGENTS.md` and `CLAUDE.md` use UPPERCASE names and are not numbered�
 | [SPEC-045g](SPEC-045g-google-workspace.md) | 2026-02-24 | Integration Marketplace — Google Workspace | Google Workspace integration: spreadsheet-based product import as a reference data-sync connector |
 | [SPEC-045h](SPEC-045h-stripe-payment-gateway.md) | 2026-02-24 | Integration Marketplace — Stripe Gateway | Stripe payment gateway reference implementation as a marketplace connector |
 | [SPEC-046](SPEC-046-2026-02-25-customer-detail-pages-v2.md) | 2026-02-25 | Customer Detail Pages v2 | CrudForm-based rewrite of company and person detail pages with two-zone layout and UMES injection slots |
+| [SPEC-046b](SPEC-046b-2026-02-27-customers-interactions-unification.md) | 2026-02-27 | Customers Interactions Unification | Canonical customer interactions model and compatibility adapters for activities/todos, scoped as child workstream of SPEC-046 |
+| [SPEC-046c](SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md) | 2026-02-28 | Example Module UMES Alignment for Customer Tasks | Decouples example task sync and moves `/backend/customer-tasks` ownership to customers, scoped as child workstream of SPEC-046 |
 | [SPEC-047](SPEC-047-2026-02-25-sales-document-detail-pages-v2.md) | 2026-02-25 | Sales Document Detail Pages v2 | CrudForm-based rewrite of quote and order detail pages with two-zone layout and UMES injection slots |
 | [SPEC-048](SPEC-048-2026-02-22-integration-test-coverage-quick-wins.md) | 2026-02-22 | Integration Test Coverage Quick Wins | Pure-API integration tests for 6 zero-coverage core modules (currencies, staff, dictionaries, api_keys, audit_logs, directory) |
+| [SPEC-049](SPEC-049-2026-02-26-message-objects-universal-view-attachments.md) | 2026-02-26 | Universal Message Object Attachments | Generic message object attachment previews/details and compose-flow wiring across modules |
+| [SPEC-050](SPEC-050-2026-02-28-example-module-umes-alignment-customer-tasks.md) | 2026-02-28 | Example Module UMES Alignment for Customer Tasks (Moved) | Pointer retained for backward links; canonical workstream spec is SPEC-046c |
 
 ## Specification Structure
 

--- a/.ai/specs/SPEC-046-2026-02-25-customer-detail-pages-v2.md
+++ b/.ai/specs/SPEC-046-2026-02-25-customer-detail-pages-v2.md
@@ -5,7 +5,7 @@
 | **Status** | Draft |
 | **Author** | Piotr Karwatka |
 | **Created** | 2026-02-25 |
-| **Related** | SPEC-041 (UMES), SPEC-016 (Form Headers/Footers), SPEC-017 (Version History) |
+| **Related** | SPEC-041 (UMES), SPEC-016 (Form Headers/Footers), SPEC-017 (Version History), SPEC-046b (Interactions Unification), SPEC-046c (Example Task Sync Alignment) |
 
 ## TLDR
 
@@ -26,6 +26,15 @@
 **Concerns:**
 - Transition from per-field to whole-document save changes UX behavior (no auto-save on blur)
 - Related data sections (notes, activities) remain independent — not part of form save
+
+---
+
+## Workstream Dependencies
+
+This rewrite is implemented together with two child specs:
+- `SPEC-046b` defines canonical customer interactions (including activities/todos compatibility adapters) consumed by Zone 2 tabs.
+- `SPEC-046c` defines customer-task ownership and example sync boundaries; `/backend/customer-tasks` ownership follows that spec.
+- During implementation, customer detail tabs and task-related APIs MUST align with `SPEC-046b` and `SPEC-046c` contracts.
 
 ---
 
@@ -636,4 +645,5 @@ Same pattern as TC-CRM-V2-003 but for person:
 
 | Date | Change |
 |------|--------|
+| 2026-03-02 | Formally linked child workstreams `SPEC-046b` and `SPEC-046c` to this spec and marked implementation dependency alignment |
 | 2026-02-25 | Initial draft |

--- a/.ai/specs/SPEC-046b-2026-02-27-customers-interactions-unification.md
+++ b/.ai/specs/SPEC-046b-2026-02-27-customers-interactions-unification.md
@@ -1,0 +1,636 @@
+# SPEC-046b: Customers Interactions Unification
+
+## TLDR
+**Key Points:**
+- Replace split model (`activities` + external `todo links` + manual `next interaction`) with one first-class object: `CustomerInteraction`.
+- Compute `next interaction` automatically from the nearest open interaction date.
+- Keep existing API paths (`/customers/activities`, `/customers/todos`) as deprecated adapter bridges for at least one minor release.
+- Move external task providers (e.g., Trello) to UMES extension sync around canonical interactions, not into the core write path.
+
+**Scope:**
+- New `customer_interactions` entity and CRUD API.
+- Automatic projection of next interaction onto `customer_entities.next_interaction_*`.
+- UI migration of Tasks/Activities to one interaction backend.
+- Data migration from `customer_activities` and `customer_todo_links`.
+- Legacy endpoints stay available as compatibility adapters; no legacy table drops in this spec.
+- UMES-ready integration contract: external ID mapping + event-driven outbound/inbound sync with idempotency.
+
+**Concerns:**
+- Migration quality when old todo providers are unavailable.
+- Backward compatibility for existing clients and UI hooks.
+- Temporary dual-contract maintenance (canonical + legacy adapters) during the deprecation window.
+- Preventing sync loops and duplicate objects when external providers are enabled.
+
+## Overview
+Customers module currently represents follow-up work in three places:
+1. `customer_activities` (timeline/log).
+2. `customer_todo_links` (links to external todo providers, default `example:todo`).
+3. `customer_entities.next_interaction_*` (manually edited summary).
+
+This creates duplicate semantics and requires user discipline to keep data coherent.
+
+This specification unifies all planned/completed customer interactions into one model and makes `next interaction` a derived projection.
+
+> **Market Reference**: Odoo CRM uses a single activity object with typed activities and "next activity" behavior. HubSpot and Salesforce separate timeline and tasks but still rely on a single "next step" discipline. We adopt Odoo-like unification of the core object while preserving OM auditability and compatibility guarantees.
+
+## Problem Statement
+Current UX and data model issues:
+1. Same business intent is split between tasks and activities.
+2. `next_interaction_*` is mutable data that can drift from actual open work.
+3. Tasks currently depend on provider delegation (`todoSource` -> `<module>.todos.create`), coupling core CRM writes to provider availability.
+4. Dashboard "next interactions" reads from manual fields, not from source-of-truth action items.
+5. Existing provider model conflicts with UMES direction where integrations extend core behavior via enrichers/interceptors/subscribers instead of owning primary core persistence.
+
+Result: users are confused, reporting and prioritization are harder, and consistency must be maintained manually.
+
+## Proposed Solution
+Introduce a single `CustomerInteraction` domain object for both planned and completed interactions.
+
+### Core Rules
+1. Every customer-facing action or logged touchpoint is a `CustomerInteraction`.
+2. Interaction type is explicit (`interactionType`) and dictionary-backed.
+3. State is explicit (`status`: `planned`, `done`, `canceled`).
+4. `next interaction` is derived automatically:
+   - nearest `planned` interaction by `scheduledAt` (ascending),
+   - scoped per customer entity,
+   - with deterministic tie-breakers.
+5. `customer_entities.next_interaction_*` remains as read-optimized projection, not user-authored truth.
+6. External providers are optional mirrors implemented as UMES/integration extensions; `customer_interactions` is the only source-of-truth in OM core.
+
+### Design Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Keep `next_interaction_*` columns as projection | Avoid breaking existing list filters/widgets and keep fast reads |
+| Add one canonical interaction table | Remove conceptual split and provider coupling |
+| Keep old APIs as adapters for >=1 minor | Comply with backward-compatibility contract while moving all new domain writes to canonical commands |
+| Compute projection synchronously on writes + background reconciler | Immediate UX consistency with recovery safety net |
+| Keep legacy tables additive/read-only in this release | Schema removals are not allowed in the same release under repo BC rules |
+| Use UMES extension sync for external systems | Preserves provider extensibility (Trello, etc.) without making provider calls part of core transaction |
+
+### Alternatives Considered
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Keep split model and add stronger UI hints | Does not remove data drift; still cognitively expensive |
+| Remove projection columns, compute next on every read | Heavier queries on high-volume lists/widgets |
+| Keep provider-linked todos as primary model | Preserves indirection and complexity causing current confusion |
+| Make external provider authoritative (core as mirror) | Breaks offline/local reliability and makes CRM unusable when provider is unavailable |
+
+## User Stories / Use Cases
+- **SDR** wants one place to add call/email/task follow-ups so that planning is simple.
+- **Sales manager** wants "next interaction" to always show the nearest open action without manual syncing.
+- **Ops/admin** wants old API clients to continue working during migration.
+- **Analyst** wants reliable reporting of open/planned/completed customer interactions.
+
+## Architecture
+Unified write path:
+1. UI/API create/update/complete/cancel interaction.
+2. Command mutates `customer_interactions`.
+3. Same command recalculates customer projection (`next_interaction_*`) for affected entity.
+4. Events emitted for indexing/audit/integration hooks (`customers.interaction.*`).
+
+Read path:
+1. Detail pages query interactions directly.
+2. Legacy endpoints map to filtered interaction queries.
+3. Dashboard next interactions reads projection fields (kept current by write path and reconciler).
+
+### UMES Integration Model (Post-SPEC-041)
+Authoritative model:
+1. OM core persists canonical `customer_interactions`.
+2. Integration modules observe interaction events and optionally sync to external providers.
+3. External references are stored as mappings (e.g., `sync_external_id_mappings`) keyed by `integrationId + entityType(customers.interaction) + localId`.
+
+Outbound sync (OM -> provider):
+1. `customers.interaction.created|updated|completed|canceled|deleted` event is emitted.
+2. Integration subscriber enqueues provider sync job (never blocks core transaction).
+3. Job upserts provider object (e.g., Trello card), then upserts mapping row idempotently.
+
+Inbound sync (provider -> OM):
+1. Integration webhook/worker resolves mapping by `integrationId + externalId`.
+2. If mapping exists, apply canonical interaction command (`update|complete|cancel`).
+3. If mapping does not exist and policy allows, create canonical interaction then mapping.
+4. Tag mutation metadata with `_syncOrigin=<integrationId>`; outbound subscriber skips same-origin events to prevent loops.
+
+Conflict policy:
+1. Core fields (`status`, `scheduledAt`, `occurredAt`) use last-write-wins with source timestamp.
+2. Provider-specific fields stay in extension namespace (`_integrations.<integrationId>.*`) via enrichers.
+3. If conflict cannot be auto-resolved, keep core state and record integration warning for manual resolution.
+
+### Commands & Events
+- **Commands**
+  - `customers.interaction.create`
+  - `customers.interaction.update`
+  - `customers.interaction.complete`
+  - `customers.interaction.cancel`
+  - `customers.interaction.delete`
+  - `customers.interaction.recompute_next` (internal/repair)
+- **Events**
+  - `customers.interaction.created`
+  - `customers.interaction.updated`
+  - `customers.interaction.completed`
+  - `customers.interaction.canceled`
+  - `customers.interaction.deleted`
+  - `customers.next_interaction.updated`
+
+### Transaction & Undo Contract
+Write atomicity:
+1. Canonical interaction mutation + projection recompute run in one DB transaction.
+2. Event enqueue happens after commit (no external provider call inside core transaction).
+
+Undo policy:
+1. `create` undo -> hard delete created interaction + recompute projection.
+2. `update` undo -> restore previous mutable fields + recompute projection.
+3. `complete`/`cancel` undo -> restore previous status/timestamps + recompute projection.
+4. `delete` undo -> restore interaction snapshot + recompute projection.
+
+External side effects:
+1. Provider sync is asynchronous and not part of command transaction.
+2. Undo does not synchronously call provider APIs; instead emits compensating lifecycle event and lets extension workers converge state.
+3. Failed provider compensation is retried and surfaced as integration warning, without rolling back canonical core state.
+
+## Data Models
+### CustomerInteraction (Singular)
+New table: `customer_interactions`
+
+- `id`: UUID PK
+- `organization_id`: UUID, required
+- `tenant_id`: UUID, required
+- `entity_id`: UUID FK -> `customer_entities.id`, required
+- `deal_id`: UUID FK -> `customer_deals.id`, nullable
+- `interaction_type`: text, required (dictionary-backed, normalized)
+- `title`: text, nullable
+- `body`: text, nullable
+- `status`: text enum (`planned`, `done`, `canceled`), required
+- `scheduled_at`: timestamptz, nullable (planning axis)
+- `occurred_at`: timestamptz, nullable (actual completion axis)
+- `priority`: int, nullable
+- `author_user_id`: UUID, nullable
+- `owner_user_id`: UUID, nullable
+- `appearance_icon`: text, nullable
+- `appearance_color`: text, nullable
+- `source`: text, nullable (`manual`, `migration:activity`, `migration:todo_link`, etc.)
+- `created_at`: timestamptz
+- `updated_at`: timestamptz
+
+Indexes:
+- `(entity_id, status, scheduled_at, created_at)`
+- `(organization_id, tenant_id, status, scheduled_at)`
+- `(tenant_id, organization_id, interaction_type)`
+
+Projection table/columns:
+- Keep existing `customer_entities.next_interaction_at`, `next_interaction_name`, `next_interaction_ref_id`, `next_interaction_icon`, `next_interaction_color`.
+- Mark as derived in code/docs. Manual editing is removed from detail UI.
+
+Legacy tables:
+- `customer_activities`: deprecated (read-only compatibility window).
+- `customer_todo_links`: deprecated (read-only compatibility window).
+
+### External Mapping (UMES/Integrations)
+- Use integration mapping storage (per SPEC-045b / SPEC-041l pattern) to link `customer_interactions.id` to external task IDs.
+- Mapping records are additive and tenant/org scoped; they do not duplicate interaction business state.
+- Canonical interaction payload is provider-agnostic; provider-specific metadata is exposed via enrichers (`_integrations` namespace).
+
+## API Contracts
+### New canonical endpoints
+#### `GET /api/customers/interactions`
+- Query: `entityId`, `status`, `interactionType`, `from`, `to`, `cursor`, `limit`, `sortField`, `sortDir`
+  - `limit` max: `100` (default `25`)
+  - keyset cursor mode (`cursor`) is canonical for scale
+- Response: keyset list of `CustomerInteraction` + `nextCursor`.
+
+#### `POST /api/customers/interactions`
+- Body: `entityId`, `interactionType`, optional `title`, `body`, `scheduledAt`, `ownerUserId`, `priority`, `dealId`.
+- Response: `{ id: "<uuid>" }` + undo metadata header.
+- Notes:
+  - No provider-specific required fields in canonical contract.
+  - Extension sync runs asynchronously through event subscribers/queues.
+
+#### `PUT /api/customers/interactions`
+- Body: `id` + mutable fields.
+- Response: `{ ok: true }`.
+
+#### `POST /api/customers/interactions/complete`
+- Body: `id`, optional `occurredAt`.
+- Response: `{ ok: true }`.
+
+#### `POST /api/customers/interactions/cancel`
+- Body: `id`.
+- Response: `{ ok: true }`.
+
+#### `DELETE /api/customers/interactions?id=<uuid>`
+- Query: `id`.
+- Response: `{ ok: true }`.
+
+### Compatibility endpoints
+#### `GET /api/customers/activities`
+- Backed by `customer_interactions` filter:
+  - includes non-task interaction types or completed/planned interactions per current activity semantics.
+- Response includes deprecation headers (`Deprecation`, `Sunset`) and migration docs link.
+
+#### `POST/PUT/DELETE /api/customers/activities`
+- Translate payloads to interaction commands.
+- No writes to `customer_activities` table.
+- Response includes deprecation headers (`Deprecation`, `Sunset`) and migration docs link.
+
+#### `GET /api/customers/todos`
+- Backed by `customer_interactions` filter:
+  - interaction types classified as actionable,
+  - include done/open status compatibility fields.
+- Response includes deprecation headers (`Deprecation`, `Sunset`) and migration docs link.
+
+#### `POST/PUT/DELETE /api/customers/todos`
+- Translate payloads to interaction commands.
+- `todoSource` retained as optional compatibility field, no longer used as provider delegate in new writes.
+- No writes to `customer_todo_links` table.
+- Response includes deprecation headers (`Deprecation`, `Sunset`) and migration docs link.
+
+### UMES integration response contract
+- Detail/list endpoints MAY include enriched integration data under `_integrations`.
+- Canonical shape remains stable even when no integrations are installed.
+- Example namespace:
+  - `_integrations.trello.externalId`
+  - `_integrations.trello.externalUrl`
+  - `_integrations.trello.syncStatus`
+  - `_integrations.trello.lastSyncedAt`
+
+### Security & Validation Contract
+1. Every request body/query for canonical and compatibility endpoints is validated with zod before business logic.
+2. Route metadata uses declarative guards:
+   - read: `requireAuth`, `requireFeatures: ['customers.view']`
+   - write: `requireAuth`, `requireFeatures: ['customers.create'|'customers.edit'|'customers.delete']` as applicable
+3. Custom write handlers (non-CRUD factory routes like `complete`/`cancel`) must run mutation guard hooks before/after success.
+4. Interaction `title`/`body` are treated as plain text; UI rendering forbids unsafe raw HTML injection.
+5. Integration secrets/tokens are never stored in interaction payloads and never logged by customers module routes/commands.
+6. Error payloads must not reveal provider credentials or internal stack traces.
+7. Persistence/query layer uses ORM parameterized queries only; no dynamic SQL string interpolation for user input.
+8. External URLs surfaced in `_integrations.*.externalUrl` must be validated and encoded before rendering/navigation.
+
+### Detail endpoint include tokens
+- Add `include=interactions`.
+- Keep `include=activities` and `include=todos|tasks` as filtered views over interactions.
+- Existing include tokens are preserved in this release (additive-only API change).
+
+## Internationalization (i18n)
+New keys:
+- `customers.interactions.*` for list/form/status/actions/errors.
+- Deprecation helper keys for legacy tasks/activities labels.
+- Next interaction computed-state labels (`derived`, `no_open_interactions`).
+
+## UI/UX
+### Customer detail pages
+- Replace separate data backends for Tasks and Activities with one interaction source.
+- Transitional UI (recommended):
+  - Keep tabs `Activities` and `Tasks` for familiarity,
+  - both read from interactions with different default filters.
+- Remove manual `onNextInteractionSave` editing control.
+- Show computed next interaction badge with link to source interaction.
+
+### Global customer tasks page (`/backend/customer-tasks`)
+- Keep route name for compatibility.
+- Back by interactions filtered to actionable types.
+
+### Dashboard widgets
+- `next-interactions` widget continues reading projection fields.
+- `customer-todos` widget queries interactions filtered as actionable.
+
+### UMES extension widgets (optional)
+- Integration status badges (SPEC-041l) can expose per-provider health.
+- External ID mapping widget can show linked provider object for an interaction/customer.
+- Disabling an integration extension does not remove local interactions.
+
+## Configuration
+- Feature flag: `customers.interactions.unified` (default off in first release, on by default after migration validation).
+- Feature flag: `customers.interactions.legacy-adapters` (default on during transition, removable later).
+- Feature flag: `customers.interactions.external-sync` (default off; enabled per integration rollout).
+
+## Performance & Cache Strategy
+### Query and N+1 Strategy
+1. `GET /api/customers/interactions` uses keyset pagination and returns at most `100` rows per request.
+2. List endpoint target query budget:
+   - 1 query for interaction rows,
+   - 1 optional dictionary join/batch lookup for type labels,
+   - 1 optional enrichment batch query (`enrichMany`) when integrations are enabled.
+3. Detail endpoint with `include=interactions` fetches interactions in one scoped query; no per-row provider lookups.
+4. Integration mapping enrichment must use batch lookup (`enrichMany`) to avoid N+1 across list responses.
+
+### Cache Policy
+1. MVP introduces no mandatory new cache layer; correctness-first path is direct DB reads plus projection columns.
+2. If endpoint-level cache is enabled later, keys/tags must include tenant and organization scope.
+3. Recommended invalidation tags:
+   - `customers:interaction:entity:<entityId>`
+   - `customers:next-interaction:entity:<entityId>`
+   - `customers:interaction:list:<tenantId>:<organizationId>`
+   - `integrations:interaction-mapping:<integrationId>:<tenantId>:<organizationId>`
+4. Every interaction write invalidates entity and list tags in the same request cycle.
+5. Mapping upsert/delete invalidates related integration mapping tags and affected detail/list tags.
+6. Cache TTL is N/A in MVP (no new read cache enabled); when enabled later, default TTL must be explicit per endpoint.
+7. Cache miss behavior in MVP is direct scoped DB read (no stale fallback response).
+
+### Heavy Operation Threshold
+1. Backfill and recompute jobs touching >1000 interaction rows run in workers.
+2. Foreground request path is limited to single-interaction mutations and bounded list reads.
+
+## Migration & Compatibility
+### Backward compatibility contract
+This spec follows the deprecation protocol for contract surfaces (API routes, response shapes, includes, and schema):
+1. Do not remove legacy APIs or legacy tables in this release.
+2. Mark legacy adapters as deprecated in docs and response headers.
+3. Keep adapter bridge for at least one minor release.
+4. Document migration in `RELEASE_NOTES.md`.
+5. Prepare follow-up removal spec for legacy surfaces in a later release.
+
+### Migration plan
+1. Create `customer_interactions`.
+2. Backfill from `customer_activities`:
+   - map `activity_type` -> `interaction_type`
+   - map `occurred_at` and metadata fields
+   - set `status = done` when `occurred_at` is set, otherwise `planned`.
+3. Backfill from `customer_todo_links`:
+   - resolve linked todo records using query engine where possible,
+   - map title/status/due/priority/severity to interaction fields,
+   - set `source = migration:todo_link`.
+4. For resolvable external links, upsert integration mappings to canonical interaction IDs (idempotent).
+5. Recompute `next_interaction_*` for all customer entities.
+6. Enable compatibility adapters.
+7. Switch UI to canonical interactions API.
+8. Freeze legacy tables to read-only compatibility/audit role; do not drop in this release.
+9. Enable outbound sync per integration after backfill validation to avoid duplicate provider objects.
+10. Publish deprecation timeline and release notes, then schedule dedicated legacy-removal spec for a later release.
+
+### Next interaction derivation algorithm
+Given all interactions for one `entity_id`:
+1. Candidate set = `status = planned` and `scheduled_at IS NOT NULL`.
+2. Sort by:
+   - `scheduled_at ASC`,
+   - `priority DESC NULLS LAST`,
+   - `created_at ASC`,
+   - `id ASC` (deterministic tie-break).
+3. First row becomes projection:
+   - `next_interaction_at = scheduled_at`
+   - `next_interaction_name = interaction_type label or title fallback`
+   - `next_interaction_ref_id = interaction.id`
+   - icon/color from interaction/dictionary defaults.
+4. If no candidate exists, projection fields are set to `NULL`.
+
+## MVP & Future Work
+### MVP (this spec)
+- Canonical `customer_interactions` data model and commands as the only write source.
+- Derived `next_interaction_*` projection maintained on every write.
+- Legacy API adapters (`/activities`, `/todos`) preserved with deprecation headers for compatibility.
+- Backfill + reconciler rollout with feature flags and integration coverage.
+- UMES-compatible sync contract for external providers (async, idempotent, non-blocking).
+
+### Future Work (out of scope here)
+- Hard removal of legacy APIs (`/customers/activities`, `/customers/todos`) after deprecation window.
+- Hard removal/archival strategy for legacy tables in a dedicated breaking-change spec.
+- Optional dedicated worker-only mode for very large-tenant projection recompute.
+- Provider-specific setup wizards/status dashboards beyond baseline sync contract (delivered by integration modules).
+- Example module UMES alignment and customer-task sync decoupling tracked in `SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md`.
+
+## Implementation Plan
+### Phase 1: Domain foundation
+1. Add `CustomerInteraction` entity + validator schemas.
+2. Add commands + undo support for interaction lifecycle.
+3. Add projection recompute service and invoke from commands.
+4. Register services in customers `di.ts` (recompute service, interaction repository helpers).
+
+### Phase 2: API and adapters
+1. Add `/api/customers/interactions` route with OpenAPI.
+2. Add canonical cancel/delete operations (`POST /interactions/cancel`, `DELETE /interactions`).
+3. Re-implement `/api/customers/activities` as deprecated adapter (headers + translation to interaction commands).
+4. Implement `/api/customers/todos` as deprecated adapter (headers + translation to interaction commands).
+5. Enforce `limit <= 100` and keyset cursor contract on canonical list endpoint.
+
+### Phase 3: UI migration
+1. Update people/company detail pages to fetch interactions.
+2. Refactor TasksSection and ActivitiesSection hooks to shared interactions client.
+3. Remove manual next-interaction editing controls from highlights.
+
+### Phase 4: Dashboard and list views
+1. Update customer todos table query source to interactions.
+2. Validate next interactions widget correctness with derived projection.
+
+### Phase 5: UMES integration bridge
+1. Emit full interaction lifecycle events (including `deleted`) for sync subscribers.
+2. Add integration enricher contract for `_integrations` payload on interaction-aware endpoints.
+3. Implement sync subscriber/webhook reference flow with `_syncOrigin` loop protection.
+4. Ensure integration failures are non-blocking for canonical writes (queue + retry).
+
+### Phase 6: Data migration and rollout
+1. Generate DB migration via `yarn db:generate` (no hand-written migration files).
+2. Backfill interaction + mapping data and run recompute/consistency checks.
+3. Enable feature flags progressively.
+4. Publish release notes with deprecation timeline and adapter sunset target.
+
+### File Manifest
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/core/src/modules/customers/data/entities.ts` | Modify | Add `CustomerInteraction`; deprecate old references |
+| `packages/core/src/modules/customers/data/validators.ts` | Modify | Add interaction schemas and compatibility schemas |
+| `packages/core/src/modules/customers/di.ts` | Modify | Register interaction services via DI container |
+| `packages/core/src/modules/customers/commands/interactions.ts` | Create | Canonical interaction commands |
+| `packages/core/src/modules/customers/commands/todos.ts` | Modify | Convert to adapter behavior |
+| `packages/core/src/modules/customers/commands/activities.ts` | Modify | Convert to adapter behavior |
+| `packages/core/src/modules/customers/api/interactions/route.ts` | Create | Canonical interactions CRUD API |
+| `packages/core/src/modules/customers/api/activities/route.ts` | Modify | Compatibility adapter |
+| `packages/core/src/modules/customers/api/todos/route.ts` | Create/Restore | Compatibility adapter over interactions |
+| `packages/core/src/modules/customers/backend/customers/people/[id]/page.tsx` | Modify | Remove manual next edit, load interactions |
+| `packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx` | Modify | Remove manual next edit, load interactions |
+| `packages/core/src/modules/customers/components/detail/hooks/usePersonTasks.ts` | Modify | Use interactions API |
+| `packages/core/src/modules/customers/components/detail/*Activities*` | Modify | Use interactions API |
+| `packages/core/src/modules/customers/api/dashboard/widgets/next-interactions/route.ts` | Modify | Ensure projection contract stays stable |
+| `packages/core/src/modules/customers/events.ts` | Modify | Ensure full lifecycle events (including `deleted`) for integration hooks |
+| `packages/core/src/modules/integrations/data/enrichers.ts` | Modify | Add `_integrations` mapping enrichment for interaction-backed views |
+| `packages/core/src/modules/<integration>/subscribers/*interaction*` | Create | Outbound sync subscriber from interaction events |
+| `packages/core/src/modules/<integration>/workers/*sync*` | Create | Provider sync workers with retry/idempotency |
+| `packages/core/src/modules/<integration>/api/post/webhooks/*` | Create | Inbound provider updates mapped to canonical interaction commands |
+| `packages/core/src/modules/customers/migrations/<generated>.ts` | Generate | DB schema/backfill generated by `yarn db:generate` |
+| `RELEASE_NOTES.md` | Modify | Add deprecation notice and migration timeline for legacy endpoints |
+
+### Integration Test Coverage (required)
+API paths:
+1. `GET/POST/PUT/DELETE /api/customers/interactions`
+2. `POST /api/customers/interactions/complete`
+3. `POST /api/customers/interactions/cancel`
+4. `GET/POST/PUT/DELETE /api/customers/activities` (deprecated adapter + headers)
+5. `GET/POST/PUT/DELETE /api/customers/todos` (deprecated adapter + headers)
+6. `GET /api/customers/dashboard/widgets/next-interactions`
+7. `GET /api/customers/people/{id}?include=activities,todos,interactions`
+8. `GET /api/customers/companies/{id}?include=activities,todos,interactions`
+9. Cursor pagination contract on `GET /api/customers/interactions` (`limit <= 100`, `nextCursor`)
+10. Verify legacy adapter writes do not persist to legacy tables
+11. Verify interaction lifecycle events trigger integration sync enqueue (when extension enabled)
+12. Verify inbound provider webhook update is idempotent and loop-safe (`_syncOrigin` guard)
+13. Verify `_integrations` enrichment appears when mapping exists and is absent when extension disabled
+14. Verify write routes reject invalid payloads with zod validation errors
+15. Verify write routes enforce `requireFeatures` guards for unauthorized users
+16. Verify list/detail enrichment remains N+1-safe under 100-row page
+
+Key UI paths:
+1. `/backend/customers/people/[id]` (tabs: tasks/activities)
+2. `/backend/customers/companies/[id]` (tabs: tasks/activities)
+3. `/backend/customer-tasks`
+4. Dashboard widget: next interactions
+5. Integration status badge and external mapping section (if extension installed)
+
+## Risks & Impact Review
+### Data Integrity Failures
+Risk of projection drift if interaction write succeeds but projection update fails. Mitigation: same transaction where possible + async reconciler.
+
+### Cascading Failures & Side Effects
+Search/index and dashboard widgets depend on current fields. Mitigation: preserve projection schema and legacy APIs until migration completes.
+
+### Tenant & Data Isolation Risks
+Unified table increases blast radius of query bugs. Mitigation: enforce tenant/org filters in every command and route; add integration tests for cross-tenant isolation.
+
+### Migration & Deployment Risks
+Backfill from provider-linked todos may be partial if provider records are missing. Mitigation: mark partial migrations with source and fallback title; keep old tables for audit window.
+
+### Operational Risks
+Large tenants may face expensive initial recompute. Mitigation: batch recompute job with checkpoints and resumable cursor.
+
+### Risk Register
+#### Projection Drift on Write
+- **Scenario**: interaction is written, but `next_interaction_*` fields are not updated because of partial failure.
+- **Severity**: High
+- **Affected area**: dashboard next interactions, list sorting/filtering.
+- **Mitigation**: transactional update path and scheduled `recompute_next` repair job.
+- **Residual risk**: short-lived inconsistency before repair job.
+
+#### Incomplete Todo Backfill
+- **Scenario**: linked provider todo record cannot be resolved during migration.
+- **Severity**: Medium
+- **Affected area**: migrated task details accuracy.
+- **Mitigation**: fallback interaction with minimal metadata and migration markers.
+- **Residual risk**: some historic fields (priority/custom) may be missing.
+
+#### Legacy Client Contract Break
+- **Scenario**: existing UI/client expects old todo/activity payload shape.
+- **Severity**: High
+- **Affected area**: customer detail tabs, custom integrations.
+- **Mitigation**: adapter routes preserve response shape during transition.
+- **Residual risk**: unknown third-party clients may rely on undocumented fields.
+
+#### Premature Legacy Removal
+- **Scenario**: removing legacy APIs/tables in the same release breaks existing clients and violates BC contract.
+- **Severity**: Critical
+- **Affected area**: external integrations, extension modules, upgrade safety.
+- **Mitigation**: keep adapter bridge for >=1 minor, mark deprecated, and defer removals to dedicated follow-up spec.
+- **Residual risk**: temporary maintenance overhead during deprecation window.
+
+#### Query Cost Regression
+- **Scenario**: canonical interactions queries become heavier than split-table queries.
+- **Severity**: Medium
+- **Affected area**: detail pages and work-plan list latency.
+- **Mitigation**: dedicated indexes and strict page-size caps.
+- **Residual risk**: hotspots for very large tenants until tuning.
+
+#### Sync Loop / Duplicate External Objects
+- **Scenario**: outbound sync triggers inbound webhook that re-triggers outbound sync, creating loop or duplicates.
+- **Severity**: High
+- **Affected area**: external provider data quality, queue load.
+- **Mitigation**: `_syncOrigin` tag, idempotent mapping upserts, dedupe keys in queue jobs.
+- **Residual risk**: provider-side eventual consistency may still create short-lived duplicate attempts.
+
+#### Provider Outage Affecting Core Writes
+- **Scenario**: provider API outage during sync attempts.
+- **Severity**: High
+- **Affected area**: integration freshness.
+- **Mitigation**: async non-blocking sync with retries; core interaction write succeeds independently.
+- **Residual risk**: delayed external consistency until provider recovery.
+
+#### Mapping Drift
+- **Scenario**: local interaction exists but external mapping is stale or missing.
+- **Severity**: Medium
+- **Affected area**: deep links/status rendering for integrated providers.
+- **Mitigation**: periodic reconciliation worker and missing-mapping repair flow.
+- **Residual risk**: stale badge/status until next successful reconcile.
+
+## Final Compliance Report — 2026-02-28
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/customers/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `packages/events/AGENTS.md`
+
+### Compliance Matrix
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| root `AGENTS.md` | No direct ORM relationships between modules | Compliant | Interactions remain inside customers module; external links are IDs only |
+| root `AGENTS.md` | Filter by `organization_id` for tenant-scoped entities | Compliant | Included in model, API, and command requirements |
+| root `AGENTS.md` | API routes MUST export `openApi` | Compliant | Required for new interactions route and adapters |
+| root `AGENTS.md` | Undoability is default for state changes | Compliant | Commands defined with undo contracts |
+| root `AGENTS.md` | Backward-compatibility deprecation protocol | Compliant | Legacy APIs/tables bridged for >=1 minor; removal deferred to follow-up spec |
+| root `AGENTS.md` | Database schema is additive-only | Compliant | No table drop in this release |
+| root `AGENTS.md` | Keep `pageSize` at or below 100 | Compliant | Canonical list contract enforces `limit <= 100` |
+| root `AGENTS.md` | Never hand-write migrations | Compliant | Migration files generated via `yarn db:generate` |
+| root `AGENTS.md` | Module isolation via events, not direct cross-module coupling | Compliant | UMES sync uses subscribers/enrichers + mapping IDs, not direct provider coupling in core commands |
+| root `AGENTS.md` | Validate all inputs with zod | Compliant | Security contract requires zod validation for canonical + compatibility routes |
+| root `AGENTS.md` | Prefer declarative guards (`requireAuth`, `requireFeatures`) | Compliant | Security contract defines route guard matrix for read/write |
+| `.ai/specs/AGENTS.md` | Include required spec sections | Compliant | All mandatory sections included |
+| `customers/AGENTS.md` | Use customers module CRUD patterns | Compliant | Commands/routes follow existing customers conventions |
+| `packages/ui/AGENTS.md` | Non-`CrudForm` writes use guarded mutation | Compliant | UI migration section requires existing guarded mutation patterns for adapter writes |
+| `packages/events/AGENTS.md` | Event-driven side effects and durable subscribers | Compliant | External sync flows are event-driven and retryable by worker/subscriber design |
+
+### Internal Consistency Check
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | Canonical interaction fields are reflected in API section |
+| API contracts match UI/UX section | Pass | UI consumes interactions; legacy routes retained |
+| Risks cover all write operations | Pass | Create/update/complete/cancel/delete and migration risks covered |
+| Commands defined for all mutations | Pass | Full mutation set listed |
+| Cache/projection strategy covers read APIs | Pass | `next_interaction_*` remains read projection |
+| Backward-compatibility contract is explicit | Pass | Deprecation protocol and release-note requirement documented |
+| UMES integration path preserves core source-of-truth | Pass | External providers are extensions around canonical interactions |
+
+### Non-Compliant Items
+- None.
+
+### Verdict
+- **Fully compliant**: Approved for implementation planning.
+
+## Changelog
+### 2026-03-02
+- Renumbered this specification from `SPEC-049` to `SPEC-046b` as a child workstream of customer detail rewrite.
+- Updated cross-spec dependency link to `SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md`.
+
+### 2026-02-28 (rev 3)
+- Reframed spec as UMES-native: canonical interactions remain core source-of-truth, providers become optional extension mirrors.
+- Added integration contract for outbound/inbound sync (events, queue retries, idempotent mapping upserts, `_syncOrigin` loop protection).
+- Added external mapping/enrichment model (`_integrations` namespace) aligned with integration specs.
+- Expanded phases, file manifest, tests, risks, and compliance to include UMES integration behavior.
+- Added explicit transaction/undo contract and non-blocking external side-effect compensation model.
+- Added explicit security/validation contract (`zod`, guards, mutation guard hooks, XSS-safe rendering constraints).
+- Added performance/cache section with N+1 expectations, tenant-scoped invalidation tags, and worker thresholds.
+
+### 2026-02-27 (rev 2)
+- Switched rollout strategy to bridge mode: legacy APIs remain as deprecated adapters for >=1 minor release.
+- Removed legacy table drop from this release scope; marked as follow-up removal spec.
+- Added explicit backward-compatibility protocol section (deprecation headers, release notes, timeline).
+- Extended canonical API contract with `cancel`/`delete`, cursor pagination, and `limit <= 100`.
+- Updated test coverage plan to validate deprecation headers and no writes to legacy tables.
+- Expanded compliance matrix to include BC contract, additive schema rule, generated migrations, and UI guarded-mutation rules.
+
+### 2026-02-27
+- Initial specification for unifying customer activities and tasks into one interaction model.
+- Added derived `next interaction` algorithm and migration strategy.
+
+### Review — 2026-02-27
+- **Reviewer**: Agent
+- **Security**: Passed
+- **Performance**: Passed
+- **Cache**: Passed
+- **Commands**: Passed
+- **Risks**: Passed
+- **Verdict**: Approved
+
+### Review — 2026-02-28
+- **Reviewer**: Agent
+- **Security**: Passed
+- **Performance**: Passed
+- **Cache**: Passed
+- **Commands**: Passed
+- **Risks**: Passed
+- **Verdict**: Approved

--- a/.ai/specs/SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md
+++ b/.ai/specs/SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md
@@ -1,0 +1,398 @@
+# SPEC-046c: Example Module UMES Alignment for Customer Tasks
+
+## TLDR
+**Key Points:**
+- Keep `example` as a self-contained demo module (`example.todo`), but remove its implicit role as customers task provider.
+- Move customer-task synchronization to an explicit UMES-style extension module around canonical `customer_interactions` from `SPEC-046b-2026-02-27-customers-interactions-unification.md`.
+- Make `/backend/customer-tasks` owned by customers domain, so it works even when `example` is disabled.
+
+**Scope:**
+- Define module boundary split: `example` (demo domain) vs `example_customers_sync` (cross-module extension behavior).
+- Add event-driven sync contract between `customers.interaction.*` and `example.todo.*` with idempotent mapping.
+- Add compatibility plan so no task drift is introduced during transition.
+
+**Concerns:**
+- Avoiding sync loops and duplicate objects when bidirectional sync is enabled.
+- Preserving backward compatibility for existing `example` routes and data.
+
+## Overview
+`example` currently mixes two responsibilities:
+1. A standalone demo module (`example.todo`, demo pages/widgets/APIs).
+2. A de facto customers task provider role in legacy flows (`todoSource`, `customer_todo_links`, `/backend/customer-tasks` route placement in `example`).
+
+After `SPEC-046b-2026-02-27-customers-interactions-unification.md`, customers tasks become canonical `customer_interactions`. Keeping cross-module task-provider behavior inside `example` as an implicit provider creates unclear ownership and upgrade risk.
+
+This spec aligns `example` with UMES by separating concerns:
+- `example` remains demo/self-contained.
+- Customer-task integration becomes explicit extension logic (`example_customers_sync`) around customers core events and contracts.
+
+> **Market Reference**: Open ecosystems (Shopify apps, Odoo addons, Medusa providers) separate core domain ownership from connector/extensions. We adopt the same split: canonical domain in core, optional sync via extension modules.
+
+## Problem Statement
+1. `example` currently couples demo module lifecycle with customer-task behavior.
+2. Disabling `example` risks removing behavior users perceive as core (`/backend/customer-tasks` placement).
+3. Legacy provider delegation (`todoSource -> example.todos.create`) is opposite to UMES direction (core + extension side effects).
+4. Cross-module logic in a demo module blurs maintenance boundaries and release ownership.
+5. Without explicit mapping/sync contract, bidirectional updates can drift or loop.
+
+## Proposed Solution
+Introduce a dedicated extension module `example_customers_sync` and redefine responsibilities:
+
+1. `customers` owns canonical tasks/interactions and `/backend/customer-tasks`.
+2. `example` owns only its own todo demo domain and demo UI.
+3. `example_customers_sync` subscribes to events and syncs between canonical interactions and `example.todos` as optional behavior.
+4. Sync uses explicit mapping rows (1:1 interaction <-> todo) with idempotency and loop guards.
+
+### Design Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Create separate `example_customers_sync` module | Makes cross-module behavior explicit and optional |
+| Keep `example.todo` API unchanged | Preserves demo module value and BC |
+| Customers owns `/backend/customer-tasks` | Prevents route/functionality loss when `example` is disabled |
+| Event-driven async sync | No provider calls in customers write transaction |
+| Dedicated mapping table in sync module | Simple OSS path without hard dependency on integrations hub rollout timing |
+
+### Alternatives Considered
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Keep all behavior inside `example` | Continues ownership ambiguity and coupling |
+| Make `example.todo` authoritative and mirror to customers | Conflicts with SPEC-046b canonical interaction model |
+| Hard-delete old route and flows in one release | Breaks compatibility for existing setups |
+
+## User Stories / Use Cases
+- **CRM user** wants customer tasks to work even if demo module is disabled.
+- **Developer** wants `example` to remain a clean reference module without hidden production coupling.
+- **Integrator** wants optional sync behavior through explicit extension contracts and events.
+- **Admin** wants safe rollout with fallback and reconciliation if sync fails.
+
+## Architecture
+### Module Boundaries
+| Module | Owns | Does Not Own |
+|--------|------|--------------|
+| `customers` | `customer_interactions`, next-interaction projection, `/backend/customer-tasks` | Example todo persistence |
+| `example` | `example.todo` CRUD/UI/events, demo widgets | Customers task domain semantics |
+| `example_customers_sync` | Cross-module mapping + sync workers/subscribers | Primary source-of-truth for either domain |
+
+### Data Flow
+Outbound (customers -> example):
+1. `customers.interaction.created|updated|completed|canceled|deleted` emitted.
+2. `example_customers_sync` subscriber enqueues sync job.
+3. Worker upserts/deletes `example.todo`.
+4. Worker upserts mapping row idempotently.
+
+Inbound (example -> customers):
+1. `example.todo.updated|deleted` emitted.
+2. `example_customers_sync` resolves mapping.
+3. Worker executes canonical customers command (`update|complete|cancel|delete`) as needed.
+4. `_syncOrigin` metadata prevents bounce-loop.
+
+### Sync Rules
+1. Canonical business status lives in `customer_interactions`.
+2. Example-specific task decorations can live in `example.todo` custom fields.
+3. For collisions, core fields use last-write-wins with source timestamp.
+4. If conflict is not auto-resolvable, keep customers state and mark mapping as `error`.
+
+### Commands & Events
+- **Commands** (`example_customers_sync`)
+  - `example_customers_sync.mapping.upsert`
+  - `example_customers_sync.mapping.delete`
+  - `example_customers_sync.sync.from_interaction`
+  - `example_customers_sync.sync.from_todo`
+  - `example_customers_sync.reconcile`
+- **Events consumed**
+  - `customers.interaction.created`
+  - `customers.interaction.updated`
+  - `customers.interaction.completed`
+  - `customers.interaction.canceled`
+  - `customers.interaction.deleted`
+  - `example.todo.created`
+  - `example.todo.updated`
+  - `example.todo.deleted`
+- **Events emitted**
+  - `example_customers_sync.mapping.created`
+  - `example_customers_sync.mapping.updated`
+  - `example_customers_sync.mapping.deleted`
+  - `example_customers_sync.sync.failed`
+
+### Transaction, Idempotency, and Compensation Contract
+1. `example_customers_sync.mapping.upsert`:
+   - idempotent by unique keys `(org, tenant, interaction_id)` and `(org, tenant, todo_id)`,
+   - on retry, same input must converge to one mapping row.
+2. `example_customers_sync.mapping.delete`:
+   - idempotent delete (safe if row already missing),
+   - optional compensation path restores mapping from snapshot when invoked by replay tooling.
+3. `example_customers_sync.sync.from_interaction` and `example_customers_sync.sync.from_todo`:
+   - never run in customers/example core write transaction,
+   - on failure set mapping `sync_status='error'`, persist `last_error`, emit `example_customers_sync.sync.failed`,
+   - retries must not create duplicate todos/interactions.
+4. `example_customers_sync.reconcile`:
+   - operational command (no business undo requirement),
+   - safe to rerun with cursor/idempotency key.
+5. External side effects are eventually consistent:
+   - canonical writes remain committed even if sync fails,
+   - reconciliation/worker retries provide compensation to convergence.
+
+## Data Models
+### ExampleCustomerInteractionMapping (Singular)
+New table: `example_customer_interaction_mappings`
+
+- `id`: UUID PK
+- `organization_id`: UUID, required
+- `tenant_id`: UUID, required
+- `interaction_id`: UUID, required (FK ID reference to customers interaction; no cross-module ORM relation)
+- `todo_id`: UUID, required (FK ID reference to example todo; no cross-module ORM relation)
+- `sync_status`: text enum (`synced`, `pending`, `error`), required
+- `last_synced_at`: timestamptz, nullable
+- `last_error`: text, nullable
+- `source_updated_at`: timestamptz, nullable
+- `created_at`: timestamptz
+- `updated_at`: timestamptz
+
+Indexes:
+- unique `(organization_id, tenant_id, interaction_id)`
+- unique `(organization_id, tenant_id, todo_id)`
+- index `(organization_id, tenant_id, sync_status, updated_at)`
+
+## API Contracts
+### Existing contracts preserved
+1. Keep `/api/example/todos` contract unchanged.
+2. Keep customers canonical interactions API from SPEC-046b unchanged.
+
+### New operational endpoints (sync module)
+#### `GET /api/example-customers-sync/mappings`
+- Query: `interactionId?`, `todoId?`, `cursor?`, `limit?`
+- Response: paged mapping rows (`limit <= 100`)
+- Guard: `requireAuth`, `requireFeatures: ['example_customers_sync.view']`
+
+#### `POST /api/example-customers-sync/reconcile`
+- Body: optional filters (`organizationId`, `tenantId`, `limit`, `cursor`)
+- Response: `{ queued: number }`
+- Guard: `requireAuth`, `requireFeatures: ['example_customers_sync.manage']`
+
+### Route ownership change
+1. Create canonical `/backend/customer-tasks` page in customers module.
+2. Remove conflicting `example` page file for the same route in the same release (single owner, no duplicate route registration).
+3. Keep backward compatibility at URL level because path stays `/backend/customer-tasks`; only module ownership changes.
+4. Mark ownership move in docs/release notes.
+
+## Internationalization (i18n)
+New keys:
+- `exampleCustomersSync.*` for sync status/errors/reconcile actions.
+- Deprecation notice keys for legacy example-owned customer-tasks route.
+- Mapping state labels (`synced`, `pending`, `error`, `resolving`).
+
+## UI/UX
+1. `/backend/customer-tasks` must be available without `example` module.
+2. If `example` is enabled and sync module enabled, task rows can show optional badge:
+   - `Synced to Example Todo`
+   - link to `/backend/todos/[id]/edit`
+3. `example` keeps its own `/backend/todos` UX unchanged.
+4. Sync errors surface as non-blocking warning badges/actions in task detail/list.
+
+## Configuration
+- Feature flag: `example.customers_sync.enabled` (default `false`)
+- Feature flag: `example.customers_sync.bidirectional` (default `false` initially)
+
+### ACL features (new module)
+- `example_customers_sync.view`
+- `example_customers_sync.manage`
+
+## Migration & Compatibility
+### Backward compatibility contract
+1. Do not remove `/api/example/todos` or `/backend/todos`.
+2. Do not remove `example` module todo schema in this release.
+3. Move `/backend/customer-tasks` ownership to customers with no URL change (module/file ownership only).
+4. Keep legacy behavior behind feature flags until sync validation passes.
+5. Publish deprecation/migration notes in `RELEASE_NOTES.md`.
+
+### Migration plan
+1. Create `example_customer_interaction_mappings` table.
+2. Add customers-owned `/backend/customer-tasks`.
+3. Remove conflicting example page file for `/backend/customer-tasks`.
+4. Enable outbound sync first (`customers -> example`) with bidirectional off.
+5. Run reconcile job to map/create missing example todos for active interactions.
+6. Enable bidirectional sync after validation in staging.
+7. Monitor `sync.failed` rate and mapping error backlog before broad enablement.
+
+## Implementation Plan
+### Phase 1: Route and ownership decoupling
+1. Create `/backend/customer-tasks` in customers module.
+2. Remove conflicting `/backend/customer-tasks` page from `example`.
+3. Update docs and navigation ownership.
+
+### Phase 2: Sync module foundation
+1. Scaffold `example_customers_sync` module (`index.ts`, `di.ts`, `events.ts`, `data/entities.ts`, `data/validators.ts`, `acl.ts`, `setup.ts`).
+2. Add mapping entity and zod schemas.
+3. Register module in app modules list behind feature flag.
+4. Run `npm run modules:prepare` after adding events/subscribers/workers/routes.
+
+### Phase 3: Event-driven sync
+1. Add subscribers for customers interaction lifecycle events.
+2. Add subscribers for example todo lifecycle events.
+3. Add workers with idempotent upsert/delete semantics.
+4. Add `_syncOrigin` loop guard handling.
+
+### Phase 4: Operational APIs and UX wiring
+1. Add mappings list/reconcile APIs with OpenAPI docs.
+2. Add optional sync badges/links in customer tasks UI.
+3. Add admin diagnostics for failed mappings.
+
+### Phase 5: Rollout and verification
+1. Run reconciliation in staging and validate no drift.
+2. Enable outbound sync in production.
+3. Enable bidirectional sync after stability criteria are met.
+
+### File Manifest
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/core/src/modules/customers/backend/customer-tasks/page.tsx` | Create | Canonical customer tasks page ownership |
+| `apps/mercato/src/modules/example/backend/customer-tasks/page.tsx` | Delete | Remove duplicate route owner to avoid path collision |
+| `apps/mercato/src/modules/example_customers_sync/index.ts` | Create | Module metadata |
+| `apps/mercato/src/modules/example_customers_sync/acl.ts` | Create | Feature declarations |
+| `apps/mercato/src/modules/example_customers_sync/di.ts` | Create | Service/worker wiring via DI |
+| `apps/mercato/src/modules/example_customers_sync/events.ts` | Create | Sync module event declarations |
+| `apps/mercato/src/modules/example_customers_sync/data/entities.ts` | Create | Mapping entity |
+| `apps/mercato/src/modules/example_customers_sync/data/validators.ts` | Create | zod schemas for APIs/commands |
+| `apps/mercato/src/modules/example_customers_sync/subscribers/*` | Create | Cross-module event handlers |
+| `apps/mercato/src/modules/example_customers_sync/workers/*` | Create | Retryable sync workers |
+| `apps/mercato/src/modules/example_customers_sync/api/get/mappings/route.ts` | Create | Mapping inspection API |
+| `apps/mercato/src/modules/example_customers_sync/api/post/reconcile/route.ts` | Create | Reconciliation trigger API |
+| `apps/mercato/src/modules.ts` | Modify | Register new extension module |
+| `RELEASE_NOTES.md` | Modify | BC/deprecation notes |
+
+### Integration Test Coverage (required)
+API paths:
+1. `GET /api/customers/interactions` (baseline canonical list still works)
+2. `POST /api/customers/interactions` triggers sync enqueue when flag enabled
+3. `POST /api/customers/interactions/complete` reflects done status to mapped example todo
+4. `DELETE /api/customers/interactions` removes/archives mapped example todo per policy
+5. `GET/POST/PUT/DELETE /api/example/todos` still works standalone when sync disabled
+6. `GET /api/example-customers-sync/mappings`
+7. `POST /api/example-customers-sync/reconcile`
+8. Loop-guard test: example update from sync origin does not re-enqueue reverse sync
+9. Tenant isolation test: mappings and sync events never cross `organization_id`
+10. Feature-disabled test: no sync side effects when `example.customers_sync.enabled=false`
+
+Key UI paths:
+1. `/backend/customer-tasks` with `example` enabled
+2. `/backend/customer-tasks` with `example` disabled
+3. `/backend/customers/people/[id]` tasks/interactions section with sync badges
+4. `/backend/todos` (example standalone todo UX remains functional)
+
+## Risks & Impact Review
+### Data Integrity Failures
+Risk of partial sync state (interaction written, mapping not yet written). Mitigation: idempotent worker retries + reconcile endpoint.
+
+### Cascading Failures & Side Effects
+Sync queue failures can delay example todo updates. Mitigation: non-blocking retries and visible sync error state.
+
+### Tenant & Data Isolation Risks
+Cross-module mapping bugs could leak references across orgs. Mitigation: strict tenant/org filters in all mapping queries and tests.
+
+### Migration & Deployment Risks
+Moving route ownership may confuse docs/navigation assumptions. Mitigation: same URL is preserved and release notes call out ownership change.
+
+### Operational Risks
+Bidirectional sync may produce event storms if guards fail. Mitigation: `_syncOrigin` + dedupe keys + alerting on failure rate.
+
+### Risk Register
+#### Route Ownership Regression
+- **Scenario**: `/backend/customer-tasks` fails when `example` is disabled.
+- **Severity**: High
+- **Affected area**: daily task planning UX.
+- **Mitigation**: customers-owned canonical route + integration test with example disabled.
+- **Residual risk**: stale external links to old page variant during transition.
+
+#### Sync Loop
+- **Scenario**: customers->example sync triggers example->customers sync repeatedly.
+- **Severity**: Critical
+- **Affected area**: queue load, duplicate updates, data stability.
+- **Mitigation**: `_syncOrigin` marker, dedupe job keys, idempotent mapping updates.
+- **Residual risk**: short-lived duplicate attempts under concurrent retries.
+
+#### Duplicate Todo Creation
+- **Scenario**: concurrent workers create multiple todos for one interaction.
+- **Severity**: High
+- **Affected area**: example todo list quality.
+- **Mitigation**: unique mapping constraints + upsert-first lookup + transactional mapping writes.
+- **Residual risk**: manual cleanup needed for already-created duplicates before constraint enforcement.
+
+#### Mapping Drift
+- **Scenario**: todo deleted manually, mapping still points to missing record.
+- **Severity**: Medium
+- **Affected area**: sync badge/link reliability.
+- **Mitigation**: reconcile API/worker and periodic repair scans.
+- **Residual risk**: temporary stale UI indicators.
+
+#### Provider-like Failure Coupling
+- **Scenario**: example sync worker outage blocks customers writes.
+- **Severity**: High
+- **Affected area**: perceived system reliability.
+- **Mitigation**: strict async boundary; customers command transactions never depend on sync worker success.
+- **Residual risk**: eventual consistency delay until workers recover.
+
+## Final Compliance Report — 2026-02-28
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/customers/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `packages/events/AGENTS.md`
+
+### Compliance Matrix
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| root `AGENTS.md` | No direct ORM relationships between modules | Compliant | Mapping table stores FK IDs only (`interaction_id`, `todo_id`) |
+| root `AGENTS.md` | Filter by `organization_id` for tenant-scoped entities | Compliant | Mapping model and sync APIs require tenant/org scope |
+| root `AGENTS.md` | Validate all inputs with zod | Compliant | Sync APIs/commands require zod validators |
+| root `AGENTS.md` | API routes MUST export `openApi` | Compliant | New sync operational routes include OpenAPI docs |
+| root `AGENTS.md` | Undoability default for state changes | Compliant | Sync commands are idempotent and compensating via events/reconcile |
+| root `AGENTS.md` | Keep pageSize at or below 100 | Compliant | Mapping list endpoint enforces `limit <= 100` |
+| root `AGENTS.md` | Backward-compatibility deprecation protocol | Compliant | `/backend/customer-tasks` URL remains stable; ownership moves to customers without route removal |
+| `packages/core/AGENTS.md` | Event declarations in `events.ts` with `as const` | Compliant | Sync and customers events explicitly declared |
+| `packages/core/AGENTS.md` | Run `npm run modules:prepare` after event/subscriber changes | Compliant | Explicit implementation step added in Phase 2 |
+| `packages/events/AGENTS.md` | Persistent subscribers must be idempotent | Compliant | Sync workers/subscribers use mapping upsert + dedupe keys |
+| `customers/AGENTS.md` | Follow customers CRUD/UI patterns | Compliant | Customer tasks page ownership moved to customers module conventions |
+| `packages/ui/AGENTS.md` | Use guarded mutations for non-`CrudForm` writes | Compliant | Any custom sync-trigger UI actions must use guarded mutation path |
+
+### Internal Consistency Check
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | Mapping entity aligns with list/reconcile API surfaces |
+| API contracts match UI/UX section | Pass | Route ownership and sync badge behavior align with APIs |
+| Risks cover all write operations | Pass | Interaction writes, todo writes, reconcile writes covered |
+| Commands defined for all mutations | Pass | Upsert/delete/sync/reconcile command set defined |
+| Cache strategy covers all read APIs | Pass | No mandatory new cache; scoped DB reads and limits defined |
+
+### Non-Compliant Items
+- None.
+
+### Verdict
+- **Fully compliant**: Approved — ready for implementation planning.
+
+## Changelog
+### 2026-03-02
+- Renumbered this specification from `SPEC-050` to `SPEC-046c` as a child workstream of customer detail rewrite.
+- Updated dependency references from `SPEC-049` to `SPEC-046b`.
+
+### 2026-02-28 (rev 2)
+- Removed conflicting dual-owner route strategy for `/backend/customer-tasks`; defined single ownership in customers module.
+- Added explicit idempotency/compensation contract for sync commands and side effects.
+- Split sync module ACL from `example.todos.*` to `example_customers_sync.*`.
+- Added required `npm run modules:prepare` step for generator registration after event/subscriber changes.
+- Clarified explicit dependency on `SPEC-046b-2026-02-27-customers-interactions-unification.md`.
+
+### 2026-02-28
+- Initial specification for splitting `example` demo ownership from customers task integration behavior.
+- Added UMES-aligned sync extension design (`example_customers_sync`) with explicit mapping, loop guards, and route ownership migration.
+
+### Review — 2026-02-28
+- **Reviewer**: Agent
+- **Security**: Passed
+- **Performance**: Passed
+- **Cache**: Passed
+- **Commands**: Passed
+- **Risks**: Passed
+- **Verdict**: Approved

--- a/.ai/specs/SPEC-049-2026-02-27-customers-interactions-unification.md
+++ b/.ai/specs/SPEC-049-2026-02-27-customers-interactions-unification.md
@@ -1,0 +1,13 @@
+# SPEC-049 (Moved): Customers Interactions Unification
+
+This specification was renumbered to align with the customer detail rewrite workstream.
+
+- New canonical file: [`SPEC-046b-2026-02-27-customers-interactions-unification.md`](SPEC-046b-2026-02-27-customers-interactions-unification.md)
+- New canonical spec id: `SPEC-046b`
+
+This file is kept as a permanent pointer so existing references to `SPEC-049-2026-02-27-customers-interactions-unification.md` do not break.
+
+## Changelog
+### 2026-03-02
+- Marked this file as moved pointer.
+- Canonical content moved to `SPEC-046b`.

--- a/.ai/specs/SPEC-050-2026-02-28-example-module-umes-alignment-customer-tasks.md
+++ b/.ai/specs/SPEC-050-2026-02-28-example-module-umes-alignment-customer-tasks.md
@@ -1,0 +1,13 @@
+# SPEC-050 (Moved): Example Module UMES Alignment for Customer Tasks
+
+This specification was renumbered to align with the customer detail rewrite workstream.
+
+- New canonical file: [`SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md`](SPEC-046c-2026-02-28-example-module-umes-alignment-customer-tasks.md)
+- New canonical spec id: `SPEC-046c`
+
+This file is kept as a permanent pointer so existing references to `SPEC-050-2026-02-28-example-module-umes-alignment-customer-tasks.md` do not break.
+
+## Changelog
+### 2026-03-02
+- Marked this file as moved pointer.
+- Canonical content moved to `SPEC-046c`.

--- a/apps/mercato/src/modules/example/__integration__/TC-UMES-006.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/TC-UMES-006.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('TC-UMES-006: transformFormData applyToForm opt-in', () => {
+  test('TC-UMES-E20: default path — transformed payload does not update visible form fields', async ({
+    page,
+  }) => {
+    const { login } = await import(
+      '@open-mercato/core/modules/core/__integration__/helpers/auth'
+    )
+    await login(page, 'admin')
+    await page.goto('/backend/umes-handlers')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('widget-transform-form-data')).toBeVisible()
+
+    const titleInput = page.locator('[data-crud-field-id="title"] input').first()
+    await titleInput.fill('  spaces around  ')
+    await page.keyboard.press('Tab')
+
+    await page.locator('form button[type="submit"]').first().click()
+
+    // Payload should contain trimmed value
+    await expect
+      .poll(async () => page.getByTestId('phase-c-submit-result').textContent(), { timeout: 8_000 })
+      .toContain('"title":"spaces around"')
+
+    // Visible form field must NOT be updated — still shows the user-typed value
+    await expect(titleInput).toHaveValue('  spaces around  ')
+  })
+
+  test('TC-UMES-E21: opt-in path — applyToForm: true reflects transformed values back into visible form fields', async ({
+    page,
+  }) => {
+    const { login } = await import(
+      '@open-mercato/core/modules/core/__integration__/helpers/auth'
+    )
+    await login(page, 'admin')
+    await page.goto('/backend/umes-handlers')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('widget-transform-form-data')).toBeVisible()
+
+    const noteInput = page.locator('[data-crud-field-id="note"] input').first()
+    await noteInput.fill('transform: make me uppercase')
+    await page.keyboard.press('Tab')
+
+    await page.locator('form button[type="submit"]').first().click()
+
+    // Payload should contain transformed value
+    await expect
+      .poll(async () => page.getByTestId('phase-c-submit-result').textContent(), { timeout: 8_000 })
+      .toContain('"note":"MAKE ME UPPERCASE"')
+
+    // Visible form field MUST be updated because applyToForm: true was returned
+    await expect(noteInput).toHaveValue('MAKE ME UPPERCASE')
+  })
+})

--- a/apps/mercato/src/modules/example/widgets/injection/crud-validation/widget.ts
+++ b/apps/mercato/src/modules/example/widgets/injection/crud-validation/widget.ts
@@ -128,6 +128,9 @@ const widget: InjectionWidgetModule<any, any> = {
           }
         }
         sharedState?.set('lastTransformFormData', trimmed)
+        if (shouldTransform) {
+          return { data: trimmed as typeof data, applyToForm: true }
+        }
         return trimmed as typeof data
       }
       return data

--- a/packages/create-app/template/src/modules/example/__integration__/TC-UMES-006.spec.ts
+++ b/packages/create-app/template/src/modules/example/__integration__/TC-UMES-006.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('TC-UMES-006: transformFormData applyToForm opt-in', () => {
+  test('TC-UMES-E20: default path — transformed payload does not update visible form fields', async ({
+    page,
+  }) => {
+    const { login } = await import(
+      '@open-mercato/core/modules/core/__integration__/helpers/auth'
+    )
+    await login(page, 'admin')
+    await page.goto('/backend/umes-handlers')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('widget-transform-form-data')).toBeVisible()
+
+    const titleInput = page.locator('[data-crud-field-id="title"] input').first()
+    await titleInput.fill('  spaces around  ')
+    await page.keyboard.press('Tab')
+
+    await page.locator('form button[type="submit"]').first().click()
+
+    // Payload should contain trimmed value
+    await expect
+      .poll(async () => page.getByTestId('phase-c-submit-result').textContent(), { timeout: 8_000 })
+      .toContain('"title":"spaces around"')
+
+    // Visible form field must NOT be updated — still shows the user-typed value
+    await expect(titleInput).toHaveValue('  spaces around  ')
+  })
+
+  test('TC-UMES-E21: opt-in path — applyToForm: true reflects transformed values back into visible form fields', async ({
+    page,
+  }) => {
+    const { login } = await import(
+      '@open-mercato/core/modules/core/__integration__/helpers/auth'
+    )
+    await login(page, 'admin')
+    await page.goto('/backend/umes-handlers')
+    await page.waitForLoadState('domcontentloaded')
+    await expect(page.getByTestId('widget-transform-form-data')).toBeVisible()
+
+    const noteInput = page.locator('[data-crud-field-id="note"] input').first()
+    await noteInput.fill('transform: make me uppercase')
+    await page.keyboard.press('Tab')
+
+    await page.locator('form button[type="submit"]').first().click()
+
+    // Payload should contain transformed value
+    await expect
+      .poll(async () => page.getByTestId('phase-c-submit-result').textContent(), { timeout: 8_000 })
+      .toContain('"note":"MAKE ME UPPERCASE"')
+
+    // Visible form field MUST be updated because applyToForm: true was returned
+    await expect(noteInput).toHaveValue('MAKE ME UPPERCASE')
+  })
+})

--- a/packages/create-app/template/src/modules/example/widgets/injection/crud-validation/widget.ts
+++ b/packages/create-app/template/src/modules/example/widgets/injection/crud-validation/widget.ts
@@ -128,6 +128,9 @@ const widget: InjectionWidgetModule<any, any> = {
           }
         }
         sharedState?.set('lastTransformFormData', trimmed)
+        if (shouldTransform) {
+          return { data: trimmed as typeof data, applyToForm: true }
+        }
         return trimmed as typeof data
       }
       return data

--- a/packages/shared/src/modules/widgets/injection.ts
+++ b/packages/shared/src/modules/widgets/injection.ts
@@ -122,8 +122,12 @@ export type WidgetInjectionEventHandlers<TContext = unknown, TData = unknown> = 
   /**
    * Transform form data before submission. Output of widget N becomes input of widget N+1.
    * Transformer event — pipeline dispatch.
+   *
+   * Return `{ data, applyToForm: true }` to also reflect the transformed values back into
+   * the visible form fields (opt-in). Default behavior (returning plain `TData`) only
+   * modifies the submit payload and leaves the visible form unchanged.
    */
-  transformFormData?: (data: TData, context: TContext) => Promise<TData>
+  transformFormData?: (data: TData, context: TContext) => Promise<TData | { data: TData; applyToForm: true }>
 
   /**
    * Transform data for display purposes. Output of widget N becomes input of widget N+1.

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -1556,6 +1556,9 @@ export function CrudForm<TValues extends Record<string, unknown>>({
             delete projectedCoreValues[injectedId]
           }
           coreSubmitValues = schema ? schema.parse(projectedCoreValues) : (projectedCoreValues as TValues)
+          if (result.applyToForm) {
+            setValues(result.data as CrudFormValues<TValues>)
+          }
         }
       } catch (err) {
         console.error('[CrudForm] Error in transformFormData:', err)


### PR DESCRIPTION
 
  ## Video
 
[open-mercato-fix-742.webm](https://github.com/user-attachments/assets/5e740025-1561-48f0-86b7-ee549f58a5e2)  

  ## Summary

  `transformFormData` injection handlers could only modify the submit payload — the visible form fields always retained
  the pre-transform values. This adds an opt-in mechanism: when a handler returns `{ data, applyToForm: true }`,
  `CrudForm` also updates the visible field values to match the transformed data. Default behavior (returning plain data)
  is unchanged.

  ## Changes

  - `packages/shared/src/modules/widgets/injection.ts` — widened `transformFormData` return type to allow `{ data: TData;
  applyToForm: true }` (additive, backward compatible)
  - `packages/ui/src/backend/injection/InjectionSpot.tsx` — pipeline now tracks `applyToForm` flag and forwards it in the
  result
  - `packages/ui/src/backend/CrudForm.tsx` — calls `setValues()` to update visible fields when `applyToForm: true` is
  returned
  - `apps/mercato/src/modules/example/widgets/injection/crud-validation/widget.ts` — example widget demonstrates opt-in by
   returning `{ data, applyToForm: true }` when transform is applied
  - `packages/create-app/template/...` — template files synced with the above changes
  - `TC-UMES-004.spec.ts` — integration tests for both paths (default and opt-in)

  ## Specification

  **Does a spec exist for this feature/module?**
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**

  ## Testing

  ```bash
  yarn test:integration --grep "TC-UMES-004"
  # 2 passed

  - TC-UMES-E20 — verifies default path: trimmed payload sent, visible field unchanged
  - TC-UMES-E21 — verifies opt-in path: applyToForm: true reflects transformed value back into visible input

  Checklist

  - This pull request targets develop.
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
  - I updated documentation, locales, or generators if the change requires it.
  - I added or adjusted tests that cover the change.
  - I added or updated integration tests in .ai/qa/tests/ (or documented why integration coverage is not required).
  - I created or updated the spec in .ai/specs/ with a changelog entry (if applicable).

  Linked issues

  Fixes https://github.com/open-mercato/open-mercato/issues/742