### PR TITLE
fix: Todo priority field accepts values outside allowed range (1–5)

### DIFF
--- a/apps/mercato/src/modules/example/__integration__/todo-priority-validation.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/todo-priority-validation.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from '@playwright/test'
+import {
+  apiRequest,
+  getAuthToken,
+} from '@open-mercato/core/helpers/integration/api'
+import { deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures'
+
+test.describe('Todo priority validation', () => {
+  let adminToken: string
+
+  test.beforeAll(async ({ request }) => {
+    adminToken = await getAuthToken(request, 'admin')
+  })
+
+  test('rejects priorities above the configured max', async ({ request }) => {
+    const response = await apiRequest(request, 'POST', '/api/example/todos', {
+      token: adminToken,
+      data: {
+        title: `QA invalid priority ${Date.now()}`,
+        cf_priority: 8,
+        cf_severity: 'high',
+      },
+    })
+
+    expect(response.status()).toBe(400)
+    const body = await response.json() as {
+      error?: string
+      fields?: Record<string, string | undefined>
+    }
+    expect(body.error).toBe('Validation failed')
+    expect(body.fields?.cf_priority).toBe('Priority must be <= 5')
+  })
+
+  test('accepts priorities inside the configured range', async ({ request }) => {
+    let todoId: string | null = null
+    try {
+      const response = await apiRequest(request, 'POST', '/api/example/todos', {
+        token: adminToken,
+        data: {
+          title: `QA valid priority ${Date.now()}`,
+          cf_priority: 5,
+          cf_severity: 'medium',
+        },
+      })
+
+      expect(response.ok()).toBeTruthy()
+      const body = await response.json() as { id?: string }
+      todoId = body.id ?? null
+      expect(todoId).toBeTruthy()
+    } finally {
+      await deleteEntityIfExists(request, adminToken, '/api/example/todos', todoId)
+    }
+  })
+
+  test('shows the max-priority error on blur before submit', async ({ page }) => {
+    test.slow()
+    const { login } = await import('@open-mercato/core/helpers/integration/auth')
+    await login(page, 'admin')
+    await page.goto('/backend/todos/create', { waitUntil: 'commit' })
+
+    const priorityField = page.locator('[data-crud-field-id="cf_priority"]').first()
+    const priorityInput = priorityField.locator('input[type="number"]').first()
+
+    await expect(priorityInput).toBeVisible()
+    await priorityInput.scrollIntoViewIfNeeded()
+    await priorityInput.click()
+    await priorityInput.type('8')
+    await page.keyboard.press('Tab')
+
+    await expect(priorityField.getByText('Priority must be <= 5')).toBeVisible()
+
+    await priorityInput.fill('5')
+    await page.keyboard.press('Tab')
+
+    await expect(priorityField.getByText('Priority must be <= 5')).toHaveCount(0)
+  })
+
+  test('accepts corrected priority after blur validation and creates the todo', async ({ page, request }) => {
+    test.slow()
+    const { login } = await import('@open-mercato/core/helpers/integration/auth')
+    const title = `QA corrected priority ${Date.now()}`
+    let createdIds: string[] = []
+
+    try {
+      await login(page, 'admin')
+      await page.goto('/backend/todos/create', { waitUntil: 'commit' })
+
+      const titleInput = page.locator('[data-crud-field-id="title"] input').first()
+      const priorityField = page.locator('[data-crud-field-id="cf_priority"]').first()
+      const priorityInput = priorityField.locator('input[type="number"]').first()
+      const severityField = page.locator('[data-crud-field-id="cf_severity"]').first()
+      const form = page.locator('[data-crud-field-id="title"]').first().locator('xpath=ancestor::form').first()
+
+      await expect(severityField.locator('select')).toBeVisible()
+      await expect(titleInput).toBeVisible()
+      await titleInput.fill(title)
+      await expect(priorityInput).toBeVisible()
+      await priorityInput.scrollIntoViewIfNeeded()
+      await priorityInput.click()
+      await priorityInput.type('8')
+      await page.keyboard.press('Tab')
+
+      await expect(priorityField.getByText('Priority must be <= 5')).toBeVisible()
+
+      await priorityInput.fill('5')
+      await severityField.locator('select').selectOption('medium')
+      await form.locator('button[type="submit"]').first().click()
+
+      await expect(page).toHaveURL(/\/backend\/todos(?:\?.*)?$/)
+
+      const response = await apiRequest(
+        request,
+        'GET',
+        `/api/example/todos?title=${encodeURIComponent(title)}&page=1&pageSize=10`,
+        { token: adminToken },
+      )
+      expect(response.ok()).toBeTruthy()
+      const body = await response.json() as { items?: Array<{ id?: string | null }> }
+      createdIds = (body.items ?? [])
+        .map((item) => item.id)
+        .filter((itemId): itemId is string => typeof itemId === 'string' && itemId.length > 0)
+      expect(createdIds.length).toBeGreaterThan(0)
+    } finally {
+      if (createdIds.length === 0) {
+        const response = await apiRequest(
+          request,
+          'GET',
+          `/api/example/todos?title=${encodeURIComponent(title)}&page=1&pageSize=10`,
+          { token: adminToken },
+        )
+
+        if (response.ok()) {
+          const body = await response.json() as { items?: Array<{ id?: string | null }> }
+          createdIds = (body.items ?? [])
+            .map((item) => item.id)
+            .filter((itemId): itemId is string => typeof itemId === 'string' && itemId.length > 0)
+        }
+      }
+
+      for (const itemId of createdIds) {
+        await deleteEntityIfExists(request, adminToken, '/api/example/todos', itemId)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/entities/lib/__tests__/validation.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/validation.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+import type { EntityManager } from '@mikro-orm/core'
+import { validateCustomFieldValuesServer } from '../validation'
+
+type ValidationRule =
+  | { rule: 'required'; message: string }
+  | { rule: 'integer'; message: string }
+  | { rule: 'lte'; param: number; message: string }
+
+type CustomFieldDefStub = {
+  key: string
+  kind: string
+  organizationId: string | null
+  tenantId: string | null
+  updatedAt: Date
+  configJson: {
+    validation: ValidationRule[]
+  }
+}
+
+function createDefinition(input: {
+  organizationId: string | null
+  tenantId: string | null
+  updatedAt?: string
+  validation: ValidationRule[]
+}): CustomFieldDefStub {
+  return {
+    key: 'priority',
+    kind: 'integer',
+    organizationId: input.organizationId,
+    tenantId: input.tenantId,
+    updatedAt: new Date(input.updatedAt ?? '2026-03-31T00:00:00.000Z'),
+    configJson: {
+      validation: input.validation,
+    },
+  }
+}
+
+describe('validateCustomFieldValuesServer', () => {
+  it('matches tenant-scoped definitions with global organization scope', async () => {
+    const definition = createDefinition({
+      organizationId: null,
+      tenantId: 'tenant-1',
+      validation: [{ rule: 'lte', param: 5, message: 'priority <= 5' }],
+    })
+    const em = {
+      find: jest.fn(async (_entity: unknown, where: Record<string, unknown>) => {
+        const clauses = Array.isArray(where.$and) ? where.$and as Array<Record<string, unknown>> : []
+        const orgClause = clauses.find((entry) => Array.isArray(entry.$or))
+        const tenantClause = clauses.find((entry) =>
+          Array.isArray(entry.$or) &&
+          (entry.$or as Array<Record<string, unknown>>).some((candidate) => Object.prototype.hasOwnProperty.call(candidate, 'tenantId')),
+        )
+        const orgOptions = Array.isArray(orgClause?.$or) ? orgClause.$or as Array<Record<string, unknown>> : []
+        const tenantOptions = Array.isArray(tenantClause?.$or) ? tenantClause.$or as Array<Record<string, unknown>> : []
+        const hasOrgMatch = orgOptions.some((candidate) => candidate.organizationId === 'org-1')
+          && orgOptions.some((candidate) => candidate.organizationId === null)
+        const hasTenantMatch = tenantOptions.some((candidate) => candidate.tenantId === 'tenant-1')
+          && tenantOptions.some((candidate) => candidate.tenantId === null)
+        return hasOrgMatch && hasTenantMatch ? [definition] : []
+      }),
+    } as unknown as EntityManager
+
+    const result = await validateCustomFieldValuesServer(em, {
+      entityId: 'example:todo',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      values: { priority: 8 },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.fieldErrors.cf_priority).toBe('priority <= 5')
+  })
+
+  it('prefers the most specific matching definition for duplicate keys', async () => {
+    const globalDefinition = createDefinition({
+      organizationId: null,
+      tenantId: null,
+      updatedAt: '2026-03-30T00:00:00.000Z',
+      validation: [{ rule: 'lte', param: 5, message: 'global <= 5' }],
+    })
+    const tenantDefinition = createDefinition({
+      organizationId: null,
+      tenantId: 'tenant-1',
+      updatedAt: '2026-03-31T00:00:00.000Z',
+      validation: [{ rule: 'lte', param: 4, message: 'tenant <= 4' }],
+    })
+    const orgDefinition = createDefinition({
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      updatedAt: '2026-03-29T00:00:00.000Z',
+      validation: [{ rule: 'lte', param: 3, message: 'org <= 3' }],
+    })
+    const em = {
+      find: jest.fn(async () => [globalDefinition, tenantDefinition, orgDefinition]),
+    } as unknown as EntityManager
+
+    const result = await validateCustomFieldValuesServer(em, {
+      entityId: 'example:todo',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      values: { priority: 4 },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.fieldErrors.cf_priority).toBe('org <= 3')
+  })
+})

--- a/packages/core/src/modules/entities/lib/validation.ts
+++ b/packages/core/src/modules/entities/lib/validation.ts
@@ -10,18 +10,46 @@ export async function validateCustomFieldValuesServer(
   const tenantId = opts.tenantId ?? null
   const defs = await em.find(CustomFieldDef, {
     entityId: opts.entityId,
-    organizationId: { $in: [organizationId, null] as any },
-    tenantId: { $in: [tenantId, null] as any },
     isActive: true,
-  })
-  // Prefer org/tenant scoped over global when duplicates
-  const seen = new Set<string>()
-  const ranked: typeof defs = [] as any
-  for (const d of defs) {
-    if (seen.has(d.key)) continue
-    seen.add(d.key)
-    ranked.push(d)
-  }
-  return validateValuesAgainstDefs(opts.values, ranked as any)
-}
+    deletedAt: null,
+    $and: [
+      {
+        $or: organizationId === null
+          ? [{ organizationId: null }]
+          : [{ organizationId }, { organizationId: null }],
+      },
+      {
+        $or: tenantId === null
+          ? [{ tenantId: null }]
+          : [{ tenantId }, { tenantId: null }],
+      },
+    ],
+  } as any)
 
+  // Prefer the most specific scope and newest definition for duplicate keys.
+  const scopeScore = (def: CustomFieldDef) => (def.tenantId ? 2 : 0) + (def.organizationId ? 1 : 0)
+  const byKey = new Map<string, CustomFieldDef>()
+  for (const d of defs) {
+    const existing = byKey.get(d.key)
+    if (!existing) {
+      byKey.set(d.key, d)
+      continue
+    }
+    const nextScore = scopeScore(d)
+    const existingScore = scopeScore(existing)
+    if (nextScore > existingScore) {
+      byKey.set(d.key, d)
+      continue
+    }
+    if (nextScore < existingScore) continue
+
+    const nextUpdatedAt = d.updatedAt instanceof Date ? d.updatedAt.getTime() : new Date(d.updatedAt).getTime()
+    const existingUpdatedAt = existing.updatedAt instanceof Date
+      ? existing.updatedAt.getTime()
+      : new Date(existing.updatedAt).getTime()
+    if (nextUpdatedAt >= existingUpdatedAt) {
+      byKey.set(d.key, d)
+    }
+  }
+  return validateValuesAgainstDefs(opts.values, Array.from(byKey.values()) as any)
+}

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -530,6 +530,18 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     [translateValidationMessage],
   )
 
+  const mapDefsForValidation = React.useCallback(
+    (definitions: CustomFieldDefDto[]): CustomFieldDefLike[] =>
+      definitions.map((definition) => ({
+        key: definition.key,
+        kind: definition.kind,
+        configJson: {
+          validation: Array.isArray(definition.validation) ? definition.validation : [],
+        },
+      })),
+    [],
+  )
+
   const canNavigateTo = React.useCallback(
     async (target: string): Promise<boolean> => {
       if (!extendedInjectionEventsEnabled) return true
@@ -1157,6 +1169,129 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     return new globalThis.Map(allFields.map((f) => [f.id, f]))
   }, [allFields])
 
+  const validateFieldOnBlur = React.useCallback(async (
+    fieldId: string,
+    sourceValues?: CrudFormValues<TValues>,
+  ) => {
+    if (formReadOnly) return
+    const field = fieldById.get(fieldId)
+    if (!field || field.disabled) return
+    if (hiddenInjectedFieldIds.has(fieldId)) return
+
+    const nextValues = sourceValues ?? valuesRef.current
+    const nextFieldErrors: Record<string, string> = {}
+    const requiredMessage = t('ui.forms.errors.required')
+    const value = nextValues[fieldId]
+    const isArray = Array.isArray(value)
+    const isString = typeof value === 'string'
+    const empty =
+      value === undefined ||
+      value === null ||
+      (isString && value.trim() === '') ||
+      (isArray && value.length === 0) ||
+      (field.type === 'checkbox' && value !== true)
+
+    if (field.required && empty) {
+      nextFieldErrors[fieldId] = requiredMessage
+    }
+
+    const customFieldKey = customEntity
+      ? cfDefinitions.some((definition) => definition.key === fieldId)
+        ? fieldId
+        : null
+      : fieldId.startsWith('cf_')
+        ? fieldId.replace(/^cf_/, '')
+        : null
+
+    if (!Object.keys(nextFieldErrors).length && customFieldKey) {
+      const defsForField = cfDefinitions.filter((definition) => definition.key === customFieldKey)
+      if (defsForField.length) {
+        try {
+          const { validateValuesAgainstDefs } = await import('@open-mercato/shared/modules/entities/validation')
+          const validationResult = validateValuesAgainstDefs(
+            { [customFieldKey]: value },
+            mapDefsForValidation(defsForField),
+          )
+          if (!validationResult.ok) {
+            const normalizedFieldErrors = customEntity
+              ? Object.fromEntries(
+                  Object.entries(validationResult.fieldErrors).map(([key, message]) => [
+                    key.replace(/^cf_/, ''),
+                    String(message),
+                  ]),
+                )
+              : Object.fromEntries(
+                  Object.entries(validationResult.fieldErrors).map(([key, message]) => [key, String(message)]),
+                )
+            const transformedErrors = await transformValidationErrors(normalizedFieldErrors)
+            Object.assign(nextFieldErrors, translateValidationErrors(transformedErrors))
+          }
+        } catch {
+          // ignore client-side custom field validation if helper is unavailable
+        }
+      }
+    }
+
+    if (!Object.keys(nextFieldErrors).length && schema) {
+      const widgetValues = { ...(nextValues as Record<string, unknown>) }
+      for (const hiddenId of hiddenInjectedFieldIds) {
+        delete widgetValues[hiddenId]
+      }
+      const coreValues = { ...widgetValues }
+      for (const injectedId of injectedFieldIdSet) {
+        delete coreValues[injectedId]
+      }
+      const result = schema.safeParse(coreValues)
+      if (!result.success) {
+        const schemaFieldErrors: Record<string, string> = {}
+        result.error.issues.forEach((issue) => {
+          const path = serializeIssuePath(issue.path)
+          if (!path) return
+          if (
+            path === fieldId ||
+            path.startsWith(`${fieldId}.`) ||
+            fieldId.startsWith(`${path}.`)
+          ) {
+            schemaFieldErrors[path] = issue.message
+          }
+        })
+        if (Object.keys(schemaFieldErrors).length) {
+          const transformedErrors = await transformValidationErrors(schemaFieldErrors)
+          Object.assign(nextFieldErrors, translateValidationErrors(transformedErrors))
+        }
+      }
+    }
+
+    setErrors((prev) => {
+      const next = Object.fromEntries(
+        Object.entries(prev).filter(([existingFieldId]) => !(
+          existingFieldId === fieldId ||
+          existingFieldId.startsWith(`${fieldId}.`) ||
+          fieldId.startsWith(`${existingFieldId}.`)
+        )),
+      )
+      for (const [key, message] of Object.entries(nextFieldErrors)) {
+        next[key] = message
+      }
+      const same =
+        Object.keys(next).length === Object.keys(prev).length &&
+        Object.entries(next).every(([key, message]) => prev[key] === message)
+      return same ? prev : next
+    })
+  }, [
+    cfDefinitions,
+    customEntity,
+    fieldById,
+    formReadOnly,
+    hiddenInjectedFieldIds,
+    injectedFieldIdSet,
+    mapDefsForValidation,
+    schema,
+    t,
+    transformValidationErrors,
+    translateValidationErrors,
+  ])
+
   const allFieldsRef = React.useRef(allFields)
   allFieldsRef.current = allFields
 
@@ -1393,6 +1528,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     setValues((prev) => {
       if (Object.is(prev[id], nextValue)) return prev
       nextData = { ...prev, [id]: nextValue } as CrudFormValues<TValues>
+      valuesRef.current = nextData
       return nextData
     })
     const clearedMessages: string[] = []
@@ -1600,8 +1736,9 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     // Custom fields validation via definitions (rules)
     if (resolvedEntityIds.length) {
       try {
-        const mod = await import('./utils/customFieldDefs')
-        const defs = await mod.fetchCustomFieldDefs(resolvedEntityIds)
+        const defs = cfDefinitions.length
+          ? cfDefinitions
+          : await import('./utils/customFieldDefs').then((mod) => mod.fetchCustomFieldDefs(resolvedEntityIds))
         const { validateValuesAgainstDefs } = await import('@open-mercato/shared/modules/entities/validation')
         // Build values keyed by def.key for validation
         const cfValues: Record<string, unknown> = {}
@@ -1616,7 +1753,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
             if (k.startsWith('cf_')) cfValues[k.replace(/^cf_/, '')] = v
           }
         }
-        const defsForValidation = defs as unknown as CustomFieldDefLike[]
+        const defsForValidation = mapDefsForValidation(defs)
         const result = validateValuesAgainstDefs(cfValues, defsForValidation)
         if (!result.ok) {
           if (customEntity) {
@@ -1964,6 +2101,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
               error={errors[f.id]}
               options={fieldOptionsById.get(f.id) || EMPTY_OPTIONS}
               setValue={setValue}
+              onBlurRequest={(fieldId) => { void validateFieldOnBlur(fieldId) }}
               values={values}
               loadFieldOptions={loadFieldOptions}
               autoFocus={!formReadOnly && Boolean(firstFieldId && f.id === firstFieldId)}
@@ -2396,6 +2534,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
                     error={errors[f.id]}
                     options={fieldOptionsById.get(f.id) || EMPTY_OPTIONS}
                     setValue={setValue}
+                    onBlurRequest={(fieldId) => { void validateFieldOnBlur(fieldId) }}
                     values={values}
                     loadFieldOptions={loadFieldOptions}
                     autoFocus={!formReadOnly && Boolean(firstFieldId && f.id === firstFieldId)}
@@ -2882,6 +3021,7 @@ type FieldControlProps = {
   error?: string
   options: CrudFieldOption[]
   setValue: (id: string, v: unknown) => void
+  onBlurRequest: (fieldId: string) => void
   values: Record<string, unknown>
   loadFieldOptions: (field: CrudField, query?: string) => Promise<CrudFieldOption[]>
   autoFocus: boolean
@@ -2889,6 +3029,17 @@ type FieldControlProps = {
   wrapperClassName?: string
   entityIdForField?: string
   recordId?: string
+}
+
+function supportsWrapperBlurValidation(field: CrudField): boolean {
+  return (
+    field.type === 'text' ||
+    field.type === 'password' ||
+    field.type === 'textarea' ||
+    field.type === 'checkbox' ||
+    field.type === 'select' ||
+    field.type === 'number'
+  )
 }
 
 type ListboxMultiSelectProps = {
@@ -2966,6 +3117,7 @@ const FieldControl = React.memo(function FieldControlImpl({
   error,
   options,
   setValue,
+  onBlurRequest,
   values,
   loadFieldOptions,
   autoFocus,
@@ -2996,9 +3148,20 @@ const FieldControl = React.memo(function FieldControlImpl({
 
   const placeholder = builtin?.placeholder
   const rootClassName = wrapperClassName ? `space-y-1 ${wrapperClassName}` : 'space-y-1'
+  const validateOnWrapperBlur = supportsWrapperBlurValidation(field)
 
   return (
-    <div className={rootClassName} data-crud-field-id={field.id}>
+    <div
+      className={rootClassName}
+      data-crud-field-id={field.id}
+      onBlur={validateOnWrapperBlur
+        ? (event) => {
+            const nextFocused = event.relatedTarget
+            if (nextFocused instanceof Node && event.currentTarget.contains(nextFocused)) return
+            onBlurRequest(field.id)
+          }
+        : undefined}
+    >
       {field.type !== 'checkbox' && field.label.trim().length > 0 ? (
         <label className="block text-sm font-medium">
           {field.label}

--- a/packages/ui/src/backend/__tests__/CrudForm.validation.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.validation.test.tsx
@@ -99,4 +99,56 @@ describe('CrudForm validation state', () => {
 
     expect(getByText('Use camelCase starting with a letter.')).toBeInTheDocument()
   })
+
+  it('validates number fields on blur', async () => {
+    const fields: CrudField[] = [
+      { id: 'title', label: 'Title', type: 'text' },
+      { id: 'cf_priority', label: 'Priority', type: 'number', required: true },
+    ]
+
+    const { container, findByText } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} onSubmit={() => {}} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.errors.required': 'This field is required',
+        },
+      },
+    )
+
+    const priorityInput = container.querySelector('[data-crud-field-id="cf_priority"] input[type="number"]')
+    expect(priorityInput).not.toBeNull()
+
+    await act(async () => {
+      fireEvent.blur(priorityInput as HTMLInputElement)
+    })
+
+    expect(await findByText('This field is required')).toBeInTheDocument()
+  })
+
+  it('does not validate date picker fields when the trigger blurs', async () => {
+    const fields: CrudField[] = [
+      { id: 'dueDate', label: 'Due date', type: 'datepicker', required: true },
+    ]
+
+    const { container, queryByText } = renderWithProviders(
+      <CrudForm title="Form" fields={fields} onSubmit={() => {}} />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'ui.forms.errors.required': 'This field is required',
+          'ui.datePicker.placeholder': 'Pick a date',
+        },
+      },
+    )
+
+    const trigger = container.querySelector('[data-crud-field-id="dueDate"] button')
+    expect(trigger).not.toBeNull()
+
+    await act(async () => {
+      fireEvent.blur(trigger as HTMLButtonElement)
+    })
+
+    expect(queryByText('This field is required')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes the todo create regression introduced around custom-field validation and blur-time validation. The change keeps client-side validation responsive on blur, avoids unsafe blur handling for portal-backed controls, and ensures the create flow still submits successfully after a user corrects an invalid priority value.

## Changes

- fixed server-side custom-field validation lookup so scoped and global definitions are resolved correctly
- limited wrapper blur validation to safe inline field types to avoid false validation while interacting with portal-based pickers
- reused already-loaded custom-field definitions during submit validation instead of refetching them during save
- added UI and integration regression coverage for:
  - invalid priority rejected by API
  - blur-time priority validation
  - correcting priority from `8` to `5` and successfully creating the todo

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A



## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
