### PR TITLE
fix(cli): wait for child processes on shutdown to prevent stale lock file

### DIFF
--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1076,6 +1076,27 @@ export async function run(argv = process.argv) {
             }
           }
 
+          async function cleanupAndWait() {
+            cleanup()
+            // Wait for all child processes to fully exit so they can release lock files
+            await Promise.all(
+              processes.map(
+                (proc) =>
+                  new Promise<void>((resolve) => {
+                    if (proc.exitCode !== null) return resolve()
+                    proc.on('exit', () => resolve())
+                  })
+              )
+            )
+            // Safety net: remove Next.js dev lock file in case the child didn't clean up
+            const lockFile = path.join(appDir, '.mercato', 'next', 'dev', 'lock')
+            try {
+              fs.unlinkSync(lockFile)
+            } catch {
+              // Lock file may already be removed by Next.js — ignore
+            }
+          }
+
           process.on('SIGTERM', cleanup)
           process.on('SIGINT', cleanup)
 
@@ -1128,7 +1149,7 @@ export async function run(argv = process.argv) {
             )
           )
 
-          cleanup()
+          await cleanupAndWait()
         },
       },
       {
@@ -1152,6 +1173,19 @@ export async function run(argv = process.argv) {
                 proc.kill('SIGTERM')
               }
             }
+          }
+
+          async function cleanupAndWait() {
+            cleanup()
+            await Promise.all(
+              processes.map(
+                (proc) =>
+                  new Promise<void>((resolve) => {
+                    if (proc.exitCode !== null) return resolve()
+                    proc.on('exit', () => resolve())
+                  })
+              )
+            )
           }
 
           process.on('SIGTERM', cleanup)
@@ -1201,7 +1235,7 @@ export async function run(argv = process.argv) {
             )
           )
 
-          cleanup()
+          await cleanupAndWait()
         },
       },
     ],


### PR DESCRIPTION
## Summary
- `mercato server dev` cleanup sent SIGTERM to child processes but exited before they could release the Next.js dev lock file (`.mercato/next/dev/lock`), blocking subsequent `yarn dev` with "Unable to acquire lock" error
- Fix: `cleanupAndWait()` now awaits all child process exits before the parent terminates, plus removes the lock file as a safety net in the `dev` command
- Same wait-for-exit fix applied to `mercato server start` for consistency

## Test plan
- [ ] Run `yarn dev`, Ctrl+C, confirm `.mercato/next/dev/lock` is removed
- [ ] Run `yarn dev` again immediately — should start without lock error
- [ ] Kill terminal window during `yarn dev`, run `yarn dev` again — lock file should not block (safety net removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)