### PR TITLE
fix-946: fixed tooltip date issue

### DIFF
--- a/packages/core/src/modules/sales/components/documents/PaymentsSection.tsx
+++ b/packages/core/src/modules/sales/components/documents/PaymentsSection.tsx
@@ -287,6 +287,10 @@ export function SalesDocumentPaymentsSection({
         header: t('sales.documents.payments.createdAt', 'Created'),
         cell: ({ row }) =>
           row.original.createdAt ? new Date(row.original.createdAt).toLocaleString() : '—',
+        meta: {
+          tooltipContent: (row: PaymentRow) =>
+            row.createdAt ? new Date(row.createdAt).toLocaleString() : undefined,
+        },
       },
       {
         id: 'actions',


### PR DESCRIPTION
**Title:** `fix: consistent timestamp format in Payments table tooltip`

**Body:**

## Summary
- The "Created" column in the Payments table showed localized time in the cell but raw UTC ISO string (`2026-03-12 14:12:32.696+00`) in the tooltip
- Root cause: `DataTable` auto-truncates columns ending with `At` to 120px; when truncated, the tooltip fell back to `String(cell.getValue())` — the raw DB value — instead of the formatted string
- Fix: added `meta.tooltipContent` to the `createdAt` column so the tooltip uses the same `toLocaleString()` formatting as the cell

