### PR TITLE
fix: issue with dead-end screens (UX)

### DIFF
--- a/packages/core/src/modules/auth/backend/profile/page.tsx
+++ b/packages/core/src/modules/auth/backend/profile/page.tsx
@@ -1,19 +1,12 @@
 'use client'
-import * as React from 'react'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Spinner } from '@open-mercato/ui/primitives/spinner'
 
 export default function ProfilePage() {
-  const t = useT()
-
-  return (
-    <div className="max-w-2xl">
-      <h1 className="text-2xl font-bold mb-2">{t('profile.page.title', 'Profile')}</h1>
-      <p className="text-muted-foreground mb-6">
-        {t('profile.page.description', 'Manage your account settings')}
-      </p>
-      <p className="text-sm text-muted-foreground">
-        {t('profile.page.selectItem', 'Select an item from the menu to manage your account.')}
-      </p>
-    </div>
-  )
+  const router = useRouter()
+  useEffect(() => {
+    router.replace('/backend/profile/change-password')
+  }, [router])
+  return <Spinner className="h-4 w-4" />
 }

--- a/packages/core/src/modules/auth/backend/settings/page.tsx
+++ b/packages/core/src/modules/auth/backend/settings/page.tsx
@@ -1,19 +1,12 @@
 'use client'
-import * as React from 'react'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { Spinner } from '@open-mercato/ui/primitives/spinner'
 
 export default function SettingsPage() {
-  const t = useT()
-
-  return (
-    <div className="max-w-2xl">
-      <h1 className="text-2xl font-bold mb-2">{t('settings.page.title', 'Settings')}</h1>
-      <p className="text-muted-foreground mb-6">
-        {t('settings.page.description', 'System configuration and administration')}
-      </p>
-      <p className="text-sm text-muted-foreground">
-        {t('settings.page.selectItem', 'Select an item from the menu to configure system settings.')}
-      </p>
-    </div>
-  )
+  const router = useRouter()
+  useEffect(() => {
+    router.replace('/backend/config/system-status')
+  }, [router])
+  return <Spinner className="h-4 w-4" />
 }


### PR DESCRIPTION
## Summary

  Navigating to top-level routes `/backend/settings` and `/backend/profile` led to dead-end placeholder screens ("Select   an item from the menu...") with no actionable content. This replaces both placeholders with client-side redirects to
  their first meaningful sub-route, eliminating the dead-end navigation states.                                         
  Fixes #769

  ## Changes

  - Replace `/backend/settings` placeholder with redirect to `/backend/config/system-status` (first settings page)
  - Replace `/backend/profile` placeholder with redirect to `/backend/profile/change-password` (only profile sub-route)
  - Both use `router.replace()` to prevent back-button loops and show a `Spinner` during the brief redirect

  ## Specification

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  N/A

  ## Testing

  - `yarn build:packages` — all 14 packages build successfully
  - Manual: navigate to `/backend/settings` → redirects to `/backend/config/system-status`
  - Manual: navigate to `/backend/profile` → redirects to `/backend/profile/change-password`
  - Manual: browser back button returns to previous page, no redirect loop
  - Manual: settings sidebar sub-navigation works normally after redirect

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it.
  - [ ] I added or adjusted tests that cover the change.
  - [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not
  required).
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable)

  > **Note on tests**: These are trivial redirect-only pages with no business logic — a `useEffect` + `router.replace()`
   with a spinner. The redirect targets themselves have existing coverage. Manual verification is sufficient.