### PR TITLE
fix(#896): add missing translations

### DIFF
--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -664,7 +664,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
             }
             if (result.fieldErrors && Object.keys(result.fieldErrors).length) {
               const transformedErrors = await transformValidationErrors(result.fieldErrors)
-              setErrors(transformedErrors)
+              setErrors(translateValidationErrors(transformedErrors))
             }
             const message = result.message || t('ui.forms.flash.saveBlocked', 'Save blocked by validation')
             flash(message, 'error')
@@ -1544,14 +1544,14 @@ export function CrudForm<TValues extends Record<string, unknown>>({
             const mapped: Record<string, string> = {}
             for (const [ek, ev] of Object.entries(result.fieldErrors)) mapped[ek.replace(/^cf_/, '')] = String(ev)
             const transformedErrors = await transformValidationErrors(mapped)
-            setErrors((prev) => ({ ...prev, ...transformedErrors }))
+            setErrors((prev) => ({ ...prev, ...translateValidationErrors(transformedErrors) }))
           } else {
             const transformedErrors = await transformValidationErrors(
               Object.fromEntries(
                 Object.entries(result.fieldErrors).map(([key, value]) => [key, String(value)]),
               ),
             )
-            setErrors((prev) => ({ ...prev, ...transformedErrors }))
+            setErrors((prev) => ({ ...prev, ...translateValidationErrors(transformedErrors) }))
           }
           flash(highlightedMessage, 'error')
           return
@@ -1636,7 +1636,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
           }
           if (result.fieldErrors && Object.keys(result.fieldErrors).length) {
             const transformedErrors = await transformValidationErrors(result.fieldErrors)
-            setErrors(transformedErrors)
+            setErrors(translateValidationErrors(transformedErrors))
           }
           const message = result.message || t('ui.forms.flash.saveBlocked', 'Save blocked by validation')
           flash(message, 'error')
@@ -1711,12 +1711,13 @@ export function CrudForm<TValues extends Record<string, unknown>>({
             const firstKey = Object.keys(combinedFieldErrors)[0]
             if (!firstKey) return null
             const value = combinedFieldErrors[firstKey]
-            return typeof value === 'string' && value.trim().length ? value.trim() : null
+            if (typeof value !== 'string' || !value.trim().length) return null
+            return translateValidationMessage(value)
           })()
         : null
       if (hasFieldErrors) {
         const transformedErrors = await transformValidationErrors(combinedFieldErrors)
-        setErrors(transformedErrors)
+        setErrors(translateValidationErrors(transformedErrors))
         if (process.env.NODE_ENV !== 'production') {
           console.debug('[crud-form] Submission failed with field errors', transformedErrors)
         }


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fix missing translation key `catalog.products.validation.baseUnitRequired` being displayed as raw text instead of a translated message in the product form. The root cause is that `CrudForm` had inconsistent i18n handling — only the client-side schema validation path translated error messages, while server-side errors, injection widget errors, and custom field errors displayed raw i18n keys.

Fixes #896

## Changes

- Added `translateValidationErrors()` wrapping to all `setErrors` calls in `CrudForm.tsx` that were missing it (server-side errors, onBeforeSave/onBeforeDelete injection errors, custom field validation errors)
- Added `translateValidationMessage()` to the `firstFieldMessage` extraction so flash banner messages also show translated text instead of raw keys

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `npx tsc --noEmit -p packages/ui/tsconfig.json` — passes cleanly
- Verified all `setErrors` call sites in `CrudForm.tsx` now consistently translate validation messages
- Manual verification: product form with a default sales unit set but no base unit should display the translated message (e.g. "Base unit is required when a default sales unit is set.") instead of the raw key `catalog.products.validation.baseUnitRequired`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #896