### PR TITLE
fix(auth): support custom roles in defaultRoleFeatures

### DIFF
--- a/packages/core/src/modules/auth/lib/setup-app.ts
+++ b/packages/core/src/modules/auth/lib/setup-app.ts
@@ -411,9 +411,11 @@ async function ensureDefaultRoleAcls(
   const employeeRole = await findRoleByName(em, 'employee', roleTenantId)
 
   // Merge features from all enabled modules' setup configs
+  const builtInRoles = ['superadmin', 'admin', 'employee'] as const
   const superadminFeatures: string[] = []
   const adminFeatures: string[] = []
   const employeeFeatures: string[] = []
+  const customRoleFeatures = new Map<string, string[]>()
 
   for (const mod of modules) {
     const roleFeatures = mod.setup?.defaultRoleFeatures
@@ -421,12 +423,24 @@ async function ensureDefaultRoleAcls(
     if (roleFeatures.superadmin) superadminFeatures.push(...roleFeatures.superadmin)
     if (roleFeatures.admin) adminFeatures.push(...roleFeatures.admin)
     if (roleFeatures.employee) employeeFeatures.push(...roleFeatures.employee)
+
+    // Collect features for custom roles (any key not in builtInRoles)
+    for (const [roleName, features] of Object.entries(roleFeatures)) {
+      if ((builtInRoles as readonly string[]).includes(roleName)) continue
+      if (!Array.isArray(features)) continue
+      const existing = customRoleFeatures.get(roleName) ?? []
+      existing.push(...features)
+      customRoleFeatures.set(roleName, existing)
+    }
   }
 
   console.log('✅ Seeded default role features', {
     superadmin: superadminFeatures,
     admin: adminFeatures,
     employee: employeeFeatures,
+    ...(customRoleFeatures.size > 0
+      ? Object.fromEntries(customRoleFeatures)
+      : {}),
   })
 
   if (includeSuperadminRole && superadminRole) {
@@ -437,6 +451,14 @@ async function ensureDefaultRoleAcls(
   }
   if (employeeRole) {
     await ensureRoleAclFor(em, employeeRole, tenantId, employeeFeatures)
+  }
+
+  // Seed ACLs for custom roles defined by app modules
+  for (const [roleName, features] of customRoleFeatures) {
+    const role = await findRoleByName(em, roleName, roleTenantId)
+    if (role) {
+      await ensureRoleAclFor(em, role, tenantId, features)
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`ensureDefaultRoleAcls` in `setup-app.ts` only processes the three built-in role keys (`superadmin`, `admin`, `employee`) from module `defaultRoleFeatures`. Custom role keys defined by app modules are silently ignored.

This means any OM app that creates custom roles (e.g., `partner_admin`, `consultant`) and declares their features in `defaultRoleFeatures` will have those features never applied. Users with custom roles get:

- "Access requires role: Admin" on login
- "You don't have access to this feature (dashboards.view)" when accessing the backend

### Reproduction

1. Create an app module with custom roles seeded in `seedDefaults`
2. Declare features for those roles in `defaultRoleFeatures`:
   ```typescript
   defaultRoleFeatures: {
     partner_admin: ['customers.*', 'dashboards.view'],
   }
   ```
3. Run `yarn initialize`
4. Log in as a user with `partner_admin` role
5. **Expected:** user sees the dashboard
6. **Actual:** "You don't have access to this feature (dashboards.view)"

### Root cause

Lines 418-424 of `setup-app.ts` only extract features for hardcoded keys:

```typescript
if (roleFeatures.superadmin) superadminFeatures.push(...)
if (roleFeatures.admin) adminFeatures.push(...)
if (roleFeatures.employee) employeeFeatures.push(...)
// ← any other key is ignored
```

## Solution

After collecting built-in role features, iterate over remaining keys in `defaultRoleFeatures` and seed their ACLs using the same `ensureRoleAclFor` mechanism. Custom role features are also included in the console log for visibility.

The fix is backward-compatible: existing apps with only `superadmin`/`admin`/`employee` keys are unaffected. Apps with custom role keys will now have their features correctly applied.

## Impact

- **Affected:** Any app using custom roles with `defaultRoleFeatures` (e.g., PRM app with `partner_admin`, `partner_member`, `partnership_manager`)
- **Not affected:** Apps using only built-in roles, `defaultCustomerRoleFeatures` (separate mechanism, already works)

## Test plan

- [ ] Existing built-in roles (superadmin, admin, employee) still get their features
- [ ] Custom role keys in `defaultRoleFeatures` now get their features seeded
- [ ] `ensureRoleAclFor` merges features idempotently (re-running initialize doesn't duplicate)
- [ ] Console log includes custom role features
- [ ] Custom role that doesn't exist in DB is silently skipped (no error)