### PR TITLE
fix/909: fixed issue

### DIFF
--- a/packages/core/src/modules/catalog/commands/__tests__/variants.sku.test.ts
+++ b/packages/core/src/modules/catalog/commands/__tests__/variants.sku.test.ts
@@ -1,0 +1,273 @@
+export {}
+
+import { UniqueConstraintViolationException } from '@mikro-orm/core'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+const registerCommand = jest.fn()
+
+const FAKE_PRODUCT = {
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  organizationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  tenantId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  taxRateId: null,
+  taxRate: null,
+}
+
+const FAKE_VARIANT = {
+  id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  organizationId: FAKE_PRODUCT.organizationId,
+  tenantId: FAKE_PRODUCT.tenantId,
+  sku: 'SKU-OLD',
+  isDefault: false,
+  isActive: true,
+  product: { id: FAKE_PRODUCT.id },
+  deletedAt: null,
+  taxRateId: null,
+  taxRate: null,
+}
+
+jest.mock('@open-mercato/shared/lib/commands', () => ({ registerCommand }))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  buildChanges: jest.fn().mockReturnValue([]),
+  requireId: jest.fn((input: Record<string, unknown>) => input.id as string),
+  parseWithCustomFields: jest.fn((schema: unknown, raw: unknown) => ({ parsed: raw, custom: {} })),
+  setCustomFieldsIfAny: jest.fn().mockResolvedValue(undefined),
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+  emitCrudUndoSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/customFieldSnapshots', () => ({
+  loadCustomFieldSnapshot: jest.fn().mockResolvedValue({}),
+  buildCustomFieldResetMap: jest.fn().mockReturnValue({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+  findOneWithDecryption: jest.fn().mockResolvedValue(null),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    catalog: {
+      catalog_product_variant: 'catalog:catalog_product_variant',
+      catalog_product_price: 'catalog:catalog_product_price',
+      catalog_product: 'catalog:catalog_product',
+    },
+  },
+}))
+
+jest.mock('#generated/entities/catalog_product_variant', () => ({}))
+
+jest.mock('@open-mercato/core/modules/attachments/data/entities', () => ({
+  Attachment: class Attachment {},
+}))
+
+jest.mock('@open-mercato/core/modules/sales/data/entities', () => ({
+  SalesTaxRate: class SalesTaxRate {},
+}))
+
+jest.mock('../shared', () => ({
+  cloneJson: (v: unknown) => JSON.parse(JSON.stringify(v)),
+  ensureOrganizationScope: jest.fn(),
+  ensureTenantScope: jest.fn(),
+  emitCatalogQueryIndexEvent: jest.fn().mockResolvedValue(undefined),
+  extractUndoPayload: jest.fn().mockReturnValue(null),
+  requireProduct: jest.fn().mockResolvedValue(FAKE_PRODUCT),
+  toNumericString: (v: unknown) => (v == null ? null : String(v)),
+  randomSuffix: () => 'abc',
+  getErrorConstraint: (error: unknown) => {
+    const e = error as Record<string, unknown>
+    return typeof e.constraint === 'string' ? e.constraint : null
+  },
+  getErrorMessage: (error: unknown) => {
+    const e = error as Record<string, unknown>
+    return typeof e.message === 'string' ? e.message : ''
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSkuConstraintError(): UniqueConstraintViolationException {
+  const err = new UniqueConstraintViolationException(
+    new Error('duplicate key value violates unique constraint "catalog_product_variants_sku_unique"')
+  )
+  ;(err as unknown as Record<string, unknown>).constraint = 'catalog_product_variants_sku_unique'
+  return err
+}
+
+function makeSkuConstraintErrorMessageOnly(): UniqueConstraintViolationException {
+  // constraint property not set — only the message contains the constraint name
+  return new UniqueConstraintViolationException(
+    new Error('duplicate key value violates unique constraint "catalog_product_variants_sku_unique"')
+  )
+}
+
+function makeOtherConstraintError(): UniqueConstraintViolationException {
+  const err = new UniqueConstraintViolationException(new Error('unique constraint violation "some_other_idx"'))
+  ;(err as unknown as Record<string, unknown>).constraint = 'some_other_idx'
+  return err
+}
+
+function buildEm(flushError?: unknown) {
+  const variantRecord = { ...FAKE_VARIANT }
+  const em: Record<string, unknown> = {
+    findOne: jest.fn().mockImplementation(async (_entity: unknown, filter: Record<string, unknown>) => {
+      if (filter?.id === FAKE_VARIANT.id) return variantRecord
+      return null
+    }),
+    find: jest.fn().mockResolvedValue([]),
+    count: jest.fn().mockResolvedValue(0),
+    create: jest.fn().mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({
+      ...payload,
+      id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+      organizationId: FAKE_PRODUCT.organizationId,
+      tenantId: FAKE_PRODUCT.tenantId,
+      isDefault: payload.isDefault ?? false,
+      product: { id: FAKE_PRODUCT.id },
+    })),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: flushError
+      ? jest.fn().mockRejectedValue(flushError)
+      : jest.fn().mockResolvedValue(undefined),
+    nativeDelete: jest.fn().mockResolvedValue(0),
+    getReference: jest.fn().mockReturnValue(null),
+  }
+  ;(em as Record<string, unknown>).fork = jest.fn().mockReturnValue(em)
+  return em
+}
+
+function buildCtx(em: Record<string, unknown>) {
+  return {
+    container: {
+      resolve: jest.fn((token: string) => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return { markOrmEntityChange: jest.fn() }
+        return undefined
+      }),
+    },
+    auth: {
+      sub: 'user-1',
+      tenantId: FAKE_PRODUCT.tenantId,
+      orgId: FAKE_PRODUCT.organizationId,
+    },
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+  }
+}
+
+async function runCommand(
+  command: { execute: (input: Record<string, unknown>, ctx: unknown) => Promise<unknown> },
+  input: Record<string, unknown>,
+  flushError?: unknown
+): Promise<{ result?: unknown; error?: unknown }> {
+  const em = buildEm(flushError)
+  try {
+    const result = await command.execute(input, buildCtx(em))
+    return { result }
+  } catch (error) {
+    return { error }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load commands — top-level mocks are already in place; no isolateModules
+// needed so instanceof checks work against the same class registry.
+// ---------------------------------------------------------------------------
+
+let createCommand: { execute: (input: Record<string, unknown>, ctx: unknown) => Promise<unknown> }
+let updateCommand: { execute: (input: Record<string, unknown>, ctx: unknown) => Promise<unknown> }
+
+beforeAll(() => {
+  require('../variants')
+  createCommand = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'catalog.variants.create')?.[0]
+  updateCommand = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'catalog.variants.update')?.[0]
+})
+
+const CREATE_INPUT = {
+  productId: FAKE_PRODUCT.id,
+  organizationId: FAKE_PRODUCT.organizationId,
+  tenantId: FAKE_PRODUCT.tenantId,
+  sku: '123',
+}
+
+const UPDATE_INPUT = {
+  id: FAKE_VARIANT.id,
+  organizationId: FAKE_PRODUCT.organizationId,
+  tenantId: FAKE_PRODUCT.tenantId,
+  sku: '123',
+}
+
+// ---------------------------------------------------------------------------
+// createVariantCommand — SKU uniqueness
+// ---------------------------------------------------------------------------
+
+describe('createVariantCommand — SKU uniqueness handling', () => {
+  it('throws CrudHttpError 400 with fieldErrors.sku when flush fails with SKU constraint via constraint property', async () => {
+    expect(createCommand).toBeDefined()
+    const { error } = await runCommand(createCommand, CREATE_INPUT, makeSkuConstraintError())
+    expect(error).toBeInstanceOf(CrudHttpError)
+    expect((error as CrudHttpError).status).toBe(400)
+    expect(((error as CrudHttpError).body as Record<string, Record<string, string>>).fieldErrors?.sku).toBeDefined()
+  })
+
+  it('throws CrudHttpError 400 with fieldErrors.sku when constraint name is only in error message', async () => {
+    expect(createCommand).toBeDefined()
+    const { error } = await runCommand(createCommand, CREATE_INPUT, makeSkuConstraintErrorMessageOnly())
+    expect(error).toBeInstanceOf(CrudHttpError)
+    expect((error as CrudHttpError).status).toBe(400)
+    expect(((error as CrudHttpError).body as Record<string, Record<string, string>>).fieldErrors?.sku).toBeDefined()
+  })
+
+  it('rethrows unrelated UniqueConstraintViolationException unchanged', async () => {
+    expect(createCommand).toBeDefined()
+    const otherError = makeOtherConstraintError()
+    const { error } = await runCommand(createCommand, CREATE_INPUT, otherError)
+    expect(error).toBe(otherError)
+  })
+
+  it('rethrows plain non-ORM error unchanged', async () => {
+    expect(createCommand).toBeDefined()
+    const plainError = new Error('unexpected db failure')
+    const { error } = await runCommand(createCommand, CREATE_INPUT, plainError)
+    expect(error).toBe(plainError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// updateVariantCommand — SKU uniqueness
+// ---------------------------------------------------------------------------
+
+describe('updateVariantCommand — SKU uniqueness handling', () => {
+  it('throws CrudHttpError 400 with fieldErrors.sku when flush fails with SKU constraint', async () => {
+    expect(updateCommand).toBeDefined()
+    const { error } = await runCommand(updateCommand, UPDATE_INPUT, makeSkuConstraintError())
+    expect(error).toBeInstanceOf(CrudHttpError)
+    expect((error as CrudHttpError).status).toBe(400)
+    expect(((error as CrudHttpError).body as Record<string, Record<string, string>>).fieldErrors?.sku).toBeDefined()
+  })
+
+  it('rethrows unrelated UniqueConstraintViolationException unchanged', async () => {
+    expect(updateCommand).toBeDefined()
+    const otherError = makeOtherConstraintError()
+    const { error } = await runCommand(updateCommand, UPDATE_INPUT, otherError)
+    expect(error).toBe(otherError)
+  })
+
+  it('rethrows plain non-ORM error unchanged', async () => {
+    expect(updateCommand).toBeDefined()
+    const plainError = new Error('unexpected db failure')
+    const { error } = await runCommand(updateCommand, UPDATE_INPUT, plainError)
+    expect(error).toBe(plainError)
+  })
+})

--- a/packages/core/src/modules/catalog/commands/variants.ts
+++ b/packages/core/src/modules/catalog/commands/variants.ts
@@ -2,6 +2,7 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler } from '@open-mercato/shared/lib/commands'
 import { buildChanges, requireId, parseWithCustomFields, setCustomFieldsIfAny, emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { UniqueConstraintViolationException } from '@mikro-orm/core'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { loadCustomFieldSnapshot, buildCustomFieldResetMap } from '@open-mercato/shared/lib/commands/customFieldSnapshots'
@@ -30,6 +31,8 @@ import {
   extractUndoPayload,
   requireProduct,
   toNumericString,
+  getErrorConstraint,
+  getErrorMessage,
 } from './shared'
 import { SalesTaxRate } from '@open-mercato/core/modules/sales/data/entities'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
@@ -575,11 +578,19 @@ const createVariantCommand: CommandHandler<VariantCreateInput, { variantId: stri
       updatedAt: now,
     })
     em.persist(record)
-    await em.flush()
+    try {
+      await em.flush()
+    } catch (error) {
+      await rethrowVariantUniqueConstraint(error)
+    }
     let previousDefaultVariantId: string | null = null
     if (record.isDefault) {
       previousDefaultVariantId = await enforceSingleDefaultVariant(em, record)
-      await em.flush()
+      try {
+        await em.flush()
+      } catch (error) {
+        await rethrowVariantUniqueConstraint(error)
+      }
     }
     await aggregateVariantMediaToProduct(em, record)
     await setCustomFieldsIfAny({
@@ -732,7 +743,11 @@ const updateVariantCommand: CommandHandler<VariantUpdateInput, { variantId: stri
     if (parsed.isDefault === true) {
       previousDefaultVariantId = await enforceSingleDefaultVariant(em, record)
     }
-    await em.flush()
+    try {
+      await em.flush()
+    } catch (error) {
+      await rethrowVariantUniqueConstraint(error)
+    }
     await aggregateVariantMediaToProduct(em, record)
     if (custom && Object.keys(custom).length) {
       await setCustomFieldsIfAny({
@@ -1011,6 +1026,30 @@ const deleteVariantCommand: CommandHandler<
       })
     }
   },
+}
+
+async function throwDuplicateVariantSkuError(): Promise<never> {
+  const { translate } = await resolveTranslations()
+  const message = translate('catalog.variants.errors.skuExists', 'SKU already in use.')
+  throw new CrudHttpError(400, {
+    error: message,
+    fieldErrors: { sku: message },
+    details: [{ path: ['sku'], message, code: 'duplicate', origin: 'validation' }],
+  })
+}
+
+async function rethrowVariantUniqueConstraint(error: unknown): Promise<never> {
+  if (error instanceof UniqueConstraintViolationException) {
+    const constraint = getErrorConstraint(error)
+    const message = getErrorMessage(error).toLowerCase()
+    if (
+      constraint === 'catalog_product_variants_sku_unique' ||
+      message.includes('catalog_product_variants_sku_unique')
+    ) {
+      await throwDuplicateVariantSkuError()
+    }
+  }
+  throw error
 }
 
 registerCommand(createVariantCommand)

--- a/packages/core/src/modules/catalog/i18n/de.json
+++ b/packages/core/src/modules/catalog/i18n/de.json
@@ -522,6 +522,7 @@
   "catalog.search.priceKind.promotion": "Aktion",
   "catalog.search.status.inactive": "Inaktiv",
   "catalog.search.variant.default": "Standard",
+  "catalog.variants.errors.skuExists": "SKU wird bereits verwendet.",
   "catalog.variants.form.barcodeLabel": "Barcode",
   "catalog.variants.form.barcodePlaceholder": "EAN, UPC usw.",
   "catalog.variants.form.createAction": "Variante erstellen",

--- a/packages/core/src/modules/catalog/i18n/en.json
+++ b/packages/core/src/modules/catalog/i18n/en.json
@@ -522,6 +522,7 @@
   "catalog.search.priceKind.promotion": "Promotion",
   "catalog.search.status.inactive": "Inactive",
   "catalog.search.variant.default": "Default",
+  "catalog.variants.errors.skuExists": "SKU already in use.",
   "catalog.variants.form.barcodeLabel": "Barcode",
   "catalog.variants.form.barcodePlaceholder": "EAN, UPC, etc.",
   "catalog.variants.form.createAction": "Create variant",

--- a/packages/core/src/modules/catalog/i18n/es.json
+++ b/packages/core/src/modules/catalog/i18n/es.json
@@ -522,6 +522,7 @@
   "catalog.search.priceKind.promotion": "Promoción",
   "catalog.search.status.inactive": "Inactivo",
   "catalog.search.variant.default": "Predeterminado",
+  "catalog.variants.errors.skuExists": "El SKU ya está en uso.",
   "catalog.variants.form.barcodeLabel": "Código de barras",
   "catalog.variants.form.barcodePlaceholder": "EAN, UPC, etc.",
   "catalog.variants.form.createAction": "Crear variante",

--- a/packages/core/src/modules/catalog/i18n/pl.json
+++ b/packages/core/src/modules/catalog/i18n/pl.json
@@ -522,6 +522,7 @@
   "catalog.search.priceKind.promotion": "Promocja",
   "catalog.search.status.inactive": "Nieaktywny",
   "catalog.search.variant.default": "Domyślny",
+  "catalog.variants.errors.skuExists": "SKU jest już używany.",
   "catalog.variants.form.barcodeLabel": "Kod kreskowy",
   "catalog.variants.form.barcodePlaceholder": "EAN, UPC itp.",
   "catalog.variants.form.createAction": "Utwórz wariant",


### PR DESCRIPTION
When saving a product variant with a SKU that already exists within the same organization/tenant scope, the API returned a generic 500 Internal Server Error instead of a user-friendly validation message.

The catalog_product_variants_sku_unique database constraint was already in place, but the UniqueConstraintViolationException thrown by MikroORM on em.flush() was never caught in the variant commands - causing it to propagate as an unhandled server error.

Affected endpoint: PUT /api/catalog/variants

Solution

Wraps both em.flush() calls in createVariantCommand and updateVariantCommand with a try/catch that intercepts UniqueConstraintViolationException. When the violation matches the catalog_product_variants_sku_unique constraint, the error is converted into a structured CrudHttpError(400) with a translated, field-targeted message - consistent with the existing pattern used for product-level SKU uniqueness in commands/products.ts.

The fieldErrors.sku field in the response causes CrudForm to render the error inline on the SKU input field.

Changes:

  - commands/variants.ts — added UniqueConstraintViolationException import; wrapped both em.flush() calls (create + update)
   in try/catch; added rethrowVariantUniqueConstraint and throwDuplicateVariantSkuError helpers
  - i18n/en.json, pl.json, de.json, es.json — added catalog.variants.errors.skuExists translation key
  - commands/__tests__/variants.sku.test.ts — 7 unit tests covering SKU constraint detection via .constraint property and
  message fallback, error shape, and pass-through for unrelated errors; both create and update commands covered

