### PR TITLE
fix: [UI] Text not visible unless focused on filter dropdowns using dark mode

### DIFF
--- a/apps/mercato/src/app/globals.css
+++ b/apps/mercato/src/app/globals.css
@@ -58,6 +58,7 @@ TODO: Fix that latter to have reference by the package names
 }
 
 :root {
+  color-scheme: light;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -104,6 +105,7 @@ TODO: Fix that latter to have reference by the package names
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -154,6 +156,11 @@ TODO: Fix that latter to have reference by the package names
   }
   body {
     @apply bg-background text-foreground;
+  }
+  select,
+  select option {
+    background-color: var(--background);
+    color: var(--foreground);
   }
 }
 

--- a/packages/create-app/template/src/app/globals.css
+++ b/packages/create-app/template/src/app/globals.css
@@ -58,6 +58,7 @@ TODO: Fix that latter to have reference by the package names
 }
 
 :root {
+  color-scheme: light;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -104,6 +105,7 @@ TODO: Fix that latter to have reference by the package names
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -154,6 +156,11 @@ TODO: Fix that latter to have reference by the package names
   }
   body {
     @apply bg-background text-foreground;
+  }
+  select,
+  select option {
+    background-color: var(--background);
+    color: var(--foreground);
   }
 }
 


### PR DESCRIPTION
## Summary

  Fix for [#783](https://github.com/open-mercato/open-mercato/issues/783) — native `<select>` dropdown text is invisible   in dark mode (white text on white background). The root cause is twofold: (1) the CSS was missing the `color-scheme`
  property that tells browsers how to render native form controls in dark mode, and (2) native `<select>` and `<option>`   elements had no explicit theme-aware background/text colors. This affects 80+ native `<select>` elements across the
  entire codebase (filters, CrudForm selects, date pickers, workflow editors, etc.).

  ## Changes

  - Added `color-scheme: light` to `:root` and `color-scheme: dark` to `.dark` in `apps/mercato/src/app/globals.css` —
  the CSS standard for telling browsers to render native controls (selects, date pickers, scrollbars) in the correct
  theme
  - Added explicit `background-color: var(--background)` and `color: var(--foreground)` for `select` and `select option`
   elements in `@layer base` — ensures native dropdown popups use theme colors on all platforms (Windows Chrome was not
  respecting `color-scheme` alone)
  - Mirrored all changes in `packages/create-app/template/src/app/globals.css` to keep standalone app template in sync

  ## Specification

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  N/A — CSS-only bugfix, no architectural changes.

  ## Testing

  - `yarn build:packages` — all 14 packages built successfully
  - `yarn build` — full Next.js app build passed
  - Manual verification: toggled dark mode and confirmed `<select>` dropdown text is now visible on filter overlays
  (`/backend/customers/people`, etc.)

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it.
  - [ ] I added or adjusted tests that cover the change.
  - [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not
  required).
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable)

  > **Note on tests**: This is a CSS-only fix (4 lines across 2 globals.css files). Dark mode styling of native
  `<select>` elements is not testable via unit tests and would require visual regression testing. Integration test
  coverage is not applicable for raw CSS property additions.

## Linked issues
#783 

<img width="724" height="280" alt="obraz" src="https://github.com/user-attachments/assets/ede6b2ff-f664-41d2-b507-9c7d922cf5a6" />
<img width="420" height="452" alt="obraz" src="https://github.com/user-attachments/assets/f3a9e0e5-90d9-405d-95f5-d1099b88826b" />
<img width="388" height="487" alt="obraz" src="https://github.com/user-attachments/assets/49c81c61-3662-4d34-b6b4-2debff87e689" />

