### PR TITLE
feat: add mandatory ci/cd-like verification gate to code-review skill

### DIFF
--- a/.ai/skills/code-review/SKILL.md
+++ b/.ai/skills/code-review/SKILL.md
@@ -45,23 +45,6 @@ Run these commands and verify each one exits successfully (exit code 0):
 - **No excuses**: "Pre-existing on develop", "flaky test", "not our code" are not valid reasons to skip. If it fails on your branch, it will fail on CI. Fix it or flag it as a blocker.
 - **Evidence required**: The review output MUST include the actual pass/fail result of each gate step. Do not assume — run the commands and report what happened.
 
-### Gate Output (include in review report)
-
-```markdown
-## CI/CD Verification
-
-| Gate | Status | Notes |
-|------|--------|-------|
-| `yarn build:packages` | PASS/FAIL | |
-| `yarn generate` | PASS/FAIL | |
-| `yarn build:packages` (rebuild) | PASS/FAIL | |
-| `yarn i18n:check-sync` | PASS/FAIL | |
-| `yarn i18n:check-usage` | PASS/FAIL/WARN | (non-blocking in CI) |
-| `yarn typecheck` | PASS/FAIL | |
-| `yarn test` | PASS/FAIL | |
-| `yarn build:app` | PASS/FAIL | |
-```
-
 ## Output Format
 
 Use this structure for every review:


### PR DESCRIPTION
## Summary

  Expand the code-review skill with a mandatory CI/CD verification gate that mirrors the exact checks from `.github/workflows/ci.yml`. This ensures no code is claimed "ready to ship" without
  locally verifying all CI gates pass first — preventing embarrassing CI failures on submitted PRs.

  ## Changes

  - Added **CI/CD Verification Gate** section to `.ai/skills/code-review/SKILL.md` as mandatory
  step 3 in the review workflow
  - Gate runs 8 commands matching CI pipeline: `build:packages`, `generate`, rebuild,
  `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`
  - Added gate output table to the review report template so every review includes pass/fail
  evidence
  - Enforces "no excuses" policy: pre-existing failures, flaky tests, and "not our code" are not
  valid reasons to skip
  - Renumbered workflow steps (4-9) to accommodate the new gate

  ## Specification

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [ ] I updated documentation, locales, or generators if the change requires it.
  - [ ] I added or adjusted tests that cover the change.
  - [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration
  coverage is not required).
    - N/A: Skill file change only, no runtime code affected.
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
    - N/A: No spec needed for skill configuration.