### PR TITLE
fix: display fallback option "Select" if value is empty

### DIFF
--- a/packages/core/src/modules/directory/backend/directory/organizations/create/page.tsx
+++ b/packages/core/src/modules/directory/backend/directory/organizations/create/page.tsx
@@ -124,7 +124,8 @@ export default function CreateOrganizationPage() {
               setSelectedTenantId(normalized)
               setValue(normalized)
             }}
-            includeEmptyOption={false}
+            includeEmptyOption
+            emptyOptionLabel={t('directory.organizations.form.tenant.select', 'Select tenant')}
             className="w-full h-9 rounded border px-2 text-sm"
           />
         ),

--- a/packages/core/src/modules/directory/i18n/de.json
+++ b/packages/core/src/modules/directory/i18n/de.json
@@ -33,6 +33,7 @@
   "directory.organizations.form.loading": "Organisation wird geladen...",
   "directory.organizations.form.pathLabel": "Pfad: {path}",
   "directory.organizations.form.rootOption": "— Wurzelebene —",
+  "directory.organizations.form.tenant.select": "Mandanten auswählen",
   "directory.organizations.form.title.edit": "Organisation bearbeiten",
   "directory.organizations.list.actions.create": "Erstellen",
   "directory.organizations.list.actions.delete": "Löschen",

--- a/packages/core/src/modules/directory/i18n/en.json
+++ b/packages/core/src/modules/directory/i18n/en.json
@@ -33,6 +33,7 @@
   "directory.organizations.form.loading": "Loading organization...",
   "directory.organizations.form.pathLabel": "Path: {path}",
   "directory.organizations.form.rootOption": "— Root level —",
+  "directory.organizations.form.tenant.select": "Select tenant",
   "directory.organizations.form.title.edit": "Edit Organization",
   "directory.organizations.list.actions.create": "Create",
   "directory.organizations.list.actions.delete": "Delete",

--- a/packages/core/src/modules/directory/i18n/es.json
+++ b/packages/core/src/modules/directory/i18n/es.json
@@ -33,6 +33,7 @@
   "directory.organizations.form.loading": "Cargando organización...",
   "directory.organizations.form.pathLabel": "Ruta: {path}",
   "directory.organizations.form.rootOption": "— Nivel raíz —",
+  "directory.organizations.form.tenant.select": "Seleccionar inquilino",
   "directory.organizations.form.title.edit": "Editar organización",
   "directory.organizations.list.actions.create": "Crear",
   "directory.organizations.list.actions.delete": "Eliminar",

--- a/packages/core/src/modules/directory/i18n/pl.json
+++ b/packages/core/src/modules/directory/i18n/pl.json
@@ -33,6 +33,7 @@
   "directory.organizations.form.loading": "Ładowanie organizacji...",
   "directory.organizations.form.pathLabel": "Ścieżka: {path}",
   "directory.organizations.form.rootOption": "— Poziom główny —",
+  "directory.organizations.form.tenant.select": "Wybierz najemcę",
   "directory.organizations.form.title.edit": "Edytuj organizację",
   "directory.organizations.list.actions.create": "Utwórz",
   "directory.organizations.list.actions.delete": "Usuń",


### PR DESCRIPTION
## Summary

Fixes #880 

This PR fixes a validation mismatch on the Create Organization form where the Tenant field could appear selected in the UI while `tenantId` remained unset in form state, causing a false "field is required" error on submit.

## Changes

- Updated tenant input rendering in page.tsx.
- Changed TenantSelect to use an explicit empty option (includeEmptyOption) instead of hiding it.
- Added emptyOptionLabel translation fallback: Select tenant.
- Result: users must explicitly choose a tenant, and the visual state now matches form validation state.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [X] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->
N/A

## Testing

After adjustments to jest config managed to run `yarn workspace @open-mercato/core test -- directory` which passed
`yarn i18n:check` reported locales are in sync

## Checklist

- [X] This pull request targets `develop`.
- [X] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [X] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #880 