### PR TITLE
Feature/787 clean

### DIFF
--- a/apps/mercato/src/components/StartPageContent.tsx
+++ b/apps/mercato/src/components/StartPageContent.tsx
@@ -145,6 +145,7 @@ export function StartPageContent({ showStartPage: initialShowStartPage, showOnbo
               <code className="px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900 font-mono text-xs">secret</code>.
               {' '}{t('startPage.defaultPassword.description2', 'To change passwords, use the CLI command:')}{' '}
               <code className="px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900 font-mono text-xs">yarn mercato auth set-password --email &lt;email&gt; --password &lt;newPassword&gt;</code>
+              <span className="mt-2 block">{t('startPage.defaultPassword.description3', 'Demo account emails are printed in the terminal output during yarn initialize.')}</span>
             </p>
           </div>
         </div>

--- a/apps/mercato/src/i18n/de.json
+++ b/apps/mercato/src/i18n/de.json
@@ -547,6 +547,7 @@
   "startPage.chooseRole.title": "Wählen Sie Ihre Rolle",
   "startPage.defaultPassword.description1": "Das Standard-Passwort für alle Demo-Konten ist",
   "startPage.defaultPassword.description2": "Um Passwörter zu ändern, verwenden Sie den CLI-Befehl:",
+  "startPage.defaultPassword.description3": "Die E-Mail-Adressen der Demo-Konten werden während yarn initialize in der Terminalausgabe angezeigt.",
   "startPage.defaultPassword.title": "Standard-Passwort",
   "startPage.onboarding.cta": "Onboarding starten",
   "startPage.onboarding.description": "Erstellen Sie in wenigen Minuten einen Mandanten, eine Organisation und ein Administrator-Konto. Wir verifizieren Ihre E-Mail und liefern eine vorkonfigurierte Umgebung, damit Sie Open Mercato mit echten Daten erkunden können.",

--- a/apps/mercato/src/i18n/en.json
+++ b/apps/mercato/src/i18n/en.json
@@ -547,6 +547,7 @@
   "startPage.chooseRole.title": "Choose Your Role",
   "startPage.defaultPassword.description1": "The default password for all demo accounts is",
   "startPage.defaultPassword.description2": "To change passwords, use the CLI command:",
+  "startPage.defaultPassword.description3": "Demo account emails are printed in the terminal output during yarn initialize.",
   "startPage.defaultPassword.title": "Default Password",
   "startPage.onboarding.cta": "Start onboarding",
   "startPage.onboarding.description": "Create a tenant, organization, and administrator account in minutes. We'll verify your email and deliver a pre-seeded environment so you can explore Open Mercato with real data.",

--- a/apps/mercato/src/i18n/es.json
+++ b/apps/mercato/src/i18n/es.json
@@ -547,6 +547,7 @@
   "startPage.chooseRole.title": "Elija su rol",
   "startPage.defaultPassword.description1": "La contraseña predeterminada para todas las cuentas de demostración es",
   "startPage.defaultPassword.description2": "Para cambiar contraseñas, use el comando CLI:",
+  "startPage.defaultPassword.description3": "Los correos de las cuentas demo se muestran en la salida de la terminal durante yarn initialize.",
   "startPage.defaultPassword.title": "Contraseña predeterminada",
   "startPage.onboarding.cta": "Iniciar incorporación",
   "startPage.onboarding.description": "Cree un inquilino, organización y cuenta de administrador en minutos. Verificaremos su correo electrónico y entregaremos un entorno preconfigurado para que pueda explorar Open Mercato con datos reales.",

--- a/apps/mercato/src/i18n/pl.json
+++ b/apps/mercato/src/i18n/pl.json
@@ -547,6 +547,7 @@
   "startPage.chooseRole.title": "Wybierz swoją rolę",
   "startPage.defaultPassword.description1": "Domyślne hasło dla wszystkich kont demonstracyjnych to",
   "startPage.defaultPassword.description2": "Aby zmienić hasła, użyj polecenia CLI:",
+  "startPage.defaultPassword.description3": "Adresy e-mail kont demo są wypisywane w terminalu podczas wykonywania yarn initialize.",
   "startPage.defaultPassword.title": "Domyślne hasło",
   "startPage.onboarding.cta": "Rozpocznij onboardowanie",
   "startPage.onboarding.description": "Utwórz najemcę, organizację i konto administratora w kilka minut. Zweryfikujemy Twój e-mail i dostarczymy wstępnie skonfigurowane środowisko, abyś mógł eksplorować Open Mercato z rzeczywistymi danymi.",

--- a/packages/create-app/template/src/components/StartPageContent.tsx
+++ b/packages/create-app/template/src/components/StartPageContent.tsx
@@ -145,6 +145,7 @@ export function StartPageContent({ showStartPage: initialShowStartPage, showOnbo
               <code className="px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900 font-mono text-xs">secret</code>.
               {' '}{t('startPage.defaultPassword.description2', 'To change passwords, use the CLI command:')}{' '}
               <code className="px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900 font-mono text-xs">yarn mercato auth set-password --email &lt;email&gt; --password &lt;newPassword&gt;</code>
+              <span className="mt-2 block">{t('startPage.defaultPassword.description3', 'Demo account emails are printed in the terminal output during yarn initialize.')}</span>
             </p>
           </div>
         </div>

--- a/packages/create-app/template/src/i18n/de.json
+++ b/packages/create-app/template/src/i18n/de.json
@@ -433,6 +433,7 @@
   "startPage.chooseRole.title": "Wählen Sie Ihre Rolle",
   "startPage.defaultPassword.description1": "Das Standard-Passwort für alle Demo-Konten ist",
   "startPage.defaultPassword.description2": "Um Passwörter zu ändern, verwenden Sie den CLI-Befehl:",
+  "startPage.defaultPassword.description3": "Die E-Mail-Adressen der Demo-Konten werden während yarn initialize in der Terminalausgabe angezeigt.",
   "startPage.defaultPassword.title": "Standard-Passwort",
   "startPage.onboarding.cta": "Onboarding starten",
   "startPage.onboarding.description": "Erstellen Sie in wenigen Minuten einen Mandanten, eine Organisation und ein Administrator-Konto. Wir verifizieren Ihre E-Mail und liefern eine vorkonfigurierte Umgebung, damit Sie Open Mercato mit echten Daten erkunden können.",

--- a/packages/create-app/template/src/i18n/en.json
+++ b/packages/create-app/template/src/i18n/en.json
@@ -547,6 +547,7 @@
   "startPage.chooseRole.title": "Choose Your Role",
   "startPage.defaultPassword.description1": "The default password for all demo accounts is",
   "startPage.defaultPassword.description2": "To change passwords, use the CLI command:",
+  "startPage.defaultPassword.description3": "Demo account emails are printed in the terminal output during yarn initialize.",
   "startPage.defaultPassword.title": "Default Password",
   "startPage.onboarding.cta": "Start onboarding",
   "startPage.onboarding.description": "Create a tenant, organization, and administrator account in minutes. We'll verify your email and deliver a pre-seeded environment so you can explore Open Mercato with real data.",

--- a/packages/create-app/template/src/i18n/es.json
+++ b/packages/create-app/template/src/i18n/es.json
@@ -432,6 +432,7 @@
   "startPage.chooseRole.title": "Elija su rol",
   "startPage.defaultPassword.description1": "La contraseña predeterminada para todas las cuentas de demostración es",
   "startPage.defaultPassword.description2": "Para cambiar contraseñas, use el comando CLI:",
+  "startPage.defaultPassword.description3": "Los correos de las cuentas demo se muestran en la salida de la terminal durante yarn initialize.",
   "startPage.defaultPassword.title": "Contraseña predeterminada",
   "startPage.onboarding.cta": "Iniciar incorporación",
   "startPage.onboarding.description": "Cree un inquilino, organización y cuenta de administrador en minutos. Verificaremos su correo electrónico y entregaremos un entorno preconfigurado para que pueda explorar Open Mercato con datos reales.",

--- a/packages/create-app/template/src/i18n/pl.json
+++ b/packages/create-app/template/src/i18n/pl.json
@@ -408,6 +408,7 @@
   "startPage.chooseRole.title": "Wybierz swoją rolę",
   "startPage.defaultPassword.description1": "Domyślne hasło dla wszystkich kont demonstracyjnych to",
   "startPage.defaultPassword.description2": "Aby zmienić hasła, użyj polecenia CLI:",
+  "startPage.defaultPassword.description3": "Adresy e-mail kont demo są wypisywane w terminalu podczas wykonywania yarn initialize.",
   "startPage.defaultPassword.title": "Domyślne hasło",
   "startPage.onboarding.cta": "Rozpocznij onboardowanie",
   "startPage.onboarding.description": "Utwórz najemcę, organizację i konto administratora w kilka minut. Zweryfikujemy Twój e-mail i dostarczymy wstępnie skonfigurowane środowisko, abyś mógł eksplorować Open Mercato z rzeczywistymi danymi.",


### PR DESCRIPTION
## Summary

This PR moves the demo-credentials hint from /login to the start page (apps/mercato), because the demo instance runs as a production build and dev-only login UI is not visible there.

## What changed

- Added a new line in the Default Password panel on the start page:
    - “Demo account emails are printed in the terminal output during yarn initialize.”

- Kept app/template parity by applying the same change in:
    - apps/mercato/src/components/StartPageContent.tsx
    - packages/create-app/template/src/components/StartPageContent.tsx
   
- Added matching i18n keys (startPage.defaultPassword.description3) in en/pl/es/de for both:
    - apps/mercato/src/i18n/*.json
    - packages/create-app/template/src/i18n/*.json

## Why
The previous approach (dev-only hint on login page) does not help on the production-built demo instance.
Placing the hint on the home/start page makes it visible in the actual demo environment.

Validation
- yarn i18n:check-sync ✅
