### PR TITLE
fix(795): Fix updatedAt value in customer people API route

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-024.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-024.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { createPersonFixture, deleteEntityIfExists, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+
+/**
+ * TC-CRM-024: Person Profile-Only Update Timestamps (fix for issue #795)
+ *
+ * Verifies that:
+ * 1. `profile.updatedAt` is exposed in GET /api/customers/people/[id] response.
+ * 2. `person.updatedAt` advances when profile-only fields (e.g. linkedInUrl) are changed.
+ * 3. `profile.updatedAt` advances when profile-only fields are changed.
+ */
+test.describe('TC-CRM-024: Person Profile-Only Update Timestamps', () => {
+  test('should update person.updatedAt and expose profile.updatedAt on profile-only field change', async ({ request }) => {
+    let token: string | null = null;
+    let personId: string | null = null;
+
+    try {
+      token = await getAuthToken(request);
+      const ts = Date.now();
+      personId = await createPersonFixture(request, token, {
+        firstName: 'QA',
+        lastName: `CRM024${ts}`,
+        displayName: `QA TC-CRM-024 ${ts}`,
+      });
+
+      // Fetch initial state
+      const getInitial = await apiRequest(request, 'GET', `/api/customers/people/${personId}`, { token });
+      expect(getInitial.ok(), `Initial GET failed: ${getInitial.status()}`).toBeTruthy();
+      const initial = await readJsonSafe<Record<string, unknown>>(getInitial);
+      expect(initial).not.toBeNull();
+
+      const personBefore = initial!.person as Record<string, unknown>;
+      const profileBefore = initial!.profile as Record<string, unknown> | null;
+
+      expect(profileBefore, 'profile must be present in GET response').not.toBeNull();
+      expect(typeof profileBefore!.updatedAt, 'profile.updatedAt must be a string').toBe('string');
+      expect(typeof personBefore.updatedAt, 'person.updatedAt must be a string').toBe('string');
+
+      const personUpdatedAtBefore = new Date(personBefore.updatedAt as string).getTime();
+      const profileUpdatedAtBefore = new Date(profileBefore!.updatedAt as string).getTime();
+
+      // Wait 1 second so timestamp comparison is unambiguous
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+
+      // Update a profile-only field — no entity-level fields included
+      const putResponse = await apiRequest(request, 'PUT', '/api/customers/people', {
+        token,
+        data: {
+          id: personId,
+          linkedInUrl: 'https://linkedin.com/in/qa-crm-024',
+        },
+      });
+      expect(putResponse.ok(), `PUT failed: ${putResponse.status()}`).toBeTruthy();
+
+      // Fetch updated state
+      const getUpdated = await apiRequest(request, 'GET', `/api/customers/people/${personId}`, { token });
+      expect(getUpdated.ok(), `Updated GET failed: ${getUpdated.status()}`).toBeTruthy();
+      const updated = await readJsonSafe<Record<string, unknown>>(getUpdated);
+      expect(updated).not.toBeNull();
+
+      const personAfter = updated!.person as Record<string, unknown>;
+      const profileAfter = updated!.profile as Record<string, unknown> | null;
+
+      expect(profileAfter, 'profile must be present after update').not.toBeNull();
+      expect(typeof profileAfter!.updatedAt).toBe('string');
+
+      const personUpdatedAtAfter = new Date(personAfter.updatedAt as string).getTime();
+      const profileUpdatedAtAfter = new Date(profileAfter!.updatedAt as string).getTime();
+
+      // person.updatedAt must have advanced (issue #795 fix)
+      expect(
+        personUpdatedAtAfter,
+        `person.updatedAt (${personAfter.updatedAt}) should be later than initial (${personBefore.updatedAt})`,
+      ).toBeGreaterThan(personUpdatedAtBefore);
+
+      // profile.updatedAt must have advanced
+      expect(
+        profileUpdatedAtAfter,
+        `profile.updatedAt (${profileAfter!.updatedAt}) should be later than initial (${profileBefore!.updatedAt})`,
+      ).toBeGreaterThan(profileUpdatedAtBefore);
+
+      // The profile field change must be visible
+      expect(profileAfter!.linkedInUrl).toBe('https://linkedin.com/in/qa-crm-024');
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -613,6 +613,7 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
             linkedInUrl: profile.linkedInUrl,
             twitterUrl: profile.twitterUrl,
             companyEntityId: profile.company ? (typeof profile.company === 'string' ? profile.company : profile.company.id) : null,
+            updatedAt: profile.updatedAt.toISOString(),
           }
         : null,
       customFields,
@@ -777,6 +778,7 @@ const personDetailResponseSchema = z.object({
       linkedInUrl: z.string().nullable().optional(),
       twitterUrl: z.string().nullable().optional(),
       companyEntityId: z.string().uuid().nullable().optional(),
+      updatedAt: z.string(),
     })
     .nullable(),
   customFields: z.record(z.string(), z.unknown()),

--- a/packages/core/src/modules/customers/commands/people.ts
+++ b/packages/core/src/modules/customers/commands/people.ts
@@ -662,6 +662,15 @@ const updatePersonCommand: CommandHandler<PersonUpdateInput, { entityId: string 
       profile.company = await resolveCompanyReference(em, parsed.companyEntityId, record.organizationId, record.tenantId)
     }
 
+    const profileFieldsUpdated = [
+      parsed.firstName, parsed.lastName, parsed.preferredName, parsed.jobTitle,
+      parsed.department, parsed.seniority, parsed.timezone, parsed.linkedInUrl,
+      parsed.twitterUrl, parsed.companyEntityId,
+    ].some((v) => v !== undefined)
+    if (profileFieldsUpdated) {
+      record.updatedAt = new Date()
+    }
+
     if (parsed.displayName !== undefined) {
       const nextDisplayName = parsed.displayName.trim()
       if (!nextDisplayName) {


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

`person.updatedAt` was not advancing when only profile-specific fields (e.g.
`linkedInUrl`, `jobTitle`) were changed via `PUT /api/customers/people`.

**Root cause:** MikroORM's `onUpdate` hook only fires for entities with dirty
properties. Profile-only updates dirtied `CustomerPersonProfile` but left
`CustomerEntity` clean, so `customer_entities.updated_at` was never touched.

The fix explicitly marks `CustomerEntity` as dirty when any profile field is
present in the update payload, and additionally exposes `profile.updatedAt` in
the `GET /api/customers/people/[id]` response so consumers can track profile
mutations independently.

## Changes

- **`packages/core/src/modules/customers/commands/people.ts`** — in
  `updatePersonCommand.execute()`, detect when any profile field is present in
  the parsed payload and set `record.updatedAt = new Date()` on `CustomerEntity`
  to force MikroORM to flush it and advance `customer_entities.updated_at`
- **`packages/core/src/modules/customers/api/people/[id]/route.ts`** — expose
  `profile.updatedAt` as an ISO string in the `GET /api/customers/people/[id]`
  response; add `updatedAt: z.string()` to `personDetailResponseSchema` (additive,
  non-breaking)
- **`packages/core/src/modules/customers/__integration__/TC-CRM-024.spec.ts`** —
  new Playwright API integration test: creates a person fixture, records initial
  timestamps, issues a profile-only PUT (`linkedInUrl`), asserts both
  `person.updatedAt` and `profile.updatedAt` advanced and the field value persisted

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- N/A -->

## Testing

- New integration test `TC-CRM-024` covers the full regression scenario
- Run with: `yarn test:integration --grep "TC-CRM-024"`
- Manually verified:
  - `GET /api/customers/people/:id` returns `profile.updatedAt` as ISO string
  - After a profile-only PUT, `person.updatedAt` in the response is later than
    the pre-update value
  - Entity-level field updates (e.g. `displayName`) continue to work as before

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #795
