### PR TITLE
fix(attachments): avoid duplicate file-required validation message

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -310,7 +310,6 @@ function AttachmentFilesField({
   value,
   setValue,
   disabled,
-  error,
   labels,
   uploading,
 }: AttachmentFilesFieldProps) {
@@ -428,7 +427,6 @@ function AttachmentFilesField({
         />
       </div>
       {renderFileList()}
-      {error ? <p className="text-xs font-medium text-red-600">{error}</p> : null}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
This PR fixes issue #978 where the upload form in Attachments showed the same validation message twice when submitting without selecting a file.

## User Impact
When a user clicks **Upload** without choosing a file, only one validation message is shown:

Select a file to upload.

## Root Cause
The custom files field in the attachment upload form rendered its own error message, while CrudForm also rendered the same field-level error.  
This caused duplicate validation text for the same field.

## What Changed
- Removed duplicate inline error rendering from the custom files field in the attachments upload form.
- Kept CrudForm as the single source of field-level error display.

## Scope
- Attachments upload dialog UI only.
- No API contract changes.
- No schema/database changes.

## Architectural Notes
- Aligns with existing CrudForm error handling pattern.
- Avoids duplicated responsibility for field error rendering in custom form components.

## Testing Performed
1. Go to Attachments.
2. Click Upload attachment.
3. Do not select a file.
4. Click Upload.

Verified:
- Validation message appears only once.
- No regression in normal upload flow when a file is selected.

## Related Issue
Fixes #978
