### PR TITLE
fix(ui): reset stale breadcrumb on client-side navigation (#847)

### DIFF
--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -721,6 +721,16 @@ export function AppShell({ productName, email, groups, rightHeaderSlot, children
     setHeaderTitle(currentTitle)
     setHeaderBreadcrumb(breadcrumb)
   }, [currentTitle, breadcrumb])
+  // Clear breadcrumb on client-side navigation so stale state doesn't persist;
+  // the new page's ApplyBreadcrumb (if any) will set the correct values
+  const prevPathname = React.useRef(pathname)
+  React.useEffect(() => {
+    if (pathname !== prevPathname.current) {
+      prevPathname.current = pathname
+      setHeaderTitle(undefined)
+      setHeaderBreadcrumb(undefined)
+    }
+  }, [pathname])
 
   // Keep navGroups in sync when server-provided groups change
   React.useEffect(() => {

--- a/packages/ui/src/backend/__tests__/AppShell.test.tsx
+++ b/packages/ui/src/backend/__tests__/AppShell.test.tsx
@@ -104,6 +104,18 @@ describe('AppShell', () => {
       },
       configurable: true,
     })
+    if (typeof globalThis.Response === 'undefined') {
+      globalThis.Response = class MockResponse {
+        _body: string; status: number; headers: Headers
+        constructor(body?: string | null, init?: ResponseInit) {
+          this._body = body ?? ''; this.status = init?.status ?? 200
+          this.headers = new Headers(init?.headers)
+        }
+        get ok() { return this.status >= 200 && this.status < 300 }
+        async json() { return JSON.parse(this._body) }
+        async text() { return this._body }
+      } as unknown as typeof Response
+    }
   })
 
   it('renders navigation and breadcrumbs with translations applied via ApplyBreadcrumb', async () => {
@@ -192,6 +204,49 @@ describe('AppShell', () => {
         'href',
         '/backend/entities/user/example%3Acalendar_entity/records',
       )
+    })
+  })
+
+  it('resets breadcrumb to server-provided values when pathname changes', async () => {
+    mockPathname = '/backend/users'
+
+    const { rerender } = renderWithProviders(
+      <AppShell
+        email="demo@example.com"
+        groups={groups}
+        currentTitle="Users List"
+        breadcrumb={[{ label: 'Users List' }]}
+      >
+        <div>Page content</div>
+      </AppShell>,
+      { dict },
+    )
+
+    const getBreadcrumbText = () => {
+      const allNavs = screen.getAllByRole('navigation')
+      const breadcrumbNav = allNavs.find((nav) => nav.classList.contains('text-sm'))
+      return breadcrumbNav?.textContent ?? ''
+    }
+
+    await waitFor(() => {
+      expect(getBreadcrumbText()).toContain('Users List')
+    })
+
+    mockPathname = '/backend'
+
+    rerender(
+      <AppShell
+        email="demo@example.com"
+        groups={groups}
+        currentTitle=""
+      >
+        <div>Dashboard content</div>
+      </AppShell>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('Dashboard content')).toBeInTheDocument()
+      expect(getBreadcrumbText()).not.toContain('Users List')
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes stale breadcrumb that persisted across client-side navigations. When navigating between pages (e.g., Products → Dashboard), the breadcrumb kept showing the previous page's trail because Next.js App Router doesn't re-render server layouts on soft navigation, leaving `currentTitle`/`breadcrumb` props stale.

Added a `pathname`-based effect in `AppShell` that clears breadcrumb state on navigation, letting each page's `ApplyBreadcrumb` set the correct values.

## Changes

- Added pathname change detection effect in `AppShell` using `useRef` + `useEffect` to clear `headerTitle` and `headerBreadcrumb` on client-side navigation
- Added `Response` polyfill in `AppShell.test.tsx` `beforeAll`
- Added unit test verifying breadcrumb resets when pathname changes

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**


## Testing

- `yarn build:packages` — 14/14 pass
- `yarn typecheck` — pass
- `yarn test` — 163/163 pass
- `yarn build:app` — pass
- Manual: navigated Products → Dashboard → Currencies, breadcrumb updates correctly each time

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

> Integration test not added — this is a client-side state reset fix verified by unit test and manual testing. The breadcrumb rendering is internal to `AppShell` and not easily assertable via Playwright without brittle DOM selectors.

## Linked issues

Fixes #847
