### PR TITLE
feat/preview-envs Implement preview Docker build stage and entrypoint…

### DIFF
--- a/.ai/specs/enterprise/SPEC-ENT-006-2026-03-01-qa-preview-deployment-dokploy.md
+++ b/.ai/specs/enterprise/SPEC-ENT-006-2026-03-01-qa-preview-deployment-dokploy.md
@@ -1,0 +1,454 @@
+# SPEC-ENT-006: QA Deployment on Dokploy via GitHub Actions
+
+## TLDR
+
+**Key Points:**
+- Two GitHub Actions workflows manage the full QA slot lifecycle: `qa-deploy.yml` (manual deploy) and `qa-stop-on-merge.yml` (automatic stop on PR close).
+- `qa-deploy.yml` builds the preview Docker image, pushes it to GHCR, updates the Dokploy slot via REST API, and optionally labels the PR (`qa:qa1` / `qa:qa2`) and posts a machine-readable marker comment used later for safe slot cleanup.
+- `qa-stop-on-merge.yml` triggers automatically when a labelled PR is closed (merged or abandoned), reads the marker comment to identify the expected image, verifies the slot still runs that image (safety check against concurrent redeployment), and stops the Dokploy application.
+- Each QA slot (`qa1`, `qa2`) maps to a pre-configured long-lived Dokploy application running as a Docker-provider app.
+
+**Scope:**
+- `.github/workflows/qa-deploy.yml` — manual build-and-deploy workflow
+- `.github/workflows/qa-stop-on-merge.yml` — automatic slot cleanup on PR merge
+- `docker/preview/Dockerfile` — dedicated preview image used for QA builds
+- `docker/preview/preview-entrypoint.sh` — baked into the image; invokes `yarn test:integration:ephemeral:start`
+- Fix `NODE_ENV` passthrough in `packages/cli/src/lib/testing/integration.ts`
+- `docker-compose.preview.yaml` — local single-service compose for running the preview image on a developer machine (port 5000→5001)
+- `.github/QA-DEPLOYMENT.md` — QA engineer runbook covering remote slot deploys and local preview usage
+- Dokploy application configuration (Docker provider, not GitHub source)
+- GitHub repository secrets and variables for GHCR + Dokploy API
+
+**Concerns:**
+- docker.sock mount gives the Dokploy container access to the host Docker daemon — acceptable for internal QA; must not be used in production.
+- First-ready latency is ~5–10 minutes per deployment (full install → generate → build → DB init → Next.js start).
+- Concurrent slot deployments are serialised per slot via GitHub Actions `concurrency` group (`cancel-in-progress: false`). A second run for the same slot queues behind the first.
+- The auto-stop workflow fires on any PR **close** (merged or abandoned). Slots deployed without a PR number association (no `qa:*` label) must be stopped manually via the Dokploy UI.
+
+---
+
+## Overview
+
+Open Mercato has no automated QA preview environment. Developers must run the full stack locally or share a single staging server. This spec introduces named QA slot deployments spanning two workflows:
+
+1. **Deploy** (`qa-deploy.yml`): A developer manually triggers the workflow, selects a slot (`qa1`/`qa2`), specifies the branch to build, and optionally associates a PR number. The workflow builds the preview image, pushes it to GHCR, updates the Dokploy application's Docker image via REST API, triggers a redeploy, and — if a PR number was supplied — labels the PR and posts a marker comment encoding the deployed slot and image tag.
+
+2. **Stop on close** (`qa-stop-on-merge.yml`): When a PR that carries a `qa:qa1` or `qa:qa2` label is closed (merged or abandoned), this workflow automatically detects the slot, reads the most recent marker comment to identify the expected image, fetches the current Dokploy application config to verify the image has not since been replaced by another deployment, and stops the slot only if the image matches.
+
+The environment uses an ephemeral PostgreSQL container (docker.sock) and resets on every deployment.
+
+---
+
+## Problem Statement
+
+- No automated QA environment exists. Testing a PR requires local setup or a shared staging server that gets overwritten.
+- Reviewers cannot verify a feature without checking out the branch locally.
+- Setting up the full stack locally takes 20–30 minutes for new contributors.
+- Shared staging environments cause race conditions and unclear ownership.
+
+---
+
+## Proposed Solution
+
+### Deploy workflow (`qa-deploy.yml`)
+
+Triggered manually via `workflow_dispatch` with inputs:
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `slot` | Yes | QA slot to deploy to (`qa1` or `qa2`) |
+| `branch` | Yes | Branch to checkout and build |
+| `pr_number` | No | PR number to label and comment on; omit for slot-only deploys |
+
+Steps:
+1. Checkout the specified branch.
+2. Build `docker/preview/Dockerfile` via `docker/build-push-action` with GHA cache (`type=gha`).
+3. Push image to GHCR as `ghcr.io/<org>/<repo>:<slot>-<sha7>`.
+4. Resolve Dokploy `applicationId` from repository variables (`DOKPLOY_APP_ID_QA1` / `DOKPLOY_APP_ID_QA2`).
+5. Call `POST /api/application.saveDockerProvider` to update the slot's Docker image reference.
+6. Call `POST /api/application.deploy` to trigger a redeploy.
+7. *(If `pr_number` provided)* Add label `qa:<slot>` to the PR.
+8. *(If `pr_number` provided)* Post a PR comment containing a machine-readable HTML marker: `<!-- dokploy-qa slot=<slot> image=<image_full> -->`, followed by a human-readable deployment summary.
+
+### Stop-on-close workflow (`qa-stop-on-merge.yml`)
+
+Triggered automatically on `pull_request` closed events (both merged and abandoned; gate: `action == 'closed'`).
+
+Steps:
+1. List labels on the merged PR; detect `qa:qa1` or `qa:qa2`.
+2. Skip silently if no QA label is present.
+3. Resolve Dokploy `applicationId` from repository variables.
+4. Paginate PR comments in reverse order; find the most recent comment containing `<!-- dokploy-qa slot=<slot> image=<image> -->` and extract the expected image tag.
+5. Fail (do not stop) if no marker comment is found — prevents accidental stops for slots that were not deployed via the workflow.
+6. Call `GET /api/application.one?applicationId=<id>` and extract `dockerImage` from the response.
+7. Compare current image with expected: if they differ (another PR redeployed the slot after this PR was last deployed), skip the stop and log a message.
+8. If images match, call `POST /api/application.stop` to stop the slot.
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Manual `workflow_dispatch` for deploy (not automatic webhook/label trigger) | Full developer control over when and what gets deployed to QA. Avoids race conditions from concurrent label events on multiple PRs. |
+| PR number as optional input, not inferred from branch | The workflow can be used for slot-only deploys (no associated PR). Explicit input avoids ambiguity. |
+| Machine-readable marker comment (`<!-- dokploy-qa ... -->`) | Embeds the expected image in the PR itself without external state storage. The stop workflow can reconstruct what was deployed without querying GHCR or a database. |
+| Image comparison safety check in stop workflow | A slot may have been redeployed for a different PR since this one last deployed. Comparing the live Dokploy image prevents stopping a slot that another team member is actively using. |
+| `action == 'closed'` gate in stop workflow | Fires on any PR close — merged or abandoned. Ensures slots are reclaimed regardless of how the PR was resolved. |
+| Pre-build image in CI, push to GHCR, then tell Dokploy | Decouples build from deployment. CI has build cache (`type=gha`); Dokploy does not need GitHub App access. Cleaner separation of concerns. |
+| Named slots (`qa1`, `qa2`) instead of per-PR ephemeral URLs | Predictable URLs, predictable resource usage, easier to share with stakeholders. |
+| `cancel-in-progress: false` concurrency per slot | Queues concurrent deploys to the same slot rather than cancelling in-flight builds; prevents partial deployments. |
+| Standalone `docker/preview/Dockerfile` | Keeps preview tooling (docker-cli, jest config) isolated from the main production `Dockerfile`. |
+
+### Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Dokploy native GitHub webhook (per-PR label trigger) | More complex to configure, requires Dokploy GitHub App installation, harder to control. Manual trigger is sufficient for QA. |
+| External state store for slot→image mapping | Adds infrastructure dependency. PR comment marker is self-contained and visible to developers directly in GitHub. |
+| Stop only on merge (not close) | Abandoned/closed PRs would leave slots running indefinitely, wasting server resources. |
+| Persistent PostgreSQL between deploys | State drift makes tests non-deterministic. Ephemeral DB is consistent with existing `test:integration:ephemeral:start` design. |
+
+---
+
+## User Stories / Use Cases
+
+- **Developer** wants to deploy a specific branch to QA manually so that a reviewer can test the feature at a stable URL without checking out the branch locally.
+- **Developer** wants the workflow to label and comment on the PR automatically so that the slot URL and image tag are discoverable from the PR page.
+- **Reviewer** wants to know which slot a PR was deployed to so that they can open the QA URL directly from GitHub.
+- **DevOps** wants the QA slot to stop automatically when the PR is closed (merged or abandoned) so that idle containers do not consume server resources.
+- **DevOps** wants the stop workflow to refuse to stop if the slot has been redeployed for another PR, preventing accidental interruption of a live QA session.
+- **DevOps** wants deployments to a slot to be serialised so that a second trigger does not corrupt a running deployment.
+
+---
+
+## Architecture
+
+### Deploy flow
+
+```
+Developer triggers workflow_dispatch
+    │  inputs: slot=qa1, branch=feat/foo, pr_number=123 (optional)
+    ▼
+[GitHub Actions: .github/workflows/qa-deploy.yml]
+    │
+    ├── Checkout branch
+    │
+    ├── docker/build-push-action
+    │       file: docker/preview/Dockerfile
+    │       context: .
+    │       push: true
+    │       platforms: linux/amd64
+    │       tag: ghcr.io/<org>/<repo>:qa1-<sha7>
+    │       cache-from/to: type=gha
+    │
+    ├── Resolve DOKPLOY_APP_ID_QA1 → applicationId
+    │
+    ├── POST /api/application.saveDockerProvider
+    │       { applicationId, dockerImage: "ghcr.io/...:<tag>" }
+    │
+    ├── POST /api/application.deploy
+    │       { applicationId }
+    │           │
+    │           ▼
+    │   [Dokploy Server]
+    │       └── docker pull ghcr.io/...:<tag>
+    │       └── docker run
+    │               ├── /var/run/docker.sock:/var/run/docker.sock (bind)
+    │               ├── ENV from Dokploy UI
+    │               └── docker/preview/preview-entrypoint.sh
+    │                       └── yarn test:integration:ephemeral:start
+    │                               ├── yarn install
+    │                               ├── yarn build:packages
+    │                               ├── yarn generate
+    │                               ├── yarn build:packages (2nd pass)
+    │                               ├── docker run postgres:16 (via docker.sock)
+    │                               ├── yarn initialize --reinstall
+    │                               ├── yarn build:app
+    │                               └── yarn start  (PORT=3000)
+    │
+    ├── (if pr_number) Add label "qa:qa1" to PR #123
+    │
+    └── (if pr_number) Post PR comment:
+            <!-- dokploy-qa slot=qa1 image=ghcr.io/...:<tag> -->
+            🚀 Deployed to **qa1**
+            - Image: `ghcr.io/...:<tag>`
+            - Branch: `feat/foo`
+```
+
+### Stop-on-close flow
+
+```
+PR #123 closed (carries label "qa:qa1") — merged or abandoned
+    │
+    ▼
+[GitHub Actions: .github/workflows/qa-stop-on-merge.yml]
+    │
+    ├── List PR labels → detect "qa:qa1" → slot=qa1
+    │
+    ├── Resolve DOKPLOY_APP_ID_QA1 → applicationId
+    │
+    ├── Paginate PR comments (reverse) →
+    │       find last "<!-- dokploy-qa slot=qa1 image=<img> -->"
+    │       → expected_image = "ghcr.io/...:<tag>"
+    │       (fail if not found)
+    │
+    ├── GET /api/application.one?applicationId=<id>
+    │       → current_image = response.dockerImage
+    │
+    ├── Compare current_image == expected_image?
+    │       NO  → log "Slot redeployed, skipping stop" → exit 0
+    │       YES ↓
+    │
+    └── POST /api/application.stop
+            { applicationId }
+```
+
+### Slot → Application ID Mapping
+
+| Slot | GitHub Variable | Label |
+|------|----------------|-------|
+| `qa1` | `vars.DOKPLOY_APP_ID_QA1` | `qa:qa1` |
+| `qa2` | `vars.DOKPLOY_APP_ID_QA2` | `qa:qa2` |
+
+---
+
+## Data Models
+
+No new database entities. Deployment state is encoded in PR comments (marker format) and managed by Dokploy.
+
+---
+
+## API Contracts
+
+### Dokploy REST API calls (outbound from GitHub Actions)
+
+**`POST /api/application.saveDockerProvider`** — update slot image
+```json
+{ "applicationId": "<string>", "dockerImage": "ghcr.io/<org>/<repo>:<tag>" }
+```
+
+**`POST /api/application.deploy`** — trigger redeploy
+```json
+{ "applicationId": "<string>" }
+```
+
+**`GET /api/application.one?applicationId=<string>`** — read current config (stop workflow)
+```json
+{ "dockerImage": "ghcr.io/<org>/<repo>:<tag>", ... }
+```
+
+**`POST /api/application.stop`** — stop the running container
+```json
+{ "applicationId": "<string>" }
+```
+
+All calls require `x-api-key: <DOKPLOY_API_KEY>` and (for POST) `Content-Type: application/json`.
+
+### PR comment marker format
+
+Written by `qa-deploy.yml`; parsed by `qa-stop-on-merge.yml`. **Do not change the format lightly.**
+
+```
+<!-- dokploy-qa slot=<slot> image=<image_full> -->
+```
+
+The stop workflow scans comments in reverse chronological order and uses the **most recent** matching marker, so multiple deployments to the same slot on the same PR are handled correctly.
+
+---
+
+## Configuration
+
+### GitHub Repository Secrets
+
+| Secret | Description |
+|--------|-------------|
+| `DOKPLOY_URL` | Base URL of the Dokploy server (e.g. `https://dokploy.example.com`) |
+| `DOKPLOY_API_KEY` | Dokploy API key with deploy + stop permissions |
+
+### GitHub Repository Variables
+
+| Variable | Description |
+|----------|-------------|
+| `DOKPLOY_APP_ID_QA1` | Dokploy `applicationId` for the `qa1` slot |
+| `DOKPLOY_APP_ID_QA2` | Dokploy `applicationId` for the `qa2` slot |
+
+### GitHub Actions Permissions
+
+**`qa-deploy.yml`**
+```yaml
+permissions:
+  contents: read
+  packages: write        # push image to GHCR
+  pull-requests: write   # post PR comment
+  issues: write          # add PR label
+  actions: read
+```
+
+**`qa-stop-on-merge.yml`**
+```yaml
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+```
+
+### Required Dokploy Application Settings (per slot)
+
+| Setting | Value |
+|---------|-------|
+| Source type | Docker (not GitHub) |
+| Docker image | `ghcr.io/<org>/<repo>:<placeholder>` (overwritten by workflow on first deploy) |
+| Exposed port | `3000` |
+| Volume — Source | `/var/run/docker.sock` |
+| Volume — Destination | `/var/run/docker.sock` |
+| Volume — Type | Bind |
+| Restart policy | `no` |
+
+### Required Dokploy Environment Variables (set in Dokploy UI per slot)
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `NODE_ENV` | `production` | Runtime mode |
+| `DEV_EPHEMERAL_PREFERRED_PORT` | `3000` | Port the app listens on |
+| `DEV_EPHEMERAL_POSTGRES_PUBLISHED_HOST` | `0.0.0.0` | Postgres bind address inside container |
+| `DEV_EPHEMERAL_POSTGRES_CONNECT_HOST` | `host.docker.internal` | Postgres host for app connection |
+| `NEXTAUTH_SECRET` | `<secret>` | Required by NextAuth |
+| Additional app secrets | — | As required by `apps/mercato/.env.example` |
+
+---
+
+## Implementation Plan
+
+### Phase 1: Standalone Preview Dockerfile ✅
+
+**Goal**: Create a dedicated `docker/preview/Dockerfile` for QA builds, fully isolated from the main `Dockerfile`.
+
+#### Steps
+
+1. **Create `docker/preview/Dockerfile`** — two-stage build (`builder` + `runner`):
+   - `builder` stage: installs deps and runs `yarn build:packages`
+   - `runner` stage: installs `docker-cli` (needed to spawn the ephemeral PostgreSQL container via docker.sock), copies the entrypoint script, runs `yarn install` + `yarn build:packages`
+
+2. **Create `docker/preview/preview-entrypoint.sh`** — baked into the `runner` stage; calls `yarn test:integration:ephemeral:start`.
+
+3. **Verify local build** — `docker build -f docker/preview/Dockerfile -t open-mercato:preview .` — must complete without errors.
+
+#### File Manifest
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `docker/preview/Dockerfile` | Create | Standalone preview image (builder + runner stages) |
+| `docker/preview/preview-entrypoint.sh` | Create | Entrypoint that invokes `yarn test:integration:ephemeral:start` |
+
+---
+
+### Phase 2: Fix NODE_ENV Passthrough ✅
+
+**Goal**: Confirm that `yarn test:integration:ephemeral:start` inherits `NODE_ENV=production` from the container environment.
+
+#### Steps
+
+1. **Fix `NODE_ENV` passthrough in `packages/cli/src/lib/testing/integration.ts`** — change the two hardcoded `NODE_ENV: 'test'` assignments to `NODE_ENV: process.env.NODE_ENV ?? 'test'`. This allows the ephemeral environment to inherit `NODE_ENV=production` set in the Dokploy container, while still defaulting to `'test'` in CI/local runs.
+
+#### File Manifest
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/cli/src/lib/testing/integration.ts` | Modify | `NODE_ENV: process.env.NODE_ENV ?? 'test'` (two occurrences) |
+
+---
+
+### Phase 3: GitHub Actions Workflows ✅
+
+**Goal**: Create both GitHub Actions workflows for the full deploy + cleanup lifecycle.
+
+#### Steps
+
+1. **Create `.github/workflows/qa-deploy.yml`** with:
+   - Trigger: `workflow_dispatch` with inputs `slot`, `branch`, `pr_number` (optional)
+   - Concurrency: `dokploy-<slot>`, `cancel-in-progress: false`
+   - Steps: checkout → QEMU → Buildx → GHCR login → compute `slot-sha7` tag → build+push → resolve app ID → `saveDockerProvider` → `deploy` → (if pr_number) add label → (if pr_number) post marker comment
+
+2. **Create `.github/workflows/qa-stop-on-merge.yml`** with:
+   - Trigger: `pull_request` `closed`, gate: `action == 'closed'` (fires on merge and abandon)
+   - Steps: detect `qa:qa1`/`qa:qa2` label → resolve app ID → find marker comment → fetch current Dokploy image → compare → stop if match
+
+3. **Add required secrets** to the GitHub repository: `DOKPLOY_URL`, `DOKPLOY_API_KEY`.
+
+4. **Add required variables** to the GitHub repository: `DOKPLOY_APP_ID_QA1`, `DOKPLOY_APP_ID_QA2`.
+
+#### File Manifest
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `.github/workflows/qa-deploy.yml` | Create | Manual QA build-and-deploy workflow |
+| `.github/workflows/qa-stop-on-merge.yml` | Create | Automatic slot stop on PR close |
+| `docker-compose.preview.yaml` | Create | Local single-service compose for developer/QA local preview runs |
+| `.github/QA-DEPLOYMENT.md` | Create | QA engineer runbook for remote slot deploys and local preview usage |
+
+---
+
+### Phase 4: Dokploy Application Configuration
+
+**Goal**: Create and configure the QA slot applications in Dokploy. This phase is a manual ops runbook.
+
+#### Steps
+
+1. **Create a new Application** in Dokploy for each slot (`qa1`, `qa2`):
+   - Name: `open-mercato-qa1`
+   - Source type: Docker
+   - Docker image: any valid placeholder; the workflow overwrites it on first run
+   - Exposed port: `3000`
+
+2. **Add volume mount** (docker.sock):
+   - Application → Advanced → Volumes
+   - Source: `/var/run/docker.sock` / Destination: `/var/run/docker.sock` / Type: `Bind`
+
+3. **Set environment variables** from the Configuration table above via Application → Environment.
+
+4. **Copy the `applicationId`** from Dokploy (Application → Settings → General) and set it as `DOKPLOY_APP_ID_QA1` / `DOKPLOY_APP_ID_QA2` in GitHub repository variables.
+
+5. **Configure domain** for each slot (e.g. `qa1.openmercato.com`) in Dokploy → Domains. Requires a DNS A record pointing to the Dokploy server IP.
+
+#### File Manifest
+
+No files created. This phase is entirely Dokploy and DNS configuration.
+
+---
+
+### Phase 5: End-to-End Validation
+
+**Goal**: Confirm the full pipeline works from workflow trigger through auto-stop on merge.
+
+#### Steps
+
+1. Trigger `qa-deploy.yml` from the GitHub Actions UI with `slot=qa1`, a target branch, and a PR number.
+2. Confirm the image is built and pushed to GHCR (Actions log).
+3. Confirm Dokploy receives the deploy trigger (Dokploy → Deployments).
+4. Wait ~10 minutes; confirm `https://qa1.openmercato.com/backend` is accessible.
+5. Confirm the PR has the `qa:qa1` label and a marker comment with the correct image tag.
+6. Trigger a second deployment to `qa1` with a different branch/PR. Confirm the first completes before the second starts (concurrency queue).
+7. Close the first PR (without merging). Confirm `qa-stop-on-merge.yml` runs, detects the image mismatch (slot was redeployed for PR #2), and skips the stop.
+8. Merge the second PR. Confirm `qa-stop-on-merge.yml` runs, images match, and the slot is stopped.
+
+---
+
+## Risks & Impact Review
+
+### Data Integrity Failures
+
+The QA environment is fully ephemeral and self-contained. No production data is involved. Risk is isolated to the QA slot.
+
+### Cascading Failures & Side Effects
+
+- **GHCR push failure**: `build-push-action` step fails; downstream Dokploy steps are skipped. Re-trigger the workflow.
+- **Dokploy API unavailable**: `saveDockerProvider`, `deploy`, or `stop` curl call fails (`-fsS` flags cause non-zero exit). Workflow fails with a clear error. Re-trigger after resolving Dokploy connectivity.
+- **docker.sock mount failure**: If the host Docker daemon is unavailable, `yarn test:integration:ephemeral:start` fails at the PostgreSQL startup step. The container exits with a non-zero code. Dokploy marks the deployment as failed. Re-trigger the workflow.
+- **No marker comment found**: If a PR with a `qa:qa*` label is closed but no marker comment exists (e.g. PR was labelled manually without a workflow deploy), `qa-stop-on-merge.yml` fails with `core.setFailed`. The slot must be stopped manually via Dokploy UI.
+
+### Migration & Deployment Risks
+
+- `docker/preview/Dockerfile` is standalone and entirely separate from the main `Dockerfile`. Existing `builder`, `dev`, and `runner` stages in the main Dockerfile are unchanged.
+- The `NODE_ENV: process.env.NODE_ENV ?? 'test'` change in `integration.ts` is backward-compatible: CI and local runs that do not set `NODE_ENV` continue to default to `'test'`.
+- No database migrations in Open Mercato's production database are involved.
+- `qa-deploy.yml` has minimal permissions (`contents: read`, `packages: write`, `pull-requests: write`, `issues: write`, `actions: read`) — it cannot modify repository settings, branch protection, or secrets.
+- `qa-stop-on-merge.yml` is read-only on GitHub (`contents: read`, `pull-requests: read`, `issues: read`) — it only calls the external Dokploy API.

--- a/.github/QA-DEPLOYMENT.md
+++ b/.github/QA-DEPLOYMENT.md
@@ -1,0 +1,166 @@
+# QA Deployment Guide
+
+This guide explains how to deploy a branch to a QA environment and what to expect during the process.
+
+---
+
+## Overview
+
+There are two named QA slots: **qa1** and **qa2**. Each slot is a long-lived environment with a fixed URL. A slot runs one deployment at a time — deploying to a slot replaces whatever was there before.
+
+| Slot | URL |
+|------|-----|
+| qa1 | https://qa1.openmercato.com/backend |
+| qa2 | https://qa2.openmercato.com/backend |
+
+Each deployment spins up a **fresh database** seeded with demo data. There is no persistent state between deployments.
+
+---
+
+## How to Deploy a Branch to QA
+
+1. Go to the repository on GitHub → **Actions** tab.
+2. Select **Deploy to Dokploy QA** from the workflow list on the left.
+3. Click **Run workflow** (top right of the workflow runs table).
+4. Fill in the inputs:
+
+   | Field | Required | What to enter |
+   |-------|----------|---------------|
+   | **QA slot** | Yes | `qa1` or `qa2` |
+   | **Branch** | Yes | The branch name you want to test (e.g. `feat/my-feature`) |
+   | **PR number** | No | The PR number associated with this branch (e.g. `123`). If provided, the workflow will label the PR and post a comment with the deployment details. |
+
+5. Click **Run workflow**.
+
+The workflow will appear in the runs list. Click it to follow the build progress.
+
+> **Only one deployment per slot can run at a time.** If another deployment to the same slot is already in progress, yours will queue and start automatically when the first one finishes.
+
+---
+
+## How Long Does It Take?
+
+The workflow itself (build + push to registry) takes **~5–15 minutes** depending on build cache.
+
+After the workflow completes, the environment still needs time to start up on the server:
+
+- Install dependencies, generate files, build packages — ~5 min
+- Initialise the database and run migrations — ~2 min
+- Build the Next.js app and start the server — ~3 min
+
+**Total from workflow trigger to ready: approximately 10–20 minutes.**
+
+The environment is ready when the URL returns the login page. Refresh until it loads — it will not send a notification when ready.
+
+---
+
+## Finding the QA URL After Deployment
+
+If you provided a **PR number**, the workflow posts a comment on the PR with the slot and deployed image:
+
+```
+🚀 Deployed to qa1
+- Image: ghcr.io/org/repo:qa1-a1b2c3d
+- Branch: feat/my-feature
+```
+
+The slot URL is always the fixed address from the table above — it does not change between deployments.
+
+---
+
+## What Is Reset on Every Deployment
+
+- **Database**: fully wiped and re-seeded with demo data on every deployment.
+- **Uploaded files**: not persisted between deployments.
+- **Application code**: updated to the deployed branch.
+
+Do not use a QA slot to store test data you need to keep — it will be gone on the next deployment.
+
+---
+
+## Slot Cleanup — What Happens When a PR Is Closed
+
+When a PR that was deployed to a slot is **closed** (merged or abandoned), a workflow runs automatically to stop the slot:
+
+1. It detects the `qa:qa1` or `qa:qa2` label on the closed PR.
+2. It checks whether the slot is still running the image that was deployed for this PR.
+3. If yes — it stops the slot.
+4. If the slot has since been redeployed for a different PR — it skips the stop to avoid interrupting an active session.
+
+**The slot is not stopped automatically if:**
+- The PR was not associated with a deployment (no PR number was entered when triggering the workflow, so no `qa:qa1`/`qa:qa2` label was added).
+
+In that case, contact a developer or DevOps to stop the slot manually.
+
+---
+
+## Running the Preview Image Locally
+
+You can build and run the same image used on QA slots on your own machine using Docker Compose.
+
+### Prerequisites
+
+- Docker Desktop running (required — the container spawns a PostgreSQL container via the Docker socket)
+- Access to the repository
+
+### 1. Create a `.env.preview` file
+
+Create `.env.preview` in the repo root with at minimum:
+
+```
+NEXTAUTH_SECRET=any-random-string-at-least-32-chars
+```
+
+Any other app-specific secrets your tenant configuration requires can be added here too (see `apps/mercato/.env.example`).
+
+### 2. Build and start
+
+```bash
+docker compose -f docker-compose.preview.yaml --env-file .env.preview up --build
+```
+
+The first run builds the image from scratch — expect **10–30 minutes** before the app is ready. Subsequent runs that skip `--build` reuse the cached image and are faster, but the database always resets.
+
+### 3. Open the app
+
+Once you see `ready` in the logs, open:
+
+```
+http://localhost:5000/backend
+```
+
+### 4. Stop and clean up
+
+```bash
+docker compose -f docker-compose.preview.yaml down
+```
+
+> The container manages its own PostgreSQL instance internally — there are no external volumes to clean up.
+
+### Notes
+
+- The `.env.preview` file is gitignored by default and should **never be committed**.
+- On Linux, the `host.docker.internal` hostname resolves automatically via `extra_hosts`. On macOS and Windows, Docker Desktop handles it natively.
+- If the container exits immediately, run with `docker compose logs preview-app` to see the startup error.
+
+---
+
+## Checking Slot Status
+
+You can always check what is currently running on a slot by visiting its URL:
+- If the login page loads — the slot is up.
+- If you get a connection error or blank page — the slot is stopped or still starting up.
+
+For detailed deployment logs, ask a developer with Dokploy access.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | What to do |
+|---------|-------------|------------|
+| Workflow fails in the build step | Build error in the branch | Ask the developer to fix the build and re-trigger |
+| Workflow succeeds but URL does not load after 20 min | Startup error inside the container | Ask a developer to check Dokploy logs |
+| "Slot queued" — workflow does not start immediately | Another deployment to the same slot is in progress | Wait for the current run to finish; yours starts automatically |
+| URL loads stale content after deployment | Browser cache | Hard-refresh (`Cmd+Shift+R` / `Ctrl+Shift+R`) or open in a private window |
+| PR has no `qa:qa1` label after deployment | PR number was not entered when triggering | The slot is deployed but not linked to the PR; auto-stop on merge will not fire |

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -1,0 +1,202 @@
+name: Deploy to Dokploy QA
+
+on:
+  workflow_dispatch:
+    inputs:
+      slot:
+        description: "QA slot to deploy to"
+        required: true
+        type: choice
+        options:
+          - qa1
+          - qa2
+
+      branch:
+        description: "Branch to build and deploy"
+        required: true
+        type: string
+
+      pr_number:
+        description: "Optional PR number to label/comment (e.g. 123)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+  issues: write
+  actions: read
+
+concurrency:
+  group: dokploy-${{ github.event.inputs.slot }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  DOCKERFILE: ./docker/preview/Dockerfile
+  BUILD_CONTEXT: .
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout selected branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Validate PR number (optional)
+        if: ${{ github.event.inputs.pr_number != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "${{ github.event.inputs.pr_number }}" =~ ^[0-9]+$ ]]; then
+            echo "pr_number must be numeric"
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SLOT="${{ github.event.inputs.slot }}"
+          SHA="${GITHUB_SHA}"
+          SHORT_SHA="${SHA:0:7}"
+
+          TAG="${SLOT}-${SHORT_SHA}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          echo "slot=$SLOT" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "image_full=${IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.BUILD_CONTEXT }}
+          file: ${{ env.DOCKERFILE }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ steps.meta.outputs.image_full }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Resolve Dokploy applicationId
+        id: app
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SLOT="${{ steps.meta.outputs.slot }}"
+
+          if [[ "$SLOT" == "qa1" ]]; then
+            APP_ID="${{ vars.DOKPLOY_APP_ID_QA1 }}"
+          elif [[ "$SLOT" == "qa2" ]]; then
+            APP_ID="${{ vars.DOKPLOY_APP_ID_QA2 }}"
+          else
+            echo "Unknown slot: $SLOT"
+            exit 1
+          fi
+
+          if [[ -z "$APP_ID" ]]; then
+            echo "Missing Dokploy app id for $SLOT"
+            exit 1
+          fi
+
+          echo "application_id=$APP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Update image in Dokploy
+        shell: bash
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          APP_ID: ${{ steps.app.outputs.application_id }}
+          DOCKER_IMAGE: ${{ steps.meta.outputs.image_full }}
+        run: |
+          set -euo pipefail
+
+          curl -fsS -X POST "${DOKPLOY_URL}/api/application.saveDockerProvider" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+              --arg applicationId "$APP_ID" \
+              --arg dockerImage "$DOCKER_IMAGE" \
+              '{applicationId: $applicationId, dockerImage: $dockerImage}')"
+
+      - name: Trigger Dokploy deploy
+        shell: bash
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          APP_ID: ${{ steps.app.outputs.application_id }}
+        run: |
+          set -euo pipefail
+
+          curl -fsS -X POST "${DOKPLOY_URL}/api/application.deploy" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n --arg applicationId "$APP_ID" '{applicationId: $applicationId}')"
+
+      - name: Add QA label to PR
+        if: ${{ github.event.inputs.pr_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = Number("${{ github.event.inputs.pr_number }}");
+            const slot = "${{ steps.meta.outputs.slot }}";
+            const label = `qa:${slot}`;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              labels: [label],
+            });
+
+      - name: Comment on PR with QA marker
+        if: ${{ github.event.inputs.pr_number != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = Number("${{ github.event.inputs.pr_number }}");
+            const slot = "${{ steps.meta.outputs.slot }}";
+            const image = "${{ steps.meta.outputs.image_full }}";
+            const branch = "${{ github.event.inputs.branch }}";
+
+            // Marker format: DO NOT change lightly (cleanup workflow parses it)
+            const marker = `<!-- dokploy-qa slot=${slot} image=${image} -->`;
+
+            const body = [
+              marker,
+              `🚀 Deployed to **${slot}**`,
+              ``,
+              `- Image: \`${image}\``,
+              `- Branch: \`${branch}\``,
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });

--- a/.github/workflows/qa-stop-on-merge.yml
+++ b/.github/workflows/qa-stop-on-merge.yml
@@ -1,0 +1,146 @@
+name: Stop QA slot on merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  stop-qa:
+    if: ${{ github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Detect QA slot label
+        id: slot
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+
+            const names = labels.map(l => l.name);
+            core.info(`Current PR labels: ${names.join(', ') || '(none)'}`);
+
+            let slot = "";
+            if (names.includes("qa:qa1")) slot = "qa1";
+            if (names.includes("qa:qa2")) slot = "qa2";
+
+            core.setOutput("slot", slot);
+
+      - name: Skip if no QA label
+        if: ${{ steps.slot.outputs.slot == '' }}
+        run: echo "No qa:qa1/qa:qa2 label -> nothing to stop."
+
+      - name: Resolve Dokploy applicationId
+        if: ${{ steps.slot.outputs.slot != '' }}
+        id: app
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.slot.outputs.slot }}" == "qa1" ]]; then
+            APP_ID="${{ vars.DOKPLOY_APP_ID_QA1 }}"
+          else
+            APP_ID="${{ vars.DOKPLOY_APP_ID_QA2 }}"
+          fi
+
+          if [[ -z "$APP_ID" ]]; then
+            echo "Missing Dokploy app id for slot=${{ steps.slot.outputs.slot }}" >&2
+            exit 1
+          fi
+
+          echo "app_id=$APP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Get expected image from PR comments
+        if: ${{ steps.slot.outputs.slot != '' }}
+        id: expected
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request.number;
+            const slot = "${{ steps.slot.outputs.slot }}";
+            const markerPrefix = `<!-- dokploy-qa slot=${slot} image=`;
+            const markerSuffix = ` -->`;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              per_page: 100,
+            });
+
+            for (let i = comments.length - 1; i >= 0; i--) {
+              const body = comments[i].body || "";
+              const start = body.indexOf(markerPrefix);
+              if (start === -1) continue;
+
+              const after = body.substring(start + markerPrefix.length);
+              const end = after.indexOf(markerSuffix);
+              if (end === -1) continue;
+
+              const image = after.substring(0, end).trim();
+              if (image) {
+                core.info(`Found expected image marker: ${image}`);
+                core.setOutput("image", image);
+                return;
+              }
+            }
+
+            core.setFailed(`No dokploy-qa marker found for slot=${slot} in PR comments. Refusing to stop.`);
+
+      - name: Get current Dokploy application config and compare dockerImage
+        if: ${{ steps.slot.outputs.slot != '' }}
+        id: current
+        shell: bash
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          APP_ID: ${{ steps.app.outputs.app_id }}
+          EXPECTED_IMAGE: ${{ steps.expected.outputs.image }}
+        run: |
+          set -euo pipefail
+
+          RESP="$(curl -fsS -X GET "${DOKPLOY_URL}/api/application.one?applicationId=${APP_ID}" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}")"
+
+          CURRENT_IMAGE="$(echo "$RESP" | jq -r '.dockerImage // empty')"
+
+          echo "expected=${EXPECTED_IMAGE}"
+          echo "current=${CURRENT_IMAGE}"
+
+          if [[ -z "$CURRENT_IMAGE" ]]; then
+            echo "Could not read dockerImage from Dokploy response. Refusing to stop." >&2
+            exit 1
+          fi
+
+          if [[ "$CURRENT_IMAGE" != "$EXPECTED_IMAGE" ]]; then
+            echo "Slot image changed since this PR deploy. Skipping stop."
+            echo "should_stop=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_stop=true" >> "$GITHUB_OUTPUT"
+
+      - name: Stop Dokploy application
+        if: ${{ steps.current.outputs.should_stop == 'true' }}
+        shell: bash
+        env:
+          DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
+          DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
+          APP_ID: ${{ steps.app.outputs.app_id }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST "${DOKPLOY_URL}/api/application.stop" \
+            -H "x-api-key: ${DOKPLOY_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "{\"applicationId\":\"${APP_ID}\"}"

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.env.preview
 !.env.example
 
 # vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,36 @@ RUN chmod +x /app/docker/scripts/dev-entrypoint.sh
 EXPOSE 3000
 CMD ["/bin/sh", "/app/docker/scripts/dev-entrypoint.sh"]
 
+
+# Preview stage: used by Dokploy preview deployments
+FROM node:24-alpine AS preview
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /app
+
+RUN apk add --no-cache python3 make g++ ca-certificates openssl docker-cli
+RUN corepack enable
+
+COPY package.json yarn.lock .yarnrc.yml turbo.json ./
+COPY tsconfig.base.json tsconfig.json ./
+COPY packages/ ./packages/
+COPY apps/ ./apps/
+COPY scripts/ ./scripts/
+RUN yarn install
+
+COPY newrelic.js ./
+COPY jest.config.cjs jest.setup.ts jest.dom.setup.ts ./
+COPY eslint.config.mjs ./
+
+RUN yarn build:packages
+
+COPY docker/scripts/preview-entrypoint.sh /app/docker/scripts/preview-entrypoint.sh
+RUN chmod +x /app/docker/scripts/preview-entrypoint.sh
+
+CMD ["/bin/sh", "/app/docker/scripts/preview-entrypoint.sh"]
+
 # Production stage
 FROM node:24-alpine AS runner
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,17 @@ MEILISEARCH_MASTER_KEY=your-strong-meilisearch-key
 OPENAI_API_KEY=sk-...  # Optional, for AI features
 ```
 
+### QA Preview
+
+Run the same image used on QA slots locally for testing a specific branch without a full dev setup:
+
+```bash
+docker compose -f docker-compose.preview.yaml --env-file .env.preview up --build
+```
+
+Navigate to `http://localhost:5000`. The environment resets its database on every start.
+
+
 ### VPS Deployment
 
 [![Watch: Deploy Open Mercato on a VPS](https://img.youtube.com/vi/xau17YBP9ek/maxresdefault.jpg)](https://www.youtube.com/watch?v=xau17YBP9ek)

--- a/docker-compose.preview.yaml
+++ b/docker-compose.preview.yaml
@@ -1,0 +1,13 @@
+services:
+  preview-app:
+    build:
+      context: .
+      dockerfile: ./docker/preview/Dockerfile
+    image: open-mercato/preview:local
+    restart: "no"
+    ports:
+      - "5000:5001"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker/preview/Dockerfile
+++ b/docker/preview/Dockerfile
@@ -1,0 +1,62 @@
+FROM node:24-alpine AS builder
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /app
+
+# Install system deps required by optional native modules (Alpine uses apk)
+RUN apk add --no-cache python3 make g++ ca-certificates openssl
+
+# Enable Corepack for Yarn
+RUN corepack enable
+
+# Copy workspace configuration files
+COPY package.json yarn.lock .yarnrc.yml turbo.json ./
+COPY tsconfig.base.json tsconfig.json ./
+
+# Copy all packages and apps (including package.json files for dependency installation)
+COPY packages/ ./packages/
+COPY apps/ ./apps/
+COPY scripts/ ./scripts/
+
+# Install all dependencies (including devDependencies for build)
+# Note: Using plain install because peer dependency warnings cause lockfile changes
+RUN yarn install
+
+# Copy other necessary files
+COPY newrelic.js ./
+COPY jest.config.cjs jest.setup.ts jest.dom.setup.ts ./
+COPY eslint.config.mjs ./
+
+
+# Build the app
+RUN yarn build
+
+FROM node:24-alpine AS runner
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /app
+
+RUN apk add --no-cache python3 make g++ ca-certificates openssl docker-cli
+RUN corepack enable
+
+COPY package.json yarn.lock .yarnrc.yml turbo.json ./
+COPY tsconfig.base.json tsconfig.json ./
+COPY packages/ ./packages/
+COPY apps/ ./apps/
+COPY scripts/ ./scripts/
+RUN yarn install
+
+COPY newrelic.js ./
+COPY jest.config.cjs jest.setup.ts jest.dom.setup.ts ./
+COPY eslint.config.mjs ./
+
+RUN yarn build:packages
+
+COPY docker/preview/preview-entrypoint.sh /app/docker/preview/preview-entrypoint.sh
+RUN chmod +x /app/docker/preview/preview-entrypoint.sh
+
+CMD ["/bin/sh", "/app/docker/preview/preview-entrypoint.sh"]

--- a/docker/preview/preview-entrypoint.sh
+++ b/docker/preview/preview-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+cd /app
+yarn install
+
+yarn build:packages
+yarn generate
+yarn build:packages
+
+cd /app/apps/mercato
+
+cd /app
+exec yarn test:integration:ephemeral:start

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -1265,7 +1265,7 @@ async function clearStaleEphemeralEnvironmentLock(logPrefix: string): Promise<bo
 function buildReusableEnvironment(baseUrl: string, captureScreenshots: boolean): NodeJS.ProcessEnv {
   return buildEnvironment({
     BASE_URL: baseUrl,
-    NODE_ENV: 'test',
+    NODE_ENV: process.env.NODE_ENV ?? 'test',
     OM_TEST_MODE: '1',
     ENABLE_CRUD_API_CACHE: 'true',
     NEXT_PUBLIC_OM_EXAMPLE_INJECTION_WIDGETS_ENABLED: 'true',
@@ -2494,7 +2494,7 @@ export async function startEphemeralEnvironment(options: EphemeralRuntimeOptions
       DATABASE_URL: databaseUrl,
       BASE_URL: applicationBaseUrl,
       JWT_SECRET: 'om-ephemeral-integration-jwt-secret',
-      NODE_ENV: 'test',
+      NODE_ENV: process.env.NODE_ENV ?? 'test',
       OM_TEST_MODE: '1',
       OM_TEST_AUTH_RATE_LIMIT_MODE: 'opt-in',
       OM_DISABLE_EMAIL_DELIVERY: '1',


### PR DESCRIPTION
## Summary

Adds automated QA preview deployment infrastructure: a Docker preview image, two GitHub Actions workflows to deploy and clean up QA slots, a local Docker Compose setup, and a QA engineer runbook.

## Changes

- `docker/preview/Dockerfile` + `preview-entrypoint.sh` — standalone preview image using ephemeral PostgreSQL via docker.sock
- `.github/workflows/qa-deploy.yml` — manual workflow to build, push to GHCR, and deploy to a named QA slot (qa1/qa2) via Dokploy REST API; optionally labels and comments on the PR
- `.github/workflows/qa-stop-on-merge.yml` — automatically stops the slot when a labelled PR is closed, with image-match safety check
- `docker-compose.preview.yaml` — single-service local compose for running the preview image on port 5000
- `.github/QA-DEPLOYMENT.md` — QA engineer guide covering remote slot deploys and local preview usage
- `packages/cli/src/lib/testing/integration.ts` — `NODE_ENV` passthrough fix (`process.env.NODE_ENV ?? 'test'`)

## Specification

- [x] Yes

**Spec file path:** `.ai/specs/enterprise/SPEC-ENT-006-2026-03-01-qa-preview-deployment-dokploy.md`

## Testing

- `docker build -f docker/preview/Dockerfile -t open-mercato:preview .` — builds without errors
- `docker compose -f docker-compose.preview.yaml --env-file .env.preview up` — app accessible at `http://localhost:5000/backend`

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
