### PR TITLE
fix: handle missing conditionExpression when creating business rules

### DIFF
--- a/packages/core/src/modules/business_rules/api/rules/route.ts
+++ b/packages/core/src/modules/business_rules/api/rules/route.ts
@@ -203,10 +203,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: `Validation failed: ${errors.join(', ')}` }, { status: 400 })
   }
 
-  const rule = em.create(BusinessRule, parsed.data)
-  await em.persistAndFlush(rule)
-
-  return NextResponse.json({ id: rule.id }, { status: 201 })
+  try {
+    const rule = em.create(BusinessRule, parsed.data)
+    await em.persistAndFlush(rule)
+    return NextResponse.json({ id: rule.id }, { status: 201 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to create rule'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
 }
 
 export async function PUT(req: Request) {
@@ -253,10 +257,14 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'Rule not found' }, { status: 404 })
   }
 
-  em.assign(rule, parsed.data)
-  await em.persistAndFlush(rule)
-
-  return NextResponse.json({ ok: true })
+  try {
+    em.assign(rule, parsed.data)
+    await em.persistAndFlush(rule)
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to update rule'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
 }
 
 export async function DELETE(req: Request) {

--- a/packages/core/src/modules/business_rules/backend/rules/[id]/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/rules/[id]/page.tsx
@@ -81,7 +81,7 @@ export default function EditBusinessRulePage() {
 
     if (!response.ok) {
       const error = await response.json()
-      throw new Error(error.message || t('business_rules.errors.updateFailed'))
+      throw new Error(error.error || error.message || t('business_rules.errors.updateFailed'))
     }
 
     router.push('/backend/rules')

--- a/packages/core/src/modules/business_rules/backend/rules/create/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/rules/create/page.tsx
@@ -51,7 +51,7 @@ export default function CreateBusinessRulePage() {
 
     if (!response.ok) {
       const error = await response.json()
-      throw new Error(error.message || t('business_rules.errors.createFailed'))
+      throw new Error(error.error || error.message || t('business_rules.errors.createFailed'))
     }
 
     const result = await response.json()

--- a/packages/core/src/modules/business_rules/backend/sets/[id]/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/sets/[id]/page.tsx
@@ -93,7 +93,7 @@ export default function EditRuleSetPage() {
 
     if (!response.ok) {
       const error = await response.json()
-      throw new Error(error.message || t('business_rules.sets.errors.updateFailed'))
+      throw new Error(error.error || error.message || t('business_rules.sets.errors.updateFailed'))
     }
 
     flash(t('business_rules.sets.messages.updated'), 'success')

--- a/packages/core/src/modules/business_rules/backend/sets/create/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/sets/create/page.tsx
@@ -41,7 +41,7 @@ export default function CreateRuleSetPage() {
 
     if (!response.ok) {
       const error = await response.json()
-      throw new Error(error.message || t('business_rules.sets.errors.createFailed'))
+      throw new Error(error.error || error.message || t('business_rules.sets.errors.createFailed'))
     }
 
     const result = await response.json()

--- a/packages/core/src/modules/business_rules/data/entities.ts
+++ b/packages/core/src/modules/business_rules/data/entities.ts
@@ -23,7 +23,7 @@ export type ExecutionResult = 'SUCCESS' | 'FAILURE' | 'ERROR'
 @Index({ name: 'business_rules_tenant_org_idx', properties: ['tenantId', 'organizationId'] })
 @Index({ name: 'business_rules_type_enabled_idx', properties: ['ruleType', 'enabled', 'priority'] })
 export class BusinessRule {
-  [OptionalProps]?: 'enabled' | 'priority' | 'version' | 'createdAt' | 'updatedAt' | 'deletedAt'
+  [OptionalProps]?: 'conditionExpression' | 'enabled' | 'priority' | 'version' | 'createdAt' | 'updatedAt' | 'deletedAt'
 
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -49,8 +49,8 @@ export class BusinessRule {
   @Property({ name: 'event_type', type: 'varchar', length: 50, nullable: true })
   eventType?: string | null
 
-  @Property({ name: 'condition_expression', type: 'jsonb' })
-  conditionExpression!: any
+  @Property({ name: 'condition_expression', type: 'jsonb', nullable: true })
+  conditionExpression?: any | null
 
   @Property({ name: 'success_actions', type: 'jsonb', nullable: true })
   successActions?: any | null

--- a/packages/core/src/modules/business_rules/data/validators.ts
+++ b/packages/core/src/modules/business_rules/data/validators.ts
@@ -141,7 +141,7 @@ const businessRuleBaseFields = {
 // Static schemas (without i18n — used for OpenAPI docs and non-route contexts)
 export const createBusinessRuleSchema = z.object({
   ...businessRuleBaseFields,
-  conditionExpression: conditionExpressionSchema,
+  conditionExpression: conditionExpressionSchema.optional().nullable(),
   successActions: actionsArraySchema,
   failureActions: actionsArraySchema,
 })
@@ -160,7 +160,7 @@ export function createLocalizedBusinessRuleSchema(t: TranslatorFn) {
   const actionsSchema = createActionsArraySchema(t)
   return z.object({
     ...businessRuleBaseFields,
-    conditionExpression: conditionSchema,
+    conditionExpression: conditionSchema.optional().nullable(),
     successActions: actionsSchema,
     failureActions: actionsSchema,
   })


### PR DESCRIPTION
## Summary

Creating a Business Rule without a `conditionExpression` resulted in a 500 Internal Server Error and an invalid JSON response on the frontend.

**Root cause:** The `conditionExpression` field was non-nullable in the database entity, but the Zod validator's `superRefine` silently allowed `null`/`undefined` to pass. When MikroORM tried to persist a null value to a NOT NULL column, it threw an unhandled exception — returning a raw 500 with no JSON body, which then caused `response.json()` to fail on the frontend.

## Changes

| File | Change |
|------|--------|
| `data/entities.ts` | Made `conditionExpression` nullable in the ORM entity |
| `data/validators.ts` | Added `.optional().nullable()` to `conditionExpression` in both static and localized create schemas |
| `api/rules/route.ts` | Wrapped `persistAndFlush` in try-catch for POST and PUT handlers to prevent unhandled 500s |
| `backend/rules/create/page.tsx` | Fixed error extraction: read `error.error` (API format) before `error.message` |
| `backend/rules/[id]/page.tsx` | Same error extraction fix |
| `backend/sets/create/page.tsx` | Same error extraction fix |
| `backend/sets/[id]/page.tsx` | Same error extraction fix |

## Migration note

The entity change (`conditionExpression` nullable) requires a database migration:
```bash
yarn db:generate   # generate migration
yarn db:migrate    # apply migration
```


## Linked issues

Fixes #1033 
