### PR TITLE
test(auth): add route-level GET tests for users and roles

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
@@ -1,0 +1,163 @@
+/** @jest-environment node */
+
+import { GET } from '@open-mercato/core/modules/auth/api/roles/route'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockLoadAcl = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockLogCrudAccess = jest.fn()
+
+const mockEm = {
+  find: jest.fn(),
+  findAndCount: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return { loadAcl: mockLoadAcl }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
+  makeCrudRoute: jest.fn((opts: { metadata: unknown }) => ({
+    metadata: opts.metadata,
+    POST: jest.fn(),
+    PUT: jest.fn(),
+    DELETE: jest.fn(),
+  })),
+  logCrudAccess: jest.fn((args: unknown) => mockLogCrudAccess(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+const actorTenantId = '123e4567-e89b-12d3-a456-426614174003'
+const requestedTenantId = '123e4567-e89b-12d3-a456-426614174004'
+
+function makeRequest(path = '/api/auth/roles') {
+  return new Request(`http://localhost${path}`, { method: 'GET' })
+}
+
+describe('GET /api/auth/roles', () => {
+  beforeEach(() => {
+    mockGetAuthFromRequest.mockReset()
+    mockLoadAcl.mockReset()
+    mockEm.find.mockReset()
+    mockEm.findAndCount.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockLogCrudAccess.mockReset()
+    mockContainer.resolve.mockClear()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: actorTenantId,
+      orgId: '223e4567-e89b-12d3-a456-426614174003',
+      roles: ['admin'],
+    })
+    mockLoadAcl.mockResolvedValue({ isSuperAdmin: false })
+    mockEm.find.mockResolvedValue([])
+    mockEm.findAndCount.mockResolvedValue([[], 0])
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockLogCrudAccess.mockResolvedValue(undefined)
+  })
+
+  test('returns an empty collection when unauthenticated', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce(null)
+
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1 })
+    expect(mockContainer.resolve).not.toHaveBeenCalled()
+  })
+
+  test('returns an empty collection for non-superadmin users without tenant context', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: '223e4567-e89b-12d3-a456-426614174003',
+      roles: ['admin'],
+    })
+    mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: false })
+
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1, isSuperAdmin: false })
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+  })
+
+  test('applies tenant-scoped filters and excludes superadmin roles for non-superadmin actor', async () => {
+    mockEm.find
+      .mockResolvedValueOnce([{ role: { id: '323e4567-e89b-12d3-a456-426614174050' } }])
+      .mockResolvedValueOnce([])
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    await GET(makeRequest('/api/auth/roles?search=manager'))
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+
+    expect(Array.isArray(where.$and)).toBe(true)
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { deletedAt: null },
+      { name: { $ilike: '%manager%' } },
+      { $or: [{ tenantId: actorTenantId }, { tenantId: null }] },
+      { name: { $ne: 'superadmin' } },
+      { id: { $nin: ['323e4567-e89b-12d3-a456-426614174050'] } },
+    ]))
+  })
+
+  test('applies requested tenant scope for superadmin actor', async () => {
+    mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: true })
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    const response = await GET(makeRequest(`/api/auth/roles?tenantId=${requestedTenantId}&page=1&pageSize=20`))
+    const body = await response.json()
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { deletedAt: null },
+      { $or: [{ tenantId: requestedTenantId }, { tenantId: null }] },
+    ]))
+    expect(where.$and).not.toEqual(expect.arrayContaining([{ name: { $ne: 'superadmin' } }]))
+    expect(body.isSuperAdmin).toBe(true)
+  })
+
+  test('returns roles with usersCount and tenant visibility fields', async () => {
+    mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: true })
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [{ id: 'role-1', name: 'Manager', tenantId: actorTenantId }],
+      1,
+    ])
+    mockEm.find
+      .mockResolvedValueOnce([{ role: 'role-1', deletedAt: null }])
+      .mockResolvedValueOnce([{ id: actorTenantId, name: 'Main Tenant' }])
+
+    const response = await GET(makeRequest('/api/auth/roles?page=1&pageSize=10'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.total).toBe(1)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).toMatchObject({
+      id: 'role-1',
+      name: 'Manager',
+      usersCount: 1,
+      tenantId: actorTenantId,
+      tenantIds: [actorTenantId],
+      tenantName: 'Main Tenant',
+    })
+  })
+})

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1,0 +1,233 @@
+/** @jest-environment node */
+
+import { GET } from '@open-mercato/core/modules/auth/api/users/route'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockLoadAcl = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockLogCrudAccess = jest.fn()
+
+const mockEm = {
+  find: jest.fn(),
+  findAndCount: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return { loadAcl: mockLoadAcl }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
+  makeCrudRoute: jest.fn((opts: { metadata: unknown }) => ({
+    metadata: opts.metadata,
+    POST: jest.fn(),
+    PUT: jest.fn(),
+    DELETE: jest.fn(),
+  })),
+  logCrudAccess: jest.fn((args: unknown) => mockLogCrudAccess(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+const tenantId = '123e4567-e89b-12d3-a456-426614174001'
+const organizationId = '223e4567-e89b-12d3-a456-426614174001'
+const secondaryOrganizationId = '223e4567-e89b-12d3-a456-426614174002'
+const roleId = '323e4567-e89b-12d3-a456-426614174001'
+
+function makeRequest(path = '/api/auth/users') {
+  return new Request(`http://localhost${path}`, { method: 'GET' })
+}
+
+describe('GET /api/auth/users', () => {
+  beforeEach(() => {
+    mockGetAuthFromRequest.mockReset()
+    mockLoadAcl.mockReset()
+    mockEm.find.mockReset()
+    mockEm.findAndCount.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockLogCrudAccess.mockReset()
+    mockContainer.resolve.mockClear()
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId,
+      orgId: organizationId,
+      isSuperAdmin: false,
+      roles: ['admin'],
+    })
+    mockLoadAcl.mockResolvedValue({ isSuperAdmin: false })
+    mockEm.find.mockResolvedValue([])
+    mockEm.findAndCount.mockResolvedValue([[], 0])
+    mockFindWithDecryption.mockResolvedValue([])
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockLogCrudAccess.mockResolvedValue(undefined)
+  })
+
+  test('returns an empty collection when unauthenticated', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce(null)
+
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1 })
+    expect(mockContainer.resolve).not.toHaveBeenCalled()
+  })
+
+  test('returns an empty collection for non-superadmin users without tenant context', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: organizationId,
+      roles: ['admin'],
+    })
+    mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: false })
+
+    const response = await GET(makeRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1, isSuperAdmin: false })
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+  })
+
+  test('applies tenant and search filters for non-superadmin users', async () => {
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [
+        {
+          id: '423e4567-e89b-12d3-a456-426614174001',
+          email: 'alice@example.com',
+          tenantId,
+          organizationId,
+        },
+      ],
+      1,
+    ])
+
+    const response = await GET(makeRequest('/api/auth/users?search=alice&page=1&pageSize=50'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockEm.findAndCount).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        deletedAt: null,
+        tenantId,
+        email: { $ilike: '%alice%' },
+      }),
+      expect.objectContaining({
+        limit: 50,
+        offset: 0,
+      }),
+    )
+    expect(body.total).toBe(1)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).toMatchObject({
+      email: 'alice@example.com',
+      tenantId,
+      organizationId,
+    })
+    expect(body.isSuperAdmin).toBe(false)
+  })
+
+  test('short-circuits with empty result when role filter has no matching users', async () => {
+    mockEm.find.mockResolvedValueOnce([])
+
+    const response = await GET(makeRequest(`/api/auth/users?roleId=${roleId}`))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1 })
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+  })
+
+  test('applies roleId filter for a single role when users are found', async () => {
+    const matchedUserId = '523e4567-e89b-12d3-a456-426614174001'
+    mockEm.find.mockResolvedValueOnce([{ user: { id: matchedUserId }, role: { id: roleId } }])
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [{ id: matchedUserId, email: 'role-filtered@example.com', tenantId, organizationId }],
+      1,
+    ])
+
+    const response = await GET(makeRequest(`/api/auth/users?roleId=${roleId}`))
+    const body = await response.json()
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { id?: { $in: string[] } }
+    expect(where.id?.$in).toEqual([matchedUserId])
+    expect(body.total).toBe(1)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0].email).toBe('role-filtered@example.com')
+  })
+
+  test('supports multiple roleId params and narrows query to union of matched user ids', async () => {
+    const secondRoleId = '323e4567-e89b-12d3-a456-426614174002'
+    const firstUserId = '523e4567-e89b-12d3-a456-426614174011'
+    const secondUserId = '523e4567-e89b-12d3-a456-426614174012'
+    mockEm.find.mockResolvedValueOnce([
+      { user: { id: firstUserId }, role: { id: roleId } },
+      { user: secondUserId, role: { id: secondRoleId } },
+      { user: { id: firstUserId }, role: { id: secondRoleId } },
+    ])
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [
+        { id: firstUserId, email: 'first@example.com', tenantId, organizationId },
+        { id: secondUserId, email: 'second@example.com', tenantId, organizationId },
+      ],
+      2,
+    ])
+
+    const response = await GET(
+      makeRequest(`/api/auth/users?roleId=${roleId}&roleId=${secondRoleId}&roleId=${secondRoleId}`),
+    )
+    const body = await response.json()
+
+    const roleFilter = mockEm.find.mock.calls[0][1] as { role?: { $in?: string[] } }
+    expect(roleFilter.role?.$in).toEqual(expect.arrayContaining([roleId, secondRoleId]))
+    expect(roleFilter.role?.$in).toHaveLength(2)
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { id?: { $in: string[] } }
+    expect(where.id?.$in).toEqual(expect.arrayContaining([firstUserId, secondUserId]))
+    expect(where.id?.$in).toHaveLength(2)
+    expect(body.total).toBe(2)
+    expect(body.items).toHaveLength(2)
+  })
+
+  test('allows superadmin to query by organization without forcing tenant filter', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: organizationId,
+      roles: ['admin'],
+    })
+    mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: true })
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    const response = await GET(
+      makeRequest(`/api/auth/users?organizationId=${secondaryOrganizationId}&page=1&pageSize=10`),
+    )
+    const body = await response.json()
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as Record<string, unknown>
+    expect(where.organizationId).toBe(secondaryOrganizationId)
+    expect(where).not.toHaveProperty('tenantId')
+    expect(body.isSuperAdmin).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Adds dedicated route-level Jest coverage for Auth API GET endpoints:

- `/api/auth/users`
- `/api/auth/roles`

These routes had complex tenant/RBAC filtering logic but no focused tests in `auth/api/__tests__`.

## Changes
Added two new test files:

- [users.route.test.ts](/Users/kalma/work/om-dev/open-mercato/packages/core/src/modules/auth/api/__tests__/users.route.test.ts)
- [roles.route.test.ts](/Users/kalma/work/om-dev/open-mercato/packages/core/src/modules/auth/api/__tests__/roles.route.test.ts)

## Covered scenarios

### `/api/auth/users` (GET)
- returns empty list when unauthenticated
- filters by tenant for non-superadmin
- returns empty list for non-superadmin without tenant
- supports search filter
- supports `roleId` filtering:
  - single role (positive/empty paths)
  - multiple role IDs (dedup + narrowed `id` query)

### `/api/auth/roles` (GET)
- returns empty list when unauthenticated
- returns empty list for non-superadmin without tenant
- non-superadmin scope includes tenant/global roles only
- excludes superadmin role visibility for non-superadmin actor
- supports search filter
- applies tenant scoping behavior for superadmin requests (`tenantId` query)

## Why
High coverage gain at low cost on auth-critical endpoints with nuanced RBAC + tenant behavior, reducing regression risk.

## Validation
Executed locally:

```bash
npx jest packages/core/src/modules/auth/api/__tests__/users.route.test.ts packages/core/src/modules/auth/api/__tests__/roles.route.test.ts
```

Result:

- 2 passed test suites
- 12 passed tests

## Notes
No runtime code changes, API contract changes, or schema changes.  
Scope is test-only for route-level behavior.

Closes #876
