### PR TITLE
fix(workflows): finish duplicate definition flow and add tests

### DIFF
--- a/packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
+
+type WorkflowDefinitionRecord = {
+  id: string
+  workflowId: string
+  version: number
+  definition: Record<string, unknown>
+  metadata?: Record<string, unknown> | null
+}
+
+function buildDefinitionPayload(timestamp: number) {
+  return {
+    workflowId: `qa-wf-dup-${timestamp}`,
+    workflowName: `QA Duplicate Workflow ${timestamp}`,
+    description: 'Workflow used to validate duplicate action integration',
+    version: 1,
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        {
+          stepId: 'review',
+          stepName: 'Review',
+          stepType: 'USER_TASK',
+          userTaskConfig: {
+            assignedTo: 'approver',
+            slaDuration: 'PT1H',
+          },
+          activities: [
+            {
+              activityId: 'review_notify',
+              activityName: 'Notify reviewer',
+              activityType: 'SEND_EMAIL',
+              config: {
+                to: '{{context.reviewer.email}}',
+                subject: 'Review needed',
+                template: 'workflow_review',
+              },
+              async: true,
+            },
+          ],
+        },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        {
+          transitionId: 'start_to_review',
+          fromStepId: 'start',
+          toStepId: 'review',
+          trigger: 'auto',
+          activities: [
+            {
+              activityId: 'emit_review_requested',
+              activityName: 'Emit review requested',
+              activityType: 'EMIT_EVENT',
+              config: {
+                eventType: 'qa.workflow.review.requested',
+                payload: { workflow: '{{workflow.instanceId}}' },
+              },
+              async: true,
+            },
+          ],
+          continueOnActivityFailure: true,
+          priority: 10,
+        },
+        {
+          transitionId: 'review_to_end',
+          fromStepId: 'review',
+          toStepId: 'end',
+          trigger: 'manual',
+          continueOnActivityFailure: true,
+          priority: 20,
+        },
+      ],
+    },
+    metadata: {
+      tags: ['qa', 'duplicate'],
+      category: 'QA',
+      icon: 'copy',
+    },
+    enabled: true,
+  }
+}
+
+async function deleteWorkflowDefinitionIfExists(
+  request: APIRequestContext,
+  token: string | null,
+  id: string | null,
+) {
+  if (!token || !id) return
+  try {
+    await apiRequest(request, 'DELETE', `/api/workflows/definitions/${id}`, { token })
+  } catch {
+    return
+  }
+}
+
+test.describe('TC-WF-002: Duplicate Workflow Definition API flow', () => {
+  test('should create copied workflowId and preserve steps/transitions/activities payload', async ({
+    request,
+  }) => {
+    const timestamp = Date.now()
+    const sourcePayload = buildDefinitionPayload(timestamp)
+    const duplicatePayload = {
+      ...sourcePayload,
+      workflowId: `${sourcePayload.workflowId}_copy`,
+    }
+
+    let token: string | null = null
+    let sourceDefinitionId: string | null = null
+    let duplicateDefinitionId: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      const sourceResponse = await apiRequest(request, 'POST', '/api/workflows/definitions', {
+        token,
+        data: sourcePayload,
+      })
+      const sourceBody = await readJsonSafe<{ data?: WorkflowDefinitionRecord; error?: string }>(sourceResponse)
+      expect(
+        sourceResponse.status(),
+        `Source definition creation failed: ${JSON.stringify(sourceBody)}`,
+      ).toBe(201)
+      sourceDefinitionId = sourceBody?.data?.id ?? null
+      expect(sourceDefinitionId).toBeTruthy()
+
+      const duplicateResponse = await apiRequest(request, 'POST', '/api/workflows/definitions', {
+        token,
+        data: duplicatePayload,
+      })
+      const duplicateBody = await readJsonSafe<{ data?: WorkflowDefinitionRecord; error?: string }>(duplicateResponse)
+      expect(
+        duplicateResponse.status(),
+        `Duplicate definition creation failed: ${JSON.stringify(duplicateBody)}`,
+      ).toBe(201)
+
+      const duplicateDefinition = duplicateBody?.data
+      duplicateDefinitionId = duplicateDefinition?.id ?? null
+      expect(duplicateDefinitionId).toBeTruthy()
+      expect(duplicateDefinition?.workflowId).toBe(duplicatePayload.workflowId)
+      expect(duplicateDefinition?.workflowId).not.toBe(sourcePayload.workflowId)
+      expect(duplicateDefinition?.version).toBe(sourcePayload.version)
+      expect(duplicateDefinition?.definition).toEqual(sourcePayload.definition)
+      expect(duplicateDefinition?.metadata).toEqual(sourcePayload.metadata)
+
+      const duplicateListResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/workflows/definitions?workflowId=${encodeURIComponent(duplicatePayload.workflowId)}`,
+        { token },
+      )
+      const duplicateListBody = await readJsonSafe<{ data?: WorkflowDefinitionRecord[] }>(duplicateListResponse)
+      expect(duplicateListResponse.status()).toBe(200)
+      const foundDuplicate = duplicateListBody?.data?.find(
+        (item) => item.id === duplicateDefinitionId,
+      )
+      expect(foundDuplicate).toBeTruthy()
+      expect(foundDuplicate?.definition).toEqual(sourcePayload.definition)
+
+      const duplicateAgainResponse = await apiRequest(request, 'POST', '/api/workflows/definitions', {
+        token,
+        data: duplicatePayload,
+      })
+      expect(duplicateAgainResponse.status()).toBe(409)
+    } finally {
+      await deleteWorkflowDefinitionIfExists(request, token, duplicateDefinitionId)
+      await deleteWorkflowDefinitionIfExists(request, token, sourceDefinitionId)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
@@ -282,6 +282,35 @@ describe('Workflow Definitions API', () => {
       expect(mockEm.persistAndFlush).toHaveBeenCalled()
     })
 
+    test('should prevent duplicate workflowId even with a different version', async () => {
+      mockEm.findOne.mockResolvedValue({
+        id: 'existing-def',
+        workflowId: 'test-workflow',
+        version: 1,
+      })
+
+      const request = new NextRequest('http://localhost/api/workflows/definitions', {
+        method: 'POST',
+        body: JSON.stringify({
+          ...validDefinition,
+          version: 2,
+        }),
+      })
+
+      const response = await createDefinition(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('already exists')
+      expect(mockEm.findOne).toHaveBeenCalledWith(
+        WorkflowDefinition,
+        expect.objectContaining({
+          workflowId: 'test-workflow',
+          tenantId: testTenantId,
+        })
+      )
+    })
+
     test('should check create permission', async () => {
       const { createRequestContainer } = require('@open-mercato/shared/lib/di/container')
       const localRbacService = {
@@ -331,11 +360,37 @@ describe('Workflow Definitions API', () => {
       expect(data.details).toBeDefined()
     })
 
-    test('should prevent duplicate workflowId + version', async () => {
+    test('should prevent duplicate workflowId', async () => {
       mockEm.findOne.mockResolvedValue({
         id: 'existing-def',
         workflowId: 'test-workflow',
         version: 1,
+      })
+
+      const request = new NextRequest('http://localhost/api/workflows/definitions', {
+        method: 'POST',
+        body: JSON.stringify(validDefinition),
+      })
+
+      const response = await createDefinition(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toContain('already exists')
+    })
+
+    test('should return 409 on database unique constraint violation', async () => {
+      mockEm.findOne.mockResolvedValue(null)
+      mockEm.create.mockReturnValue({
+        id: 'new-def-id',
+        ...validDefinition,
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+      })
+      mockEm.persistAndFlush.mockRejectedValue({
+        code: '23505',
+        constraint: 'workflow_definitions_workflow_id_tenant_id_unique',
+        detail: 'Key (workflow_id, tenant_id) already exists.',
       })
 
       const request = new NextRequest('http://localhost/api/workflows/definitions', {

--- a/packages/core/src/modules/workflows/api/definitions/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/route.ts
@@ -22,6 +22,30 @@ export const metadata = {
   requireFeatures: ['workflows.definitions.view'],
 }
 
+const WORKFLOW_ID_TENANT_UNIQUE_CONSTRAINT = 'workflow_definitions_workflow_id_tenant_id_unique'
+
+function isWorkflowIdUniqueConstraintError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const value = error as Record<string, unknown>
+  const constraint = value.constraint
+  const code = value.code
+  const message = typeof value.message === 'string' ? value.message : ''
+  const detail = typeof value.detail === 'string' ? value.detail : ''
+
+  if (constraint === WORKFLOW_ID_TENANT_UNIQUE_CONSTRAINT) {
+    return true
+  }
+
+  if (code === '23505' && detail.includes('(workflow_id, tenant_id)')) {
+    return true
+  }
+
+  return message.includes(WORKFLOW_ID_TENANT_UNIQUE_CONSTRAINT)
+}
+
 /**
  * GET /api/workflows/definitions
  *
@@ -151,19 +175,16 @@ export async function POST(request: NextRequest) {
 
     const input: CreateWorkflowDefinitionApiInput = validation.data
 
-    // Check if workflow with same ID and version already exists
+    // workflow_id is unique per tenant; check upfront to return 409 instead of DB error.
     const existing = await em.findOne(WorkflowDefinition, {
       workflowId: input.workflowId,
-      version: input.version,
       tenantId,
-      organizationId,
-      deletedAt: null,
     })
 
     if (existing) {
       return NextResponse.json(
         {
-          error: `Workflow definition with ID "${input.workflowId}" and version ${input.version} already exists`,
+          error: `Workflow definition with ID "${input.workflowId}" already exists`,
         },
         { status: 409 }
       )
@@ -194,6 +215,13 @@ export async function POST(request: NextRequest) {
       { status: 201 }
     )
   } catch (error) {
+    if (isWorkflowIdUniqueConstraintError(error)) {
+      return NextResponse.json(
+        { error: 'Workflow definition with this ID already exists' },
+        { status: 409 }
+      )
+    }
+
     console.error('Error creating workflow definition:', error)
     return NextResponse.json(
       { error: 'Failed to create workflow definition' },

--- a/packages/core/src/modules/workflows/backend/definitions/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/page.tsx
@@ -23,7 +23,7 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
-import {Trash2} from "lucide-react";
+import { Trash2 } from 'lucide-react'
 
 type WorkflowDefinition = {
   id: string
@@ -31,6 +31,7 @@ type WorkflowDefinition = {
   workflowName: string
   description: string | null
   version: number
+  definition: Record<string, unknown>
   enabled: boolean
   effectiveFrom: string | null
   effectiveTo: string | null
@@ -54,6 +55,22 @@ type DefinitionsResponse = {
     offset: number
     hasMore: boolean
   }
+}
+
+type CreateDefinitionResponse = {
+  data?: {
+    id?: string
+  }
+  error?: string
+}
+
+const WORKFLOW_ID_MAX_LENGTH = 100
+
+function buildDuplicateWorkflowId(sourceWorkflowId: string, attempt: number): string {
+  const suffix = attempt === 0 ? '_copy' : `_copy_${attempt + 1}`
+  const maxBaseLength = Math.max(1, WORKFLOW_ID_MAX_LENGTH - suffix.length)
+  const base = sourceWorkflowId.slice(0, maxBaseLength)
+  return `${base}${suffix}`
 }
 
 export default function WorkflowDefinitionsListPage() {
@@ -138,8 +155,34 @@ export default function WorkflowDefinitionsListPage() {
   }
 
   const handleDuplicate = async (definition: WorkflowDefinition) => {
-    // TODO: Implement duplicate functionality
-    flash(t('workflows.messages.duplicateNotYetImplemented'), 'info')
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const duplicateWorkflowId = buildDuplicateWorkflowId(definition.workflowId, attempt)
+      const result = await apiCall<CreateDefinitionResponse>('/api/workflows/definitions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          workflowId: duplicateWorkflowId,
+          workflowName: definition.workflowName,
+          description: definition.description,
+          version: definition.version,
+          definition: definition.definition,
+          metadata: definition.metadata,
+          enabled: definition.enabled,
+        }),
+      })
+
+      if (result.ok) {
+        flash(t('workflows.messages.workflowDuplicated'), 'success')
+        queryClient.invalidateQueries({ queryKey: ['workflow-definitions'] })
+        return
+      }
+
+      if (result.status !== 409) {
+        break
+      }
+    }
+
+    flash(t('workflows.errors.createFailed'), 'error')
   }
 
   const handleFiltersApply = React.useCallback((values: FilterValues) => {


### PR DESCRIPTION
## Summary
This PR completes the missing "Duplicate" bugfix in workflows definitions and adds regression coverage.

- Implemented Duplicate action in workflow definitions list.
- Duplicate now creates a copied workflow ID (`*_copy`, `*_copy_2`, ...) to satisfy tenant-level uniqueness.
- Added conflict-safe behavior for API create route (`409` on workflow ID uniqueness conflict, including DB-level unique-constraint handling).
- Added/updated route tests for duplicate-related behavior.
- Added integration test coverage for duplicate flow payload correctness.

## Technical details
- UI duplicate logic now posts a copied definition with a unique `workflowId` candidate and retries on `409`.
- API create route now validates uniqueness by `workflowId + tenantId` (matching DB constraint).
- API catches unique-constraint races and returns `409` instead of `500`.

## Testing
- `npx jest packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts` ✅
- `BASE_URL=http://127.0.0.1:5001 npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts --retries=0` ✅

## Issue
Closes #878

## Checklist
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
  Integration test was added in module-local `__integration__`:
  `packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts`
