### PR TITLE
fix: translate CRUD validation messages

### DIFF
--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-002.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-002.spec.ts
@@ -13,7 +13,7 @@ test.describe('TC-CAT-002: Product Creation Validation Errors', () => {
     await page.getByRole('button', { name: 'Create product' }).last().click();
 
     await expect(
-      page.locator('p.text-red-600', { hasText: 'catalog.products.validation.titleRequired' }),
+      page.locator('p.text-red-600', { hasText: 'Title is required.' }),
     ).toBeVisible();
     await expect(page).toHaveURL(/\/backend\/catalog\/products\/create$/);
   });

--- a/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
@@ -808,6 +808,12 @@ export default function EditCatalogProductPage({
 
   const handleSubmit = React.useCallback(
     async (formValues: ProductFormValues) => {
+      const translateValidationMessage = (message: string | null | undefined) => {
+        if (typeof message !== "string") return "";
+        const trimmed = message.trim();
+        if (!trimmed) return "";
+        return t(trimmed, trimmed);
+      };
       if (!productId) {
         throw createCrudFormError(
           t(
@@ -822,10 +828,12 @@ export default function EditCatalogProductPage({
         const fieldErrors: Record<string, string> = {};
         issues.forEach((issue) => {
           const path = issue.path.join(".") || "form";
-          if (!fieldErrors[path]) fieldErrors[path] = issue.message;
+          if (!fieldErrors[path]) {
+            fieldErrors[path] = translateValidationMessage(issue.message);
+          }
         });
         const message =
-          issues[0]?.message ??
+          translateValidationMessage(issues[0]?.message) ||
           t(
             "catalog.products.edit.errors.validation",
             "Fix highlighted fields.",

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -103,6 +103,8 @@ import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 - Use manual `useInjectionSpotEvents(GLOBAL_MUTATION_INJECTION_SPOT_ID)` wiring only when you need behavior that `useGuardedMutation` does not support.
 - Keep `CrudForm` implementations reusable: extract shared field/group builders and submit handlers into module-level helpers when multiple pages or dialogs need the same shape.
 - Drive validation with a Zod schema and surface field errors via `createCrudFormError`.
+- When using `CrudForm` with Zod, validation messages may be i18n keys because `CrudForm` translates them before display.
+- If you validate outside `CrudForm` or manually map `safeParse(...).error.issues`, you MUST translate `issue.message` before passing it to `createCrudFormError` or rendering it in the UI.
 - Keep `fields` and `groups` in memoized helpers (see customers person form config).
 - Pass `entityIds` when custom fields are involved so form helpers load correct custom-field sets.
 - Use `createCrud`/`updateCrud`/`deleteCrud` for submit actions and call `flash()` for success or failure messaging.

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -482,6 +482,24 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     [extendedInjectionEventsEnabled, triggerInjectionEvent],
   )
 
+  const translateValidationMessage = React.useCallback(
+    (message: string | null | undefined): string => {
+      if (typeof message !== 'string') return ''
+      const trimmed = message.trim()
+      if (!trimmed) return ''
+      return t(trimmed, trimmed)
+    },
+    [t],
+  )
+
+  const translateValidationErrors = React.useCallback(
+    (fieldErrors: Record<string, string>): Record<string, string> =>
+      Object.fromEntries(
+        Object.entries(fieldErrors).map(([fieldId, message]) => [fieldId, translateValidationMessage(message)]),
+      ),
+    [translateValidationMessage],
+  )
+
   const canNavigateTo = React.useCallback(
     async (target: string): Promise<boolean> => {
       if (!extendedInjectionEventsEnabled) return true
@@ -1563,7 +1581,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
           console.debug('[crud-form] Schema validation failed', res.error.issues)
         }
         const transformedErrors = await transformValidationErrors(fieldErrors)
-        setErrors(transformedErrors)
+        setErrors(translateValidationErrors(transformedErrors))
         flash(highlightedMessage, 'error')
         return
       }


### PR DESCRIPTION
## Summary

Translate Zod-backed validation messages before rendering them in CrudForm and the catalog product edit flow so i18n keys no longer leak into the UI.

## Changes

- translate Zod-backed validation messages in `CrudForm` before rendering field errors
- translate manually mapped product edit validation messages in catalog to match the shared form behavior
- update the catalog regression test and document the validation-message rule in `packages/ui/AGENTS.md`

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- [x] ReadLints on changed files
- [x] Update catalog regression test expectation

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).

No new `.ai/qa/tests/` coverage was added. This change updates the existing regression test at `packages/core/src/modules/catalog/__integration__/TC-CAT-002.spec.ts` to cover the corrected behavior. Full Playwright execution was not completed locally because the app base URL / dev server was not configured.

- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #949
