### PR TITLE
fix search settings visibility (#746)

### DIFF
--- a/packages/search/src/modules/search/backend/config/search/page.meta.ts
+++ b/packages/search/src/modules/search/backend/config/search/page.meta.ts
@@ -12,11 +12,13 @@ export const metadata = {
   requireFeatures: ['search.view'],
   pageTitle: 'Search Settings',
   pageTitleKey: 'search.config.nav.hybridSearch',
-  pageGroup: 'Configuration',
-  pageGroupKey: 'backend.nav.configuration',
+  pageGroup: 'Module Configs',
+  pageGroupKey: 'settings.sections.moduleConfigs',
   pageOrder: 425,
   icon: searchIcon,
+  pageContext: 'settings' as const,
   breadcrumb: [
     { label: 'Search Settings', labelKey: 'search.config.nav.hybridSearch' },
   ],
 } as const
+


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The Search Settings page (`/backend/config/search`) was accessible via direct URL but did not appear in the Settings navigation sidebar under Module Configurations. The `page.meta.ts` file was missing the `pageContext: 'settings'` marker and used an incorrect `pageGroup` value, so the navigation builder never included the page.

## Changes

- Added `pageContext: 'settings' as const` to `packages/search/src/modules/search/backend/config/search/page.meta.ts`
- Updated `pageGroup` to `'Module Configs'` and added `pageGroupKey: 'settings.sections.moduleConfigs'` to align with other module config pages (Catalog, Sales, Customers)

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Verified Search Settings appears under Settings → Module Configurations after login as admin
- Confirmed page is hidden from users without `search.view` feature
- Direct URL access still works as before

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required) — no integration test required for a metadata-only navigation fix.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable) — N/A.

## Linked issues

Fixes #746