### PR TITLE
test(search): cover fallback presenter and improve name/title resolution

### DIFF
--- a/packages/search/src/__tests__/fallback-presenter.test.ts
+++ b/packages/search/src/__tests__/fallback-presenter.test.ts
@@ -1,0 +1,145 @@
+import { extractFallbackPresenter } from '../lib/fallback-presenter'
+
+describe('extractFallbackPresenter', () => {
+  it('prefers higher-priority title fields', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        display_name: 'Display Name',
+        name: 'Name Value',
+        title: 'Title Value',
+      },
+      'customers:person',
+      'record-1',
+    )
+
+    expect(presenter.title).toBe('Display Name')
+    expect(presenter.badge).toBe('Person')
+  })
+
+  it('builds title from first_name and last_name when no higher-priority title exists', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        first_name: 'Jan',
+        last_name: 'Kowalski',
+      },
+      'customers:person',
+      'record-2',
+    )
+
+    expect(presenter.title).toBe('Jan Kowalski')
+  })
+
+  it('builds title from firstName and lastName for camelCase records', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        firstName: 'Anna',
+        lastName: 'Nowak',
+      },
+      'customers:person',
+      'record-3',
+    )
+
+    expect(presenter.title).toBe('Anna Nowak')
+  })
+
+  it('uses available single name part when only first_name exists', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        first_name: 'Monika',
+      },
+      'customers:person',
+      'record-4',
+    )
+
+    expect(presenter.title).toBe('Monika')
+  })
+
+  it('prefers composed name from parts before email fallback', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        first_name: 'Tomasz',
+        last_name: 'Brzęczyszczykiewicz',
+        email: 'tomasz@example.com',
+      },
+      'customers:person',
+      'record-5',
+    )
+
+    expect(presenter.title).toBe('Tomasz Brzęczyszczykiewicz')
+  })
+
+  it('truncates subtitle to at most 120 characters', () => {
+    const longDescription = 'A'.repeat(90)
+    const longSummary = 'B'.repeat(90)
+
+    const presenter = extractFallbackPresenter(
+      {
+        name: 'Long Subtitle Record',
+        description: longDescription,
+        summary: longSummary,
+      },
+      'search:document',
+      'record-6',
+    )
+
+    expect(presenter.subtitle).toBeDefined()
+    expect((presenter.subtitle ?? '').length).toBeLessThanOrEqual(120)
+    expect(presenter.subtitle).toContain('A')
+  })
+
+  it('does not duplicate title as subtitle part', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        name: 'Acme Corp',
+        description: 'Acme Corp',
+        summary: 'Important customer',
+      },
+      'customers:company',
+      'record-7',
+    )
+
+    expect(presenter.title).toBe('Acme Corp')
+    expect(presenter.subtitle).toBe('Important customer')
+  })
+
+  it('falls back to entity label and short id when no string fields are available', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        id: 'ignored',
+        created_at: '2026-01-01',
+      },
+      'catalog:product_variant',
+      '1234567890abcdef',
+    )
+
+    expect(presenter.title).toBe('Product Variant 12345678...')
+    expect(presenter.badge).toBe('Product Variant')
+  })
+
+  it('excludes technical tenant/organization/timestamp fields from generic fallback title selection', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        tenant_id: 'Tenant Name Should Not Be Used',
+        organizationId: 'Org Name Should Not Be Used',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+      'customers:company',
+      'abcdef1234567890',
+    )
+
+    expect(presenter.title).toBe('Company abcdef12...')
+  })
+
+  it('does not use cf:* or cf_* values as generic fallback title', () => {
+    const presenter = extractFallbackPresenter(
+      {
+        'cf:custom_display_name': 'Custom Field Value',
+        cf_custom_name: 'Another Custom Field Value',
+      },
+      'catalog:product',
+      'fedcba9876543210',
+    )
+
+    expect(presenter.title).toBe('Product fedcba98...')
+  })
+})

--- a/packages/search/src/lib/fallback-presenter.ts
+++ b/packages/search/src/lib/fallback-presenter.ts
@@ -1,19 +1,23 @@
 import type { SearchResultPresenter } from '@open-mercato/shared/modules/search'
 
-// Fields to check for title, in priority order
-const TITLE_FIELDS = [
+const TITLE_FIELDS_PRIMARY = [
   'display_name', 'displayName',
   'name', 'title', 'label',
   'full_name', 'fullName',
   'brand_name', 'brandName',
   'legal_name', 'legalName',
-  'first_name', 'firstName',
-  'last_name', 'lastName',
   'preferred_name', 'preferredName',
+]
+
+const TITLE_FIELDS_SECONDARY = [
   'email', 'primary_email', 'primaryEmail',
   'code', 'sku', 'reference',
   'identifier', 'slug',
 ]
+
+const FIRST_NAME_FIELDS = ['first_name', 'firstName']
+const LAST_NAME_FIELDS = ['last_name', 'lastName']
+const MAX_SUBTITLE_LENGTH = 120
 
 // Fields to check for subtitle
 const SUBTITLE_FIELDS = [
@@ -31,6 +35,13 @@ function findFirstValue(doc: Record<string, unknown>, fields: string[]): string 
     }
   }
   return null
+}
+
+function buildNameFromParts(doc: Record<string, unknown>): string | null {
+  const firstName = findFirstValue(doc, FIRST_NAME_FIELDS)
+  const lastName = findFirstValue(doc, LAST_NAME_FIELDS)
+  if (firstName && lastName) return `${firstName} ${lastName}`
+  return firstName ?? lastName
 }
 
 function findAnyStringValue(doc: Record<string, unknown>, excludeFields: Set<string>): string | null {
@@ -58,6 +69,11 @@ function formatEntityLabel(entityId: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
+function truncateSubtitle(value: string): string {
+  if (value.length <= MAX_SUBTITLE_LENGTH) return value
+  return value.slice(0, MAX_SUBTITLE_LENGTH).trimEnd()
+}
+
 /**
  * Extract a presenter from doc fields when no search.ts config exists.
  *
@@ -74,21 +90,28 @@ export function extractFallbackPresenter(
 ): SearchResultPresenter {
   const entityLabel = formatEntityLabel(entityId)
 
-  // 1. Try common title fields
-  let title = findFirstValue(doc, TITLE_FIELDS)
+  let title = findFirstValue(doc, TITLE_FIELDS_PRIMARY)
 
-  // 2. If no title found, try any string field
   if (!title) {
-    title = findAnyStringValue(doc, new Set(SUBTITLE_FIELDS))
+    title = buildNameFromParts(doc)
   }
 
-  // 3. Last resort: use entity label + truncated record ID
+  if (!title) {
+    title = findFirstValue(doc, TITLE_FIELDS_SECONDARY)
+  }
+
+  if (!title) {
+    title = findAnyStringValue(
+      doc,
+      new Set([...SUBTITLE_FIELDS, ...FIRST_NAME_FIELDS, ...LAST_NAME_FIELDS]),
+    )
+  }
+
   if (!title) {
     const shortId = recordId.length > 8 ? recordId.slice(0, 8) + '...' : recordId
     title = `${entityLabel} ${shortId}`
   }
 
-  // Build subtitle from multiple relevant fields to show more context
   const subtitleParts: string[] = []
   for (const field of SUBTITLE_FIELDS) {
     const value = doc[field]
@@ -100,7 +123,7 @@ export function extractFallbackPresenter(
 
   return {
     title,
-    subtitle: subtitleParts.length > 0 ? subtitleParts.join(' · ').slice(0, 120) : undefined,
+    subtitle: subtitleParts.length > 0 ? truncateSubtitle(subtitleParts.join(' · ')) : undefined,
     badge: entityLabel,
   }
 }


### PR DESCRIPTION
## Summary
Implements unit-test coverage and a focused bugfix for search fallback presenter behavior (`extractFallbackPresenter`).

This PR improves fallback title/subtitle resolution for records without explicit `formatResult`, especially person-like records.

Closes #877

## What changed

### 1. Fallback presenter bugfix
Updated [fallback-presenter.ts](/Users/kalma/work/om-dev/open-mercato/packages/search/src/lib/fallback-presenter.ts):

- Added explicit title priority split:
  - primary fields first (`display_name`, `name`, `title`, etc.)
  - name-part composition
  - secondary fallback fields (`email`, `code`, `identifier`, etc.)
- Added person-name composition support:
  - `first_name + last_name`
  - `firstName + lastName`
  - single available name part as fallback
- Kept generic fallback safe:
  - excludes technical fields (`id`, tenant/org IDs, timestamps)
  - excludes `cf:*` and `cf_*` from generic fallback title selection
- Standardized subtitle truncation to max 120 chars via dedicated helper.

### 2. New unit tests
Added [fallback-presenter.test.ts](/Users/kalma/work/om-dev/open-mercato/packages/search/src/__tests__/fallback-presenter.test.ts) covering:

- title priority ordering
- snake_case and camelCase name-part composition
- single name-part fallback
- precedence of composed name over email fallback
- subtitle max-length cap (120)
- subtitle not repeating title
- technical field exclusion from generic title fallback
- `cf:*` / `cf_*` exclusion from generic title fallback
- stable final fallback: `<Entity Label> <short record id>`
- badge formatting consistency from `entityId`

## Why
Reduces odd fallback search result labels and protects this behavior from regressions with deterministic unit tests.

## Validation
Executed locally:

```bash
npx jest packages/search/src/__tests__/fallback-presenter.test.ts
npx jest packages/search/src/__tests__
```

Result: all passing (including existing search test suites).

## Scope / compatibility
- No API contract changes
- No changes outside search fallback presenter behavior + tests
- Existing search tests continue to pass