### PR TITLE
Feat: #787: initial demo credentials more visible

### DIFF
--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -91,6 +91,7 @@ export default function LoginPage() {
   const [tenantLoading, setTenantLoading] = useState(false)
   const [tenantInvalid, setTenantInvalid] = useState<string | null>(null)
   const showTenantInvalid = tenantId != null && tenantInvalid === tenantId
+  const showGettingStartedPanel = process.env.NODE_ENV === 'development'
 
   useEffect(() => {
     const tenantParam = (searchParams.get('tenant') || '').trim()
@@ -314,6 +315,15 @@ export default function LoginPage() {
                 {translate('auth.login.forgotPassword', 'Forgot password?')}
               </Link>
             </div>
+            {showGettingStartedPanel ? (
+              <Notice compact className="text-xs leading-relaxed">
+                <span className="font-medium">{translate('auth.login.gettingStarted.title', 'Getting started')}</span>{' '}
+                {translate(
+                  'auth.login.gettingStarted.description',
+                  'Looking for demo credentials? Check the terminal output from yarn initialize.',
+                )}
+              </Notice>
+            ) : null}
           </form>
         </CardContent>
       </Card>

--- a/packages/core/src/modules/auth/i18n/de.json
+++ b/packages/core/src/modules/auth/i18n/de.json
@@ -26,6 +26,8 @@
   "auth.login.errors.tenantRequired": "Nutze den Login-Link aus deiner Tenant-Aktivierung, um fortzufahren.",
   "auth.login.featureDenied": "Du hast keinen Zugriff auf diese Funktion ({feature}). Bitte wende dich an deine Administration.",
   "auth.login.forgotPassword": "Passwort vergessen?",
+  "auth.login.gettingStarted.description": "Suchst du Demo-Zugangsdaten? Prüfe die Terminal-Ausgabe beim Ausführen von yarn initialize.",
+  "auth.login.gettingStarted.title": "Erste Schritte",
   "auth.login.loading": "Wird geladen ...",
   "auth.login.logoAlt": "Open Mercato Logo",
   "auth.login.rememberMe": "Angemeldet bleiben",

--- a/packages/core/src/modules/auth/i18n/en.json
+++ b/packages/core/src/modules/auth/i18n/en.json
@@ -26,6 +26,8 @@
   "auth.login.errors.tenantRequired": "Use the login link provided with your tenant activation to continue.",
   "auth.login.featureDenied": "You don't have access to this feature ({feature}). Please contact your administrator.",
   "auth.login.forgotPassword": "Forgot password?",
+  "auth.login.gettingStarted.description": "Looking for demo credentials? Check the terminal output from yarn initialize.",
+  "auth.login.gettingStarted.title": "Getting started",
   "auth.login.loading": "Loading...",
   "auth.login.logoAlt": "Open Mercato logo",
   "auth.login.rememberMe": "Remember me",

--- a/packages/core/src/modules/auth/i18n/es.json
+++ b/packages/core/src/modules/auth/i18n/es.json
@@ -26,6 +26,8 @@
   "auth.login.errors.tenantRequired": "Usa el enlace de inicio de sesión proporcionado con la activación de tu inquilino para continuar.",
   "auth.login.featureDenied": "No tienes acceso a esta funcionalidad ({feature}). Ponte en contacto con tu administrador.",
   "auth.login.forgotPassword": "¿Olvidaste tu contraseña?",
+  "auth.login.gettingStarted.description": "¿Buscas credenciales de demo? Revisa la salida de la terminal al ejecutar yarn initialize.",
+  "auth.login.gettingStarted.title": "Primeros pasos",
   "auth.login.loading": "Cargando...",
   "auth.login.logoAlt": "Logotipo de Open Mercato",
   "auth.login.rememberMe": "Recordarme",

--- a/packages/core/src/modules/auth/i18n/pl.json
+++ b/packages/core/src/modules/auth/i18n/pl.json
@@ -26,6 +26,8 @@
   "auth.login.errors.tenantRequired": "Użyj linku logowania z aktywacji najemcy, aby kontynuować.",
   "auth.login.featureDenied": "Nie masz dostępu do tej funkcji ({feature}). Skontaktuj się z administratorem.",
   "auth.login.forgotPassword": "Nie pamiętasz hasła?",
+  "auth.login.gettingStarted.description": "Szukasz danych demo? Sprawdź logi terminala z uruchomienia yarn initialize.",
+  "auth.login.gettingStarted.title": "Pierwsze kroki",
   "auth.login.loading": "Ładowanie...",
   "auth.login.logoAlt": "Logo Open Mercato",
   "auth.login.rememberMe": "Zapamiętaj mnie",


### PR DESCRIPTION
## Summary

Displays a small "Getting Started" / "Onboarding" panel (visible in dev mode) on login page, that reminds users where to find demo credentials.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [X] N/A (minor change, no spec needed)

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

