### PR TITLE
fix(catalog): variant price no longer decreases by VAT on reopen (#786)

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
@@ -18,6 +18,7 @@ import {
   type OptionDefinition,
   createVariantInitialValues,
   normalizeOptionSchema,
+  mapPriceItemToDraft,
 } from '@open-mercato/core/modules/catalog/components/products/variantForm'
 import {
   type PriceKindSummary,
@@ -152,7 +153,7 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
   }, [t])
 
   React.useEffect(() => {
-    if (!variantId || isCreateSentinel) return
+    if (!variantId || isCreateSentinel || priceKinds.length === 0) return
     let cancelled = false
     async function load() {
       setLoading(true)
@@ -173,7 +174,7 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
         if (resolvedProductId) setCurrentProductId(resolvedProductId)
         const metadata = typeof record.metadata === 'object' && record.metadata ? { ...(record.metadata as Record<string, unknown>) } : {}
         const attachments = await fetchVariantAttachments(variantId!)
-        const priceDrafts = await loadVariantPrices(variantId!)
+        const priceDrafts = await loadVariantPrices(variantId!, priceKinds)
         const priceIdMap: Record<string, string> = {}
         Object.entries(priceDrafts).forEach(([kindId, draft]) => {
           if (draft.priceId) priceIdMap[kindId] = draft.priceId
@@ -299,7 +300,7 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
     }
     load()
     return () => { cancelled = true }
-  }, [variantId, t, currentProductId])
+  }, [variantId, t, currentProductId, priceKinds])
 
   const groups = React.useMemo<CrudFormGroup[]>(() => {
     const list: CrudFormGroup[] = [
@@ -598,7 +599,8 @@ async function fetchVariantAttachments(variantId: string): Promise<ProductMediaI
   }
 }
 
-async function loadVariantPrices(variantId: string): Promise<Record<string, VariantPriceDraft>> {
+async function loadVariantPrices(variantId: string, priceKinds: PriceKindSummary[]): Promise<Record<string, VariantPriceDraft>> {
+  const kindDisplayModes = new Map(priceKinds.map((k) => [k.id, k.displayMode]))
   const drafts: Record<string, VariantPriceDraft> = {}
   const pageSize = 100
   let page = 1
@@ -610,37 +612,8 @@ async function loadVariantPrices(variantId: string): Promise<Record<string, Vari
       if (!res.ok) break
       const items = Array.isArray(res.result?.items) ? res.result?.items : []
       for (const item of items) {
-        const kindId =
-          typeof item.price_kind_id === 'string'
-            ? item.price_kind_id
-            : typeof item.priceKindId === 'string'
-              ? item.priceKindId
-              : null
-        if (!kindId) continue
-        const unitNet =
-          typeof item.unit_price_net === 'string'
-            ? item.unit_price_net
-            : typeof item.unitPriceNet === 'string'
-              ? item.unitPriceNet
-              : null
-        const unitGross =
-          typeof item.unit_price_gross === 'string'
-            ? item.unit_price_gross
-            : typeof item.unitPriceGross === 'string'
-              ? item.unitPriceGross
-              : null
-        drafts[kindId] = {
-          priceKindId: kindId,
-          priceId: typeof item.id === 'string' ? item.id : undefined,
-          amount: unitNet ?? unitGross ?? '',
-          currencyCode:
-            typeof item.currency_code === 'string'
-              ? item.currency_code
-              : typeof item.currencyCode === 'string'
-                ? item.currencyCode
-                : null,
-          displayMode: unitGross ? 'including-tax' : 'excluding-tax',
-        }
+        const draft = mapPriceItemToDraft(item as Record<string, unknown>, kindDisplayModes)
+        if (draft) drafts[draft.priceKindId] = draft
       }
       if (items.length < pageSize) break
       page += 1

--- a/packages/core/src/modules/catalog/components/products/__tests__/variantForm.test.ts
+++ b/packages/core/src/modules/catalog/components/products/__tests__/variantForm.test.ts
@@ -3,6 +3,7 @@ import {
   createVariantInitialValues,
   normalizeOptionSchema,
   buildVariantMetadata,
+  mapPriceItemToDraft,
 } from '../variantForm'
 import type { VariantFormValues } from '../variantForm'
 
@@ -218,5 +219,121 @@ describe('buildVariantMetadata', () => {
     expect(result).toEqual({ alpha: 'a', beta: 2, gamma: true })
     result['alpha'] = 'modified'
     expect(metadata.alpha).toBe('a')
+  })
+})
+
+describe('mapPriceItemToDraft', () => {
+  it('picks unitGross for amount when price kind is including-tax', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>([['kind-1', 'including-tax']])
+    const item = {
+      id: 'price-1',
+      price_kind_id: 'kind-1',
+      unit_price_net: '975.61',
+      unit_price_gross: '1200.00',
+      currency_code: 'USD',
+    }
+    const draft = mapPriceItemToDraft(item, modes)
+    expect(draft).not.toBeNull()
+    expect(draft!.amount).toBe('1200.00')
+    expect(draft!.displayMode).toBe('including-tax')
+  })
+
+  it('picks unitNet for amount when price kind is excluding-tax', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>([['kind-2', 'excluding-tax']])
+    const item = {
+      id: 'price-2',
+      price_kind_id: 'kind-2',
+      unit_price_net: '975.61',
+      unit_price_gross: '1200.00',
+      currency_code: 'EUR',
+    }
+    const draft = mapPriceItemToDraft(item, modes)
+    expect(draft).not.toBeNull()
+    expect(draft!.amount).toBe('975.61')
+    expect(draft!.displayMode).toBe('excluding-tax')
+  })
+
+  it('falls back to heuristic when price kind is unknown', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>()
+    const itemWithGross = {
+      price_kind_id: 'unknown-kind',
+      unit_price_net: '100.00',
+      unit_price_gross: '123.00',
+    }
+    const draft = mapPriceItemToDraft(itemWithGross, modes)
+    expect(draft).not.toBeNull()
+    expect(draft!.displayMode).toBe('including-tax')
+    expect(draft!.amount).toBe('123.00')
+  })
+
+  it('falls back to excluding-tax when price kind is unknown and no gross value', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>()
+    const itemNetOnly = {
+      price_kind_id: 'unknown-kind',
+      unit_price_net: '100.00',
+    }
+    const draft = mapPriceItemToDraft(itemNetOnly, modes)
+    expect(draft).not.toBeNull()
+    expect(draft!.displayMode).toBe('excluding-tax')
+    expect(draft!.amount).toBe('100.00')
+  })
+
+  it('returns null when no price kind ID is present', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>()
+    const item = { unit_price_net: '100.00' }
+    expect(mapPriceItemToDraft(item, modes)).toBeNull()
+  })
+
+  it('round-trip stability: including-tax load produces same value that save would send', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>([['kind-1', 'including-tax']])
+    const item = {
+      id: 'price-1',
+      price_kind_id: 'kind-1',
+      unit_price_net: '975.61',
+      unit_price_gross: '1200.00',
+    }
+    const draft = mapPriceItemToDraft(item, modes)
+    expect(draft!.amount).toBe('1200.00')
+    expect(draft!.displayMode).toBe('including-tax')
+  })
+
+  it('round-trip stability: excluding-tax load produces same value that save would send', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>([['kind-1', 'excluding-tax']])
+    const item = {
+      id: 'price-1',
+      price_kind_id: 'kind-1',
+      unit_price_net: '975.61',
+      unit_price_gross: '1200.00',
+    }
+    const draft = mapPriceItemToDraft(item, modes)
+    expect(draft!.amount).toBe('975.61')
+    expect(draft!.displayMode).toBe('excluding-tax')
+  })
+
+  it('handles camelCase field names from API', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>([['kind-1', 'including-tax']])
+    const item = {
+      id: 'price-1',
+      priceKindId: 'kind-1',
+      unitPriceNet: '80.00',
+      unitPriceGross: '100.00',
+      currencyCode: 'PLN',
+    }
+    const draft = mapPriceItemToDraft(item, modes)
+    expect(draft).not.toBeNull()
+    expect(draft!.amount).toBe('100.00')
+    expect(draft!.currencyCode).toBe('PLN')
+    expect(draft!.priceKindId).toBe('kind-1')
+  })
+
+  it('falls back to net when gross is missing for including-tax kind', () => {
+    const modes = new Map<string, 'including-tax' | 'excluding-tax'>([['kind-1', 'including-tax']])
+    const item = {
+      price_kind_id: 'kind-1',
+      unit_price_net: '100.00',
+    }
+    const draft = mapPriceItemToDraft(item, modes)
+    expect(draft!.amount).toBe('100.00')
+    expect(draft!.displayMode).toBe('including-tax')
   })
 })

--- a/packages/core/src/modules/catalog/components/products/variantForm.ts
+++ b/packages/core/src/modules/catalog/components/products/variantForm.ts
@@ -96,3 +96,41 @@ export function buildVariantMetadata(values: VariantFormValues): Record<string, 
   const metadata = typeof values.metadata === 'object' && values.metadata ? { ...values.metadata } : {}
   return metadata
 }
+
+export function mapPriceItemToDraft(
+  item: Record<string, unknown>,
+  kindDisplayModes: Map<string, 'including-tax' | 'excluding-tax'>,
+): VariantPriceDraft | null {
+  const kindId =
+    typeof item.price_kind_id === 'string'
+      ? item.price_kind_id
+      : typeof item.priceKindId === 'string'
+        ? item.priceKindId
+        : null
+  if (!kindId) return null
+  const unitNet =
+    typeof item.unit_price_net === 'string'
+      ? item.unit_price_net
+      : typeof item.unitPriceNet === 'string'
+        ? item.unitPriceNet
+        : null
+  const unitGross =
+    typeof item.unit_price_gross === 'string'
+      ? item.unit_price_gross
+      : typeof item.unitPriceGross === 'string'
+        ? item.unitPriceGross
+        : null
+  const kindMode = kindDisplayModes.get(kindId) ?? (unitGross ? 'including-tax' : 'excluding-tax')
+  return {
+    priceKindId: kindId,
+    priceId: typeof item.id === 'string' ? item.id : undefined,
+    amount: kindMode === 'including-tax' ? (unitGross ?? unitNet ?? '') : (unitNet ?? unitGross ?? ''),
+    currencyCode:
+      typeof item.currency_code === 'string'
+        ? item.currency_code
+        : typeof item.currencyCode === 'string'
+          ? item.currencyCode
+          : null,
+    displayMode: kindMode,
+  }
+}


### PR DESCRIPTION
## Summary

Variant prices decreased by the VAT amount every time the edit view was reopened and saved. The root cause was a mismatch between the load and save paths in the variant edit page: `loadVariantPrices()` always picked the net price value (`unitNet ?? unitGross`) regardless of the price kind's display mode, while `syncVariantPricesUpdate()` correctly used the authoritative `kind.displayMode` to decide which field to write. This created a compounding degradation cycle - on each reopen+save, the net value was treated as gross, the backend recalculated an even lower net, and the price ratcheted down by the VAT percentage.

Additionally, seeded prices appeared correct on first edit because seeds set `unitPriceNet` and `unitPriceGross` to the same value. After the first save, the backend recalculated them to differ, triggering the degradation on subsequent edits.

## Changes

- **Fix `loadVariantPrices()`** in the variant edit page to accept `priceKinds` parameter and use the price kind's `displayMode` to select the correct amount field (`unitGross` for `including-tax`, `unitNet` for `excluding-tax`)
- **Gate the variant load effect** on `priceKinds.length > 0` to ensure price kind configuration is available before loading prices
- **Extract `mapPriceItemToDraft()`** as a pure function into `variantForm.ts` - reduces the page's `loadVariantPrices` body from by half and enables direct unit testing
- **Add 9 unit tests** for `mapPriceItemToDraft` covering: including-tax picks gross, excluding-tax picks net, unknown kind fallback heuristic, null when no kind ID, round-trip stability for both modes, camelCase field handling, and fallback when gross is missing

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix only, no architectural changes.

## Testing

- `yarn build:packages` - 14/14 packages pass
- `yarn generate` - pass
- `yarn i18n:check-sync` - pass
- `yarn typecheck` - 14/14 packages pass
- `yarn test` - 1981 tests across 202 suites pass (9 new tests for `mapPriceItemToDraft`)
- `yarn build:app` - pass
- Manual: edited Atlas Runner Sneaker -> Glacier Grey variant, set price, saved, reopened - price stable, no VAT degradation

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #786
