### PR TITLE
fix: generate new order number when converting quote to order

### DIFF
--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -5589,16 +5589,13 @@ const convertQuoteToOrderCommand: CommandHandler<
     const generator = ctx.container.resolve(
       "salesDocumentNumberGenerator",
     ) as SalesDocumentNumberGenerator;
-    const generatedNumber =
-      snapshot.quote.quoteNumber && snapshot.quote.quoteNumber.trim().length
-        ? snapshot.quote.quoteNumber
-        : (
-            await generator.generate({
-              kind: "order",
-              organizationId: snapshot.quote.organizationId,
-              tenantId: snapshot.quote.tenantId,
-            })
-          ).number;
+    const generatedNumber = (
+      await generator.generate({
+        kind: "order",
+        organizationId: snapshot.quote.organizationId,
+        tenantId: snapshot.quote.tenantId,
+      })
+    ).number;
     const orderNumber =
       typeof payload.orderNumber === "string" &&
       payload.orderNumber.trim().length


### PR DESCRIPTION
## Summary

- Fixes a bug where converting a Quote to an Order reused the quote's document number (e.g. `QUOTE-20260310-00007`) instead of generating a proper order number (e.g. `ORDER-20260310-00001`)
- The conversion command now always calls `salesDocumentNumberGenerator` with `kind: "order"` to produce a correctly prefixed and sequenced order number

## Root Cause

In `packages/core/src/modules/sales/commands/documents.ts`, the `sales.quotes.convert_to_order` command had a conditional that checked if the quote already had a `quoteNumber` — if it did, it was passed through as the order number verbatim, retaining the `QUOTE-` prefix.

## Fix

Removed the conditional fallback to `snapshot.quote.quoteNumber` so a new order number is always generated via the document number generator. The explicit `payload.orderNumber` override is preserved for callers that provide a custom order number.

## Linked issues

Fixes #919
