### PR TITLE
fix: Duplicate "Add address" actions in Customer addresses empty state

### DIFF
--- a/packages/core/src/modules/customers/components/AddressTiles.tsx
+++ b/packages/core/src/modules/customers/components/AddressTiles.tsx
@@ -500,7 +500,7 @@ export function CustomerAddressTiles({
 
   return (
     <div className="space-y-4">
-      {!hideAddButton ? (
+      {!hideAddButton && hasAddresses ? (
         <div className="flex justify-end">
           <Button
             type="button"

--- a/packages/ui/src/backend/detail/AddressTiles.tsx
+++ b/packages/ui/src/backend/detail/AddressTiles.tsx
@@ -486,7 +486,7 @@ export function AddressTiles<C = unknown>({
 
   return (
     <div className="space-y-4">
-      {!hideAddButton ? (
+      {!hideAddButton && hasAddresses ? (
         <div className="flex justify-end">
           <Button
             type="button"


### PR DESCRIPTION
## Summary

  Fix duplicate "Add address" buttons appearing in the Customer addresses empty state (fixes #945). When no addresses     exist, both an inline top-right button and a centered empty state button rendered simultaneously. The fix ensures the
  inline button only appears when addresses already exist, since the empty state panel already provides its own add       action.

  ## Changes

  - `packages/ui/src/backend/detail/AddressTiles.tsx`: Changed `{!hideAddButton ? (` to `{!hideAddButton && hasAddresses
   ? (` so the inline add button only renders when there are existing addresses
  - `packages/core/src/modules/customers/components/AddressTiles.tsx`: Same change in the parallel
  `CustomerAddressTiles` component used on create/edit forms

  ## Specification

  - [x] N/A (minor change, no spec needed)

  **Spec file path:**


  ## Testing

  - `yarn build:packages` — passes
  - `yarn typecheck` — passes
  - Manual: verified single centered button in empty state on both create form and detail page
  - Manual: verified inline button reappears after first address is saved

  ## Checklist

  - [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it.
  - [ ] I added or adjusted tests that cover the change.
  - [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not
  required).
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable)
  
  ##Issue #945 
  
  
<img width="2452" height="604" alt="obraz" src="https://github.com/user-attachments/assets/ec7d8786-c045-48ee-9631-ff5fca111453" />

<img width="2441" height="507" alt="obraz" src="https://github.com/user-attachments/assets/44e8ce1b-7bbc-4bf2-ab8b-e0eaeef5d556" />
