### PR TITLE
fix: set Testcontainers Docker Desktop overrides for Windows in docker-compose.preview.yaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/docker-compose.preview.yaml
+++ b/docker-compose.preview.yaml
@@ -9,5 +9,9 @@ services:
       - "5000:5001"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      DOCKER_HOST: unix:///var/run/docker.sock
+      TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: /var/run/docker.sock
+      TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary
Fix preview Docker startup on Windows by normalizing shell script line endings and configuring Testcontainers Docker Desktop host/socket overrides.

## Changes
- Normalize `docker/preview/preview-entrypoint.sh` to LF endings.
- Add `.gitattributes` rule: `*.sh text eol=lf`.
- Add preview compose env vars for Testcontainers:
  - `DOCKER_HOST`
  - `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`
  - `TESTCONTAINERS_HOST_OVERRIDE`

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

- `docker compose -f docker-compose.preview.yaml up --build`
- Verified previous `/app/docker/preview/preview-entrypoint.sh: set: line 2: illegal option -` is resolved.
- Verified preview now proceeds past entrypoint and package/app build steps on Windows.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

N/A
