### PR TITLE
fix: add enterprise module availability check to prevent import errors

### DIFF
--- a/apps/mercato/src/modules.ts
+++ b/apps/mercato/src/modules.ts
@@ -52,13 +52,26 @@ export const enabledModules: ModuleEntry[] = [
 const enterpriseModulesEnabled = parseBooleanWithDefault(process.env.OM_ENABLE_ENTERPRISE_MODULES, false)
 const enterpriseSsoEnabled = parseBooleanWithDefault(process.env.OM_ENABLE_ENTERPRISE_MODULES_SSO, false)
 
-if (enterpriseModulesEnabled) {
+// Check if enterprise package is available before trying to use it
+function isEnterprisePackageAvailable(): boolean {
+  try {
+    // Try to resolve the enterprise package without importing it
+    require.resolve('@open-mercato/enterprise/package.json')
+    return true
+  } catch {
+    return false
+  }
+}
+
+if (enterpriseModulesEnabled && isEnterprisePackageAvailable()) {
   enabledModules.push(
     { id: 'record_locks', from: '@open-mercato/enterprise' },
     { id: 'system_status_overlays', from: '@open-mercato/enterprise' },
   )
+} else if (enterpriseModulesEnabled && !isEnterprisePackageAvailable()) {
+  console.warn('[modules] Enterprise modules requested but @open-mercato/enterprise package not found. Skipping enterprise modules.')
 }
 
-if (enterpriseModulesEnabled && enterpriseSsoEnabled) {
+if (enterpriseModulesEnabled && enterpriseSsoEnabled && isEnterprisePackageAvailable()) {
   enabledModules.push({ id: 'sso', from: '@open-mercato/enterprise' })
 }

--- a/packages/create-app/template/src/modules.ts
+++ b/packages/create-app/template/src/modules.ts
@@ -52,13 +52,26 @@ export const enabledModules: ModuleEntry[] = [
 const enterpriseModulesEnabled = parseBooleanWithDefault(process.env.OM_ENABLE_ENTERPRISE_MODULES, false)
 const enterpriseSsoEnabled = parseBooleanWithDefault(process.env.OM_ENABLE_ENTERPRISE_MODULES_SSO, false)
 
-if (enterpriseModulesEnabled) {
+// Check if enterprise package is available before trying to use it
+function isEnterprisePackageAvailable(): boolean {
+  try {
+    // Try to resolve the enterprise package without importing it
+    require.resolve('@open-mercato/enterprise/package.json')
+    return true
+  } catch {
+    return false
+  }
+}
+
+if (enterpriseModulesEnabled && isEnterprisePackageAvailable()) {
   enabledModules.push(
     { id: 'record_locks', from: '@open-mercato/enterprise' },
     { id: 'system_status_overlays', from: '@open-mercato/enterprise' },
   )
+} else if (enterpriseModulesEnabled && !isEnterprisePackageAvailable()) {
+  console.warn('[modules] Enterprise modules requested but @open-mercato/enterprise package not found. Skipping enterprise modules.')
 }
 
-if (enterpriseModulesEnabled && enterpriseSsoEnabled) {
+if (enterpriseModulesEnabled && enterpriseSsoEnabled && isEnterprisePackageAvailable()) {
   enabledModules.push({ id: 'sso', from: '@open-mercato/enterprise' })
 }


### PR DESCRIPTION
## Bug
Fixes #966 — enterprise security module isn't installed but bootstrap.ts

The issue was that `modules.ts` was trying to reference `@open-mercato/enterprise` modules even when the enterprise package wasn't installed in standalone apps created with `npx create-mercato-app`.

## Root Cause
When `OM_ENABLE_ENTERPRISE_MODULES=true` was set, the modules configuration would add enterprise module references to `enabledModules`, but the module resolution system would fail during bootstrap because the `@open-mercato/enterprise` package doesn't exist in standalone apps.

## Solution
Added `isEnterprisePackageAvailable()` function that:
- Uses `require.resolve()` to check if `@open-mercato/enterprise/package.json` exists
- Only adds enterprise modules to `enabledModules` if the package is available
- Shows a helpful warning when enterprise modules are requested but package not found
- Gracefully degrades to core functionality when enterprise package is missing

## Changes
- **packages/create-app/template/src/modules.ts**: Add availability check for enterprise modules
- **apps/mercato/src/modules.ts**: Same fix for consistency

## Testing
This prevents the module resolution error during bootstrap while maintaining backward compatibility:
- ✅ Standalone apps work without enterprise package
- ✅ Enterprise setups continue to work when package is installed
- ✅ Clear warning when configuration mismatch occurs

Greetings, saschabuehrle