### PR TITLE
fix(ui): hide pagination bar on empty results and fix loading flash (#806)

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -1033,7 +1033,7 @@ export function AttachmentLibrary() {
   }, [deleteTarget, queryClient, selectedRow, t])
 
   const total = data?.total ?? 0
-  const totalPages = data?.totalPages ?? 1
+  const totalPages = data?.totalPages ?? 0
   return (
     <>
       <DataTable<AttachmentRow>

--- a/packages/core/src/modules/catalog/components/categories/CategoriesDataTable.tsx
+++ b/packages/core/src/modules/catalog/components/categories/CategoriesDataTable.tsx
@@ -111,7 +111,7 @@ export default function CategoriesDataTable() {
 
   const rows = data?.items ?? []
   const total = data?.total ?? 0
-  const totalPages = data?.totalPages ?? 1
+  const totalPages = data?.totalPages ?? 0
 
   const columns = React.useMemo<ColumnDef<CategoryRow>[]>(() => [
     {

--- a/packages/core/src/modules/customers/components/detail/hooks/usePersonTasks.ts
+++ b/packages/core/src/modules/customers/components/detail/hooks/usePersonTasks.ts
@@ -155,7 +155,7 @@ export function usePersonTasks({
     const mapped = Array.isArray(payload.items) ? payload.items.map(mapRowToSummary) : []
     setPageInfo({
       page: payload.page ?? 1,
-      totalPages: payload.totalPages ?? 1,
+      totalPages: payload.totalPages ?? 0,
       total: payload.total ?? mapped.length,
     })
     setError(null)

--- a/packages/core/src/modules/directory/backend/directory/organizations/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/organizations/page.tsx
@@ -172,7 +172,7 @@ export default function DirectoryOrganizationsPage() {
     return base
   }, [isSuperAdmin, t])
   const total = data?.total ?? 0
-  const totalPages = data?.totalPages ?? 1
+  const totalPages = data?.totalPages ?? 0
 
   const handleDelete = React.useCallback(async (org: OrganizationRow) => {
     const confirmLabel = t('directory.organizations.list.confirmDelete', 'Archive organization "{{name}}"?', { name: org.name })

--- a/packages/core/src/modules/directory/backend/directory/tenants/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/tenants/page.tsx
@@ -113,7 +113,7 @@ export default function DirectoryTenantsPage() {
 
   const rows = data?.items ?? []
   const total = data?.total ?? 0
-  const totalPages = data?.totalPages ?? 1
+  const totalPages = data?.totalPages ?? 0
 
   const handleDelete = React.useCallback(async (tenant: TenantRow) => {
     const confirmMessage = t('directory.tenants.list.confirmDelete', 'Delete tenant "{{name}}"? This will archive it.').replace('{{name}}', tenant.name)

--- a/packages/core/src/modules/feature_toggles/components/FeatureTogglesTable.tsx
+++ b/packages/core/src/modules/feature_toggles/components/FeatureTogglesTable.tsx
@@ -207,7 +207,7 @@ export function FeatureTogglesTable() {
         page: featureTogglesData?.page ?? 1,
         pageSize: featureTogglesData?.pageSize ?? 25,
         total: featureTogglesData?.total ?? 0,
-        totalPages: featureTogglesData?.totalPages ?? 1,
+        totalPages: featureTogglesData?.totalPages ?? 0,
         onPageChange: handlePageChange,
       }}
       rowActions={(row) => (

--- a/packages/core/src/modules/feature_toggles/components/OverridesTable.tsx
+++ b/packages/core/src/modules/feature_toggles/components/OverridesTable.tsx
@@ -151,7 +151,7 @@ export default function OverridesTable() {
                 page: featureTogglesData?.page ?? 1,
                 pageSize: featureTogglesData?.pageSize ?? 25,
                 total: featureTogglesData?.total ?? 0,
-                totalPages: featureTogglesData?.totalPages ?? 1,
+                totalPages: featureTogglesData?.totalPages ?? 0,
                 onPageChange: handlePageChange,
             }}
             refreshButton={{

--- a/packages/core/src/modules/messages/components/MessagesInboxPageClient.tsx
+++ b/packages/core/src/modules/messages/components/MessagesInboxPageClient.tsx
@@ -149,7 +149,7 @@ export function MessagesInboxPageClient() {
         total: Number(call.result?.total ?? 0),
         page: Number(call.result?.page ?? page),
         pageSize: Number(call.result?.pageSize ?? pageSize),
-        totalPages: Number(call.result?.totalPages ?? 1),
+        totalPages: Number(call.result?.totalPages ?? 0),
       }
     },
   })
@@ -375,7 +375,7 @@ export function MessagesInboxPageClient() {
 
   const rows = listQuery.data?.items ?? []
   const total = listQuery.data?.total ?? 0
-  const totalPages = listQuery.data?.totalPages ?? 1
+  const totalPages = listQuery.data?.totalPages ?? 0
 
   return (
     <div className="space-y-4">

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -1449,8 +1449,8 @@ export function DataTable<T>({
     containerRef.current?.scrollIntoView({ behavior, block: 'start' })
   }, [])
 
-  const renderPagination = () => {
-    if (!pagination) return null
+  const paginationNode = React.useMemo(() => {
+    if (!pagination || pagination.total === 0) return null
 
     const { page, totalPages, onPageChange, durationMs, cacheStatus } = pagination
     const startItem = (page - 1) * pagination.pageSize + 1
@@ -1508,7 +1508,7 @@ export function DataTable<T>({
         </div>
       </div>
     )
-  }
+  }, [pagination, measuredDurationMs, scrollTableIntoView, t])
 
   // Auto filters: fetch custom field defs when requested
   const resolvedEntityIds = React.useMemo(() => {
@@ -2033,7 +2033,7 @@ export function DataTable<T>({
           <InjectionSpot spotId={footerInjectionSpotId} context={resolvedInjectionContext} />
         </div>
       ) : null}
-      {renderPagination()}
+      {paginationNode}
       {canUsePerspectives ? (
         <PerspectiveSidebar
           open={isPerspectiveOpen}


### PR DESCRIPTION
## Summary

Fixes #806 — inconsistent pagination behavior when data tables have no results.

- **Hide pagination bar when empty**: Added a guard in `DataTable` `paginationNode` that returns `null` when `pagination.total === 0`, eliminating the broken "Page 1 of 0" / "Showing 1 to 0 of 0 results" state.
- **Fix loading flash**: Fixed `totalPages ?? 1` → `totalPages ?? 0` in 8 caller modules so the pagination bar stays hidden during loading (instead of briefly showing "Page 1 of 1" before data arrives).
- **Performance**: Converted `renderPagination()` plain function to `React.useMemo` so the pagination JSX subtree is only rebuilt when `pagination`, `measuredDurationMs`, `scrollTableIntoView`, or `t` actually change.

## Files changed

| File | Change |
|------|--------|
| `packages/ui/src/backend/DataTable.tsx` | `renderPagination()` → `paginationNode` useMemo; `total === 0` null guard |
| `packages/core/src/modules/messages/components/MessagesInboxPageClient.tsx` | `totalPages ?? 1` → `?? 0` (×2) |
| `packages/core/src/modules/attachments/components/AttachmentLibrary.tsx` | `totalPages ?? 1` → `?? 0` |
| `packages/core/src/modules/catalog/components/categories/CategoriesDataTable.tsx` | `totalPages ?? 1` → `?? 0` |
| `packages/core/src/modules/feature_toggles/components/OverridesTable.tsx` | `totalPages ?? 1` → `?? 0` |
| `packages/core/src/modules/feature_toggles/components/FeatureTogglesTable.tsx` | `totalPages ?? 1` → `?? 0` |
| `packages/core/src/modules/directory/backend/directory/organizations/page.tsx` | `totalPages ?? 1` → `?? 0` |
| `packages/core/src/modules/directory/backend/directory/tenants/page.tsx` | `totalPages ?? 1` → `?? 0` |
| `packages/core/src/modules/customers/components/detail/hooks/usePersonTasks.ts` | `totalPages ?? 1` → `?? 0` |

## Testing

- `yarn build:packages` passes clean (14/14 tasks, 0 errors)
- Integration test failures confirmed pre-existing and unrelated to this change (no pagination-related failures)

## Spec

No spec required — this is a pure bug fix with no new API, data model, or architecture changes (per `.ai/specs/AGENTS.md` skip rule for isolated bug fixes).