### PR TITLE
fix(794): Fix  misleading 404 for deal UUID in entityId

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/shared.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/shared.test.ts
@@ -1,7 +1,9 @@
 import * as shared from '../shared'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import {
+  CustomerDeal,
   CustomerDictionaryEntry,
+  CustomerEntity,
   CustomerTag,
   CustomerTagAssignment,
 } from '../../data/entities'
@@ -12,6 +14,7 @@ const {
   ensureSameScope,
   extractUndoPayload,
   assertFound,
+  requireCustomerEntity,
   ensureDictionaryEntry,
   loadEntityTagIds,
   syncEntityTags,
@@ -61,6 +64,40 @@ describe('customers commands shared utilities', () => {
       const record = { id: '123' }
       expect(assertFound(record, 'Missing')).toBe(record)
       expect(() => assertFound(null, 'Missing')).toThrow(CrudHttpError)
+    })
+  })
+
+  describe('requireCustomerEntity', () => {
+    const personEntity = Object.assign(new CustomerEntity(), { id: 'person-1', kind: 'person' })
+
+    it('returns the entity when a valid person or company ID is provided', async () => {
+      const em = { findOne: jest.fn().mockResolvedValue(personEntity) }
+      const result = await requireCustomerEntity(em as any, 'person-1')
+      expect(result).toBe(personEntity)
+    })
+
+    it('throws 404 when entity is not found and the ID is not a deal', async () => {
+      const em = { findOne: jest.fn().mockResolvedValue(null) }
+      await expect(requireCustomerEntity(em as any, 'unknown-id')).rejects.toMatchObject({ status: 404 })
+    })
+
+    it('throws 422 with a descriptive message when entityId references a deal', async () => {
+      const dealRecord = Object.assign(new CustomerDeal(), { id: 'deal-1', deletedAt: null })
+      const em = {
+        findOne: jest.fn(async (model: unknown) => {
+          if (model === CustomerDeal) return dealRecord
+          return null
+        }),
+      }
+      const error = await requireCustomerEntity(em as any, 'deal-1').catch((e) => e)
+      expect(error).toBeInstanceOf(CrudHttpError)
+      expect(error.status).toBe(422)
+      expect(error.body.error).toMatch(/person or company/)
+    })
+
+    it('throws 400 when entity kind does not match the required kind', async () => {
+      const em = { findOne: jest.fn().mockResolvedValue(personEntity) }
+      await expect(requireCustomerEntity(em as any, 'person-1', 'company')).rejects.toMatchObject({ status: 400 })
     })
   })
 

--- a/packages/core/src/modules/customers/commands/shared.ts
+++ b/packages/core/src/modules/customers/commands/shared.ts
@@ -32,7 +32,13 @@ export async function requireCustomerEntity(
   message = 'Customer entity not found'
 ): Promise<CustomerEntity> {
   const entity = await em.findOne(CustomerEntity, { id, deletedAt: null })
-  if (!entity) throw new CrudHttpError(404, { error: message })
+  if (!entity) {
+    const isDeal = await em.findOne(CustomerDeal, { id, deletedAt: null })
+    if (isDeal) {
+      throw new CrudHttpError(422, { error: 'entityId must reference a person or company, not a deal' })
+    }
+    throw new CrudHttpError(404, { error: message })
+  }
   if (kind && entity.kind !== kind) {
     throw new CrudHttpError(400, { error: 'Invalid entity type' })
   }


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

When a deal UUID was passed as `entityId` to `POST /api/customers/comments` or `POST /api/customers/activities`, both endpoints returned `404 "Customer not found"`. This was misleading because the route exists and the deal record exists — the problem is that `entityId` only accepts person or company IDs, not deals. The fix detects when the supplied UUID belongs to a deal and returns a clear `422 Unprocessable Entity` with the message `"entityId must reference a person or company, not a deal"`.

## Changes

- `packages/core/src/modules/customers/commands/shared.ts` — extended `requireCustomerEntity` to perform a secondary lookup against `CustomerDeal` when the entity is not found; throws `422` with a descriptive message if the ID belongs to a deal instead of the generic `404`
- `packages/core/src/modules/customers/commands/__tests__/shared.test.ts` — added a `requireCustomerEntity` test suite covering: valid entity lookup, unknown-ID 404, deal-ID 422 with message assertion, and kind-mismatch 400

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:** —

## Testing

```bash
yarn jest packages/core/src/modules/customers/commands/__tests__/shared.test.ts --no-coverage
```

All 19 tests pass, including 4 new cases for `requireCustomerEntity`.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #794
