### PR TITLE
fix(directory): TenantSelect 400 error, misleading validation respons…

### DIFF
--- a/packages/core/src/modules/directory/api/tenants/route.ts
+++ b/packages/core/src/modules/directory/api/tenants/route.ts
@@ -109,7 +109,10 @@ export async function GET(req: Request) {
     isActive: url.searchParams.get('isActive') ?? undefined,
   })
   if (!parsed.success) {
-    return NextResponse.json({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 1 }, { status: 400 })
+    return NextResponse.json(
+      { error: 'Invalid query parameters', details: parsed.error.flatten() },
+      { status: 400 },
+    )
   }
 
   const container = await createRequestContainer()

--- a/packages/core/src/modules/directory/components/TenantSelect.tsx
+++ b/packages/core/src/modules/directory/components/TenantSelect.tsx
@@ -60,7 +60,7 @@ function filterTenantsByStatus(list: TenantRecord[], status: 'all' | 'active' | 
 async function fetchDirectoryTenants(status: 'all' | 'active' | 'inactive', errorMessage: string): Promise<TenantRecord[]> {
   const search = new URLSearchParams()
   search.set('page', '1')
-  search.set('pageSize', '200')
+  search.set('pageSize', '100')
   search.set('sortField', 'name')
   search.set('sortDir', 'asc')
   if (status === 'active') search.set('isActive', 'true')
@@ -145,10 +145,16 @@ export const TenantSelect = React.forwardRef<HTMLSelectElement, TenantSelectProp
     let cancelled = false
     const loadTenants = async () => {
       setFetchStatus('loading')
+      const autoSelect = (tenants: TenantRecord[]) => {
+        if (!value && !includeEmptyOption && tenants.length > 0) {
+          onChange?.(tenants[0].id)
+        }
+      }
       try {
         const tenants = await fetchDirectoryTenants(status, fetchErrorMessage)
         if (cancelled) return
         setRemoteTenants(tenants)
+        autoSelect(tenants)
         setFetchStatus('success')
         return
       } catch {
@@ -156,6 +162,7 @@ export const TenantSelect = React.forwardRef<HTMLSelectElement, TenantSelectProp
           const fallbackTenants = await fetchTenantsFromOrganizationSwitcher(status, fetchErrorMessage)
           if (cancelled) return
           setRemoteTenants(fallbackTenants)
+          autoSelect(fallbackTenants)
           setFetchStatus('success')
           return
         } catch {
@@ -166,6 +173,7 @@ export const TenantSelect = React.forwardRef<HTMLSelectElement, TenantSelectProp
     }
     void loadTenants()
     return () => { cancelled = true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- value/onChange/includeEmptyOption are read once at fetch time for auto-select
   }, [fetchOnMount, status, t])
 
   const mergedTenants = React.useMemo(

--- a/packages/core/src/modules/directory/components/__tests__/TenantSelect.test.tsx
+++ b/packages/core/src/modules/directory/components/__tests__/TenantSelect.test.tsx
@@ -61,6 +61,72 @@ describe('TenantSelect', () => {
     })
   })
 
+  it('requests pageSize=100 from the directory tenants endpoint', async () => {
+    let capturedUrl: string | undefined
+    ;(readApiResultOrThrow as jest.Mock).mockImplementationOnce(async (url: string) => {
+      capturedUrl = url
+      return { items: [{ id: 't-100', name: 'Tenant A', isActive: true }] }
+    })
+
+    renderWithProviders(<TenantSelect />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Tenant A' })).toBeInTheDocument()
+    })
+
+    expect(capturedUrl).toContain('pageSize=100')
+    expect(capturedUrl).not.toContain('pageSize=200')
+  })
+
+  it('auto-selects first tenant when value is null and includeEmptyOption is false', async () => {
+    const onChange = jest.fn()
+    ;(readApiResultOrThrow as jest.Mock).mockResolvedValueOnce({
+      items: [
+        { id: 't-first', name: 'First Tenant', isActive: true },
+        { id: 't-second', name: 'Second Tenant', isActive: true },
+      ],
+    })
+
+    renderWithProviders(<TenantSelect value={null} onChange={onChange} />, { dict })
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('t-first')
+    })
+  })
+
+  it('does not auto-select when value is already set', async () => {
+    const onChange = jest.fn()
+    ;(readApiResultOrThrow as jest.Mock).mockResolvedValueOnce({
+      items: [
+        { id: 't-first', name: 'First Tenant', isActive: true },
+        { id: 't-second', name: 'Second Tenant', isActive: true },
+      ],
+    })
+
+    renderWithProviders(<TenantSelect value="t-second" onChange={onChange} />, { dict })
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'First Tenant' })).toBeInTheDocument()
+    })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('auto-selects first tenant from fallback endpoint', async () => {
+    const onChange = jest.fn()
+    ;(readApiResultOrThrow as jest.Mock)
+      .mockRejectedValueOnce(new Error('directory down'))
+      .mockResolvedValueOnce({
+        tenants: [{ id: 't-fallback', name: 'Fallback Tenant', isActive: true }],
+      })
+
+    renderWithProviders(<TenantSelect value={null} onChange={onChange} />, { dict })
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith('t-fallback')
+    })
+  })
+
   it('shows an error option when both fetch attempts fail', async () => {
     ;(readApiResultOrThrow as jest.Mock)
       .mockRejectedValueOnce(new Error('directory down'))


### PR DESCRIPTION
## Summary

Superadmins could not create organizations via Settings -> Organizations -> Create. Three bugs combined to cause the failure: TenantSelect requested `pageSize=200` (exceeding the route's Zod `max(100)`), the tenants route returned a misleading empty-list-shaped 400 response instead of an error, and after the fallback endpoint populated the dropdown, React's controlled value stayed `null` — causing "field is required" on submit despite a tenant being visually selected.

## Changes

- **`TenantSelect.tsx`**: Changed `pageSize` from `200` to `100` to comply with the route's Zod schema and AGENTS.md `pageSize <= 100` rule
- **`TenantSelect.tsx`**: Added `autoSelect()` logic that calls `onChange` with the first tenant's ID when `value` is null and `includeEmptyOption` is false — applied to both primary fetch and fallback (`organization-switcher`) paths
- **`route.ts`** (tenants GET): Changed validation failure response from `{ items: [], total: 0, page: 1, pageSize: 50, totalPages: 1 }` (status 400) to `{ error: 'Invalid query parameters', details: parsed.error.flatten() }` (status 400) — aligning the implementation with the already-documented OpenAPI contract (`directoryErrorSchema`)
- **`TenantSelect.test.tsx`**: Added 4 unit tests:
  - `pageSize=100` contract pin (verifies request URL)
  - Auto-selects first tenant when `value` is null and `includeEmptyOption` is false
  - Does not auto-select when `value` is already set
  - Auto-selects first tenant from fallback endpoint

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:** N/A — small bug fix, no spec per AGENTS.md ("Skip for small fixes")

## Testing

### Automated
- `yarn build:packages` — 14/14 packages PASS
- `yarn generate` — PASS (no changes needed)
- `yarn build:packages` (rebuild) — PASS
- `yarn i18n:check-sync` — PASS
- `yarn i18n:check-usage` — PASS
- `yarn typecheck` — 14/14 packages PASS
- `yarn test` — 1964/1964 tests PASS (including 8 TenantSelect tests: 4 existing + 4 new)
- `yarn build:app` — PASS
- `yarn template:sync` — pre-existing drift in `example` module (3 files), unrelated to this change

### Manual
- Login as `superadmin@acme.com` → Settings → Organizations → Create
- Tenant dropdown populates without 400 in network tab
- First tenant is auto-selected (React controlled value matches visual state)
- Submit works without manually touching the dropdown

### Consumer impact
- Verified no other code in the codebase depends on the previous 400 response shape (`{ items: [], ... }`)
- Only 3 consumers of `GET /api/directory/tenants` found; none trigger validation failure or parse the 400 body
- The OpenAPI doc (`tenantGetDoc`) already documented `{ status: 400, schema: directoryErrorSchema }` - fix aligns the actual response with the documented contract

## Checklist
- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

**Integration test note:** No integration test added. This is a small client-side bug fix with comprehensive unit test coverage (4 new tests). The affected page (Create Organization) is superadmin-only and the fix is validated by manual testing. A `TC-DIR-002` integration test for the route validation response shape could be added as a follow-up.

**Spec note:** N/A — bug fix only, no new feature or architectural change.

## Linked issues

Fixes #857
