### PR TITLE
docs: update enterprise README with all delivered modules & fix license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Open Mercato contributors
+Copyright (c) 2025-2026 Open Mercato contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/enterprise/README.md
+++ b/packages/enterprise/README.md
@@ -2,7 +2,11 @@
 
 Enterprise-only package for commercial Open Mercato modules and overlays.
 
-This package is where Enterprise Edition implementations such as advanced MFA/2FA security features are delivered.
+This package is where Enterprise Edition implementations are delivered, currently including:
+
+- **MFA / 2FA** — multi-factor authentication with TOTP and backup codes
+- **SSO & Directory Sync** — SAML/OIDC single sign-on with SCIM directory provisioning
+- **Record Locking** — pessimistic locking to prevent concurrent editing conflicts
 
 ## Open Mercato Partnership Program
 


### PR DESCRIPTION
## Problem

`packages/enterprise/README.md` describes the enterprise package as delivering only "advanced MFA/2FA security features". This is outdated — the package currently ships **three** distinct modules, and a developer or prospective enterprise customer reading this file gets an incomplete (and misleading) picture of what Enterprise Edition provides.

Additionally, `LICENSE` still carries `Copyright (c) 2025` despite the project being actively developed in 2026.

## Changes

- **`packages/enterprise/README.md`** — replaced the vague one-liner with an explicit list of all three delivered enterprise modules:
  - **MFA / 2FA** — TOTP + backup codes
  - **SSO & Directory Sync** — SAML/OIDC + SCIM provisioning
  - **Record Locking** — pessimistic locking for concurrent editing
- **`LICENSE`** — updated copyright year to `2025-2026`

## Test plan

- [x] No code changes — documentation only
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)