### PR TITLE
bug(#947): added fix

### DIFF
--- a/packages/core/src/modules/sales/api/payments/route.ts
+++ b/packages/core/src/modules/sales/api/payments/route.ts
@@ -82,8 +82,8 @@ const crud = makeCrudRoute({
       receivedAt: F.received_at,
       amount: F.amount,
     },
-    buildFilters: async (query: any) => {
-      const filters: Record<string, any> = {}
+    buildFilters: async (query: z.infer<typeof listSchema>) => {
+      const filters: Record<string, { $eq: string }> = {}
       if (query.orderId) filters.order_id = { $eq: query.orderId }
       if (query.paymentMethodId) filters.payment_method_id = { $eq: query.paymentMethodId }
       return filters

--- a/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
@@ -2581,11 +2581,15 @@ export default function SalesDocumentDetailPage({
   React.useEffect(() => {
     if (kind !== 'order') return
     ensureShippingMethodOption(record?.shippingMethodId ?? null, record?.shippingMethodSnapshot ?? null)
-    ensurePaymentMethodOption(record?.paymentMethodId ?? null, record?.paymentMethodSnapshot ?? null)
+    const paymentMethodSnapshotOrCode =
+      record?.paymentMethodSnapshot ??
+      (record?.paymentMethodCode ? { code: record.paymentMethodCode } : null)
+    ensurePaymentMethodOption(record?.paymentMethodId ?? null, paymentMethodSnapshotOrCode)
   }, [
     ensurePaymentMethodOption,
     ensureShippingMethodOption,
     kind,
+    record?.paymentMethodCode,
     record?.paymentMethodId,
     record?.paymentMethodSnapshot,
     record?.shippingMethodId,
@@ -4200,21 +4204,9 @@ export default function SalesDocumentDetailPage({
           tenantId={(record as any)?.tenantId ?? (record as any)?.tenant_id ?? null}
           onActionChange={handleSectionActionChange}
           onPaymentsChange={(payments) => setHasPayments(payments.length > 0)}
-          onTotalsChange={(totals) =>
-            setRecord((prev) =>
-              prev
-                ? {
-                    ...prev,
-                    paidTotalAmount:
-                      totals?.paidTotalAmount ?? prev.paidTotalAmount ?? null,
-                    refundedTotalAmount:
-                      totals?.refundedTotalAmount ?? prev.refundedTotalAmount ?? null,
-                    outstandingAmount:
-                      totals?.outstandingAmount ?? prev.outstandingAmount ?? null,
-                  }
-                : prev
-            )
-          }
+          onTotalsChange={() => {
+            void refreshDocumentTotals()
+          }}
         />
       )
     }

--- a/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
@@ -1,0 +1,90 @@
+/** @jest-environment node */
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+function buildPaymentSnapshot(overrides?: Record<string, unknown>) {
+  return {
+    id: 'payment-1',
+    orderId: 'order-1',
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+    paymentMethodId: 'method-1',
+    paymentReference: null,
+    statusEntryId: null,
+    status: null,
+    amount: 100,
+    currencyCode: 'USD',
+    capturedAmount: 0,
+    refundedAmount: 0,
+    receivedAt: null,
+    capturedAt: null,
+    metadata: null,
+    allocations: [],
+    ...overrides,
+  }
+}
+
+describe('createPaymentCommand buildLog — orderPaymentMethodIdBefore in undo payload', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../payments')
+  })
+
+  const getCreateBuildLog = () =>
+    commandRegistry.get('sales.payments.create')?.buildLog as NonNullable<
+      ReturnType<typeof commandRegistry.get>
+    >['buildLog']
+
+  it('stores orderPaymentMethodIdBefore=null in undo payload when order had no method before', async () => {
+    const buildLog = getCreateBuildLog()
+    expect(buildLog).toBeInstanceOf(Function)
+
+    const after = buildPaymentSnapshot()
+    const log = (await buildLog?.({
+      result: { paymentId: 'payment-1', orderPaymentMethodIdBefore: null, orderPaymentMethodCodeBefore: null },
+      snapshots: { after },
+    } as any)) as any
+
+    expect(log.payload?.undo?.orderPaymentMethodIdBefore).toBeNull()
+    expect(log.payload?.undo?.orderPaymentMethodCodeBefore).toBeNull()
+  })
+
+  it('stores orderPaymentMethodIdBefore in undo payload when order already had a method', async () => {
+    const buildLog = getCreateBuildLog()
+    expect(buildLog).toBeInstanceOf(Function)
+
+    const after = buildPaymentSnapshot()
+    const log = (await buildLog?.({
+      result: {
+        paymentId: 'payment-1',
+        orderPaymentMethodIdBefore: 'existing-method-id',
+        orderPaymentMethodCodeBefore: 'existing-code',
+      },
+      snapshots: { after },
+    } as any)) as any
+
+    expect(log.payload?.undo?.orderPaymentMethodIdBefore).toBe('existing-method-id')
+    expect(log.payload?.undo?.orderPaymentMethodCodeBefore).toBe('existing-code')
+  })
+
+  it('returns null log when no after snapshot is available', async () => {
+    const buildLog = getCreateBuildLog()
+    expect(buildLog).toBeInstanceOf(Function)
+
+    const log = await buildLog?.({
+      result: { paymentId: 'payment-1', orderPaymentMethodIdBefore: null, orderPaymentMethodCodeBefore: null },
+      snapshots: {},
+    } as any)
+
+    expect(log).toBeNull()
+  })
+})

--- a/packages/core/src/modules/sales/commands/payments.ts
+++ b/packages/core/src/modules/sales/commands/payments.ts
@@ -73,6 +73,8 @@ export type PaymentSnapshot = {
 type PaymentUndoPayload = {
   before?: PaymentSnapshot | null
   after?: PaymentSnapshot | null
+  orderPaymentMethodIdBefore?: string | null
+  orderPaymentMethodCodeBefore?: string | null
 }
 
 const toNumber = (value: unknown): number => {
@@ -311,7 +313,7 @@ async function recomputeOrderPaymentTotals(
 
 const createPaymentCommand: CommandHandler<
   PaymentCreateInput,
-  { paymentId: string; orderTotals?: { paidTotalAmount: number; refundedTotalAmount: number; outstandingAmount: number } }
+  { paymentId: string; orderTotals?: { paidTotalAmount: number; refundedTotalAmount: number; outstandingAmount: number }; orderPaymentMethodIdBefore?: string | null; orderPaymentMethodCodeBefore?: string | null }
 > = {
   id: 'sales.payments.create',
   async execute(rawInput, ctx) {
@@ -348,6 +350,14 @@ const createPaymentCommand: CommandHandler<
       )
       ensureSameScope(method, input.organizationId, input.tenantId)
       paymentMethod = method
+    }
+    const orderPaymentMethodIdBefore = order.paymentMethodId ?? null
+    const orderPaymentMethodCodeBefore = order.paymentMethodCode ?? null
+    if (paymentMethod && !order.paymentMethodId) {
+      order.paymentMethodId = paymentMethod.id
+      order.paymentMethodCode = paymentMethod.code ?? null
+      order.updatedAt = new Date()
+      em.persist(order)
     }
     if (input.documentStatusEntryId !== undefined) {
       const orderStatus = await resolveDictionaryEntryValue(em, input.documentStatusEntryId ?? null)
@@ -482,7 +492,7 @@ const createPaymentCommand: CommandHandler<
       console.error('[sales.payments.create] Failed to create notification:', err)
     }
 
-    return { paymentId: payment.id, orderTotals: totals }
+    return { paymentId: payment.id, orderTotals: totals, orderPaymentMethodIdBefore, orderPaymentMethodCodeBefore }
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
@@ -501,7 +511,7 @@ const createPaymentCommand: CommandHandler<
       tenantId: after.tenantId,
       organizationId: after.organizationId,
       snapshotAfter: after,
-      payload: { undo: { after } satisfies PaymentUndoPayload },
+      payload: { undo: { after, orderPaymentMethodIdBefore: result.orderPaymentMethodIdBefore ?? null, orderPaymentMethodCodeBefore: result.orderPaymentMethodCodeBefore ?? null } satisfies PaymentUndoPayload },
     }
   },
   undo: async ({ logEntry, ctx }) => {
@@ -539,6 +549,12 @@ const createPaymentCommand: CommandHandler<
       for (const id of orderIds) {
         const order = await em.findOne(SalesOrder, { id })
         if (!order) continue
+        if (id === after.orderId && 'orderPaymentMethodIdBefore' in (payload ?? {})) {
+          order.paymentMethodId = payload.orderPaymentMethodIdBefore ?? null
+          order.paymentMethodCode = payload.orderPaymentMethodCodeBefore ?? null
+          order.updatedAt = new Date()
+          await em.flush()
+        }
         await recomputeOrderPaymentTotals(em, order)
         await em.flush()
       }

--- a/packages/core/src/modules/sales/components/documents/PaymentsSection.tsx
+++ b/packages/core/src/modules/sales/components/documents/PaymentsSection.tsx
@@ -39,7 +39,7 @@ type SalesDocumentPaymentsSectionProps = {
   organizationId?: string | null
   tenantId?: string | null
   onActionChange?: (action: SectionAction | null) => void
-  onTotalsChange?: (totals: PaymentTotals) => void
+  onTotalsChange?: () => void
   onPaymentsChange?: (payments: PaymentRow[]) => void
 }
 
@@ -198,10 +198,8 @@ export function SalesDocumentPaymentsSection({
   )
 
   const handlePaymentSaved = React.useCallback(
-    async (totals?: PaymentTotals | null) => {
-      if (totals && onTotalsChange) {
-        onTotalsChange(totals)
-      }
+    async (_totals?: PaymentTotals | null) => {
+      onTotalsChange?.()
       await loadPayments()
       emitSalesDocumentTotalsRefresh({ documentId: orderId, kind: 'order' })
       handleDialogChange(false)
@@ -222,10 +220,7 @@ export function SalesDocumentPaymentsSection({
           errorMessage: t('sales.documents.payments.errorDelete', 'Failed to delete payment.'),
         })
         if (result.ok) {
-          const totals = result.result?.orderTotals ?? null
-          if (totals && onTotalsChange) {
-            onTotalsChange(totals)
-          }
+          onTotalsChange?.()
           flash(t('sales.documents.payments.deleted', 'Payment deleted.'), 'success')
           await loadPayments()
           emitSalesDocumentTotalsRefresh({ documentId: orderId, kind: 'order' })


### PR DESCRIPTION
## Summary

When a payment with a payment method was added to an order, the "Payment method" field in Order Details remained empty ("Not set"). This happened because the order's preferred payment method and each payment's method are stored as two separate fields that were never connected. Fix #947 

**Changes:**
- When a payment is created and the order has no preferred payment method set, the order's `paymentMethodId` and `paymentMethodCode` are automatically populated from the payment
- `onTotalsChange` now triggers a full order re-fetch (`refreshDocumentTotals`) so the updated field is reflected in the UI immediately
- Added `paymentMethodCode` as a display fallback when no payment method snapshot is available
- Undo correctly restores the order's previous payment method state (`orderPaymentMethodCodeBefore` added to undo payload)

**Behavior:**
- Only sets the order's payment method if it wasn't already set — never overwrites
- User can still change the payment method in Order Details manually at any time
