### PR TITLE
Fix/upload button visibility without permission

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -17,6 +17,7 @@ import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customF
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { hasFeature } from '@open-mercato/shared/security/features'
 import { z } from 'zod'
 import { E } from '#generated/entities.ids.generated'
 import type { LucideIcon } from 'lucide-react'
@@ -751,6 +752,20 @@ export function AttachmentLibrary() {
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false)
   const [deleteTarget, setDeleteTarget] = React.useState<AttachmentRow | null>(null)
   const [deletePending, setDeletePending] = React.useState(false)
+
+  const { data: featureCheckData } = useQuery({
+    queryKey: ['attachments-feature-check'],
+    queryFn: async () => {
+      const call = await apiCall<{ granted?: string[] }>('/api/auth/feature-check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ features: ['attachments.manage'] }),
+      })
+      return call.result ?? {}
+    },
+    staleTime: 60_000,
+  })
+  const canManage = hasFeature(featureCheckData?.granted, 'attachments.manage')
   const filterSignature = React.useMemo(() => buildFilterSignature(filterValues), [filterValues])
   const sortingSignature = React.useMemo(() => JSON.stringify(sorting), [sorting])
 
@@ -1041,11 +1056,13 @@ export function AttachmentLibrary() {
           onRefresh: () => { void refetch() },
           isRefreshing: isLoading,
         }}
-        actions={(
-          <Button onClick={() => setUploadDialogOpen(true)}>
-            {t('attachments.library.actions.upload', 'Upload')}
-          </Button>
-        )}
+        actions={
+          canManage ? (
+            <Button onClick={() => setUploadDialogOpen(true)}>
+              {t('attachments.library.actions.upload', 'Upload')}
+            </Button>
+          ) : undefined
+        }
         columns={columns}
         data={items}
         sorting={sorting}


### PR DESCRIPTION
 <!--
  Please ensure this pull request targets the `develop` branch.
  Checking the CLA box below confirms you accept the terms in docs/cla.md.                                                                                               -->
                                                                                                                                                                       
  ## Summary      

  Users with the `employee` role could see and click the **Upload** button on
  `/backend/storage/attachments` despite lacking the `attachments.manage`
  permission. The API correctly denied the request, but the button was rendered
  unconditionally. This PR adds a client-side feature check so the button is
  hidden for users without `attachments.manage`.

  Closes #1067

  ## Changes

  - `packages/core/src/modules/attachments/components/AttachmentLibrary.tsx`
    - Added import of `hasFeature` from `@open-mercato/shared/security/features`
    - Added `useQuery` call to `POST /api/auth/feature-check` for
      `attachments.manage` on component mount
    - Conditionally render the Upload button only when `canManage === true`

  ## Specification

  **Does a spec exist for this feature/module?**
  - [x] N/A (minor change, no spec needed)

  **Spec file path:**
  <!-- N/A -->

  ## Testing

  - Logged in as a user with `employee` role → Upload button is no longer visible
    on `/backend/storage/attachments`
  - Logged in as a user with `admin` role → Upload button is visible and functions
    correctly
  - Verified that the `POST /api/auth/feature-check` endpoint correctly returns
    `granted: []` for `employee` and `granted: ['attachments.manage']` for `admin`

  ## Checklist

  - [x] PR targets the `develop` branch
  - [x] I accept the terms in `docs/cla.md`
  - [x] Change is minimal and does not touch unrelated code
  - [x] No new user-facing strings introduced (button was already translated)
  - [x] Follows the feature-check pattern used in `useWebhookFeatureAccess`