### PR TITLE
fix(#900): add missing validation translations

### DIFF
--- a/packages/core/src/modules/customers/components/detail/DealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealForm.tsx
@@ -90,8 +90,14 @@ const schema = z.object({
     .trim()
     .max(100, 'customers.people.detail.deals.pipelineTooLong')
     .optional(),
-  pipelineId: z.string().uuid().optional(),
-  pipelineStageId: z.string().uuid().optional(),
+  pipelineId: z.preprocess(
+    (v) => (typeof v === 'string' && !v.trim() ? undefined : v),
+    z.string().uuid('customers.people.detail.deals.pipelineIdInvalid').optional(),
+  ),
+  pipelineStageId: z.preprocess(
+    (v) => (typeof v === 'string' && !v.trim() ? undefined : v),
+    z.string().uuid('customers.people.detail.deals.pipelineStageIdInvalid').optional(),
+  ),
   valueAmount: z
     .preprocess((value) => {
       if (value === '' || value === null || value === undefined) return undefined

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -616,6 +616,8 @@
   "customers.people.detail.deals.loadMore": "Weitere Deals laden",
   "customers.people.detail.deals.loading": "Deals werden geladen…",
   "customers.people.detail.deals.openDeal": "Deal öffnen",
+  "customers.people.detail.deals.pipelineIdInvalid": "Wählen Sie eine gültige Pipeline.",
+  "customers.people.detail.deals.pipelineStageIdInvalid": "Wählen Sie eine gültige Pipeline-Phase.",
   "customers.people.detail.deals.pipelineTooLong": "Die Pipeline-Phase ist zu lang",
   "customers.people.detail.deals.probabilityInvalid": "Die Wahrscheinlichkeit muss zwischen 0 und 100 liegen",
   "customers.people.detail.deals.save": "Deal speichern (⌘/Ctrl + Enter)",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -616,6 +616,8 @@
   "customers.people.detail.deals.loadMore": "Load more deals",
   "customers.people.detail.deals.loading": "Loading deals…",
   "customers.people.detail.deals.openDeal": "Open deal",
+  "customers.people.detail.deals.pipelineIdInvalid": "Select a valid pipeline.",
+  "customers.people.detail.deals.pipelineStageIdInvalid": "Select a valid pipeline stage.",
   "customers.people.detail.deals.pipelineTooLong": "Pipeline stage is too long",
   "customers.people.detail.deals.probabilityInvalid": "Probability must be between 0 and 100",
   "customers.people.detail.deals.save": "Save deal (⌘/Ctrl + Enter)",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -616,6 +616,8 @@
   "customers.people.detail.deals.loadMore": "Cargar más oportunidades",
   "customers.people.detail.deals.loading": "Cargando oportunidades…",
   "customers.people.detail.deals.openDeal": "Abrir oportunidad",
+  "customers.people.detail.deals.pipelineIdInvalid": "Seleccione un pipeline válido.",
+  "customers.people.detail.deals.pipelineStageIdInvalid": "Seleccione una etapa de pipeline válida.",
   "customers.people.detail.deals.pipelineTooLong": "La etapa del pipeline es demasiado larga",
   "customers.people.detail.deals.probabilityInvalid": "La probabilidad debe estar entre 0 y 100",
   "customers.people.detail.deals.save": "Guardar oportunidad (⌘/Ctrl + Enter)",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -616,6 +616,8 @@
   "customers.people.detail.deals.loadMore": "Załaduj więcej szans",
   "customers.people.detail.deals.loading": "Ładowanie szans…",
   "customers.people.detail.deals.openDeal": "Otwórz szansę",
+  "customers.people.detail.deals.pipelineIdInvalid": "Wybierz prawidłowy lejek.",
+  "customers.people.detail.deals.pipelineStageIdInvalid": "Wybierz prawidłowy etap lejka.",
   "customers.people.detail.deals.pipelineTooLong": "Etap lejka jest za długi",
   "customers.people.detail.deals.probabilityInvalid": "Prawdopodobieństwo musi mieścić się między 0 a 100",
   "customers.people.detail.deals.save": "Zapisz szansę (⌘/Ctrl + Enter)",


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fix missing translations for validation errors on the Pipeline and Pipeline stage fields in the customer deal form. The `<select>` dropdown passes `""` (empty string) when the placeholder is selected, but `z.string().uuid().optional()` only allows `undefined` — so zod rejects `""` with its default English "Invalid uuid" message, which doesn't translate.

Fixes #900

## Changes

- Updated `pipelineId` and `pipelineStageId` schema fields in `DealForm.tsx` to use `z.preprocess()` — converts empty strings to `undefined` before UUID validation, consistent with the existing `valueAmount`/`probability` patterns in the same file
- Added custom i18n error message keys to the `.uuid()` validator for defensive correctness
- Added translations for both keys in all four locale files (en, pl, es, de)

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Verified schema change is syntactically correct and consistent with existing `z.preprocess` patterns in the same file
- Traced the full data flow: CrudForm schema validation → preprocess converts `""` → `undefined` → `.optional()` passes → no spurious error
- For the defensive edge case (non-UUID non-empty string): error uses the i18n key, CrudForm translates it via `translateValidationErrors`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #900