### PR TITLE
fix(sales): auto-select primary shipping address when customer is chosen

### DIFF
--- a/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
@@ -1117,7 +1117,7 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
                     if (primary) {
                       setValue('shippingAddressId', primary.id)
                     }
-                  }).catch(() => {})
+                  }).catch((err) => { console.error('sales.documents.autoSelectAddress', err) })
                   if (next) {
                     const match = customers.find((entry) => entry.id === next)
                     const possibleEmail =
@@ -1174,7 +1174,7 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
                         if (primary) {
                           setValue('shippingAddressId', primary.id)
                         }
-                      }).catch(() => {})
+                      }).catch((err) => { console.error('sales.documents.autoSelectAddress', err) })
                       if (email && !values.customerEmail) {
                         setValue('customerEmail', email)
                       }


### PR DESCRIPTION
## Summary

- When a customer with a primary shipping address was selected on the document creation form, the Shipping Address field remained empty
- The API was already returning `is_primary` per address but it was silently discarded during option mapping
- `loadAddresses` now preserves `isPrimary` on each `AddressOption` and returns the resolved list
- Both call sites (existing customer select and inline quick-create) find the primary address and call `setValue('shippingAddressId', primary.id)` automatically
- Since `sameAsShipping` defaults to `true`, billing is mirrored for free with no additional changes

## Related issue

Closes #921

## Changes

`packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx`
- Added `isPrimary: boolean` to `AddressOption` type
- Changed `loadAddresses` return type to `Promise<AddressOption[]>`, returns options on success and `[]` on error/abort
- Captures `item.is_primary` in the reduce loop
- Both customer-select call sites chain `.then()` to auto-set `shippingAddressId` to the primary address id