### PR TITLE
fix(navigation): move Security and Developers modules to Settings sid…

### DIFF
--- a/packages/core/src/modules/api_docs/backend/docs/page.meta.ts
+++ b/packages/core/src/modules/api_docs/backend/docs/page.meta.ts
@@ -17,4 +17,5 @@ export const metadata = {
   pageGroupKey: 'backend.nav.developers',
   pageOrder: 1000,
   icon: bookIcon,
+  pageContext: 'settings' as const,
 }

--- a/packages/core/src/modules/audit_logs/backend/audit-logs/page.meta.ts
+++ b/packages/core/src/modules/audit_logs/backend/audit-logs/page.meta.ts
@@ -15,5 +15,6 @@ export const metadata = {
   pageGroupKey: 'backend.nav.security',
   pageOrder: 160,
   icon: activityIcon,
+  pageContext: 'settings' as const,
   breadcrumb: [{ label: 'Audit Logs', labelKey: 'audit_logs.nav.title' }],
 }

--- a/packages/ui/src/backend/__tests__/nav-utils.test.ts
+++ b/packages/ui/src/backend/__tests__/nav-utils.test.ts
@@ -1,6 +1,38 @@
 import { buildSettingsSections, convertToSectionNavGroups, type AdminNavItem } from '../utils/nav'
 
 describe('settings navigation helpers', () => {
+  it('includes only settings-context entries', () => {
+    const entries: AdminNavItem[] = [
+      {
+        group: 'System',
+        groupId: 'settings.sections.system',
+        groupKey: 'settings.sections.system',
+        groupDefaultName: 'System',
+        title: 'Audit Logs',
+        defaultTitle: 'Audit Logs',
+        href: '/backend/audit-logs',
+        enabled: true,
+        order: 10,
+        pageContext: 'settings',
+      },
+      {
+        group: 'Customers',
+        groupId: 'customers.nav.group',
+        groupDefaultName: 'Customers',
+        title: 'People',
+        defaultTitle: 'People',
+        href: '/backend/customers/people',
+        enabled: true,
+        order: 1,
+      },
+    ]
+
+    const sections = buildSettingsSections(entries, { system: 1 })
+
+    expect(sections).toHaveLength(1)
+    expect(sections[0].items.map((item) => item.href)).toEqual(['/backend/audit-logs'])
+  })
+
   it('preserves nested children for settings section items', () => {
     const entries: AdminNavItem[] = [
       {


### PR DESCRIPTION
## Summary

This PR fixes sidebar navigation context for administrative modules.
Security (Audit Logs) and Developers (API documentation) were appearing in the main sidebar.
They now appear under Settings only, matching the sidebar reorganization behavior.

## Changes

- Added `pageContext: 'settings' as const` in Audit Logs page metadata so it is routed to Settings navigation.
- Added `pageContext: 'settings' as const` in API documentation page metadata so it is routed to Settings navigation.
- Added a regression unit test to verify Settings navigation includes only settings-context items.

## Testing

- `yarn workspace @open-mercato/ui test packages/ui/src/backend/__tests__/nav-utils.test.ts --runInBand`
- Result: 1 suite passed, 2 tests passed

## Linked issues

Fixes #1029
