### PR TITLE
fix(sales): cancel/back on document creation returns to correct list page

### DIFF
--- a/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
@@ -1366,16 +1366,18 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
     [onCreated, t],
   )
 
+  const cancelHref = initialKind === 'order' ? '/backend/sales/orders' : '/backend/sales/quotes'
+
   return (
     <CrudForm<SalesDocumentFormValues>
       title={t('sales.documents.form.title', 'Create sales document')}
-      backHref="/backend/sales/channels"
+      backHref={cancelHref}
       fields={fields}
       groups={groups}
       initialValues={initialValues}
       entityIds={[E.sales.sales_quote, E.sales.sales_order]}
       submitLabel={t('sales.documents.form.submit', 'Create')}
-      cancelHref="/backend/sales/channels"
+      cancelHref={cancelHref}
       onSubmit={handleSubmit}
     />
   )


### PR DESCRIPTION
## Summary

- Fixes hardcoded `backHref` and `cancelHref` values in `SalesDocumentForm` that pointed to `/backend/sales/channels` (an unrelated page)
- Cancel and back arrow now navigate to `/backend/sales/orders` when `initialKind === 'order'`, and `/backend/sales/quotes` otherwise

## Related issue

Closes #918

## Changes

`packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx`
- Derive `cancelHref` from `initialKind` prop instead of hardcoding `/backend/sales/channels`
- Apply the same value to both `backHref` and `cancelHref` on `CrudForm`