### PR TITLE
fix: restore variant list after clearing selection in quote/order line items

### DIFF
--- a/packages/ui/src/backend/inputs/LookupSelect.tsx
+++ b/packages/ui/src/backend/inputs/LookupSelect.tsx
@@ -68,8 +68,10 @@ export function LookupSelect({
   const [loading, setLoading] = React.useState(false)
   const [hasTyped, setHasTyped] = React.useState(defaultOpen)
   const [error, setError] = React.useState<string | null>(null)
+  const [fetchKey, setFetchKey] = React.useState(0)
   const fetchItemsRef = React.useRef(fetchItems ?? fetchOptions)
   const setQueryRef = React.useRef(setQuery)
+  const optionsWasArrayRef = React.useRef(Array.isArray(options))
 
   React.useEffect(() => {
     fetchItemsRef.current = fetchItems ?? fetchOptions
@@ -77,7 +79,11 @@ export function LookupSelect({
 
   React.useEffect(() => {
     if (Array.isArray(options)) {
+      optionsWasArrayRef.current = true
       setItems(options)
+    } else if (optionsWasArrayRef.current) {
+      optionsWasArrayRef.current = false
+      setFetchKey((k) => k + 1)
     }
   }, [options])
 
@@ -127,7 +133,7 @@ export function LookupSelect({
       cancelled = true
       if (timer) clearTimeout(timer)
     }
-  }, [query, shouldSearch])
+  }, [query, shouldSearch, fetchKey])
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary

Fixes the variant selector in LineItemDialog (Sales → Quotes/Orders → Add Item) not restoring the full variant list after clearing a selected variant.

When a product with multiple variants is selected, the variant LookupSelect receives a single-item static `options` array (the selected variant). After clearing the variant selection, `options` becomes `undefined` — meaning the component should switch to fetching all variants from the API. However, the fetch effect was not re-triggered on this transition, leaving only the previously selected variant visible.

Fixes #917

## Test plan

- [ ] Create a Quote → Items → Add Item
- [ ] Search and select a product with multiple variants
- [ ] Select one variant — confirm it appears as selected
- [ ] Click "Clear selection" on the variant
- [ ] Confirm all variants are listed again (not just the previously selected one)