### PR TITLE
fix(ui): "Blocked" checkbox incorrectly placed inside Attachments section #1113

### DIFF
--- a/apps/mercato/src/modules/example/backend/todos/[id]/edit/page.tsx
+++ b/apps/mercato/src/modules/example/backend/todos/[id]/edit/page.tsx
@@ -34,10 +34,11 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
       placeholder: t('example.todos.form.fields.title.placeholder'),
     },
     { id: 'is_done', label: t('example.todos.form.fields.isDone.label'), type: 'checkbox' },
+    { id: 'cf_blocked', label: t('example.todos.table.column.blocked'), type: 'checkbox' },
   ], [t])
   const groups = React.useMemo<CrudFormGroup[]>(() => [
     { id: 'details', title: t('example.todos.form.groups.details'), column: 1, fields: ['title'] },
-    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done'] },
+    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done', 'cf_blocked'] },
     { id: 'attributes', title: t('example.todos.form.groups.attributes'), column: 1, kind: 'customFields' },
     {
       id: 'actions',

--- a/apps/mercato/src/modules/example/backend/todos/create/page.tsx
+++ b/apps/mercato/src/modules/example/backend/todos/create/page.tsx
@@ -16,10 +16,11 @@ export default function CreateTodoPage() {
       placeholder: t('example.todos.form.fields.title.placeholder'),
     },
     { id: 'is_done', label: t('example.todos.form.fields.isDone.label'), type: 'checkbox' },
+    { id: 'cf_blocked', label: t('example.todos.table.column.blocked'), type: 'checkbox' },
   ], [t])
   const groups = React.useMemo<CrudFormGroup[]>(() => [
     { id: 'details', title: t('example.todos.form.groups.details'), column: 1, fields: ['title'] },
-    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done'] },
+    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done', 'cf_blocked'] },
     { id: 'attributes', title: t('example.todos.form.groups.attributes'), column: 1, kind: 'customFields' },
     {
       id: 'tips',

--- a/packages/create-app/template/src/modules/example/backend/todos/[id]/edit/page.tsx
+++ b/packages/create-app/template/src/modules/example/backend/todos/[id]/edit/page.tsx
@@ -34,10 +34,11 @@ export default function EditTodoPage({ params }: { params?: { id?: string } }) {
       placeholder: t('example.todos.form.fields.title.placeholder'),
     },
     { id: 'is_done', label: t('example.todos.form.fields.isDone.label'), type: 'checkbox' },
+    { id: 'cf_blocked', label: t('example.todos.table.column.blocked'), type: 'checkbox' },
   ], [t])
   const groups = React.useMemo<CrudFormGroup[]>(() => [
     { id: 'details', title: t('example.todos.form.groups.details'), column: 1, fields: ['title'] },
-    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done'] },
+    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done', 'cf_blocked'] },
     { id: 'attributes', title: t('example.todos.form.groups.attributes'), column: 1, kind: 'customFields' },
     {
       id: 'actions',

--- a/packages/create-app/template/src/modules/example/backend/todos/create/page.tsx
+++ b/packages/create-app/template/src/modules/example/backend/todos/create/page.tsx
@@ -16,10 +16,11 @@ export default function CreateTodoPage() {
       placeholder: t('example.todos.form.fields.title.placeholder'),
     },
     { id: 'is_done', label: t('example.todos.form.fields.isDone.label'), type: 'checkbox' },
+    { id: 'cf_blocked', label: t('example.todos.table.column.blocked'), type: 'checkbox' },
   ], [t])
   const groups = React.useMemo<CrudFormGroup[]>(() => [
     { id: 'details', title: t('example.todos.form.groups.details'), column: 1, fields: ['title'] },
-    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done'] },
+    { id: 'status', title: t('example.todos.form.groups.status'), column: 2, fields: ['is_done', 'cf_blocked'] },
     { id: 'attributes', title: t('example.todos.form.groups.attributes'), column: 1, kind: 'customFields' },
     {
       id: 'tips',

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -1576,9 +1576,21 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     [injectionWidgets],
   )
 
+  const placedCustomFieldIds = React.useMemo(() => {
+    const placed = new Set<string>()
+    for (const other of (groups ?? [])) {
+      if (other.kind === 'customFields' || !other.fields) continue
+      for (const entry of other.fields) {
+        if (typeof entry === 'string') placed.add(entry)
+        else if (entry && typeof (entry as CrudField).id === 'string') placed.add((entry as CrudField).id)
+      }
+    }
+    return placed
+  }, [groups])
+
   const resolveGroupFields = React.useCallback((g: CrudFormGroup): CrudField[] => {
     if (g.kind === 'customFields') {
-      return cfFields
+      return cfFields.filter((f) => !placedCustomFieldIds.has(f.id))
     }
 
     const src = g.fields || []
@@ -1594,7 +1606,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     }
 
     return result
-  }, [cfFields, fieldById])
+  }, [cfFields, fieldById, placedCustomFieldIds])
 
   const customFieldsManageHref = React.useMemo(() => buildCustomFieldsManageHref(primaryEntityId), [buildCustomFieldsManageHref, primaryEntityId])
 
@@ -2452,6 +2464,10 @@ export function CrudForm<TValues extends Record<string, unknown>>({
               </div>
               {section.groups.map((group) => {
                 const groupKey = `${section.fieldsetCode ?? 'default'}:${group.code ?? 'default'}`
+                const visibleFields = placedCustomFieldIds.size > 0
+                  ? group.fields.filter((f) => !placedCustomFieldIds.has(f.id))
+                  : group.fields
+                if (!visibleFields.length) return null
                 return (
                   <div key={groupKey} className="space-y-2">
                     {group.label ? (
@@ -2464,7 +2480,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
                         ) : null}
                       </div>
                     ) : null}
-                    {renderFields(group.fields)}
+                    {renderFields(visibleFields)}
                   </div>
                 )
               })}
@@ -2494,6 +2510,7 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     handleFieldsetSelectionChange,
     handleOpenFieldsetEditor,
     manageFieldsetLabel,
+    placedCustomFieldIds,
     renderFields,
   ])
 


### PR DESCRIPTION
## Summary

The "Blocked" checkbox was appearing twice: once in the **Status** card (correct) and once inside the **Custom Attributes / Attachments** section (incorrect).

## Root Cause

`CrudForm` has two separate rendering paths for custom fields:

1. **`resolveGroupFields()`** — renders fields for explicit groups (e.g., the `status` group containing `cf_blocked`). This path already excluded custom fields placed in other groups.
2. **`renderCustomFieldsContent()`** — renders the `kind: 'customFields'` group. This path iterated over all custom field definitions from the server **without checking** whether a field was already placed in an explicit group.

When `cf_blocked` was explicitly placed in the `status` group AND returned by the server as a custom field definition, both paths rendered it — causing the duplicate.

## Changes

### Framework fix (`packages/ui/src/backend/CrudForm.tsx`)
- Extracted `placedCustomFieldIds` into a shared `useMemo` so both rendering paths can reference it
- Added filtering in `renderCustomFieldsContent()` to skip custom fields already placed in explicit groups
- Groups that become empty after filtering are skipped entirely

### Todo form pages (app + template)
- Added `cf_blocked` field to the `status` group in both create and edit pages
- Synced `packages/create-app/template/` pages with `apps/mercato/` pages

## Files Changed

- `packages/ui/src/backend/CrudForm.tsx`
- `apps/mercato/src/modules/example/backend/todos/create/page.tsx`
- `apps/mercato/src/modules/example/backend/todos/[id]/edit/page.tsx`
- `packages/create-app/template/src/modules/example/backend/todos/create/page.tsx`
- `packages/create-app/template/src/modules/example/backend/todos/[id]/edit/page.tsx`

## Testing

- TypeScript compilation passes (`tsc --noEmit`)
- "Blocked" checkbox now appears **only** in the Status card, no longer duplicated in Custom Attributes



## Linked issues

Fixes #1113 
