### PR TITLE
fix(currencies): correct handleSetBase API path (#843)

### DIFF
--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-004.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-004.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import {
+  createCurrencyFixture,
+  deleteCurrenciesEntityIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/currenciesFixtures';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { getTokenContext } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+/**
+ * TC-CUR-004: Set Base Currency from UI
+ * Covers: PUT /api/currencies/currencies (set isBase via list row action)
+ *
+ * Regression test for a bug where handleSetBase called PUT /api/currencies
+ * (missing /currencies suffix), resulting in a 404.
+ */
+test.describe('TC-CUR-004: Set Base Currency from UI', () => {
+  test('should set a non-base currency as base from the currencies list view', async ({ page, request }) => {
+    let token: string | null = null;
+    let currencyId: string | null = null;
+    let originalBaseId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const { organizationId, tenantId } = getTokenContext(token);
+
+      // Create a fixture currency
+      const randLetter = () => String.fromCharCode(65 + Math.floor(Math.random() * 26));
+      const code = `B${randLetter()}${randLetter()}`;
+      currencyId = await createCurrencyFixture(request, token, {
+        code,
+        name: `QA TC-CUR-004 Base Test`,
+      });
+
+      // Record the current base currency so we can restore it
+      const listResponse = await apiRequest(
+        request,
+        'GET',
+        '/api/currencies/currencies?isBase=true&pageSize=1',
+        { token },
+      );
+      const listBody = (await listResponse.json()) as { items?: Array<{ id: string }> };
+      originalBaseId = listBody.items?.[0]?.id ?? null;
+
+      // Navigate to currencies list page
+      await login(page, 'admin');
+      await page.goto('/backend/currencies');
+
+      // Wait for the table to load and find our fixture row
+      const row = page.getByRole('row').filter({ hasText: code });
+      await expect(row).toBeVisible({ timeout: 10_000 });
+
+      // Open row actions menu (focus + Enter, same pattern as TC-ADMIN-002)
+      const actionsButton = row.getByRole('button', { name: 'Open actions' });
+      await actionsButton.focus();
+      await actionsButton.press('Enter');
+
+      // Click the "Set as base" menu item (portalled to document.body)
+      const setBaseItem = page.getByRole('menuitem').filter({ hasText: /Set as Base/ }).first();
+      await setBaseItem.click();
+
+      // Verify the row now shows the base badge after reload
+      await expect(
+        row.getByText(/base|currencies\.list\.base/i),
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      // Restore original base currency if we changed it
+      if (token && originalBaseId) {
+        await apiRequest(request, 'PUT', '/api/currencies/currencies', {
+          token,
+          data: { id: originalBaseId, isBase: true },
+        });
+      }
+      await deleteCurrenciesEntityIfExists(request, token, '/api/currencies/currencies', currencyId);
+    }
+  });
+});

--- a/packages/core/src/modules/currencies/backend/currencies/__tests__/CurrenciesPage.test.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/__tests__/CurrenciesPage.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import CurrenciesPage from '../page'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: any) => (
+    <div data-testid="data-table-mock">
+      <div data-testid="data-table-title">{props.title}</div>
+      <button data-testid="search-trigger" onClick={() => props.onSearchChange?.('USD')}>
+        trigger-search
+      </button>
+      <div data-testid="row-actions-non-base">
+        {props.rowActions?.({
+          id: 'cur-1',
+          code: 'EUR',
+          isBase: false,
+          organizationId: 'org-1',
+          tenantId: 'ten-1',
+        })}
+      </div>
+      <div data-testid="row-actions-base">
+        {props.rowActions?.({
+          id: 'cur-2',
+          code: 'USD',
+          isBase: true,
+          organizationId: 'org-1',
+          tenantId: 'ten-1',
+        })}
+      </div>
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: any) => (
+    <div>
+      {items.map((item: any, idx: number) => (
+        <button key={item.id} data-testid={`row-action-${item.id}`} onClick={() => item.onSelect?.()}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, asChild, ...rest }: any) =>
+    asChild ? <span {...rest}>{children}</span> : <button {...rest}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/badge', () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}))
+
+jest.mock('@open-mercato/ui/backend/ValueIcons', () => ({
+  BooleanIcon: ({ value }: { value: boolean }) => <span>{String(value)}</span>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: jest.fn().mockReturnValue(1),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(() => new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(true), 0)
+    })),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('lucide-react', () => ({
+  Plus: () => null,
+  Star: () => null,
+}))
+
+HTMLDialogElement.prototype.showModal = jest.fn(function (this: HTMLDialogElement) {
+  this.open = true
+  this.setAttribute('open', '')
+})
+HTMLDialogElement.prototype.close = jest.fn(function (this: HTMLDialogElement) {
+  this.open = false
+  this.removeAttribute('open')
+})
+
+describe('CurrenciesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        items: [
+          { id: 'cur-1', code: 'EUR', name: 'Euro', symbol: '€', decimalPlaces: 2, isBase: false, isActive: true, organizationId: 'org-1', tenantId: 'ten-1', createdAt: '2024-01-01', updatedAt: '2024-01-01' },
+          { id: 'cur-2', code: 'USD', name: 'US Dollar', symbol: '$', decimalPlaces: 2, isBase: true, isActive: true, organizationId: 'org-1', tenantId: 'ten-1', createdAt: '2024-01-01', updatedAt: '2024-01-01' },
+        ],
+        total: 2,
+        page: 1,
+        totalPages: 1,
+      },
+    })
+  })
+
+  it('loads currencies from the correct API endpoint', async () => {
+    render(<CurrenciesPage />)
+
+    await waitFor(() => expect(apiCall).toHaveBeenCalled())
+    expect((apiCall as jest.Mock).mock.calls[0][0]).toContain('/api/currencies/currencies?page=1&pageSize=50')
+  })
+
+  it('passes search query to the correct API endpoint', async () => {
+    render(<CurrenciesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByTestId('search-trigger'))
+
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(2))
+    const secondCallUrl = (apiCall as jest.Mock).mock.calls[1][0] as string
+    expect(secondCallUrl).toContain('/api/currencies/currencies')
+    expect(secondCallUrl).toContain('search=USD')
+  })
+
+  it('handleSetBase calls PUT /api/currencies/currencies', async () => {
+    render(<CurrenciesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    const setBaseButton = screen.getByTestId('row-action-set-base')
+    fireEvent.click(setBaseButton)
+
+    await waitFor(() => {
+      const putCall = (apiCall as jest.Mock).mock.calls.find(
+        (call: unknown[]) => typeof call[1] === 'object' && (call[1] as Record<string, unknown>).method === 'PUT',
+      )
+      expect(putCall).toBeDefined()
+      expect(putCall[0]).toBe('/api/currencies/currencies')
+    })
+  })
+
+  it('handleDelete calls DELETE /api/currencies/currencies after confirmation', async () => {
+    render(<CurrenciesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    const deleteButton = screen.getByTestId('row-action-delete')
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      const deleteCall = (apiCall as jest.Mock).mock.calls.find(
+        (call: unknown[]) => typeof call[1] === 'object' && (call[1] as Record<string, unknown>).method === 'DELETE',
+      )
+      expect(deleteCall).toBeDefined()
+      expect(deleteCall[0]).toBe('/api/currencies/currencies')
+    })
+  })
+})

--- a/packages/core/src/modules/currencies/backend/currencies/__tests__/EditCurrencyPage.test.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/__tests__/EditCurrencyPage.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import EditCurrencyPage from '../[id]/page'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+const mockPush = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useParams: () => ({ id: 'cur-1' }),
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: (props: any) => (
+    <div data-testid="crud-form-mock">
+      <div data-testid="crud-form-title">{props.title}</div>
+      <button data-testid="submit-button" onClick={() => props.onSubmit?.(props.initialValues)}>
+        {props.submitLabel}
+      </button>
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  updateCrud: jest.fn(),
+  deleteCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  createCrudFormError: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/messages', () => ({
+  SendObjectMessageDialog: () => null,
+}))
+
+jest.mock('@open-mercato/ui/primitives/DataLoader', () => ({
+  DataLoader: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(() => new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(true), 0)
+    })),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+HTMLDialogElement.prototype.showModal = jest.fn(function (this: HTMLDialogElement) {
+  this.open = true
+  this.setAttribute('open', '')
+})
+HTMLDialogElement.prototype.close = jest.fn(function (this: HTMLDialogElement) {
+  this.open = false
+  this.removeAttribute('open')
+})
+
+const mockCurrency = {
+  id: 'cur-1',
+  code: 'EUR',
+  name: 'Euro',
+  symbol: '€',
+  decimalPlaces: 2,
+  thousandsSeparator: ',',
+  decimalSeparator: '.',
+  isBase: false,
+  isActive: true,
+  organizationId: 'org-1',
+  tenantId: 'ten-1',
+}
+
+describe('EditCurrencyPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        items: [mockCurrency],
+      },
+    })
+  })
+
+  it('loads currency from the correct API endpoint with id parameter', async () => {
+    render(<EditCurrencyPage params={{ id: 'cur-1' }} />)
+
+    await waitFor(() => expect(apiCall).toHaveBeenCalled())
+    expect((apiCall as jest.Mock).mock.calls[0][0]).toBe('/api/currencies/currencies?id=cur-1')
+  })
+
+  it('renders the form after loading currency data', async () => {
+    render(<EditCurrencyPage params={{ id: 'cur-1' }} />)
+
+    await waitFor(() => expect(screen.getByTestId('crud-form-mock')).toBeTruthy())
+    expect(screen.getByTestId('crud-form-title')).toHaveTextContent('currencies.edit.title')
+  })
+})

--- a/packages/core/src/modules/currencies/backend/currencies/page.tsx
+++ b/packages/core/src/modules/currencies/backend/currencies/page.tsx
@@ -99,7 +99,7 @@ export default function CurrenciesPage() {
   const handleSetBase = React.useCallback(
     async (row: CurrencyRow) => {
       try {
-        const call = await apiCall('/api/currencies', {
+        const call = await apiCall('/api/currencies/currencies', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ id: row.id, isBase: true }),

--- a/packages/core/src/modules/currencies/backend/exchange-rates/__tests__/ExchangeRatesPage.test.tsx
+++ b/packages/core/src/modules/currencies/backend/exchange-rates/__tests__/ExchangeRatesPage.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import type React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import ExchangeRatesPage from '../page'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
+
+const mockTranslate = (key: string, fallback?: string) => fallback ?? key
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('next/link', () => ({ children, href }: any) => <a href={href}>{children}</a>)
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: any) => <div>{children}</div>,
+  PageBody: ({ children }: any) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: any) => (
+    <div data-testid="data-table-mock">
+      <div data-testid="data-table-title">{props.title}</div>
+      <div data-testid="row-actions-wrapper">
+        {props.rowActions?.({
+          id: 'rate-1',
+          fromCurrencyCode: 'EUR',
+          toCurrencyCode: 'USD',
+          rate: '1.10',
+          organizationId: 'org-1',
+          tenantId: 'ten-1',
+        })}
+      </div>
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: any) => (
+    <div>
+      {items.map((item: any) => (
+        <button key={item.id} data-testid={`row-action-${item.id}`} onClick={() => item.onSelect?.()}>
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, asChild, ...rest }: any) =>
+    asChild ? <span {...rest}>{children}</span> : <button {...rest}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/backend/ValueIcons', () => ({
+  BooleanIcon: ({ value }: { value: boolean }) => <span>{String(value)}</span>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: jest.fn().mockReturnValue(1),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn(() => new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(true), 0)
+    })),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('lucide-react', () => ({
+  Plus: () => null,
+}))
+
+HTMLDialogElement.prototype.showModal = jest.fn(function (this: HTMLDialogElement) {
+  this.open = true
+  this.setAttribute('open', '')
+})
+HTMLDialogElement.prototype.close = jest.fn(function (this: HTMLDialogElement) {
+  this.open = false
+  this.removeAttribute('open')
+})
+
+describe('ExchangeRatesPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      result: {
+        items: [
+          { id: 'rate-1', fromCurrencyCode: 'EUR', toCurrencyCode: 'USD', rate: '1.10', date: '2024-01-01', source: 'Manual', type: null, isActive: true, organizationId: 'org-1', tenantId: 'ten-1', createdAt: '2024-01-01', updatedAt: '2024-01-01' },
+        ],
+        total: 1,
+        page: 1,
+        totalPages: 1,
+      },
+    })
+  })
+
+  it('loads exchange rates from the correct API endpoint', async () => {
+    render(<ExchangeRatesPage />)
+
+    await waitFor(() => expect(apiCall).toHaveBeenCalled())
+    expect((apiCall as jest.Mock).mock.calls[0][0]).toContain('/api/currencies/exchange-rates?page=1&pageSize=50')
+  })
+
+  it('handleDelete calls DELETE /api/currencies/exchange-rates after confirmation', async () => {
+    render(<ExchangeRatesPage />)
+    await waitFor(() => expect(apiCall).toHaveBeenCalledTimes(1))
+
+    const deleteButton = screen.getByTestId('row-action-delete')
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => {
+      const deleteCall = (apiCall as jest.Mock).mock.calls.find(
+        (call: unknown[]) => typeof call[1] === 'object' && (call[1] as Record<string, unknown>).method === 'DELETE',
+      )
+      expect(deleteCall).toBeDefined()
+      expect(deleteCall[0]).toBe('/api/currencies/exchange-rates')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fixed `handleSetBase` in the currencies list page calling `PUT /api/currencies` instead of `PUT /api/currencies/currencies`, resulting in a 404. Added 8 unit tests across 3 currencies frontend pages and a Playwright integration test TC-CUR-004.

## Changes

- **`packages/core/src/modules/currencies/backend/currencies/page.tsx`** — fixed API path in `handleSetBase` (`/api/currencies` → `/api/currencies/currencies`)
- **`CurrenciesPage.test.tsx`** — 4 unit tests: load URL, search URL, set-base PUT URL (regression), delete URL
- **`EditCurrencyPage.test.tsx`** — 2 unit tests: load URL with id param, form rendering
- **`ExchangeRatesPage.test.tsx`** — 2 unit tests: load URL, delete URL
- **`TC-CUR-004.spec.ts`** — Playwright test: creates fixture currency, sets as base via UI row action, verifies badge, restores original base

## Specification

- Does a spec exist? N/A — bug fix with regression tests

## Testing

- [x] `yarn build:packages` — PASS (14/14)
- [x] `yarn typecheck` — PASS (14/14)
- [x] `yarn test` — PASS (1931 tests, 199 suites)
- [x] `yarn build:app` — PASS
- [x] `yarn i18n:check-sync` — PASS
- [x] Playwright TC-CUR-004 — PASS against local dev server

## Linked issues

Fixes #843
