### PR TITLE
fix: CrudForm infinite loop

### DIFF
--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -1079,7 +1079,17 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   const fieldById = React.useMemo(() => {
     return new globalThis.Map(allFields.map((f) => [f.id, f]))
   }, [allFields])
-  
+
+  const allFieldsRef = React.useRef(allFields)
+  allFieldsRef.current = allFields
+
+  const dynamicOptionLoaderKey = React.useMemo(() => {
+    return allFields
+      .filter(f => f.type !== 'custom' && typeof (f as CrudBuiltinField).loadOptions === 'function')
+      .map(f => f.id)
+      .join('\0')
+  }, [allFields])
+
   const injectionGroupCards = React.useMemo<CrudFormGroup[]>(() => {
     if (!injectionWidgets || injectionWidgets.length === 0) return []
     const pairs = injectionWidgets
@@ -1700,11 +1710,11 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     }
   }
 
-  // Load dynamic options for fields that require it
+  // Stable key prevents infinite re-render loop (see #814) — do not depend on allFields directly.
   React.useEffect(() => {
     let cancelled = false
     const loadAll = async () => {
-      const loaders = allFields
+      const loaders = allFieldsRef.current
         .filter(
           (f): f is CrudBuiltinField & { loadOptions: NonNullable<CrudBuiltinField['loadOptions']> } =>
             f.type !== 'custom' && typeof f.loadOptions === 'function'
@@ -1723,7 +1733,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     return () => {
       cancelled = true
     }
-  }, [allFields])
+  }, [dynamicOptionLoaderKey])
 
   const loadFieldOptions = React.useCallback(async (field: CrudField, query?: string): Promise<CrudFieldOption[]> => {
     if (!('type' in field) || field.type === 'custom') return EMPTY_OPTIONS

--- a/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.render.test.tsx
@@ -1,3 +1,4 @@
+/** @jest-environment jsdom */
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: () => {} }),
   usePathname: () => '/',
@@ -56,6 +57,26 @@ describe('CrudForm initialValues', () => {
     })
 
     expect(getInput(container).value).toBe('Bob')
+  })
+
+  it('does not re-invoke loadOptions on parent re-render (#814)', async () => {
+    const loader = jest.fn().mockResolvedValue([{ label: 'A', value: 'a' }])
+    const baseFields: CrudField[] = [
+      { id: 'pick', label: 'Pick', type: 'combobox', loadOptions: loader },
+    ]
+    const { rerender } = renderWithProviders(
+      <CrudForm title="Form" fields={baseFields} onSubmit={() => {}} />
+    )
+    await act(() => Promise.resolve())
+    const callsAfterMount = loader.mock.calls.length
+
+    await act(async () => {
+      rerender(
+        <CrudForm title="Form" fields={[...baseFields]} onSubmit={() => {}} />
+      )
+    })
+    await act(() => Promise.resolve())
+    expect(loader).toHaveBeenCalledTimes(callsAfterMount)
   })
 
   it('does not reset fields on initialValues reference churn', async () => {


### PR DESCRIPTION
## Summary

  `CrudForm` enters an infinite re-render loop ("Maximum update depth exceeded") when any component outside   the form fields triggers a parent re-render (e.g., toggling an `extraActions` switch). The `useEffect`
  that loads dynamic options depends on `[allFields]`, and parent re-renders cause `allFields` to get a new   identity each time, creating an infinite cycle: re-render → new `allFields` → useEffect fires →
  `setDynamicOptions` → re-render → repeat.

  The fix stabilizes the effect dependency by replacing the unstable `[allFields]` array reference with a
  stable string key derived from the IDs of fields that have `loadOptions`, and uses a ref to access current
   fields inside the effect.

  Fixes #814

  ## Changes

  - Added `allFieldsRef` to track current `allFields` without triggering effect re-runs
  - Added `dynamicOptionLoaderKey` useMemo that derives a stable string from field IDs with `loadOptions`
  - Changed `useEffect` dependency from `[allFields]` to `[dynamicOptionLoaderKey]` and reads fields from
  `allFieldsRef.current`
  - Added missing `@jest-environment jsdom` directive to `CrudForm.render.test.tsx` (pre-existing issue)
  - Added regression test: `does not re-invoke loadOptions on parent re-render (#814)`

  ## Specification

  **Does a spec exist for this feature/module?**
  - [ ] Yes
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  N/A — targeted bugfix in a single React hook dependency.

  ## Testing

  - `yarn build:packages` — 14/14 successful
  - `yarn typecheck` — 14/14 successful
  - `yarn test` — all suites pass (including new regression test)
  - `yarn jest packages/ui/src/backend/__tests__/CrudForm.render.test.tsx` — 4/4 passed
  - Manual: navigate to `/backend/config/scheduled-jobs/new`, toggle Enabled/Disabled switch repeatedly — no
   console errors

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it.
  - [x] I added or adjusted tests that cover the change.
  - [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is
  not required).
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

  > **Integration tests note:** This is a React render-cycle bug in `CrudForm` internals. The regression is
  covered by a unit test that asserts `loadOptions` call count stability across re-renders. Integration
  tests cannot reliably detect infinite re-render loops as they crash the page before assertions run.
  
  ##Issue
  #814 