### PR TITLE
fix: add back-to-login navigation on reset password page (#969)

### DIFF
--- a/packages/core/src/modules/auth/frontend/reset.tsx
+++ b/packages/core/src/modules/auth/frontend/reset.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useState } from 'react'
+import Link from 'next/link'
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@open-mercato/ui/primitives/card'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Input } from '@open-mercato/ui/primitives/input'
@@ -39,8 +40,13 @@ export default function ResetPage() {
         </CardHeader>
         <CardContent>
           {sent ? (
-            <div className="text-sm text-muted-foreground">
-              {t('auth.reset.sent', 'If an account with that email exists, we sent a reset link. Please check your inbox.')}
+            <div className="grid gap-3">
+              <p className="text-sm text-muted-foreground">
+                {t('auth.reset.sent', 'If an account with that email exists, we sent a reset link. Please check your inbox.')}
+              </p>
+              <Link href="/login" className="text-sm underline">
+                {t('auth.reset.backToLogin', 'Back to login')}
+              </Link>
             </div>
           ) : (
             <form className="grid gap-3" onSubmit={onSubmit} noValidate>
@@ -52,6 +58,11 @@ export default function ResetPage() {
               <Button type="submit" className="mt-2 w-full" disabled={submitting}>
                 {submitting ? '...' : t('auth.sendResetLink')}
               </Button>
+              <div className="text-center">
+                <Link href="/login" className="text-xs text-muted-foreground underline">
+                  {t('auth.reset.backToLogin', 'Back to login')}
+                </Link>
+              </div>
             </form>
           )}
         </CardContent>

--- a/packages/core/src/modules/auth/i18n/de.json
+++ b/packages/core/src/modules/auth/i18n/de.json
@@ -85,6 +85,7 @@
   "auth.profile.form.success": "Profil aktualisiert.",
   "auth.profile.subtitle": "Passwort ändern",
   "auth.profile.title": "Profil",
+  "auth.reset.backToLogin": "Zurück zur Anmeldung",
   "auth.reset.description": "Gib deine E-Mail-Adresse ein, um einen Zurücksetzungslink zu erhalten",
   "auth.reset.error": "Etwas ist schiefgelaufen",
   "auth.reset.errors.failed": "Passwort konnte nicht zurückgesetzt werden",

--- a/packages/core/src/modules/auth/i18n/en.json
+++ b/packages/core/src/modules/auth/i18n/en.json
@@ -85,6 +85,7 @@
   "auth.profile.form.success": "Profile updated.",
   "auth.profile.subtitle": "Change password",
   "auth.profile.title": "Profile",
+  "auth.reset.backToLogin": "Back to login",
   "auth.reset.description": "Enter your email to receive reset link",
   "auth.reset.error": "Something went wrong",
   "auth.reset.errors.failed": "Unable to reset password",

--- a/packages/core/src/modules/auth/i18n/es.json
+++ b/packages/core/src/modules/auth/i18n/es.json
@@ -85,6 +85,7 @@
   "auth.profile.form.success": "Perfil actualizado.",
   "auth.profile.subtitle": "Cambiar contraseña",
   "auth.profile.title": "Perfil",
+  "auth.reset.backToLogin": "Volver al inicio de sesión",
   "auth.reset.description": "Ingresa tu correo para recibir un enlace de restablecimiento",
   "auth.reset.error": "Algo salió mal",
   "auth.reset.errors.failed": "No se pudo restablecer la contraseña",

--- a/packages/core/src/modules/auth/i18n/pl.json
+++ b/packages/core/src/modules/auth/i18n/pl.json
@@ -85,6 +85,7 @@
   "auth.profile.form.success": "Profil zaktualizowany.",
   "auth.profile.subtitle": "Zmiana hasła",
   "auth.profile.title": "Profil",
+  "auth.reset.backToLogin": "Powrót do logowania",
   "auth.reset.description": "Podaj swój adres e-mail, aby otrzymać link do resetowania",
   "auth.reset.error": "Coś poszło nie tak",
   "auth.reset.errors.failed": "Nie udało się zresetować hasła",


### PR DESCRIPTION
## Summary

- Add "Back to login" navigation link on the reset password page to eliminate the UX dead-end after form submission
- Link appears in both states: after the confirmation message and below the submit button

## Context

After submitting the reset password form, the user saw a confirmation message but had no way to navigate back to the login page without using the browser back button.

## Changes

- `packages/core/src/modules/auth/frontend/reset.tsx` — import `Link` from Next.js, add "Back to login" link in the sent confirmation state and below the form submit button
- `packages/core/src/modules/auth/i18n/{en,pl,de,es}.json` — added `auth.reset.backToLogin` key in all four locales

## Testing

- Submit reset form with valid email -> confirmation message shown with "Back to login" link
- Click "Back to login" -> navigates to `/login`
- Before submitting -> "Back to login" link visible below the submit button

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement.
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] Translations added for all 4 locales (en, pl, de, es).

## Linked issues

Closes #969
