### PR TITLE
feat(create-app): bundle .ai directory into scaffolded standalone apps

### DIFF
--- a/packages/create-app/build.mjs
+++ b/packages/create-app/build.mjs
@@ -1,6 +1,9 @@
 import * as esbuild from 'esbuild'
-import { writeFileSync, readFileSync, chmodSync } from 'fs'
+import { writeFileSync, readFileSync, chmodSync, cpSync, rmSync, existsSync, mkdirSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
 const shebang = '#!/usr/bin/env node\n'
 
 await esbuild.build({
@@ -16,7 +19,29 @@ await esbuild.build({
   },
 })
 
-// Make the output executable
 chmodSync('dist/index.js', 0o755)
+
+const repoRoot = join(__dirname, '..', '..')
+const aiSrc = join(repoRoot, '.ai')
+const aiDest = join(__dirname, 'dist', 'ai')
+
+if (existsSync(aiDest)) {
+  rmSync(aiDest, { recursive: true })
+}
+
+if (existsSync(aiSrc)) {
+  cpSync(join(aiSrc, 'skills'), join(aiDest, 'skills'), { recursive: true })
+  cpSync(join(aiSrc, 'qa', 'AGENTS.md'), join(aiDest, 'qa', 'AGENTS.md'))
+  mkdirSync(join(aiDest, 'qa', 'scenarios'), { recursive: true })
+
+  cpSync(join(aiSrc, 'specs', 'AGENTS.md'), join(aiDest, 'specs', 'AGENTS.md'))
+  mkdirSync(join(aiDest, 'specs', 'enterprise'), { recursive: true })
+
+  writeFileSync(join(aiDest, 'lessons.md'), '# Lessons Learned\n\nRecord debugging insights, recurring fixes, and patterns discovered during development.\n')
+
+  console.log('Bundled .ai/ directory into dist/ai/')
+} else {
+  console.warn('Warning: .ai/ directory not found at repo root, skipping ai bundle')
+}
 
 console.log('Build complete: dist/index.js')

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -94,6 +94,8 @@ const FILE_RENAMES: Record<string, string> = {
   gitignore: '.gitignore',
 }
 
+const AI_DIR = join(__dirname, 'ai')
+
 const SKIP_DIRS = new Set(['__tests__', '__integration__'])
 
 function copyDirRecursive(src: string, dest: string, placeholders: Record<string, string>): void {
@@ -197,6 +199,10 @@ async function main(): Promise<void> {
   try {
     copyDirRecursive(TEMPLATE_DIR, targetDir, placeholders)
 
+    if (existsSync(AI_DIR)) {
+      copyDirRecursive(AI_DIR, join(targetDir, '.ai'), placeholders)
+    }
+
     console.log(pc.green('Success!') + ` Created ${pc.bold(appName)}`)
     console.log('')
     console.log('Next steps:')
@@ -209,6 +215,9 @@ async function main(): Promise<void> {
     console.log(pc.cyan('  yarn db:migrate'))
     console.log(pc.cyan('  yarn initialize'))
     console.log(pc.cyan('  yarn dev'))
+    console.log('')
+    console.log(pc.dim('  # Set up AI skills for spec-driven development'))
+    console.log(pc.cyan('  yarn install-skills'))
     console.log('')
     console.log('Docker alternatives:')
     console.log(pc.cyan('  # Dev (recommended on Windows): docker compose -f docker-compose.fullapp.dev.yml up --build'))

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -107,6 +107,47 @@ Add new modules to `src/modules.ts` with `from: '@app'`.
 
 Translation files in `src/i18n/{locale}.json`. Supported locales: en, pl, es, de.
 
+## Spec-Driven Development
+
+This app includes the `.ai/` directory for spec-driven development workflows.
+
+### Structure
+
+```
+.ai/
+├── lessons.md          # Debugging insights and recurring fixes
+├── qa/                 # QA integration testing instructions
+│   ├── AGENTS.md       # Testing conventions and templates
+│   └── scenarios/      # Optional markdown test case descriptions
+├── skills/             # Reusable AI agent workflows
+│   ├── README.md       # Skill installation and usage guide
+│   ├── spec-writing/   # Writing feature specifications
+│   ├── implement-spec/ # Implementing specs with coordinated agents
+│   ├── code-review/    # Code review against project conventions
+│   └── ...             # Additional skills
+└── specs/              # Feature specifications
+    ├── AGENTS.md       # Spec naming and structure conventions
+    └── enterprise/     # Enterprise-only specs
+```
+
+### Setup
+
+Install skills for your AI coding tool:
+
+```bash
+yarn install-skills
+```
+
+This creates symlinks so Claude Code (`/skills`) and Codex (`/skills`) can discover the skills.
+
+### Workflow
+
+1. Write a spec in `.ai/specs/` using `/spec-writing` skill
+2. Review with `/pre-implement-spec` before coding
+3. Implement with `/implement-spec` for coordinated execution
+4. Test with `/integration-tests` for automated QA
+5. Review with `/code-review` for quality gates
+
 ## Requirements
 
 - Node.js >= 24

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -15,6 +15,7 @@
     "db:greenfield": "mercato db greenfield",
     "initialize": "mercato init",
     "reinstall": "mercato init --reinstall",
+    "install-skills": "./scripts/install-skills.sh",
     "preinstall": "node -e \"const v = process.versions.node.split('.').map(Number); if (v[0] < 24) { console.error('Node >= 24 required'); process.exit(1); }\""
   },
   "dependencies": {

--- a/packages/create-app/template/scripts/install-skills.sh
+++ b/packages/create-app/template/scripts/install-skills.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ensure_skills_link() {
+  local target_path="$1"
+  local link_path="$2"
+
+  echo "Linking $link_path → $target_path"
+  mkdir -p "$(dirname "$link_path")"
+
+  if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
+    echo "Expected $link_path to be a symlink. Remove the existing path and re-run." >&2
+    exit 1
+  fi
+
+  if [ -L "$link_path" ]; then
+    rm -f "$link_path"
+  fi
+
+  ln -s "$target_path" "$link_path"
+  echo "Linked $link_path"
+}
+
+ensure_skills_link "../.ai/skills" ".codex/skills"
+ensure_skills_link "../.ai/skills" ".claude/skills"
+echo ""
+echo "Skills installation complete."
+echo ""
+echo "Test the install:"
+echo "  Claude Code: claude → /skills"
+echo "  Codex: codex → /skills"


### PR DESCRIPTION


<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The .ai folder (skills, specs structure, QA framework) was not being copied when scaffolding standalone apps via create-mercato-app. This makes spec-driven development available out of the box.

## Changes

- Build step copies .ai/ from repo root into dist/ai/ (skills, qa, specs structure only — no actual specs)
- Scaffolding copies dist/ai/ into the target app as .ai/
- Adds install-skills.sh script to template for skill symlink setup
- Documents spec-driven development workflow in template AGENTS.md

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

I run locally `node packages/create-app/dist/index.js test-ai` and ensured required files are copied

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #805 