### PR TITLE
fix(create-app): wire integration test infrastructure for standalone apps

### DIFF
--- a/packages/create-app/template/.ai/qa/tests/playwright.config.ts
+++ b/packages/create-app/template/.ai/qa/tests/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { discoverIntegrationSpecFiles } from '@open-mercato/cli/lib/testing/integration-discovery';
+
+const captureScreenshots = process.env.PW_CAPTURE_SCREENSHOTS === '1';
+const isGitHubActions = process.env.GITHUB_ACTIONS === 'true';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '..', '..', '..');
+const qaTestResultsRoot = path.join(projectRoot, '.ai', 'qa', 'test-results');
+const normalizePath = (value: string) => value.split(path.sep).join('/');
+const STATIC_TEST_IGNORES = [
+  `${normalizePath(path.join(projectRoot, '.claude'))}/**`,
+  `${normalizePath(path.join(projectRoot, '.codex'))}/**`,
+];
+const discoveredSpecs = discoverIntegrationSpecFiles(projectRoot, path.join(projectRoot, '.ai', 'qa', 'tests'));
+const discoveredSpecPaths = discoveredSpecs.map((entry) => entry.path);
+
+export default defineConfig({
+  testDir: projectRoot,
+  testMatch: discoveredSpecPaths.length > 0 ? discoveredSpecPaths : ['.ai/qa/tests/__no_tests__/*.spec.ts'],
+  testIgnore: [
+    ...STATIC_TEST_IGNORES,
+  ],
+  timeout: 20_000,
+  expect: {
+    timeout: 20_000,
+  },
+  retries: 1,
+  workers: 1,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    headless: true,
+    screenshot: captureScreenshots ? 'on' : 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  reporter: isGitHubActions
+    ? [
+        ['github'],
+        ['list'],
+        ['json', { outputFile: path.join(qaTestResultsRoot, 'results.json') }],
+        ['html', { outputFolder: path.join(qaTestResultsRoot, 'html'), open: 'never' }],
+      ]
+    : [
+        ['list'],
+        ['json', { outputFile: path.join(qaTestResultsRoot, 'results.json') }],
+        ['html', { outputFolder: path.join(qaTestResultsRoot, 'html'), open: 'never' }],
+      ],
+  outputDir: path.join(qaTestResultsRoot, 'artifacts'),
+});

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -35,11 +35,20 @@ yarn typecheck
 # Linting
 yarn lint
 
-# Run tests
+# Run unit tests
 yarn test
 
-# Run a single test
+# Run a single unit test
 yarn test path/to/test.spec.ts
+
+# Run integration tests (spins up fresh ephemeral app + DB, runs Playwright)
+mercato test integration
+
+# Start ephemeral app only (for manual QA exploration)
+mercato test ephemeral
+
+# View HTML integration test report
+mercato test coverage
 
 # Generate code from modules
 yarn generate

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -10,6 +10,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.cjs",
+    "test:integration": "npx playwright test --config .ai/qa/tests/playwright.config.ts",
     "generate": "mercato generate",
     "db:generate": "mercato db generate",
     "db:migrate": "mercato db migrate",
@@ -70,6 +71,7 @@
     "@open-mercato/sync-akeneo": "{{PACKAGE_VERSION}}"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.17",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Problem

Standalone apps scaffolded by `create-mercato-app` cannot run integration tests via `mercato test integration`. Three issues compound:

### 1. Missing `test:integration` script → infinite recursion

The CLI's `runIntegrationTestSuiteOnce` calls `yarn run test:integration` to execute Playwright. The template doesn't ship this script. When a developer manually adds `"test:integration": "mercato test integration"` (the intuitive guess), it creates an infinite loop:

```
mercato test integration
  → runIntegrationTestSuiteOnce()
    → yarn run test:integration
      → mercato test integration   ← back to start
```

The correct value must point directly to Playwright:
```json
"test:integration": "npx playwright test --config .ai/qa/tests/playwright.config.ts"
```

### 2. Missing Playwright config

The CLI hardcodes `.ai/qa/tests/playwright.config.ts` as the config path. The monorepo has this file, but the template doesn't ship it. Without it, `yarn test:integration` fails with "config not found".

### 3. ESM `__dirname` incompatibility

The monorepo's Playwright config uses bare `__dirname`. This works because the monorepo is CJS (`"type"` not set in root `package.json`). But standalone apps use `"type": "module"`, causing:

```
ReferenceError: __dirname is not defined in ES module scope
```

Note: the template already ships 15 integration tests (`TC-UMES-*`, `TC-AUTH-*`) but has zero infrastructure to run them.

## Solution

Three changes to `packages/create-app/template/`:

| File | Change |
|------|--------|
| `package.json.template` | Add `test:integration` script + `@playwright/test` devDependency |
| `.ai/qa/tests/playwright.config.ts` | New file — ESM-compatible config with `fileURLToPath` polyfill |
| `AGENTS.md` | Document `mercato test integration` and related commands |

## AI Piotr Challenge

CTO skill review — verified each claim against upstream `develop`:

| # | Check | Result |
|---|-------|--------|
| 1 | Does the platform already solve this? | **No.** Template ships 15 integration tests but zero infrastructure to run them. |
| 2 | Could CLI solve it instead? | Possible (call `npx playwright` directly) but breaks the `yarn run X` convention used for `build`, `generate`, `initialize`. The `yarn test:integration` script also lets users customize (e.g. `cross-env ENABLE_CRUD_API_CACHE=true`). **Template fix is the right layer.** |
| 3 | Is ESM polyfill correct? | **Yes.** Template is `"type": "module"`. Monorepo is CJS (no `"type"` in root). `import.meta.url` + `fileURLToPath` is the standard Node polyfill. |
| 4 | Is `@playwright/test` in devDeps correct? | **Yes.** Monorepo has it as workspace root dep. Standalone apps need it explicitly. |
| 5 | Does `SKIP_DIRS` affect `.ai/qa/tests/`? | **No.** Only `__tests__` and `__integration__` are skipped. `.ai/` copies fine. |
| 6 | Backward compatibility? | **N/A.** New file + new script. No existing contract broken. |
| 7 | Quality: self-contained? | **Yes.** Config discovers tests from `__integration__/` dirs automatically. Zero user wiring. |

## How we found this

Debugging integration tests for the PRM example app (`ready-apps/apps/prm`) across multiple sessions. Each session hit a different layer of this issue:
1. `mercato test ephemeral` doesn't run tests (it's QA-exploration-only mode)
2. `mercato test integration` enters infinite loop (recursive script)
3. Playwright config missing
4. `__dirname` crash in ESM context

Follow-up to #1037 (which exported test helpers but didn't wire the test runner for standalone apps).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>