### PR TITLE
fix/780: added scroll function

### DIFF
--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -657,6 +657,7 @@ export function DataTable<T>({
   const t = useT()
   const router = useRouter()
   const resolvedRowClickActionIds = rowClickActionIds ?? DEFAULT_ROW_CLICK_ACTION_IDS
+  const containerRef = React.useRef<HTMLDivElement>(null)
   const lastScopeRef = React.useRef<OrganizationScopeChangedDetail | null>(null)
   const hasInitializedScopeRef = React.useRef(false)
   React.useEffect(() => {
@@ -1441,6 +1442,13 @@ export function DataTable<T>({
     initialPerspectiveAppliedRef.current = true
   }, [canUsePerspectives, perspectiveData, perspectiveTableId, perspectiveConfig, applyPerspectiveSettings, activePerspectiveId])
 
+  const scrollTableIntoView = React.useCallback(() => {
+    const rect = containerRef.current?.getBoundingClientRect()
+    if (!rect || rect.top >= 0) return
+    const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'instant' : 'smooth'
+    containerRef.current?.scrollIntoView({ behavior, block: 'start' })
+  }, [])
+
   const renderPagination = () => {
     if (!pagination) return null
 
@@ -1481,7 +1489,7 @@ export function DataTable<T>({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => onPageChange(page - 1)}
+            onClick={() => { onPageChange(page - 1); scrollTableIntoView() }}
             disabled={page <= 1}
           >
             {t('ui.dataTable.pagination.previous', 'Previous')}
@@ -1492,7 +1500,7 @@ export function DataTable<T>({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => onPageChange(page + 1)}
+            onClick={() => { onPageChange(page + 1); scrollTableIntoView() }}
             disabled={page >= totalPages}
           >
             {t('ui.dataTable.pagination.next', 'Next')}
@@ -1803,7 +1811,7 @@ export function DataTable<T>({
 
   return (
     <TooltipProvider delayDuration={300}>
-    <div className={containerClassName} data-component-handle={resolvedReplacementHandle}>
+    <div ref={containerRef} className={containerClassName} data-component-handle={resolvedReplacementHandle}>
       {shouldRenderHeader && (
         <div className={headerWrapperClassName}>
           {(hasTitle || shouldRenderActionsWrapper || renderToolbarInline) && (


### PR DESCRIPTION
## Summary

When navigating between pages in a paginated DataTable, the scroll position remained at the bottom of the page after the new page loaded, forcing users to manually scroll back up to see the results. This fix automatically scrolls to the top of the table container when the user clicks Next or Previous in the pagination controls.

The scroll is skipped entirely if the table top is already visible in the viewport (no unnecessary jumps). Animation respects the user's system-level prefers-reduced-motion preference — smooth scrolling is used by default, falling back to an instant jump for users who have motion reduction enabled in their OS accessibility settings.

Changes

- packages/ui/src/backend/DataTable.tsx: added containerRef (React.useRef) on the root container <div>
- added scrollTableIntoView (memoized with React.useCallback) that:
- skips scroll if containerRef.current.getBoundingClientRect().top >= 0 (table already visible)
- reads window.matchMedia('(prefers-reduced-motion: reduce)') at call time to select 'smooth' or 'instant'
- calls scrollIntoView({ behavior, block: 'start' }) on the container ref
- wired scrollTableIntoView() into the Previous and Next button onClick handlers alongside the existing onPageChange


Specification

Does a spec exist for this feature/module?
- N/A (minor change, no spec needed)

Linked issues: https://github.com/open-mercato/open-mercato/issues/780