### PR TITLE
fix: forward ports for postgres, redis and meilisearch services (#954)

### DIFF
--- a/.ai/skills/dev-container-maintenance/references/audit-checklist.md
+++ b/.ai/skills/dev-container-maintenance/references/audit-checklist.md
@@ -75,12 +75,15 @@ Read `devcontainer.json` `remoteEnv` section. Verify all API keys that developer
 1. Read `.devcontainer/docker-compose.yml` — extract all exposed ports from services
 2. Read `.devcontainer/devcontainer.json` `forwardPorts` array
 3. Every service port should appear in `forwardPorts` with appropriate `portsAttributes` (label + onAutoForward)
+4. **Non-workspace services MUST use named service syntax** — numeric entries (e.g., `5432`) are forwarded on the workspace container, not on the service that actually listens on that port. This breaks host tool connections.
 
-Standard ports:
-- `3000` — App (Next.js) — `onAutoForward: "notify"`
-- `5432` — PostgreSQL — `onAutoForward: "silent"`
-- `6379` — Redis — `onAutoForward: "silent"`
-- `7700` — Meilisearch — `onAutoForward: "silent"`
+Standard ports and required `forwardPorts` entries:
+- `3000` — App (Next.js, workspace service) — numeric OK — `onAutoForward: "notify"`
+- `"postgres:5432"` — PostgreSQL — named syntax required — `onAutoForward: "silent"`
+- `"redis:6379"` — Redis — named syntax required — `onAutoForward: "silent"`
+- `"meilisearch:7700"` — Meilisearch — named syntax required — `onAutoForward: "silent"`
+
+**Action on mismatch**: Replace numeric entries for non-workspace services with `"<service>:<port>"` named syntax.
 
 ## 7. Build Sequence
 

--- a/.ai/skills/dev-container-maintenance/references/troubleshooting.md
+++ b/.ai/skills/dev-container-maintenance/references/troubleshooting.md
@@ -137,10 +137,19 @@ Container is running but development workflow has problems.
 **Diagnose**: User edited `.env` directly instead of `.env.local`.
 **Fix**: Move custom overrides to `apps/mercato/.env.local` (Next.js native priority, never overwritten).
 
-### Cannot connect to database from host tools
-**Symptom**: Host-based DB tools (pgAdmin, DBeaver) cannot connect to postgres.
-**Diagnose**: Check `devcontainer.json` `forwardPorts` includes `5432`.
-**Fix**: Port must be forwarded. Connection string from host: `postgresql://postgres:postgres@localhost:5432/open-mercato`.
+### Cannot connect to database/Redis/Meilisearch from host tools
+**Symptom**: Host-based tools (pgAdmin, DBeaver, redis-cli, Meilisearch dashboard) get "connection refused" or "server closed the connection unexpectedly".
+**Diagnose**: Check `devcontainer.json` `forwardPorts`. Non-workspace services must use named service syntax (`"postgres:5432"`, not `5432`). Numeric entries forward the port on the workspace container, not on the service that actually listens.
+**Fix**: Ensure `forwardPorts` uses named syntax for all non-workspace services:
+```json
+"forwardPorts": [3000, "postgres:5432", "redis:6379", "meilisearch:7700"]
+```
+Rebuild the container after changing `devcontainer.json`.
+
+Connection strings from host after forwarding:
+- PostgreSQL: `postgresql://postgres:postgres@localhost:5432/open-mercato`
+- Redis: `redis://localhost:6379`
+- Meilisearch: `http://localhost:7700`
 
 ### New package missing dist/ in container
 **Symptom**: Import errors for a newly added package. Its `dist/` is empty inside the container.

--- a/.ai/specs/SPEC-050-2026-02-26-dev-container-setup.md
+++ b/.ai/specs/SPEC-050-2026-02-26-dev-container-setup.md
@@ -55,6 +55,7 @@ A `.devcontainer/` directory containing a Docker Compose-based Dev Container con
 | 12 GB Docker Desktop memory recommendation | Turbopack compilation + 14 package watchers + workers spike to ~8-10 GB during page compilation |
 | Always regenerate `.env` on rebuild | New keys from `.env.example` appear automatically; personal overrides live in `.env.local` (Next.js native priority) |
 | Claude Code CLI native install (`~/.claude/bin/`) | Enables AI-assisted development out of the box; native install supports auto-updates without sudo |
+| Named service syntax for non-workspace `forwardPorts` (e.g., `"postgres:5432"`) | When the primary `service` is `workspace`, VS Code forwards numeric port entries on the workspace container — not on the service that actually listens. Named syntax routes the forward to the correct service, fixing host tool connections to PostgreSQL, Redis, and Meilisearch. |
 | Database query for first-run detection | Queries `information_schema.tables` to determine init vs migrate — no marker volume needed, eliminates stale state issues |
 
 ### Alternatives Considered
@@ -164,12 +165,14 @@ Host env vars `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are forwarded into the co
 
 ### Forwarded Ports
 
-| Port | Service | Auto-forward |
-|------|---------|-------------|
-| 3000 | App (Next.js) | Notify |
-| 5432 | PostgreSQL | Silent |
-| 6379 | Redis | Silent |
-| 7700 | Meilisearch | Silent |
+| Entry in `forwardPorts` | Port | Service | Auto-forward |
+|------------------------|------|---------|-------------|
+| `3000` | 3000 | App (Next.js) | Notify |
+| `"postgres:5432"` | 5432 | PostgreSQL | Silent |
+| `"redis:6379"` | 6379 | Redis | Silent |
+| `"meilisearch:7700"` | 7700 | Meilisearch | Silent |
+
+Non-workspace services **must** use the named service syntax (`"<service>:<port>"`) in `forwardPorts`. Numeric entries are forwarded on the primary `workspace` container, not on the container that actually listens on that port, causing connection failures from host tools.
 
 ### Service Versions
 
@@ -286,8 +289,9 @@ When the project evolves, the Dev Container needs corresponding updates:
 
 | Check | Status | Notes |
 |-------|--------|-------|
-| Docker Compose services match forwarded ports in devcontainer.json | Pass | 3000, 5432, 6379, 7700 all match |
+| Docker Compose services match forwarded ports in devcontainer.json | Pass | 3000, 5432, 6379, 7700 all match via named service syntax |
 | Named volumes cover all gitignored dirs | Pass | Static: node_modules, .next, storage. Auto-generated: all package dist/ dirs via `generate-compose-volumes.sh` |
+| Non-workspace `forwardPorts` use named service syntax | Pass | `"postgres:5432"`, `"redis:6379"`, `"meilisearch:7700"` — numeric entries broke host connections |
 | setup-env.sh hostname rewrites match docker-compose service names | Pass | postgres, redis, meilisearch all consistent |
 | Meilisearch API key in compose matches setup-env.sh | Pass | Both use `meilisearch-dev-key` |
 | Dockerfile Yarn version matches project's packageManager | Pass | `yarn@4.12.0` |
@@ -331,3 +335,10 @@ None.
 - Added Homebrew shellenv to `.bashrc`, `.profile`, and `.zshrc` for the `node` user
 - Switched Claude Code CLI from npm-global install to native install (`curl https://claude.ai/install.sh | bash`) — installs to `~/.claude/bin/`, enabling auto-updates without sudo; uses `bash` explicitly because Debian-slim's `/bin/sh` is `dash` which doesn't support bash-specific syntax
 - Updated README: new "Included Developer Tools" section, updated services table, added Debian design decision, updated maintenance guide
+
+### 2026-03-13
+- Fixed `forwardPorts` for all non-workspace services: changed numeric entries (`5432`, `6379`, `7700`) to named service syntax (`"postgres:5432"`, `"redis:6379"`, `"meilisearch:7700"`). Numeric entries are forwarded on the primary `workspace` container, not on the service that listens on that port, causing "server closed the connection unexpectedly" errors for host-based DB/Redis/Meilisearch tools. Fixes [#954](https://github.com/open-mercato/open-mercato/issues/954).
+- Updated README: added design decision row for named service syntax, added troubleshooting row for host tool connection failures.
+- Updated spec: Forwarded Ports table now shows the `forwardPorts` entry string alongside port/service, added design decision row, added internal consistency check row.
+- Updated audit checklist: port forwarding check now verifies named service syntax.
+- Updated troubleshooting guide: extended "Cannot connect to database from host tools" to cover Redis and Meilisearch; added named service syntax note.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -95,6 +95,7 @@ Homebrew is available in all terminal sessions (bash, zsh). Install tools as nee
 | Decision | Rationale |
 |----------|-----------|
 | Self-contained compose (not reusing `docker-compose.yml`) | Existing file includes unneeded services, uses `container_name` directives that conflict with Dev Containers |
+| Named service syntax for `forwardPorts` (e.g., `"postgres:5432"`) | When the Dev Container's primary `service` is `workspace`, numeric port entries (e.g., `5432`) are forwarded on the workspace container, not on the service that actually listens on that port. Named syntax (`"<service>:<port>"`) tells VS Code which service owns the port, fixing connection failures for PostgreSQL, Redis, and Meilisearch. |
 | Debian-slim instead of Alpine | Homebrew requires glibc (Alpine uses musl); Debian-slim provides glibc with a modest image size increase |
 | `init: true` on workspace | Proper signal forwarding and zombie process reaping for the complex process tree (`yarn dev` spawns turbo + watchers + Next.js + workers) |
 | `WATCHPACK_POLLING` + `CHOKIDAR_USEPOLLING` | macOS Docker bind mounts don't support native filesystem events — polling is required |
@@ -154,3 +155,4 @@ When the project evolves, the Dev Container setup may need updates. Here's when 
 | `brew: command not found` | Shell profile not loaded | Run `eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"` or open a new terminal |
 | `Syntax error: "(" unexpected` during build (Claude CLI install) | Install script piped to `sh` (dash on Debian) instead of `bash` | Already fixed in Dockerfile — `curl ... \| bash`. If you see this, pull latest `.devcontainer/Dockerfile` and rebuild |
 | Stale build artifacts | Named volumes persisted old `dist/` | Wipe all: `docker volume ls -q \| grep open-mercato_devcontainer \| xargs docker volume rm` then reopen |
+| Host DB/Redis/Meilisearch tools show "connection refused" or "server closed connection unexpectedly" | `forwardPorts` used numeric port entries for non-workspace services | Fixed — `devcontainer.json` now uses named service syntax (`"postgres:5432"`, `"redis:6379"`, `"meilisearch:7700"`). Rebuild the container to pick up the change. |

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
   "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
   "postStartCommand": "bash .devcontainer/scripts/post-start.sh",
 
-  "forwardPorts": [3000, 5432, 6379, 7700],
+  "forwardPorts": [3000, "postgres:5432", "redis:6379", "meilisearch:7700"],
   "portsAttributes": {
     "3000": { "label": "App", "onAutoForward": "notify" },
     "5432": { "label": "PostgreSQL", "onAutoForward": "silent" },


### PR DESCRIPTION
## Summary

VS Code Dev Containers' `forwardPorts` feature routes numeric port entries (e.g., `5432`) to the primary service defined in `devcontainer.json` (`workspace`), not to the service that actually listens on that port. This caused PostgreSQL, Redis, and Meilisearch to appear forwarded but reject connections from host-side tools with "server closed the connection unexpectedly". The fix is to use named service syntax (`"postgres:5432"`) for all non-workspace services.

## Changes

- `devcontainer.json`: changed `forwardPorts` entries for non-workspace services from numeric (`5432`, `6379`, `7700`) to named service syntax (`"postgres:5432"`, `"redis:6379"`, `"meilisearch:7700"`)
- `.devcontainer/README.md`: added design decision row explaining named service syntax requirement; added troubleshooting row for host tool connection failures
- `.ai/specs/SPEC-050-2026-02-26-dev-container-setup.md`: updated Forwarded Ports table to show exact `forwardPorts` entry strings; added design decision row; added internal consistency check row; added changelog entry
- `.ai/skills/dev-container-maintenance/references/audit-checklist.md`: port forwarding check now explicitly requires named service syntax for non-workspace services
- `.ai/skills/dev-container-maintenance/references/troubleshooting.md`: extended "Cannot connect from host tools" entry to cover Redis and Meilisearch; documents root cause and correct `forwardPorts` config

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:** `.ai/specs/SPEC-050-2026-02-26-dev-container-setup.md`

## Testing

- Confirmed port appears open via `nc` with numeric syntax but PostgreSQL client gets "server closed the connection unexpectedly"
- Confirmed `psql postgresql://postgres:postgres@127.0.0.1:5432/postgres` succeeds after switching to `"postgres:5432"` syntax
- Same verified for Redis (`redis-cli -h localhost -p 6379 ping`) and Meilisearch (`curl http://localhost:7700/health`)

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
  > Infrastructure/config-only change — no application code paths affected; no integration test coverage required.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #954
