### PR TITLE
fix(workflows): block private/internal URLs in CALL_WEBHOOK (SSRF prevention)

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -440,6 +440,7 @@ describe('Activity Executor (Unit Tests)', () => {
       ['http://[::1]/'],              // loopback
       ['http://[::1]:8080/path'],     // loopback with port
       ['http://[fe80::1]/'],          // link-local
+      ['http://[fe80::1%25eth0]/'],   // link-local with zone ID (URL-encoded %)
       ['http://[fc00::1]/'],          // unique local fc00::/7
       ['http://[fd12:3456:789a::1]/'],// unique local fd::/7
     ])('blocks IPv6 private address %s', (url) => {
@@ -463,6 +464,24 @@ describe('Activity Executor (Unit Tests)', () => {
       ['http://localhost:3000/'],
       ['http://foo.localhost/'],
     ])('blocks localhost hostname %s', (url) => {
+      expect(activityExecutor.isPrivateUrl(url)).toBe(true)
+    })
+
+    // 0.0.0.0/8 — Linux routes outbound TCP to loopback
+    test.each([
+      ['http://0.0.0.0/'],
+      ['http://0.1.2.3/'],
+      ['http://0.255.255.255/'],
+    ])('blocks 0.0.0.0/8 address %s', (url) => {
+      expect(activityExecutor.isPrivateUrl(url)).toBe(true)
+    })
+
+    // Trailing-dot localhost — WHATWG URL preserves trailing dot, must still be blocked
+    test.each([
+      ['http://localhost./'],
+      ['http://localhost.:3000/path'],
+      ['http://foo.localhost./'],
+    ])('blocks localhost with trailing dot %s', (url) => {
       expect(activityExecutor.isPrivateUrl(url)).toBe(true)
     })
 
@@ -691,6 +710,7 @@ describe('Activity Executor (Unit Tests)', () => {
       }
 
       const prev = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       try {
         process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = 'true'
 
@@ -706,8 +726,16 @@ describe('Activity Executor (Unit Tests)', () => {
           'http://10.255.255.1/health',
           expect.any(Object)
         )
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('SSRF protection is bypassed')
+        )
       } finally {
-        process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prev
+        warnSpy.mockRestore()
+        if (prev === undefined) {
+          delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prev
+        }
       }
     })
   })

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -17,6 +17,10 @@ import { createQueue, Queue } from '@open-mercato/queue'
 import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import { WorkflowActivityJob, WORKFLOW_ACTIVITIES_QUEUE_NAME } from './activity-queue-types'
 import { logWorkflowEvent } from './event-logger'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+import { isPrivateUrl } from '@open-mercato/shared/lib/network'
+
+export { isPrivateUrl } from '@open-mercato/shared/lib/network'
 
 // ============================================================================
 // Types and Interfaces
@@ -593,86 +597,6 @@ async function resolveDictionaryEntryId(
 }
 
 /**
- * Returns true if the dotted-decimal IPv4 string is in a private/internal range.
- * Covers RFC 1918, loopback (127/8), and link-local (169.254/16).
- */
-function isPrivateIPv4(ip: string): boolean {
-  const parts = ip.split('.').map(Number)
-  const [a, b] = parts
-  return (
-    a === 10 || // 10.0.0.0/8
-    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-    (a === 192 && b === 168) || // 192.168.0.0/16
-    a === 127 || // 127.0.0.0/8 loopback
-    (a === 169 && b === 254) // 169.254.0.0/16 link-local
-  )
-}
-
-/**
- * Returns true if the bare IPv6 address (brackets already stripped) is private.
- * Covers: loopback (::1), link-local (fe80::/10), unique local (fc00::/7),
- * and IPv4-mapped addresses (::ffff:<ipv4>) whose embedded IPv4 is private.
- */
-function isPrivateIPv6(addr: string): boolean {
-  const lower = addr.toLowerCase()
-
-  // Loopback ::1
-  if (lower === '::1') return true
-
-  // Link-local fe80::/10 — hex prefix fe8x through febx (bits 1111111010xxxxxx)
-  if (/^fe[89ab]/i.test(lower)) return true
-
-  // Unique local fc00::/7 — hex prefix fc or fd (bits 1111110x)
-  if (/^f[cd]/i.test(lower)) return true
-
-  // IPv4-mapped ::ffff:<dotted-decimal>  e.g. ::ffff:192.168.1.1
-  const mixedMatch = lower.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
-  if (mixedMatch) return isPrivateIPv4(mixedMatch[1])
-
-  // IPv4-mapped ::ffff:<hex16>:<hex16>  e.g. ::ffff:c0a8:0101 (= 192.168.1.1)
-  const hexMatch = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
-  if (hexMatch) {
-    const hi = parseInt(hexMatch[1].padStart(4, '0'), 16)
-    const lo = parseInt(hexMatch[2].padStart(4, '0'), 16)
-    return isPrivateIPv4(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`)
-  }
-
-  return false
-}
-
-/**
- * Returns true if the URL targets a private/internal host.
- * Covers IPv4 RFC 1918/loopback/link-local, IPv6 loopback/link-local/unique-local,
- * IPv4-mapped IPv6, and the localhost hostname family.
- * Does not perform DNS resolution — checks the literal host only.
- */
-export function isPrivateUrl(rawUrl: string): boolean {
-  let hostname: string
-  try {
-    hostname = new URL(rawUrl).hostname
-  } catch {
-    return false
-  }
-
-  // IPv6 — WHATWG URL includes brackets in hostname: [::1], [fc00::1], etc.
-  if (hostname.startsWith('[') && hostname.endsWith(']')) {
-    return isPrivateIPv6(hostname.slice(1, -1))
-  }
-
-  // IPv4 dotted-decimal
-  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(hostname)) {
-    return isPrivateIPv4(hostname)
-  }
-
-  // Loopback hostname
-  if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
-    return true
-  }
-
-  return false
-}
-
-/**
  * CALL_WEBHOOK activity handler
  *
  * Makes HTTP request to external URL
@@ -687,7 +611,10 @@ export async function executeCallWebhook(
     throw new Error('CALL_WEBHOOK requires "url" field')
   }
 
-  const allowPrivate = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS === 'true'
+  const allowPrivate = parseBooleanWithDefault(process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS, false)
+  if (allowPrivate) {
+    console.warn('[CALL_WEBHOOK] WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS is enabled — SSRF protection is bypassed')
+  }
   if (!allowPrivate && isPrivateUrl(url)) {
     throw new Error(
       `CALL_WEBHOOK blocked: "${url}" resolves to a private/internal address (SSRF prevention). Set WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS=true to allow.`

--- a/packages/shared/src/lib/network.ts
+++ b/packages/shared/src/lib/network.ts
@@ -1,0 +1,76 @@
+/**
+ * Network and URL security utilities.
+ */
+
+/**
+ * Returns true if the dotted-decimal IPv4 string is in a private/internal range.
+ * Covers RFC 1918, loopback (127/8), link-local (169.254/16), and 0.0.0.0/8
+ * (which the Linux kernel routes to loopback for outbound TCP connections).
+ */
+export function isPrivateIPv4(ip: string): boolean {
+    const parts = ip.split('.').map(Number)
+    const [a, b] = parts
+    return (
+        a === 0 ||
+        a === 10 ||
+        (a === 172 && b >= 16 && b <= 31) ||
+        (a === 192 && b === 168) ||
+        a === 127 ||
+        (a === 169 && b === 254)
+    )
+}
+
+/**
+ * Returns true if the bare IPv6 address (brackets already stripped) is private.
+ * Covers: loopback (::1), link-local (fe80::/10), unique local (fc00::/7),
+ * and IPv4-mapped addresses (::ffff:<ipv4>) whose embedded IPv4 is private.
+ */
+export function isPrivateIPv6(addr: string): boolean {
+    const lower = addr.toLowerCase()
+    if (lower === '::1') return true
+    if (/^fe[89ab]/i.test(lower)) return true
+    if (/^f[cd]/i.test(lower)) return true
+    const mixedMatch = lower.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
+    if (mixedMatch) return isPrivateIPv4(mixedMatch[1])
+    const hexMatch = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+    if (hexMatch) {
+        const hi = parseInt(hexMatch[1].padStart(4, '0'), 16)
+        const lo = parseInt(hexMatch[2].padStart(4, '0'), 16)
+        return isPrivateIPv4(`${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`)
+    }
+    return false
+}
+
+/**
+ * Returns true if the URL targets a private/internal host.
+ * Covers IPv4 RFC 1918/loopback/link-local/0.0.0.0, IPv6 loopback/link-local/unique-local,
+ * IPv4-mapped IPv6, and the localhost hostname family (including trailing-dot forms).
+ * Does not perform DNS resolution — checks the literal host only.
+ */
+export function isPrivateUrl(rawUrl: string): boolean {
+    // Strip IPv6 zone IDs before parsing — WHATWG URL rejects zone IDs in http/https
+    // (e.g. "http://[fe80::1%25eth0]/" → "http://[fe80::1]/").
+    // The underlying address is still private, so we strip and check to fail closed.
+    const urlToParse = rawUrl.replace(/\[([0-9a-fA-F:]+)%25[^\]]*\]/g, '[$1]')
+
+    let hostname: string
+    try {
+        hostname = new URL(urlToParse).hostname
+    } catch {
+        return false
+    }
+    // Normalize: strip trailing dot preserved by the WHATWG URL parser
+    // (e.g. "http://localhost./" parses to hostname "localhost.")
+    const host = hostname.replace(/\.$/, '')
+
+    if (host.startsWith('[') && host.endsWith(']')) {
+        return isPrivateIPv6(host.slice(1, -1))
+    }
+    if (/^(\d{1,3}\.){3}\d{1,3}$/.test(host)) {
+        return isPrivateIPv4(host)
+    }
+    if (host === 'localhost' || host.endsWith('.localhost')) {
+        return true
+    }
+    return false
+}


### PR DESCRIPTION
## Summary

- Add `isPrivateUrl()` to `activity-executor.ts` covering RFC 1918 ranges (`10/8`, `172.16-31/12`, `192.168/16`), loopback (`127/8`), link-local (`169.254/16`), and `localhost`
- `executeCallWebhook()` rejects private-URL targets by default with a descriptive error message
- Opt-out via `WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS=true` for environments where internal webhook targets are intentional (e.g. internal staging integrations)

## Security rationale

Before this fix, a workflow definition could include a `CALL_WEBHOOK` step targeting `http://169.254.169.254/latest/meta-data/` (AWS IMDS), `http://10.x.x.x/`, or any other server-internal address. Any user with workflow-edit access could reach infrastructure not intended to be externally reachable (SSRF).

The `CALL_API` activity already had SSRF protection (domain pinned to `APP_URL`); this brings `CALL_WEBHOOK` to parity.

## Test plan

- [ ] `should block private URLs by default` — confirms `10.255.255.1` is rejected without env var
- [ ] `should allow private URLs when WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS=true` — env saved in `const prev`, restored in `finally`; fetch mock called with exact URL
- [ ] Existing CALL_WEBHOOK tests against `https://example.com` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)