### PR TITLE
fix(runtime): preserve Redis URL semantics across queue and scheduler

### DIFF
--- a/packages/events/src/bridge.ts
+++ b/packages/events/src/bridge.ts
@@ -1,4 +1,5 @@
 import { Client, Pool } from 'pg'
+import { getSslConfig } from '@open-mercato/shared/lib/db/ssl'
 import type { EmitOptions, EventPayload } from './types'
 
 const BRIDGE_CHANNEL = 'om_event_bridge'
@@ -29,16 +30,33 @@ function getDatabaseUrl(): string | null {
   return value && value.length > 0 ? value : null
 }
 
+function getPgBridgeConnectionString(): string | null {
+  const connectionString = getDatabaseUrl()
+  if (!connectionString) return null
+
+  try {
+    const url = new URL(connectionString)
+    for (const key of ['sslmode', 'sslcert', 'sslkey', 'sslrootcert', 'sslcrl']) {
+      url.searchParams.delete(key)
+    }
+    return url.toString()
+  } catch {
+    return connectionString
+  }
+}
+
 function getPublisherPool(): InstanceType<typeof Pool> | null {
   if (publisherPool !== undefined) return publisherPool
-  const connectionString = getDatabaseUrl()
+  const connectionString = getPgBridgeConnectionString()
   if (!connectionString) {
     publisherPool = null
     return null
   }
+  const ssl = getSslConfig()
   publisherPool = new Pool({
     connectionString,
     max: 2,
+    ...(ssl ? { ssl } : {}),
   })
   return publisherPool
 }
@@ -83,11 +101,15 @@ function scheduleReconnect(): void {
 
 async function ensureCrossProcessListener(): Promise<void> {
   if (listenerClient || listenerConnectPromise || listeners.size === 0) return
-  const connectionString = getDatabaseUrl()
+  const connectionString = getPgBridgeConnectionString()
   if (!connectionString) return
 
   listenerConnectPromise = (async () => {
-    const client = new Client({ connectionString })
+    const ssl = getSslConfig()
+    const client = new Client({
+      connectionString,
+      ...(ssl ? { ssl } : {}),
+    })
 
     client.on('notification', (message: PgNotificationMessage) => {
       if (message.channel !== BRIDGE_CHANNEL || !message.payload) return

--- a/packages/queue/jest.config.cjs
+++ b/packages/queue/jest.config.cjs
@@ -17,4 +17,7 @@ module.exports = {
   },
   testMatch: ['<rootDir>/src/**/__tests__/**/*.test.(ts|tsx)'],
   passWithNoTests: true,
+  moduleNameMapper: {
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+  },
 }

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -48,5 +48,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@open-mercato/shared": "workspace:*"
   }
 }

--- a/packages/queue/src/__tests__/async.strategy.test.ts
+++ b/packages/queue/src/__tests__/async.strategy.test.ts
@@ -1,0 +1,121 @@
+import { createQueue } from '../factory'
+import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+
+const queueCtor = jest.fn()
+const workerCtor = jest.fn()
+const queueAdd = jest.fn(async () => ({ id: 'bull-job-id' }))
+const queueClose = jest.fn(async () => {})
+const queueObliterate = jest.fn(async () => {})
+const queueGetJobCounts = jest.fn(async () => ({
+  waiting: 2,
+  active: 1,
+  completed: 3,
+  failed: 4,
+}))
+const workerClose = jest.fn(async () => {})
+const workerOn = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/redis/connection', () => ({
+  getRedisUrl: jest.fn(),
+}))
+
+jest.mock('bullmq', () => {
+  class MockQueue<T> {
+    constructor(name: string, opts: unknown) {
+      queueCtor(name, opts)
+    }
+
+    add = queueAdd as unknown as (name: string, data: T, opts?: unknown) => Promise<{ id?: string }>
+    close = queueClose
+    obliterate = queueObliterate
+    getJobCounts = queueGetJobCounts
+  }
+
+  class MockWorker<T> {
+    constructor(
+      name: string,
+      processor: (job: { id?: string; data: T; attemptsMade: number }) => Promise<void>,
+      opts: unknown,
+    ) {
+      workerCtor(name, processor, opts)
+    }
+
+    on = workerOn
+    close = workerClose
+  }
+
+  return {
+    Queue: MockQueue,
+    Worker: MockWorker,
+  }
+})
+
+describe('Queue - async strategy', () => {
+  const getRedisUrlMock = getRedisUrl as jest.MockedFunction<typeof getRedisUrl>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getRedisUrlMock.mockReturnValue('rediss://default:secret@example.com:6380/1')
+  })
+
+  it('passes the full Redis URL to BullMQ when using env-based async config', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'async', {
+      concurrency: 3,
+    })
+
+    await queue.enqueue({ value: 42 })
+    await queue.process(async () => {})
+
+    expect(queueCtor).toHaveBeenCalledWith('test-queue', {
+      connection: { url: 'rediss://default:secret@example.com:6380/1' },
+    })
+    expect(workerCtor).toHaveBeenCalledWith(
+      'test-queue',
+      expect.any(Function),
+      {
+        connection: { url: 'rediss://default:secret@example.com:6380/1' },
+        concurrency: 3,
+      },
+    )
+  })
+
+  it('preserves an explicit Redis URL without converting it to host/port fields', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'async', {
+      connection: {
+        url: 'rediss://user:secret@example.com:6380/4?family=6',
+      },
+    })
+
+    await queue.enqueue({ value: 42 })
+
+    expect(queueCtor).toHaveBeenCalledWith('test-queue', {
+      connection: { url: 'rediss://user:secret@example.com:6380/4?family=6' },
+    })
+  })
+
+  it('keeps structured Redis options when host-based config is used', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'async', {
+      connection: {
+        host: 'redis.internal',
+        port: 6380,
+        username: 'default',
+        password: 'secret',
+        db: 6,
+        tls: {},
+      },
+    })
+
+    await queue.enqueue({ value: 42 })
+
+    expect(queueCtor).toHaveBeenCalledWith('test-queue', {
+      connection: {
+        host: 'redis.internal',
+        port: 6380,
+        username: 'default',
+        password: 'secret',
+        db: 6,
+        tls: {},
+      },
+    })
+  })
+})

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -1,9 +1,17 @@
 import type { Queue, QueuedJob, JobHandler, AsyncQueueOptions, ProcessResult, EnqueueOptions } from '../types'
-import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 
 // BullMQ interface types - we define the shape we use to maintain type safety
 // while keeping bullmq as an optional peer dependency
-type ConnectionOptions = { host?: string; port?: number; password?: string; db?: number }
+type ConnectionOptions = {
+  url?: string
+  host?: string
+  port?: number
+  username?: string
+  password?: string
+  db?: number
+  tls?: Record<string, never>
+}
 
 interface BullQueueInterface<T> {
   add: (
@@ -33,26 +41,27 @@ interface BullMQModule {
 /**
  * Resolves Redis connection options from various sources.
  *
- * BullMQ requires connection options as `{ host, port, password, db }` object.
- * It does NOT accept raw URL strings in `{ connection: string }` format.
+ * BullMQ expects an ioredis-compatible connection object. Preserve the full
+ * Redis URL under the `url` key so rediss://, username, database, and query
+ * params are not lost in translation.
  */
 function resolveConnection(options?: AsyncQueueOptions['connection']): ConnectionOptions {
-  // Priority: explicit options > shared env helper
   if (options?.url) {
-    return parseRedisUrl(options.url)
+    return { url: options.url }
   }
 
   if (options?.host) {
     return {
       host: options.host,
       port: options.port ?? 6379,
+      username: options.username,
       password: options.password,
+      db: options.db,
+      tls: options.tls,
     }
   }
 
-  // Delegate env var resolution to the shared helper
-  const url = getRedisUrl('QUEUE')
-  return parseRedisUrl(url)
+  return { url: getRedisUrl('QUEUE') }
 }
 
 /**

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -73,8 +73,14 @@ export type RedisConnectionOptions = {
   host?: string
   /** Redis port */
   port?: number
+  /** Redis username */
+  username?: string
   /** Redis password */
   password?: string
+  /** Redis database number */
+  db?: number
+  /** TLS configuration for rediss / encrypted Redis */
+  tls?: Record<string, never>
 }
 
 /**

--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-001.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-001.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+
+const isAsyncQueueStrategy = (process.env.QUEUE_STRATEGY || 'local') === 'async'
+
+type CreateScheduleResponse = { id?: string }
+type SchedulerListResponse = { items?: Array<{ id?: string }> }
+type SchedulerErrorResponse = { error?: string; message?: string; available?: boolean; items?: unknown[] }
+
+async function createSchedule(request: import('@playwright/test').APIRequestContext, token: string) {
+  const response = await apiRequest(request, 'POST', '/api/scheduler/jobs', {
+    token,
+    data: {
+      name: `Integration Scheduler ${Date.now()}`,
+      description: 'Runtime Redis URL integration probe',
+      scopeType: 'organization',
+      scheduleType: 'interval',
+      scheduleValue: '15m',
+      timezone: 'UTC',
+      targetType: 'queue',
+      targetQueue: 'scheduler-execution',
+      targetPayload: { source: 'integration-test' },
+      isEnabled: true,
+      sourceType: 'user',
+    },
+  })
+
+  expect(response.status()).toBe(201)
+  const body = (await response.json()) as CreateScheduleResponse
+  expect(body.id).toMatch(/^[0-9a-f-]{36}$/i)
+  return String(body.id)
+}
+
+test.describe('TC-SCHED-001: Scheduler runtime queue APIs', () => {
+  test('lists created schedules and exposes execution-history endpoint semantics', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    let scheduleId: string | null = null
+
+    try {
+      scheduleId = await createSchedule(request, token)
+
+      const listResponse = await apiRequest(request, 'GET', `/api/scheduler/jobs?id=${scheduleId}`, { token })
+      expect(listResponse.status()).toBe(200)
+      const listBody = (await listResponse.json()) as SchedulerListResponse
+      const ids = (listBody.items ?? []).map((item) => item.id)
+      expect(ids).toContain(scheduleId)
+
+      const executionsResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/scheduler/jobs/${scheduleId}/executions?pageSize=5`,
+        { token },
+      )
+
+      if (isAsyncQueueStrategy) {
+        expect(executionsResponse.status()).toBe(200)
+        const executionsBody = (await executionsResponse.json()) as { items?: unknown[]; total?: number; pageSize?: number }
+        expect(Array.isArray(executionsBody.items)).toBe(true)
+        expect(typeof executionsBody.total).toBe('number')
+        expect(executionsBody.pageSize).toBe(5)
+      } else {
+        expect(executionsResponse.status()).toBe(400)
+        const executionsBody = (await executionsResponse.json()) as SchedulerErrorResponse
+        expect(executionsBody.error ?? '').toMatch(/QUEUE_STRATEGY=async|Execution history requires/i)
+        expect(Array.isArray(executionsBody.items)).toBe(true)
+      }
+    } finally {
+      if (scheduleId) {
+        await apiRequest(request, 'DELETE', '/api/scheduler/jobs', {
+          token,
+          data: { id: scheduleId },
+        }).catch(() => null)
+      }
+    }
+  })
+
+  test('validates queue names and async-only queue job access', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+
+    const invalidQueueResponse = await apiRequest(
+      request,
+      'GET',
+      '/api/scheduler/queue-jobs/non-existent?queue=not-a-registered-queue',
+      { token },
+    )
+    expect(invalidQueueResponse.status()).toBe(400)
+    const invalidQueueBody = (await invalidQueueResponse.json()) as SchedulerErrorResponse
+    expect(invalidQueueBody.error ?? '').toMatch(/Invalid queue name/i)
+
+    const validQueueResponse = await apiRequest(
+      request,
+      'GET',
+      '/api/scheduler/queue-jobs/non-existent?queue=scheduler-execution',
+      { token },
+    )
+
+    if (isAsyncQueueStrategy) {
+      expect(validQueueResponse.status()).toBe(404)
+      const validQueueBody = (await validQueueResponse.json()) as SchedulerErrorResponse
+      expect(validQueueBody.error ?? '').toMatch(/Job not found/i)
+    } else {
+      expect(validQueueResponse.status()).toBe(400)
+      const validQueueBody = (await validQueueResponse.json()) as SchedulerErrorResponse
+      expect(validQueueBody.error ?? '').toMatch(/QUEUE_STRATEGY=async|BullMQ job logs are only available/i)
+      expect(validQueueBody.available).toBe(false)
+    }
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/api/jobs/[id]/executions/route.ts
+++ b/packages/scheduler/src/modules/scheduler/api/jobs/[id]/executions/route.ts
@@ -5,7 +5,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/core'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { ScheduledJob } from '../../../../data/entities.js'
-import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
 
@@ -77,7 +77,7 @@ export async function GET(
 
     // Fetch jobs from BullMQ scheduler-execution queue
     const { Queue } = await import('bullmq')
-    const queue = new Queue('scheduler-execution', { connection: parseRedisUrl(getRedisUrl('QUEUE')) })
+    const queue = new Queue('scheduler-execution', { connection: { url: getRedisUrl('QUEUE') } })
 
     try {
       // Validate query params with Zod schema

--- a/packages/scheduler/src/modules/scheduler/api/queue-jobs/[jobId]/route.ts
+++ b/packages/scheduler/src/modules/scheduler/api/queue-jobs/[jobId]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import { getModules } from '@open-mercato/shared/lib/modules/registry'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
@@ -69,7 +69,7 @@ export async function GET(
 
     // Fetch job from BullMQ
     const { Queue } = await import('bullmq')
-    const queue = new Queue(queueName, { connection: parseRedisUrl(getRedisUrl('QUEUE')) })
+    const queue = new Queue(queueName, { connection: { url: getRedisUrl('QUEUE') } })
 
     const job = await queue.getJob(jobId)
 

--- a/packages/scheduler/src/modules/scheduler/services/bullmqSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/bullmqSchedulerService.ts
@@ -3,7 +3,7 @@ import { ScheduledJob } from '../data/entities.js'
 import { recalculateNextRun } from '../lib/nextRunCalculator'
 import { parseCronExpression } from '../lib/cronParser'
 import { parseInterval } from '../lib/intervalParser'
-import { getRedisUrl, parseRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 
 interface BullRepeatableJob {
   key: string
@@ -55,7 +55,7 @@ export class BullMQSchedulerService {
     if (!this.queue) {
       try {
         const { Queue } = await import('bullmq')
-        this.queue = new Queue('scheduler-execution', { connection: parseRedisUrl(getRedisUrl('QUEUE')) })
+        this.queue = new Queue('scheduler-execution', { connection: { url: getRedisUrl('QUEUE') } })
       } catch {
         throw new Error('BullMQ is required for async scheduler. Install it with: npm install bullmq')
       }

--- a/packages/shared/src/lib/redis/__tests__/connection.test.ts
+++ b/packages/shared/src/lib/redis/__tests__/connection.test.ts
@@ -1,0 +1,23 @@
+import { parseRedisUrl } from '../connection'
+
+describe('parseRedisUrl', () => {
+  it('adds tls config for rediss URLs', () => {
+    expect(parseRedisUrl('rediss://:secret@example.cache.amazonaws.com:6379/2')).toEqual({
+      host: 'example.cache.amazonaws.com',
+      port: 6379,
+      password: 'secret',
+      db: 2,
+      tls: {},
+    })
+  })
+
+  it('keeps tls undefined for plain redis URLs', () => {
+    expect(parseRedisUrl('redis://:secret@localhost:6379/0')).toEqual({
+      host: 'localhost',
+      port: 6379,
+      password: 'secret',
+      db: 0,
+      tls: undefined,
+    })
+  })
+})

--- a/packages/shared/src/lib/redis/connection.ts
+++ b/packages/shared/src/lib/redis/connection.ts
@@ -15,6 +15,7 @@ export type ParsedRedisConnection = {
   port: number
   password?: string
   db?: number
+  tls?: Record<string, never>
 }
 
 /**
@@ -45,6 +46,7 @@ export function parseRedisUrl(url: string): ParsedRedisConnection {
       port: parseInt(parsed.port, 10) || 6379,
       password: parsed.password || undefined,
       db,
+      tls: parsed.protocol === 'rediss:' ? {} : undefined,
     }
   } catch {
     const safeUrl = url.replace(/\/\/[^:]*:[^@]*@/, '//<redacted>@')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5928,6 +5928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@open-mercato/queue@workspace:packages/queue"
   dependencies:
+    "@open-mercato/shared": "workspace:*"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^20.0.0"
     jest: "npm:^30.2.0"


### PR DESCRIPTION
## Summary

This PR fixes runtime connection handling so queue and scheduler BullMQ clients preserve the full Redis connection URL instead of reconstructing partial connection settings.

It also makes the PostgreSQL event bridge honor the existing DB SSL configuration.

The main goal is to avoid environment-specific runtime failures in hosted setups where Redis and Postgres connection behavior depends on URL-encoded settings such as:

- `rediss://`
- username / password
- database index
- query parameters
- provider-specific TLS options

## Track

- [x] `contrib/*` – intended to stay upstream-candidate friendly
- [ ] `fork/*` – intentionally fork-only
- [ ] `sync/*` – branch used only for sync or extraction work

## Changes

- preserve full Redis URL semantics in the async queue strategy
- align scheduler queue access with the same Redis connection handling
- make the PostgreSQL event bridge respect DB SSL configuration
- add focused unit coverage for queue / Redis connection handling
- add integration coverage for scheduler queue-runtime API behavior

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (small runtime fix, no spec needed)

**Spec file path:**
N/A

## Testing

Ran locally:

- `corepack yarn build:packages`
- `corepack yarn generate`
- `corepack yarn build:packages`
- `corepack yarn check:dep-versions`
- `corepack yarn i18n:check-sync`
- `corepack yarn i18n:check-usage`
- `corepack yarn typecheck`
- `corepack yarn test`
- `corepack yarn build:app`
- `corepack yarn mercato test:integration packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-001.spec.ts`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added integration coverage for the touched scheduler runtime API paths.
- [x] No fork-only AWS / deployment recovery changes are included.

## Upstreamability

- [x] This branch is rebased on the latest `develop`.
- [x] This change is isolated from fork-only history.
- [x] This change still makes sense without this fork's deployment, branding, or local business rules.
- [x] I checked `BACKWARD_COMPATIBILITY.md` for touched contract surfaces.
- [x] I ran the local quality gate relevant to this change.

## Linked issues

N/A
