### PR TITLE
fix: scroll active result into view on arrow key navigation in search…

### DIFF
--- a/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
+++ b/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
@@ -166,6 +166,7 @@ export function GlobalSearchDialog({
   const [error, setError] = React.useState<string | null>(null)
   const [selectedIndex, setSelectedIndex] = React.useState(0)
   const inputRef = React.useRef<HTMLInputElement | null>(null)
+  const listRef = React.useRef<HTMLDivElement | null>(null)
   const abortRef = React.useRef<AbortController | null>(null)
   const t = useT()
   const [showScopeHint, setShowScopeHint] = React.useState<boolean>(() => hasActiveOrganizationSelection())
@@ -305,6 +306,19 @@ export function GlobalSearchDialog({
     }
   }, [results, selectedIndex, openResult])
 
+  React.useEffect(() => {
+    const container = listRef.current
+    const active = container?.querySelector<HTMLElement>('[data-active="true"]')
+    if (!container || !active) return
+    const { top: containerTop, bottom: containerBottom } = container.getBoundingClientRect()
+    const { top: activeTop, bottom: activeBottom } = active.getBoundingClientRect()
+    if (activeTop < containerTop) {
+      container.scrollTop -= containerTop - activeTop
+    } else if (activeBottom > containerBottom) {
+      container.scrollTop += activeBottom - containerBottom
+    }
+  }, [selectedIndex])
+
   // Check if vector search is enabled but not configured
   const showVectorWarning = !embeddingConfigured && enabledStrategies.includes('vector') && !error
 
@@ -364,7 +378,7 @@ export function GlobalSearchDialog({
               </p>
             ) : null}
           </div>
-          <div className="max-h-96 overflow-y-auto px-2 pb-3">
+          <div ref={listRef} className="max-h-96 overflow-y-auto px-2 pb-3">
             {results.length === 0 && !loading && !error ? (
               <div className="px-4 py-6 text-sm text-muted-foreground">
                 {query.trim().length < MIN_QUERY_LENGTH
@@ -379,7 +393,7 @@ export function GlobalSearchDialog({
                 const hasLink = pickPrimaryLink(result) !== null
                 const Icon = presenter?.icon ? resolveIcon(presenter.icon) : null
                 return (
-                  <li key={`${result.entityId}:${result.recordId}`}>
+                  <li key={`${result.entityId}:${result.recordId}`} data-active={isActive}>
                     <button
                       type="button"
                       onClick={() => openResult(result)}


### PR DESCRIPTION
## Summary

Keyboard navigation with arrow keys in the global search dialog (`⌘K` / `Ctrl+K`) was not scrolling the results list. Items below the visible area were unreachable without a mouse. This fix ensures the active result is always scrolled into view when navigating with arrow keys.

## Changes

- Add `listRef` on the scrollable results container in `GlobalSearchDialog.tsx`
- Add `data-active` attribute on the active result `<li>` element
- Add `useEffect` that adjusts `container.scrollTop` via `getBoundingClientRect` when `selectedIndex` changes

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

## Testing

- Manually verified: open search dialog, type a query with 10 results, navigate with `ArrowDown` — list scrolls correctly and active item stays visible
- Manually verified: `ArrowUp` from first item wraps to last and scrolls to bottom
- Existing unit tests pass: `yarn test --filter=@open-mercato/search`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #883