### PR TITLE
 fix: enforce min/max constraints on custom field number inputs 

### DIFF
--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -128,6 +128,9 @@ export type CrudBuiltinField = CrudFieldBase & {
   suggestions?: string[]
   // for combobox fields; allow custom values or restrict to suggestions only
   allowCustomValues?: boolean
+  // for number fields; HTML min/max constraints
+  min?: number
+  max?: number
   // for datetime/time fields
   minuteStep?: number
   minDate?: Date
@@ -2726,12 +2729,16 @@ function NumberInput({
   placeholder,
   autoFocus,
   onSubmit,
+  min,
+  max,
 }: {
   value: number | string | null | undefined
   onChange: (v: number | undefined) => void
   placeholder?: string
   autoFocus?: boolean
   onSubmit?: () => void
+  min?: number
+  max?: number
 }) {
   const [local, setLocal] = React.useState<string>(value !== undefined && value !== null ? String(value) : '')
   const isFocusedRef = React.useRef(false)
@@ -2775,6 +2782,8 @@ function NumberInput({
       className="w-full h-9 rounded border px-2 text-sm"
       placeholder={placeholder}
       value={local}
+      min={min}
+      max={max}
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       onFocus={handleFocus}
@@ -3197,6 +3206,8 @@ const FieldControl = React.memo(function FieldControlImpl({
           onChange={fieldSetValue}
           autoFocus={autoFocusField}
           onSubmit={onSubmitRequest}
+          min={field.min}
+          max={field.max}
         />
       )}
       {field.type === 'date' && (

--- a/packages/ui/src/backend/__tests__/custom-field-forms.test.ts
+++ b/packages/ui/src/backend/__tests__/custom-field-forms.test.ts
@@ -51,4 +51,42 @@ describe('buildFormFieldsFromCustomFields', () => {
     }
     expect(byId['cf_hidden']).toBeUndefined()
   })
+
+  it('extracts min/max from gte/lte validation rules for number fields', () => {
+    const defs: CustomFieldDefDto[] = [
+      {
+        key: 'priority',
+        kind: 'integer',
+        filterable: true,
+        formEditable: true,
+        validation: [
+          { rule: 'required', message: 'Priority is required' },
+          { rule: 'integer', message: 'Priority must be an integer' },
+          { rule: 'gte', param: 1, message: 'Priority must be >= 1' },
+          { rule: 'lte', param: 5, message: 'Priority must be <= 5' },
+        ],
+      } as any,
+      {
+        key: 'score',
+        kind: 'float',
+        filterable: true,
+        formEditable: true,
+      } as any,
+    ]
+
+    const fields = buildFormFieldsFromCustomFields(defs)
+    const priority = fields.find(f => f.id === 'cf_priority')
+    expect(priority?.type).toBe('number')
+    if (priority?.type === 'number') {
+      expect(priority.min).toBe(1)
+      expect(priority.max).toBe(5)
+    }
+
+    const score = fields.find(f => f.id === 'cf_score')
+    expect(score?.type).toBe('number')
+    if (score?.type === 'number') {
+      expect(score.min).toBeUndefined()
+      expect(score.max).toBeUndefined()
+    }
+  })
 })

--- a/packages/ui/src/backend/utils/customFieldForms.ts
+++ b/packages/ui/src/backend/utils/customFieldForms.ts
@@ -73,8 +73,16 @@ export function buildFormFieldFromCustomFieldDef(
     case 'boolean':
       return { id, label, type: 'checkbox', description: def.description, required }
     case 'integer':
-    case 'float':
-      return { id, label, type: 'number', description: def.description, required }
+    case 'float': {
+      const rules: Array<{ rule: string; param?: number }> = Array.isArray((def as any).validation) ? (def as any).validation : []
+      let min: number | undefined
+      let max: number | undefined
+      for (const r of rules) {
+        if ((r.rule === 'gte' || r.rule === 'gt') && typeof r.param === 'number') min = r.param
+        if ((r.rule === 'lte' || r.rule === 'lt') && typeof r.param === 'number') max = r.param
+      }
+      return { id, label, type: 'number', description: def.description, required, min, max }
+    }
     case 'multiline': {
       let editor: 'simple' | 'uiw' | 'html' = 'uiw'
       if (def.editor === 'simpleMarkdown') editor = 'simple'


### PR DESCRIPTION
## Summary

The `priority` field on Todos accepted values outside the allowed range (1–5) because the frontend number input had no `min`/`max` constraints.

- Extract `gte`/`gt` and `lte`/`lt` validation rules from custom field definitions and map them to `min`/`max` props on number form fields
- Add `min`/`max` support to `CrudBuiltinField` type and the internal `NumberInput` component
- Apply `min`/`max` as HTML attributes on `<input type="number">`, enabling browser-native range validation

This is a generic fix — any custom field (not just `priority`) with numeric validation rules will now have input constraints enforced on the frontend.

## Changes

| File | Change |
|------|--------|
| `packages/ui/src/backend/CrudForm.tsx` | Added `min`/`max` to `CrudBuiltinField` type, `NumberInput` component, and field rendering |
| `packages/ui/src/backend/utils/customFieldForms.ts` | Extract `gte`/`lte`/`gt`/`lt` validation rules as `min`/`max` for `integer`/`float` fields |
| `packages/ui/src/backend/__tests__/custom-field-forms.test.ts` | Added test for min/max extraction from validation rules |

## Test plan

- [x] Unit test: `buildFormFieldsFromCustomFields` correctly extracts `min`/`max` from `gte`/`lte` rules
- [x] Unit test: fields without validation rules have `undefined` min/max
- [ ] Manual: go to `/backend/todos`, create a todo, verify the Priority input restricts values to 1–5
- [ ] Manual: try entering -1 or 8 in the Priority field — browser should show validation error on submit
- [ ] Manual: verify number spinner arrows respect the min/max bounds


## Linked issues

Fixes #1104
