### PR TITLE
fix(translations): guard catalog_product_offers references in migration

### DIFF
--- a/packages/core/src/modules/translations/migrations/Migration20260215120000.ts
+++ b/packages/core/src/modules/translations/migrations/Migration20260215120000.ts
@@ -41,23 +41,40 @@ export class Migration20260215120000 extends Migration {
       end $$;
     `);
 
-    // Drop localized_content column from catalog_product_offers
-    this.addSql(`alter table "catalog_product_offers" drop column if exists "localized_content";`);
+    // Drop localized_content column from catalog_product_offers (guard: table may not exist in apps without catalog module)
+    this.addSql(`
+      do $$
+      begin
+        if exists (
+          select 1 from information_schema.tables
+          where table_schema = current_schema() and table_name = 'catalog_product_offers'
+        ) then
+          alter table "catalog_product_offers" drop column if exists "localized_content";
+        end if;
+      end $$;
+    `);
   }
 
   override async down(): Promise<void> {
-    // Re-add localized_content column
-    this.addSql(`alter table "catalog_product_offers" add column "localized_content" jsonb null;`);
-
-    // Migrate data back
+    // Re-add localized_content column (guard: table may not exist in apps without catalog module)
     this.addSql(`
-      update "catalog_product_offers" o
-      set "localized_content" = et."translations"
-      from "entity_translations" et
-      where et."entity_type" = 'catalog:catalog_offer'
-        and et."entity_id" = o."id"::text
-        and (et."organization_id" is not distinct from o."organization_id")
-        and (et."tenant_id" is not distinct from o."tenant_id")
+      do $$
+      begin
+        if exists (
+          select 1 from information_schema.tables
+          where table_schema = current_schema() and table_name = 'catalog_product_offers'
+        ) then
+          alter table "catalog_product_offers" add column if not exists "localized_content" jsonb null;
+
+          update "catalog_product_offers" o
+          set "localized_content" = et."translations"
+          from "entity_translations" et
+          where et."entity_type" = 'catalog:catalog_offer'
+            and et."entity_id" = o."id"::text
+            and (et."organization_id" is not distinct from o."organization_id")
+            and (et."tenant_id" is not distinct from o."tenant_id");
+        end if;
+      end $$;
     `);
 
     // Drop entity_translations table


### PR DESCRIPTION
## Problem

`Migration20260215120000` (translations module) fails on standalone apps that don't include the catalog module:

```
Migration Migration20260215120000 (up) failed: Original error:
alter table "catalog_product_offers" drop column if exists "localized_content";
- relation "catalog_product_offers" does not exist
```

The migration creates `entity_translations` and migrates data from `catalog_product_offers.localized_content`. The data migration (INSERT ... SELECT) was already correctly guarded with `IF EXISTS` on the column. But the subsequent `ALTER TABLE DROP COLUMN` (line 45) and the entire `down()` rollback both reference `catalog_product_offers` without checking if the table exists.

Standalone apps without the catalog module (e.g. PRM example app) have no `catalog_product_offers` table.

## Solution

Wrap both the `up()` DROP COLUMN and `down()` ADD COLUMN + data restore in `DO $$ IF EXISTS` blocks that check for the table first. Same pattern already used on lines 17-42 for the data migration.

| Direction | Before | After |
|-----------|--------|-------|
| `up()` | Bare `ALTER TABLE ... DROP COLUMN` | Guarded with `IF EXISTS` on table |
| `down()` | Bare `ALTER TABLE ... ADD COLUMN` + bare `UPDATE` | Both guarded with `IF EXISTS` on table |

## AI Piotr Challenge

| # | Check | Result |
|---|-------|--------|
| 1 | Is this the right layer? | **Yes.** Migration must be self-contained — it can't assume which modules are installed. |
| 2 | Does the guard match the existing pattern? | **Yes.** Lines 17-42 already use the same `information_schema.columns` guard for the data migration. This PR extends it to the DDL statement. |
| 3 | Backward compatibility? | **N/A.** Migration already ran on monorepo DBs (which have the table). Guard is a no-op there. |
| 4 | Does `down()` need the same fix? | **Yes.** Added — `down()` also referenced `catalog_product_offers` without guard. |

## Immediate consumer

`ready-apps/apps/prm` — blocked on `yarn initialize` / `yarn reinstall` with canary `0.4.9-develop.1013`.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
