### PR TITLE
fix(ui): show full loaded currency list in exchange-rate combobox (fixes #980)

### DIFF
--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -92,12 +92,12 @@ export function ComboboxInput({
 
   const filteredSuggestions = React.useMemo(() => {
     const query = input.toLowerCase().trim()
-    if (!query) return availableOptions.slice(0, 8)
+    if (!query) return availableOptions
     return availableOptions.filter((option) => {
       const labelMatch = option.label.toLowerCase().includes(query)
       const descMatch = option.description?.toLowerCase().includes(query)
       return labelMatch || Boolean(descMatch)
-    }).slice(0, 8)
+    })
   }, [availableOptions, input])
 
   React.useEffect(() => {


### PR DESCRIPTION
**PR description:**

- Fixed a combobox rendering cap that limited visible options to 8 items even when more currencies were loaded.
The currency loader already fetches up to 100 active currencies, but the combobox truncated display via .slice(0, 8).
Removed the hard cap so From/To Currency dropdowns now show all loaded values with scrollbar support.

## Related Issue 
Fixes #980 