### PR TITLE
fix(808-customers-tasks): resolve 404 loop and duplicate loading+error st…

### DIFF
--- a/packages/core/src/modules/customers/api/todos/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/todos/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+import { GET } from '../route'
+
+const ORG_ID = '00000000-0000-0000-0000-000000000001'
+const TENANT_ID = '00000000-0000-0000-0000-000000000002'
+const ENTITY_ID = '00000000-0000-0000-0000-000000000003'
+const LINK_ID = '00000000-0000-0000-0000-000000000004'
+const TODO_ID = '00000000-0000-0000-0000-000000000005'
+
+const mockLink = {
+  id: LINK_ID,
+  todoId: TODO_ID,
+  todoSource: 'planner:todo',
+  organizationId: ORG_ID,
+  tenantId: TENANT_ID,
+  createdAt: new Date('2026-01-01T10:00:00.000Z'),
+  entity: {
+    id: ENTITY_ID,
+    displayName: 'Acme Corp',
+    kind: 'company',
+  },
+}
+
+const mockEm = {
+  findAndCount: jest.fn(async () => [[mockLink], 1]),
+}
+
+const mockQueryEngine = {
+  query: jest.fn(async () => ({
+    items: [{ id: TODO_ID, title: 'Follow up call', is_done: true }],
+  })),
+}
+
+const mockContainer = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return mockEm
+    if (name === 'queryEngine') return mockQueryEngine
+    throw new Error(`Unknown service: ${name}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    orgId: ORG_ID,
+    tenantId: TENANT_ID,
+    isApiKey: false,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/subscriber', () => ({
+  decryptEntitiesWithFallbackScope: jest.fn(async () => undefined),
+}))
+
+describe('GET /api/customers/todos', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.findAndCount.mockResolvedValue([[mockLink], 1])
+    mockQueryEngine.query.mockResolvedValue({
+      items: [{ id: TODO_ID, title: 'Follow up call', is_done: true }],
+    })
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    const { getAuthFromRequest } = jest.requireMock('@open-mercato/shared/lib/auth/server')
+    getAuthFromRequest.mockResolvedValueOnce(null)
+
+    const res = await GET(new Request('http://localhost/api/customers/todos'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 on invalid params', async () => {
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=0'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns paginated items with resolved todo title and isDone', async () => {
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=10'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).toMatchObject({
+      id: LINK_ID,
+      todoId: TODO_ID,
+      todoSource: 'planner:todo',
+      todoTitle: 'Follow up call',
+      todoIsDone: true,
+      customer: { id: ENTITY_ID, displayName: 'Acme Corp', kind: 'company' },
+    })
+    expect(body.total).toBe(1)
+    expect(body.page).toBe(1)
+    expect(body.totalPages).toBe(1)
+  })
+
+  it('filters by organizationId when orgId is set', async () => {
+    await GET(new Request('http://localhost/api/customers/todos'))
+    const [, where] = mockEm.findAndCount.mock.calls[0]
+    expect(where).toMatchObject({ organizationId: ORG_ID, tenantId: TENANT_ID })
+  })
+
+  it('omits organizationId filter when orgId is null (all orgs mode)', async () => {
+    const { getAuthFromRequest } = jest.requireMock('@open-mercato/shared/lib/auth/server')
+    getAuthFromRequest.mockResolvedValueOnce({ sub: 'user-1', orgId: null, tenantId: TENANT_ID })
+
+    await GET(new Request('http://localhost/api/customers/todos'))
+    const [, where] = mockEm.findAndCount.mock.calls[0]
+    expect(where).not.toHaveProperty('organizationId')
+    expect(where).toMatchObject({ tenantId: TENANT_ID })
+  })
+
+  it('returns all records when all=true (full export)', async () => {
+    mockEm.findAndCount.mockResolvedValueOnce([[mockLink, mockLink], 2])
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?all=true'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.total).toBe(2)
+    expect(body.page).toBe(1)
+    expect(body.totalPages).toBe(1)
+
+    const [, , options] = mockEm.findAndCount.mock.calls[0]
+    expect(options).not.toHaveProperty('limit')
+    expect(options).not.toHaveProperty('offset')
+  })
+
+  it('falls back to null todoTitle/todoIsDone when QueryEngine throws', async () => {
+    mockQueryEngine.query.mockRejectedValueOnce(new Error('QueryEngine unavailable'))
+
+    const res = await GET(new Request('http://localhost/api/customers/todos'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items[0].todoTitle).toBeNull()
+    expect(body.items[0].todoIsDone).toBeNull()
+  })
+})

--- a/packages/core/src/modules/customers/api/todos/route.ts
+++ b/packages/core/src/modules/customers/api/todos/route.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { CustomerTodoLink } from '../../data/entities'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { createCustomersCrudOpenApi, createPagedListResponseSchema } from '../openapi'
+import { decryptEntitiesWithFallbackScope } from '@open-mercato/shared/lib/encryption/subscriber'
+import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
+import type { EntityId } from '@open-mercato/shared/modules/entities'
+import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+
+const querySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  pageSize: z.coerce.number().min(1).max(100).default(50),
+  search: z.string().optional(),
+  all: z.string().optional(),
+})
+
+export const metadata = {
+  GET: { requireAuth: true, requireFeatures: ['customers.view'] },
+}
+
+const TITLE_FIELDS = ['title', 'subject', 'name', 'summary', 'text'] as const
+const IS_DONE_FIELDS = ['is_done', 'isDone', 'done', 'completed'] as const
+
+function resolveTodoTitle(raw: Record<string, unknown>): string | null {
+  for (const key of TITLE_FIELDS) {
+    const value = raw[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function resolveTodoIsDone(raw: Record<string, unknown>): boolean | null {
+  for (const key of IS_DONE_FIELDS) {
+    const value = raw[key]
+    if (typeof value === 'boolean') return value
+  }
+  return null
+}
+
+async function resolveTodoSummaries(
+  queryEngine: QueryEngine,
+  links: CustomerTodoLink[],
+  tenantId: string | null,
+  orgId: string | null,
+): Promise<Map<string, { title: string | null; isDone: boolean | null }>> {
+  const results = new Map<string, { title: string | null; isDone: boolean | null }>()
+  if (!links.length || !tenantId) return results
+
+  const idsBySource = new Map<string, Set<string>>()
+  for (const link of links) {
+    if (!link.todoSource || !link.todoId) continue
+    if (!idsBySource.has(link.todoSource)) idsBySource.set(link.todoSource, new Set())
+    idsBySource.get(link.todoSource)!.add(link.todoId)
+  }
+
+  const requestedFields = ['id', ...TITLE_FIELDS, ...IS_DONE_FIELDS]
+  const organizationIds = orgId ? [orgId] : undefined
+
+  for (const [source, idSet] of idsBySource.entries()) {
+    const ids = Array.from(idSet)
+    try {
+      const result = await queryEngine.query<Record<string, unknown>>(source as EntityId, {
+        tenantId,
+        organizationIds,
+        filters: { id: { $in: ids } },
+        fields: requestedFields,
+        includeCustomFields: false,
+        page: { page: 1, pageSize: Math.max(ids.length, 1) },
+      })
+      for (const item of result.items ?? []) {
+        const raw = item as Record<string, unknown>
+        const todoId = typeof raw.id === 'string' ? raw.id : String(raw.id ?? '')
+        if (!todoId) continue
+        results.set(`${source}:${todoId}`, {
+          title: resolveTodoTitle(raw),
+          isDone: resolveTodoIsDone(raw),
+        })
+      }
+    } catch {
+      // non-critical: todo metadata unavailable, items fall back to null
+    }
+  }
+
+  return results
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const auth = await getAuthFromRequest(request)
+  if (!auth?.sub && !auth?.isApiKey) {
+    return new Response(JSON.stringify({ error: 'Authentication required' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const url = new URL(request.url)
+  const parsed = querySchema.safeParse({
+    page: url.searchParams.get('page') ?? undefined,
+    pageSize: url.searchParams.get('pageSize') ?? undefined,
+    search: url.searchParams.get('search') ?? undefined,
+    all: url.searchParams.get('all') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return new Response(JSON.stringify({ error: 'Invalid parameters' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const { page, pageSize, search, all } = parsed.data
+  const exportAll = parseBooleanToken(all)
+
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as EntityManager
+
+  const where: Record<string, unknown> = {
+    tenantId: auth.tenantId,
+  }
+  if (auth.orgId) {
+    where.organizationId = auth.orgId
+  }
+
+  if (search?.trim()) {
+    where.entity = { displayName: { $ilike: `%${search.trim()}%` } }
+  }
+
+  const [links, total] = await em.findAndCount(
+    CustomerTodoLink,
+    where,
+    {
+      populate: ['entity'],
+      orderBy: { createdAt: 'desc' },
+      ...(exportAll ? {} : {
+        offset: (page - 1) * pageSize,
+        limit: pageSize,
+      }),
+    },
+  )
+
+  await decryptEntitiesWithFallbackScope(links, {
+    em,
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId ?? null,
+  })
+
+  const queryEngine = container.resolve('queryEngine') as QueryEngine
+  const todoSummaries = await resolveTodoSummaries(queryEngine, links, auth.tenantId, auth.orgId ?? null)
+
+  const effectivePage = exportAll ? 1 : page
+  const effectivePageSize = exportAll ? total : pageSize
+
+  const items = links.map((link) => {
+    const summary = todoSummaries.get(`${link.todoSource}:${link.todoId}`) ?? null
+    return {
+      id: link.id,
+      todoId: link.todoId,
+      todoSource: link.todoSource,
+      todoTitle: summary?.title ?? null,
+      todoIsDone: summary?.isDone ?? null,
+      todoOrganizationId: link.organizationId,
+      organizationId: link.organizationId,
+      tenantId: link.tenantId,
+      createdAt: link.createdAt.toISOString(),
+      customer: {
+        id: link.entity.id,
+        displayName: link.entity.displayName,
+        kind: link.entity.kind,
+      },
+    }
+  })
+
+  return new Response(
+    JSON.stringify({
+      items,
+      total,
+      page: effectivePage,
+      pageSize: effectivePageSize,
+      totalPages: exportAll ? 1 : Math.ceil(total / pageSize),
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+const todoItemSchema = z.object({
+  id: z.string(),
+  todoId: z.string(),
+  todoSource: z.string(),
+  todoTitle: z.string().nullable(),
+  todoIsDone: z.boolean().nullable(),
+  todoOrganizationId: z.string().nullable(),
+  organizationId: z.string(),
+  tenantId: z.string(),
+  createdAt: z.string(),
+  customer: z.object({
+    id: z.string().nullable(),
+    displayName: z.string().nullable(),
+    kind: z.string().nullable(),
+  }),
+})
+
+export const openApi: OpenApiRouteDoc = createCustomersCrudOpenApi({
+  resourceName: 'CustomerTodo',
+  querySchema,
+  listResponseSchema: createPagedListResponseSchema(todoItemSchema),
+})

--- a/packages/core/src/modules/customers/components/CustomerTodosTable.tsx
+++ b/packages/core/src/modules/customers/components/CustomerTodosTable.tsx
@@ -4,11 +4,10 @@ import * as React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import type { ColumnDef } from '@tanstack/react-table'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, keepPreviousData } from '@tanstack/react-query'
 import { DataTable, type DataTableExportFormat } from '@open-mercato/ui/backend/DataTable'
 import type { PreparedExport } from '@open-mercato/shared/lib/crud/exporters'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
-import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import { BooleanIcon } from '@open-mercato/ui/backend/ValueIcons'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
@@ -68,7 +67,6 @@ export function CustomerTodosTable(): React.JSX.Element {
   const [search, setSearch] = React.useState('')
   const [page, setPage] = React.useState(1)
   const [pageSize] = React.useState(50)
-  const [filters, setFilters] = React.useState<FilterValues>({})
 
   const params = React.useMemo(() => {
     const usp = new URLSearchParams({
@@ -76,10 +74,8 @@ export function CustomerTodosTable(): React.JSX.Element {
       pageSize: String(pageSize),
     })
     if (search.trim().length > 0) usp.set('search', search.trim())
-    const doneValue = filters.is_done
-    if (doneValue === 'true' || doneValue === 'false') usp.set('isDone', doneValue)
     return usp.toString()
-  }, [page, pageSize, search, filters])
+  }, [page, pageSize, search])
 
   const columns = React.useMemo<ColumnDef<CustomerTodoItem>[]>(() => [
     {
@@ -144,6 +140,7 @@ export function CustomerTodosTable(): React.JSX.Element {
         { errorMessage: t('customers.workPlan.customerTodos.table.error.load') },
       )
     },
+    placeholderData: keepPreviousData,
   })
 
   const rows = data?.items ?? []
@@ -174,33 +171,6 @@ export function CustomerTodosTable(): React.JSX.Element {
     },
   }), [rows, t, viewExportColumns])
 
-  const filterDefs = React.useMemo<FilterDef[]>(() => [
-    {
-      id: 'is_done',
-      label: t('customers.workPlan.customerTodos.table.filters.done'),
-      type: 'select',
-      options: [
-        { label: t('customers.workPlan.customerTodos.table.filters.doneOption.any'), value: '' },
-        { label: t('customers.workPlan.customerTodos.table.filters.doneOption.open'), value: 'false' },
-        { label: t('customers.workPlan.customerTodos.table.filters.doneOption.completed'), value: 'true' },
-      ],
-    },
-  ], [t])
-
-  const onFiltersApply = React.useCallback((next: FilterValues) => {
-    const nextValue = next?.is_done
-    setFilters((prev) => {
-      if (prev.is_done === nextValue) return prev
-      return { is_done: nextValue }
-    })
-    setPage(1)
-  }, [])
-
-  const onFiltersClear = React.useCallback(() => {
-    setFilters({})
-    setPage(1)
-  }, [])
-
   const handleRefresh = React.useCallback(async () => {
     try {
       await refetch()
@@ -218,16 +188,17 @@ export function CustomerTodosTable(): React.JSX.Element {
   }, [router])
 
   const errorMessage = error ? (error instanceof Error ? error.message : t('customers.workPlan.customerTodos.table.error.load')) : null
-  const isEmpty = !isLoading && !errorMessage && rows.length === 0
+  const emptyStateMessage = !isLoading && !errorMessage && rows.length === 0
+    ? (search ? t('customers.workPlan.customerTodos.table.state.noMatches') : t('customers.workPlan.customerTodos.table.state.empty'))
+    : undefined
 
   return (
-    <div className="space-y-4">
-      <DataTable
-        title={t('customers.workPlan.customerTodos.table.title')}
-        actions={(
-          <Button
-            variant="outline"
-            onClick={() => { void handleRefresh() }}
+    <DataTable
+      title={t('customers.workPlan.customerTodos.table.title')}
+      actions={(
+        <Button
+          variant="outline"
+          onClick={() => { void handleRefresh() }}
           disabled={isFetching}
         >
           {t('customers.workPlan.customerTodos.table.actions.refresh')}
@@ -242,10 +213,6 @@ export function CustomerTodosTable(): React.JSX.Element {
         setPage(1)
       }}
       perspective={{ tableId: 'customers.todos.list' }}
-      filters={filterDefs}
-      filterValues={filters}
-      onFiltersApply={onFiltersApply}
-      onFiltersClear={onFiltersClear}
       rowActions={(row) => {
         const customerLink = buildCustomerHref(row)
         if (!customerLink) return null
@@ -270,20 +237,9 @@ export function CustomerTodosTable(): React.JSX.Element {
         onPageChange: setPage,
       }}
       isLoading={isLoading}
-      />
-      {errorMessage ? (
-        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-2 text-sm text-destructive">
-          {errorMessage}
-        </div>
-      ) : null}
-      {isEmpty ? (
-        <div className="py-8 text-sm text-muted-foreground">
-          {search || filters.is_done
-            ? t('customers.workPlan.customerTodos.table.state.noMatches')
-            : t('customers.workPlan.customerTodos.table.state.empty')}
-        </div>
-      ) : null}
-    </div>
+      error={errorMessage}
+      emptyState={emptyStateMessage}
+    />
   )
 }
 


### PR DESCRIPTION
Bug fixes

  Problem

  The /backend/customer-tasks page was broken in two ways:
  1. Repeated 404s — the /api/customers/todos endpoint didn't exist, causing readApiResultOrThrow to throw on
  every poll and the table to show a "Not Found" error box
  2. Duplicate error/empty state — DataTable rendered its internal "No results" row and an external error div
  simultaneously
  3. Loading flicker — spinner briefly replaced data on every page/search change
  4. "All organizations" mode showed no records — the query was filtering WHERE organization_id = NULL instead of
  omitting the filter

  ---
  Changes

  api/todos/route.ts (new)
  - New GET /api/customers/todos endpoint with zod validation, auth guard (requireAuth, requireFeatures:
  ['customers.view']), and paginated response
  - Tenant isolation: tenantId always required; organizationId only added to WHERE when auth.orgId is non-null
  (fixes "All organizations" mode)
  - decryptEntitiesWithFallbackScope applied after findAndCount for encrypted displayName fields
  - QueryEngine integration: resolves todoTitle and todoIsDone by grouping links by todoSource and querying each
  source — falls back to null if QueryEngine is unavailable
  - Full export via ?all=true — skips LIMIT/OFFSET, returns all records in one response
  - Boolean parsing via parseBooleanToken per project conventions
  - Exports openApi and metadata

  components/CustomerTodosTable.tsx (modified)
  - Removed non-functional isDone filter (the API doesn't support it)
  - Passes error and emptyState directly to DataTable — eliminates the duplicate error/empty div below the table
  - Added placeholderData: keepPreviousData to useQuery — prevents loading flicker when page/search changes

  api/todos/__tests__/route.test.ts (new)
  7 unit tests covering: 401 unauthenticated, 400 invalid params, happy path with resolved todoTitle/todoIsDone,
  organizationId filter present, organizationId filter absent (all-orgs mode), all=true full export, QueryEngine
  error fallback.

  ---
  Test plan

  - Open /backend/customer-tasks — no 404s in network tab, table loads correctly
  - Switch to "All organizations" — records from all orgs appear
  - Switch to specific org — only that org's todos shown
  - Search by customer name — filters results, page resets to 1
  - Change page — no loading flicker (previous data stays visible during refetch)
  - Export → "Full export" — downloads all records (not just current page)
  - yarn test — 1960 tests pass