### PR TITLE
fix(catalog): handle price variant validation #904

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
@@ -19,6 +19,7 @@ import {
   createVariantInitialValues,
   normalizeOptionSchema,
   mapPriceItemToDraft,
+  findInvalidVariantPriceKinds,
 } from '@open-mercato/core/modules/catalog/components/products/variantForm'
 import {
   type PriceKindSummary,
@@ -26,6 +27,7 @@ import {
   type TaxRateSummary,
   normalizePriceKindSummary,
 } from '@open-mercato/core/modules/catalog/components/products/productForm'
+import { parseNumericInput } from '@open-mercato/core/modules/catalog/components/products/productFormUtils'
 import {
   VariantBasicsSection,
   VariantOptionValuesSection,
@@ -463,6 +465,11 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
               const message = t('catalog.variants.form.errors.nameRequired', 'Provide the variant name.')
               throw createCrudFormError(message, { name: message })
             }
+            const invalidPriceKinds = findInvalidVariantPriceKinds(priceKinds, values.prices)
+            if (invalidPriceKinds.length) {
+              const message = t('catalog.variants.form.errors.invalidPrice', 'Provide a valid non-negative price.')
+              throw createCrudFormError(message, { prices: message })
+            }
             const resolveTaxRateValue = (taxRateId?: string | null) => {
               if (!taxRateId) return null
               const match = taxRates.find((rate) => rate.id === taxRateId)
@@ -678,8 +685,8 @@ async function syncVariantPricesUpdate({
       }
       continue
     }
-    const numeric = Number(amount)
-    if (Number.isNaN(numeric) || numeric < 0) continue
+    const numeric = parseNumericInput(amount)
+    if (!Number.isFinite(numeric) || numeric < 0) continue
     const payload: Record<string, unknown> = {
       productId,
       variantId,

--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx
@@ -17,6 +17,7 @@ import {
   type OptionDefinition,
   createVariantInitialValues,
   normalizeOptionSchema,
+  findInvalidVariantPriceKinds,
 } from '@open-mercato/core/modules/catalog/components/products/variantForm'
 import {
   type PriceKindSummary,
@@ -24,6 +25,7 @@ import {
   type TaxRateSummary,
   normalizePriceKindSummary,
 } from '@open-mercato/core/modules/catalog/components/products/productForm'
+import { parseNumericInput } from '@open-mercato/core/modules/catalog/components/products/productFormUtils'
 import {
   VariantBasicsSection,
   VariantOptionValuesSection,
@@ -316,6 +318,11 @@ export default function CreateVariantPage({ params }: { params?: { productId?: s
               const message = t('catalog.variants.form.errors.nameRequired', 'Provide the variant name.')
               throw createCrudFormError(message, { name: message })
             }
+            const invalidPriceKinds = findInvalidVariantPriceKinds(priceKinds, values.prices)
+            if (invalidPriceKinds.length) {
+              const message = t('catalog.variants.form.errors.invalidPrice', 'Provide a valid non-negative price.')
+              throw createCrudFormError(message, { prices: message })
+            }
             const resolveTaxRateValue = (taxRateId?: string | null) => {
               if (!taxRateId) return null
               const match = taxRates.find((rate) => rate.id === taxRateId)
@@ -447,8 +454,8 @@ async function syncVariantPrices({
     const draft = priceDrafts?.[kind.id]
     const amount = typeof draft?.amount === 'string' ? draft.amount.trim() : ''
     if (!amount) continue
-    const numeric = Number(amount)
-    if (Number.isNaN(numeric) || numeric < 0) continue
+    const numeric = parseNumericInput(amount)
+    if (!Number.isFinite(numeric) || numeric < 0) continue
     const payload: Record<string, unknown> = {
       productId,
       variantId,

--- a/packages/core/src/modules/catalog/components/products/__tests__/variantForm.test.ts
+++ b/packages/core/src/modules/catalog/components/products/__tests__/variantForm.test.ts
@@ -4,8 +4,10 @@ import {
   normalizeOptionSchema,
   buildVariantMetadata,
   mapPriceItemToDraft,
+  findInvalidVariantPriceKinds,
 } from '../variantForm'
 import type { VariantFormValues } from '../variantForm'
+import type { PriceKindSummary } from '../productForm'
 
 describe('VARIANT_BASE_VALUES', () => {
   it('has correct string defaults', () => {
@@ -335,5 +337,46 @@ describe('mapPriceItemToDraft', () => {
     const draft = mapPriceItemToDraft(item, modes)
     expect(draft!.amount).toBe('100.00')
     expect(draft!.displayMode).toBe('including-tax')
+  })
+})
+
+describe('findInvalidVariantPriceKinds', () => {
+  const priceKinds: PriceKindSummary[] = [
+    { id: 'regular', code: 'regular', title: 'Regular', currencyCode: 'USD', displayMode: 'excluding-tax' },
+    { id: 'promo', code: 'promo', title: 'Promo', currencyCode: 'USD', displayMode: 'including-tax' },
+  ]
+
+  it('returns empty list when no prices provided', () => {
+    expect(findInvalidVariantPriceKinds(priceKinds, undefined)).toEqual([])
+    expect(findInvalidVariantPriceKinds(priceKinds, {})).toEqual([])
+  })
+
+  it('ignores empty amounts', () => {
+    const drafts = {
+      regular: { priceKindId: 'regular', amount: '   ', displayMode: 'excluding-tax' as const },
+    }
+    expect(findInvalidVariantPriceKinds(priceKinds, drafts)).toEqual([])
+  })
+
+  it('accepts valid numeric input', () => {
+    const drafts = {
+      regular: { priceKindId: 'regular', amount: '99.50', displayMode: 'excluding-tax' as const },
+      promo: { priceKindId: 'promo', amount: '1 000', displayMode: 'including-tax' as const },
+    }
+    expect(findInvalidVariantPriceKinds(priceKinds, drafts)).toEqual([])
+  })
+
+  it('flags negative values', () => {
+    const drafts = {
+      regular: { priceKindId: 'regular', amount: '-10', displayMode: 'excluding-tax' as const },
+    }
+    expect(findInvalidVariantPriceKinds(priceKinds, drafts)).toEqual(['regular'])
+  })
+
+  it('flags non-numeric values', () => {
+    const drafts = {
+      promo: { priceKindId: 'promo', amount: '99q', displayMode: 'including-tax' as const },
+    }
+    expect(findInvalidVariantPriceKinds(priceKinds, drafts)).toEqual(['promo'])
   })
 })

--- a/packages/core/src/modules/catalog/components/products/variantForm.ts
+++ b/packages/core/src/modules/catalog/components/products/variantForm.ts
@@ -1,7 +1,8 @@
 "use client"
 
 import type { ProductMediaItem } from './ProductMediaManager'
-import { createLocalId } from './productForm'
+import { createLocalId, type PriceKindSummary } from './productForm'
+import { parseNumericInput } from './productFormUtils'
 
 export type OptionDefinition = {
   id: string
@@ -95,6 +96,21 @@ function extractString(value: unknown): string {
 export function buildVariantMetadata(values: VariantFormValues): Record<string, unknown> {
   const metadata = typeof values.metadata === 'object' && values.metadata ? { ...values.metadata } : {}
   return metadata
+}
+
+export function findInvalidVariantPriceKinds(
+  priceKinds: PriceKindSummary[],
+  priceDrafts: Record<string, VariantPriceDraft> | undefined,
+): string[] {
+  const invalid: string[] = []
+  for (const kind of priceKinds) {
+    const draft = priceDrafts?.[kind.id]
+    const amount = typeof draft?.amount === 'string' ? draft.amount.trim() : ''
+    if (!amount) continue
+    const numeric = parseNumericInput(amount)
+    if (!Number.isFinite(numeric) || numeric < 0) invalid.push(kind.id)
+  }
+  return invalid
 }
 
 export function mapPriceItemToDraft(

--- a/packages/core/src/modules/catalog/i18n/de.json
+++ b/packages/core/src/modules/catalog/i18n/de.json
@@ -539,6 +539,7 @@
   "catalog.variants.form.editTitleFor": "Variante bearbeiten · {{title}}",
   "catalog.variants.form.errors.deleteError": "Variante konnte nicht gelöscht werden.",
   "catalog.variants.form.errors.idMissing": "Varianten-ID fehlt nach dem Erstellen.",
+  "catalog.variants.form.errors.invalidPrice": "Geben Sie einen gultigen, nicht negativen Preis an.",
   "catalog.variants.form.errors.load": "Variante konnte nicht geladen werden.",
   "catalog.variants.form.errors.nameRequired": "Geben Sie den Variantennamen an.",
   "catalog.variants.form.errors.notFound": "Variante nicht gefunden.",

--- a/packages/core/src/modules/catalog/i18n/en.json
+++ b/packages/core/src/modules/catalog/i18n/en.json
@@ -539,6 +539,7 @@
   "catalog.variants.form.editTitleFor": "Edit variant • {{title}}",
   "catalog.variants.form.errors.deleteError": "Failed to delete variant.",
   "catalog.variants.form.errors.idMissing": "Variant id missing after create.",
+  "catalog.variants.form.errors.invalidPrice": "Provide a valid non-negative price.",
   "catalog.variants.form.errors.load": "Failed to load variant.",
   "catalog.variants.form.errors.nameRequired": "Provide the variant name.",
   "catalog.variants.form.errors.notFound": "Variant not found.",

--- a/packages/core/src/modules/catalog/i18n/es.json
+++ b/packages/core/src/modules/catalog/i18n/es.json
@@ -539,6 +539,7 @@
   "catalog.variants.form.editTitleFor": "Editar variante · {{title}}",
   "catalog.variants.form.errors.deleteError": "No se pudo eliminar la variante.",
   "catalog.variants.form.errors.idMissing": "Falta el ID de la variante después de la creación.",
+  "catalog.variants.form.errors.invalidPrice": "Proporcione un precio valido y no negativo.",
   "catalog.variants.form.errors.load": "No se pudo cargar la variante.",
   "catalog.variants.form.errors.nameRequired": "Ingrese el nombre de la variante.",
   "catalog.variants.form.errors.notFound": "Variante no encontrada.",

--- a/packages/core/src/modules/catalog/i18n/pl.json
+++ b/packages/core/src/modules/catalog/i18n/pl.json
@@ -539,6 +539,7 @@
   "catalog.variants.form.editTitleFor": "Edytuj wariant • {{title}}",
   "catalog.variants.form.errors.deleteError": "Nie udało się usunąć wariantu.",
   "catalog.variants.form.errors.idMissing": "Brak ID wariantu po utworzeniu.",
+  "catalog.variants.form.errors.invalidPrice": "Podaj poprawną, nienegatywną cene.",
   "catalog.variants.form.errors.load": "Nie udało się załadować wariantu.",
   "catalog.variants.form.errors.nameRequired": "Podaj nazwę wariantu.",
   "catalog.variants.form.errors.notFound": "Nie znaleziono wariantu.",


### PR DESCRIPTION
## Summary
Fixes price variant validation in catalog product variant pages to handle validation properly and improve coverage.

## Changes
- add guard/handling for price variant validation in variant create/edit pages  
- update variant form logic to support validation feedback  
- add tests for variant form validation  
- add localized strings for validation messages (de/en/es/pl)

## Specification
**Does a spec exist for this feature/module?**  
- [ ] Yes  
- [ ] No (created a new spec)  
- [x] N/A (minor change, no spec needed)  

## Testing
- `.../products/__tests__/variantForm.test.ts`

## Checklist
- [x] This pull request targets `develop`.  
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).  
- [x] I updated documentation, locales, or generators if the change requires it.  
- [x] I added or adjusted tests that cover the change.  
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).  
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).  

## Linked issues
Fixes #904