### PR TITLE
fix: ai assistant settings visibility (#852)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/backend/config/ai-assistant/page.meta.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/backend/config/ai-assistant/page.meta.ts
@@ -16,10 +16,11 @@ export const metadata = {
   requireFeatures: ['ai_assistant.view'],
   pageTitle: 'AI Assistant',
   pageTitleKey: 'ai_assistant.config.nav.settings',
-  pageGroup: 'Configuration',
-  pageGroupKey: 'backend.nav.configuration',
+  pageGroup: 'Module Configs',
+  pageGroupKey: 'settings.sections.moduleConfigs',
   pageOrder: 430,
   icon: aiIcon,
+  pageContext: 'settings' as const,
   breadcrumb: [
     { label: 'AI Assistant', labelKey: 'ai_assistant.config.nav.settings' },
   ],


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The AI Assistant Settings page (`/backend/config/ai-assistant`) was accessible via direct URL but did not appear in the Settings navigation sidebar under Module Configurations. The `page.meta.ts` file was missing the `pageContext: 'settings'` marker and used an incorrect `pageGroup` value, so the navigation builder never included the page.

## Changes

- Added `pageContext: 'settings' as const` to `packages/ai-assistant/src/modules/ai_assistant/backend/config/ai-assistant/page.meta.ts`
- Updated `pageGroup` to `'Module Configs'` and added `pageGroupKey: 'settings.sections.moduleConfigs'` to align with other module config pages (Catalog, Sales, Customers, Search)

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Verified AI Assistant appears under Settings → Module Configurations after login as admin
- Confirmed page is hidden from users without `ai_assistant.view` feature
- Direct URL access still works as before

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [] I updated documentation, locales, or generators if the change requires it.
- [] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required) — no integration test required for a metadata-only navigation fix.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable) — N/A.

## Linked issues

Fixes #852
