### PR TITLE
fix(#893): add missing translations for double name label

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/[variantId]/page.tsx
@@ -309,7 +309,7 @@ export default function EditVariantPage({ params }: { params?: { productId?: str
       {
         id: 'general',
         column: 1,
-        title: t('catalog.variants.form.nameLabel', 'Name'),
+        title: t('catalog.variants.form.general', 'General'),
         component: ({ values, setValue, errors }) => (
           <VariantBasicsSection values={values as VariantFormValues} setValue={setValue} errors={errors} />
         ),

--- a/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[productId]/variants/create/page.tsx
@@ -203,7 +203,7 @@ export default function CreateVariantPage({ params }: { params?: { productId?: s
       {
         id: 'general',
         column: 1,
-        title: t('catalog.variants.form.nameLabel', 'Name'),
+        title: t('catalog.variants.form.general', 'General'),
         component: ({ values, setValue, errors }) => (
           <VariantBasicsSection values={values as VariantFormValues} setValue={setValue} errors={errors} />
         ),

--- a/packages/core/src/modules/catalog/i18n/de.json
+++ b/packages/core/src/modules/catalog/i18n/de.json
@@ -556,6 +556,7 @@
   "catalog.variants.form.errors.notFound": "Variante nicht gefunden.",
   "catalog.variants.form.errors.productMissing": "Produktkennung fehlt.",
   "catalog.variants.form.errors.variantMissing": "Variantenkennung fehlt.",
+  "catalog.variants.form.general": "Allgemein",
   "catalog.variants.form.height": "Höhe",
   "catalog.variants.form.isActiveHint": "Inaktive Varianten bleiben verborgen",
   "catalog.variants.form.isActiveLabel": "Aktiv",

--- a/packages/core/src/modules/catalog/i18n/en.json
+++ b/packages/core/src/modules/catalog/i18n/en.json
@@ -556,6 +556,7 @@
   "catalog.variants.form.errors.notFound": "Variant not found.",
   "catalog.variants.form.errors.productMissing": "Product identifier is missing.",
   "catalog.variants.form.errors.variantMissing": "Variant identifier is missing.",
+  "catalog.variants.form.general": "General",
   "catalog.variants.form.height": "Height",
   "catalog.variants.form.isActiveHint": "Inactive variants stay hidden",
   "catalog.variants.form.isActiveLabel": "Active",

--- a/packages/core/src/modules/catalog/i18n/es.json
+++ b/packages/core/src/modules/catalog/i18n/es.json
@@ -556,6 +556,7 @@
   "catalog.variants.form.errors.notFound": "Variante no encontrada.",
   "catalog.variants.form.errors.productMissing": "Falta el identificador del producto.",
   "catalog.variants.form.errors.variantMissing": "Falta el identificador de la variante.",
+  "catalog.variants.form.general": "General",
   "catalog.variants.form.height": "Alto",
   "catalog.variants.form.isActiveHint": "Las variantes inactivas permanecen ocultas",
   "catalog.variants.form.isActiveLabel": "Activa",

--- a/packages/core/src/modules/catalog/i18n/pl.json
+++ b/packages/core/src/modules/catalog/i18n/pl.json
@@ -556,6 +556,7 @@
   "catalog.variants.form.errors.notFound": "Nie znaleziono wariantu.",
   "catalog.variants.form.errors.productMissing": "Brak identyfikatora produktu.",
   "catalog.variants.form.errors.variantMissing": "Brak identyfikatora wariantu.",
+  "catalog.variants.form.general": "Ogólne",
   "catalog.variants.form.height": "Wysokość",
   "catalog.variants.form.isActiveHint": "Nieaktywne warianty pozostają ukryte",
   "catalog.variants.form.isActiveLabel": "Aktywny",


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fix doubled "Name" label on the variant create and edit pages. The CrudForm group title reused the field label translation key, causing "Name" to appear twice — once as the section header and once as the field label with the required asterisk. Changed the group title to "General" (consistent with the product form) since the group contains multiple fields (Name, SKU, Barcode, Default variant, Active).

Fixes #893

## Changes

- Changed the `general` group `title` from `catalog.variants.form.nameLabel` ("Name") to `catalog.variants.form.general` ("General") in both the variant edit and create pages
- Added the `catalog.variants.form.general` translation key to all four locale files (en, pl, es, de)

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Manual verification: variant edit/create forms should show "General" as the section header, with "Name *" as the field label beneath — no duplication

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Fixes #893