### PR TITLE
fix(customers): preserve nested profile payload fields in people API

### DIFF
--- a/packages/core/src/modules/customers/api/__tests__/people.payload.test.ts
+++ b/packages/core/src/modules/customers/api/__tests__/people.payload.test.ts
@@ -1,0 +1,46 @@
+import { normalizePersonPayload } from '../people/payload'
+
+describe('customers people payload normalization', () => {
+  it('lifts nested profile fields to top-level payload', () => {
+    const normalized = normalizePersonPayload({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      profile: {
+        linkedInUrl: 'https://linkedin.example.com/in/ada',
+        timezone: 'America/Chicago',
+      },
+    })
+
+    expect(normalized).toMatchObject({
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      linkedInUrl: 'https://linkedin.example.com/in/ada',
+      timezone: 'America/Chicago',
+    })
+    expect(normalized).not.toHaveProperty('profile')
+  })
+
+  it('keeps explicit top-level values when both shapes are provided', () => {
+    const normalized = normalizePersonPayload({
+      linkedInUrl: 'https://linkedin.example.com/in/top-level',
+      profile: {
+        linkedInUrl: 'https://linkedin.example.com/in/nested',
+      },
+    })
+
+    expect(normalized.linkedInUrl).toBe('https://linkedin.example.com/in/top-level')
+    expect(normalized).not.toHaveProperty('profile')
+  })
+
+  it('returns non-profile payloads unchanged', () => {
+    const normalized = normalizePersonPayload({
+      id: '7f8ee770-1f3e-41e2-b80d-a0fdbf527f66',
+      linkedInUrl: 'https://linkedin.example.com/in/person',
+    })
+
+    expect(normalized).toEqual({
+      id: '7f8ee770-1f3e-41e2-b80d-a0fdbf527f66',
+      linkedInUrl: 'https://linkedin.example.com/in/person',
+    })
+  })
+})

--- a/packages/core/src/modules/customers/api/people/payload.ts
+++ b/packages/core/src/modules/customers/api/people/payload.ts
@@ -1,0 +1,39 @@
+const NESTED_PROFILE_FIELDS = [
+  'firstName',
+  'lastName',
+  'preferredName',
+  'jobTitle',
+  'department',
+  'seniority',
+  'timezone',
+  'linkedInUrl',
+  'twitterUrl',
+  'companyEntityId',
+] as const
+
+export function normalizePersonPayload(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {}
+  }
+
+  const payload = { ...(raw as Record<string, unknown>) }
+  const profile = payload.profile
+
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    return payload
+  }
+
+  const profileRecord = profile as Record<string, unknown>
+
+  for (const field of NESTED_PROFILE_FIELDS) {
+    if (payload[field] !== undefined) continue
+    if (!Object.prototype.hasOwnProperty.call(profileRecord, field)) continue
+    const value = profileRecord[field]
+    if (value !== undefined) {
+      payload[field] = value
+    }
+  }
+
+  delete payload.profile
+  return payload
+}

--- a/packages/core/src/modules/customers/api/people/route.ts
+++ b/packages/core/src/modules/customers/api/people/route.ts
@@ -7,6 +7,7 @@ import { E } from '#generated/entities.ids.generated'
 import { personCreateSchema, personUpdateSchema } from '../../data/validators'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { withScopedPayload } from '../utils'
+import { normalizePersonPayload } from './payload'
 import { buildCustomFieldFiltersFromQuery, extractAllCustomFieldEntries, splitCustomFieldPayload } from '@open-mercato/shared/lib/crud/custom-fields'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
@@ -203,7 +204,8 @@ const crud = makeCrudRoute({
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
         const scoped = withScopedPayload(raw ?? {}, ctx, translate)
-        const { base, custom } = splitCustomFieldPayload(scoped)
+        const normalized = normalizePersonPayload(scoped)
+        const { base, custom } = splitCustomFieldPayload(normalized)
         const parsed = personCreateSchema.parse(base)
         return Object.keys(custom).length ? { ...parsed, customFields: custom } : parsed
       },
@@ -219,7 +221,8 @@ const crud = makeCrudRoute({
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
         const scoped = withScopedPayload(raw ?? {}, ctx, translate)
-        const { base, custom } = splitCustomFieldPayload(scoped)
+        const normalized = normalizePersonPayload(scoped)
+        const { base, custom } = splitCustomFieldPayload(normalized)
         const parsed = personUpdateSchema.parse(base)
         return Object.keys(custom).length ? { ...parsed, customFields: custom } : parsed
       },


### PR DESCRIPTION
## Summary
Fixes silent data loss/no-op updates when clients send person profile fields inside a nested `profile` object (for example `profile.linkedInUrl`) to `/api/customers/people` create/update endpoints.

Fixes #792
Also addresses #793

## Changes
- added `normalizePersonPayload` to lift known `profile.*` fields into the top-level payload shape consumed by existing validators/commands
- wired normalization into both `POST /api/customers/people` and `PUT /api/customers/people` mapInput flows
- added regression tests for nested-field lifting and top-level precedence

## Specification
**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor bug fix; no new module/feature surface)

**Spec file path:**
N/A

## Testing
- `corepack yarn workspace @open-mercato/core test src/modules/customers/api/__tests__/people.payload.test.ts`

## Checklist
- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues
Fixes #792
References #793
