### PR TITLE
fix: role assignment issues

### DIFF
--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -53,6 +53,7 @@ const userListItemSchema = z.object({
   tenantId: z.string().uuid().nullable(),
   tenantName: z.string().nullable(),
   roles: z.array(z.string()),
+  roleIds: z.array(z.string().uuid()).optional(),
 })
 
 const userListResponseSchema = z.object({
@@ -191,11 +192,15 @@ export async function GET(req: Request) {
       )
     : []
   const roleMap: Record<string, string[]> = {}
+  const roleIdMap: Record<string, string[]> = {}
   for (const l of links) {
     const uid = String((l as any).user?.id || (l as any).user)
     const rname = String((l as any).role?.name || '')
+    const rid = String((l as any).role?.id ?? '')
     if (!roleMap[uid]) roleMap[uid] = []
+    if (!roleIdMap[uid]) roleIdMap[uid] = []
     if (rname) roleMap[uid].push(rname)
+    if (rid) roleIdMap[uid].push(rid)
   }
   const orgIds = rows
     .map((u: any) => (u.organizationId ? String(u.organizationId) : null))
@@ -264,6 +269,7 @@ export async function GET(req: Request) {
       tenantId: u.tenantId ? String(u.tenantId) : null,
       tenantName: u.tenantId ? tenantMap[String(u.tenantId)] ?? String(u.tenantId) : null,
       roles: roleMap[uid] || [],
+      roleIds: roleIdMap[uid] || [],
       ...(cfByUser[uid] || {}),
     }
   })
@@ -297,12 +303,27 @@ export const PUT = async (req: Request) => {
 
 export const DELETE = crud.DELETE
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 async function assertCanAssignRoles(req: Request, roles: unknown) {
   if (!Array.isArray(roles)) return
-  const normalized = roles
-    .map((role) => (typeof role === 'string' ? role.trim().toLowerCase() : null))
+  const values = roles
+    .map((role) => (typeof role === 'string' ? role.trim() : null))
     .filter((role): role is string => !!role)
-  if (!normalized.includes('superadmin')) return
+  if (!values.length) return
+
+  let hasSuperAdmin = values.some((v) => v.toLowerCase() === 'superadmin')
+  if (!hasSuperAdmin) {
+    const uuids = values.filter((v) => UUID_RE.test(v))
+    if (uuids.length) {
+      const container = await createRequestContainer()
+      const em = container.resolve('em') as EntityManager
+      const matched = await em.find(Role, { id: { $in: uuids as any } })
+      hasSuperAdmin = matched.some((r) => String(r.name).toLowerCase() === 'superadmin')
+    }
+  }
+  if (!hasSuperAdmin) return
+
   const auth = await getAuthFromRequest(req)
   if (!auth) throw new Error('Unauthorized')
   const container = await createRequestContainer()

--- a/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
@@ -30,6 +30,7 @@ type LoadedUser = {
   tenantName: string | null
   organizationName: string | null
   roles: string[]
+  roleIds: string[]
 }
 
 type UserApiItem = {
@@ -40,6 +41,7 @@ type UserApiItem = {
   tenantName?: string | null
   organizationName?: string | null
   roles?: unknown
+  roleIds?: unknown
 }
 
 type UserListResponse = {
@@ -146,6 +148,14 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
             setInitialUser(null)
             setSelectedTenantId(null)
           } else {
+            const roleNames = Array.isArray(item.roles)
+              ? item.roles
+                  .map((role) => (typeof role === 'string' ? role : role == null ? '' : String(role)))
+                  .filter((role) => role.trim().length > 0)
+              : []
+            const roleIds = Array.isArray(item.roleIds)
+              ? (item.roleIds as string[]).filter((rid) => typeof rid === 'string' && rid.trim().length > 0)
+              : []
             setInitialUser({
               id: item.id ? String(item.id) : String(id),
               email: item.email ? String(item.email) : '',
@@ -153,11 +163,8 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
               tenantId: item.tenantId ? String(item.tenantId) : null,
               tenantName: item.tenantName ? String(item.tenantName) : null,
               organizationName: item.organizationName ? String(item.organizationName) : null,
-              roles: Array.isArray(item.roles)
-                ? item.roles
-                    .map((role) => (typeof role === 'string' ? role : role == null ? '' : String(role)))
-                    .filter((role) => role.trim().length > 0)
-                : [],
+              roles: roleNames,
+              roleIds: roleIds.length > 0 ? roleIds : roleNames,
             })
             setSelectedTenantId(item.tenantId ? String(item.tenantId) : null)
             const custom: Record<string, unknown> = {}
@@ -323,7 +330,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
         password: '',
         tenantId: initialUser.tenantId,
         organizationId: initialUser.organizationId,
-        roles: initialUser.roles,
+        roles: initialUser.roleIds,
         ...customFieldValues,
       }
     }

--- a/packages/core/src/modules/auth/backend/users/roleOptions.ts
+++ b/packages/core/src/modules/auth/backend/users/roleOptions.ts
@@ -25,10 +25,11 @@ export async function fetchRoleOptions(query?: string, params?: FetchRoleOptions
     const { items } = call.result
     return items
       .map((item) => {
+        const id = typeof item?.id === 'string' ? item.id.trim() : ''
         const name = typeof item?.name === 'string' ? item?.name.trim() : ''
-        if (!name) return null
+        if (!id || !name) return null
         if (name === 'superadmin') return null
-        return { value: name, label: name }
+        return { value: id, label: name }
       })
       .filter((opt): opt is CrudFieldOption => !!opt)
   } catch {

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -687,48 +687,66 @@ registerCommand(createUserCommand)
 registerCommand(updateUserCommand)
 registerCommand(deleteUserCommand)
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+async function resolveRole(
+  em: EntityManager,
+  value: string,
+  normalizedTenantId: string | null,
+): Promise<Role | null> {
+  if (UUID_RE.test(value)) {
+    const where: Record<string, unknown> = { id: value }
+    if (normalizedTenantId !== null) {
+      where.$or = [{ tenantId: normalizedTenantId }, { tenantId: null }]
+    }
+    return em.findOne(Role, where as any)
+  }
+  let role = await em.findOne(Role, { name: value, tenantId: normalizedTenantId })
+  if (!role && normalizedTenantId !== null) {
+    role = await em.findOne(Role, { name: value, tenantId: null })
+  }
+  return role
+}
+
 async function syncUserRoles(em: EntityManager, user: User, desiredRoles: string[], tenantId: string | null) {
   const unique = Array.from(new Set(desiredRoles.map((role) => role.trim()).filter(Boolean)))
-  const currentLinks = await em.find(UserRole, { user })
-  const currentNames = new Map(
-    currentLinks.map((link) => {
-      const roleEntity = link.role
-      const name = roleEntity?.name ?? ''
-      return [name, link] as const
-    }),
-  )
-
-  for (const [name, link] of currentNames.entries()) {
-    if (!unique.includes(name) && link) {
-      em.remove(link)
-    }
-  }
-
   const normalizedTenantId = normalizeTenantId(tenantId ?? null) ?? null
-  const missingRoles: string[] = []
-  const roleAssignments: Role[] = []
 
-  for (const name of unique) {
-    if (!currentNames.has(name)) {
-      let role = await em.findOne(Role, { name, tenantId: normalizedTenantId })
-      if (!role && normalizedTenantId !== null) {
-        role = await em.findOne(Role, { name, tenantId: null })
-      }
-      if (!role) {
-        missingRoles.push(name)
-      } else {
-        roleAssignments.push(role)
-      }
+  const resolvedRoles: Role[] = []
+  const missingRoles: string[] = []
+  for (const value of unique) {
+    const role = await resolveRole(em, value, normalizedTenantId)
+    if (!role) {
+      missingRoles.push(value)
+    } else {
+      resolvedRoles.push(role)
     }
   }
 
   if (missingRoles.length) {
-    const names = missingRoles.map((n) => `"${n}"`).join(', ')
-    throw new CrudHttpError(400, { error: `Role(s) not found: ${names}` })
+    const labels = missingRoles.map((n) => `"${n}"`).join(', ')
+    throw new CrudHttpError(400, { error: `Role(s) not found: ${labels}` })
   }
 
-  for (const role of roleAssignments) {
-    em.persist(em.create(UserRole, { user, role, createdAt: new Date() }))
+  const desiredIds = new Set(resolvedRoles.map((r) => String(r.id)))
+  const currentLinks = await em.find(UserRole, { user })
+  const currentRoleIds = new Map(
+    currentLinks.map((link) => {
+      const roleId = String(link.role?.id ?? (link.role as unknown as string) ?? '')
+      return [roleId, link] as const
+    }),
+  )
+
+  for (const [roleId, link] of currentRoleIds.entries()) {
+    if (!desiredIds.has(roleId) && link) {
+      em.remove(link)
+    }
+  }
+
+  for (const role of resolvedRoles) {
+    if (!currentRoleIds.has(String(role.id))) {
+      em.persist(em.create(UserRole, { user, role, createdAt: new Date() }))
+    }
   }
 
   await em.flush()

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -2985,12 +2985,12 @@ const FieldControl = React.memo(function FieldControlImpl({
           onChange={(next) => fieldSetValue(next)}
           placeholder={placeholder}
           autoFocus={autoFocusField}
-          suggestions={options.map((opt) => opt.label)}
+          suggestions={options.map((opt) => ({ value: opt.value, label: opt.label }))}
           loadSuggestions={
             typeof builtin?.loadOptions === 'function'
               ? async (query?: string) => {
                   const opts = await loadFieldOptions(field, query)
-                  return opts.map((opt) => opt.label)
+                  return opts.map((opt) => ({ value: opt.value, label: opt.label }))
                 }
               : undefined
           }


### PR DESCRIPTION
## Summary

  When creating a new user and assigning roles (e.g., "admin", "employee"), the system threw `Role(s) not found:          "admin"` because `syncUserRoles` looked up roles by name + tenantId, which could mismatch between the roles API
  (actor's tenant) and the command layer (organization's tenant). This PR switches the role assignment flow from role     **names** to role **IDs** (UUIDs), which are globally unique and eliminate tenantId matching issues entirely. It also
  fixes CrudForm's `tags` field to pass full `{ value, label }` objects to `TagsInput` so selected tags display
  human-readable names instead of raw UUIDs.

  ## Changes

  - **`roleOptions.ts`**: Dropdown now returns `{ value: id, label: name }` instead of `{ value: name, label: name }`     - **`commands/users.ts`**: Rewrote `syncUserRoles` with a new `resolveRole` helper that detects UUIDs (lookup by ID
  with tenant scoping) vs names (existing name+tenantId lookup for backward-compatible undo/redo). Comparison logic uses   role IDs instead of names for correct add/remove diffing
  - **`users/route.ts` GET**: Added `roleIds: string[]` to the response (additive-only, backward compatible alongside     existing `roles: string[]` names)                                                                                       - **`users/route.ts` `assertCanAssignRoles`**: Updated to resolve UUID role values to names before checking for
  `superadmin`, preventing the security guard from being bypassed by ID-based requests                                    - **`[id]/edit/page.tsx`**: Edit form initializes with `roleIds` (falls back to role names if unavailable for backward   compat)                                                                                                                - **`CrudForm.tsx`**: Tags field now passes `{ value, label }` objects to `TagsInput` via `suggestions` and
  `loadSuggestions` instead of stripping to label-only strings — fixes UUID display, duplicate suggestion filtering, and   reactive re-addition of removed tags

## Specification
  - [ ] Yes   
  - [ ] No (created a new spec)
  - [x] N/A (minor change, no spec needed)     
                                                                                                                                                                                                 
 ## Testing
- `yarn build:packages` — passed    
- `yarn generate` — passed
- `yarn typecheck` — passed (all 16 packages) 
- `yarn test` — passed (170 tests)
- `yarn build:app` — passed  
- `yarn tsx scripts/i18n-check-sync.ts` — passed       
 ## Checklist

- [x] This pull request targets `develop`.
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
  - [x] I updated documentation, locales, or generators if the change requires it.                                        - [ ] I added or adjusted tests that cover the change.
  - [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not            required).
  - [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).                                                                                                                                                     ## Linked issues                                                                                                                                                                                                                                Fixes #996 