### PR TITLE
fix(cli): fix db:generate metadata leak and migration filename collision

### DIFF
--- a/packages/cli/src/lib/db/commands.ts
+++ b/packages/cli/src/lib/db/commands.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import ts from 'typescript'
-import { MikroORM, MetadataStorage, type Logger } from '@mikro-orm/core'
+import { MikroORM, type Logger } from '@mikro-orm/core'
 import { Migrator } from '@mikro-orm/migrations'
 import { PostgreSqlDriver } from '@mikro-orm/postgresql'
 import { getSslConfig } from '@open-mercato/shared/lib/db/ssl'
@@ -217,14 +217,18 @@ export async function dbGenerate(resolver: PackageResolver, options: DbOptions =
   const ordered = sortModules(modules)
   const results: string[] = []
 
+  const moduleClasses = new Map<string, any[]>()
   for (const entry of ordered) {
-    // Clear global metadata registry to prevent decorator side effects from
-    // previously loaded modules leaking into this module's migration generation.
-    MetadataStorage.clear()
+    moduleClasses.set(entry.id, await loadModuleEntities(entry, resolver))
+  }
 
+  const sslConfig = getSslConfig()
+  const usedFileNames = new Set<string>()
+
+  for (const entry of ordered) {
     const modId = entry.id
     const sanitizedModId = sanitizeModuleId(modId)
-    const entities = await loadModuleEntities(entry, resolver)
+    const entities = moduleClasses.get(modId) ?? []
     if (!entities.length) {
       if (entry.from === '@app') {
         results.push(formatResult(modId, 'no entities discovered', ''))
@@ -238,7 +242,6 @@ export async function dbGenerate(resolver: PackageResolver, options: DbOptions =
     const tableName = `mikro_orm_migrations_${sanitizedModId}`
     validateTableName(tableName)
 
-    const sslConfig = getSslConfig()
     const orm = await MikroORM.init<PostgreSqlDriver>({
       driver: PostgreSqlDriver,
       clientUrl: getClientUrl(),
@@ -269,36 +272,44 @@ export async function dbGenerate(resolver: PackageResolver, options: DbOptions =
       } : undefined,
     })
 
-    const migrator = orm.getMigrator() as Migrator
-    const diff = await migrator.createMigration()
-    if (diff && diff.fileName) {
-      try {
-        const orig = diff.fileName
-        const base = path.basename(orig)
-        const dir = path.dirname(orig)
-        const ext = path.extname(base)
-        const stem = base.replace(ext, '')
-        const suffix = `_${modId}`
-        const newBase = stem.endsWith(suffix) ? base : `${stem}${suffix}${ext}`
-        const newPath = path.join(dir, newBase)
-        let content = fs.readFileSync(orig, 'utf8')
-        content = makeConstraintDropsIdempotent(content)
-        // Rename class to ensure uniqueness as well
-        content = content.replace(
-          /export class (Migration\d+)/,
-          `export class $1_${modId.replace(/[^a-zA-Z0-9]/g, '_')}`
-        )
-        fs.writeFileSync(newPath, content, 'utf8')
-        if (newPath !== orig) fs.unlinkSync(orig)
-        results.push(formatResult(modId, `generated ${newBase}`, ''))
-      } catch {
-        results.push(formatResult(modId, `generated ${path.basename(diff.fileName)} (rename failed)`, ''))
-      }
-    } else {
-      results.push(formatResult(modId, 'no changes', ''))
-    }
+    try {
+      const diff = await orm.getMigrator().createMigration()
+      if (diff && diff.fileName) {
+        try {
+          const orig = diff.fileName
+          const base = path.basename(orig)
+          const dir = path.dirname(orig)
+          const ext = path.extname(base)
+          const stem = base.replace(ext, '')
+          const suffix = `_${modId}`
+          let candidate = stem.endsWith(suffix) ? base : `${stem}${suffix}${ext}`
+          let dedupe = 1
 
-    await orm.close(true)
+          while (usedFileNames.has(path.join(dir, candidate))) {
+            candidate = `${stem}${suffix}_${dedupe++}${ext}`
+          }
+
+          const newPath = path.join(dir, candidate)
+          let content = fs.readFileSync(orig, 'utf8')
+          content = makeConstraintDropsIdempotent(content)
+          content = content.replace(
+            /export class (Migration\d+)/,
+            `export class $1_${modId.replace(/[^a-zA-Z0-9]/g, '_')}`
+          )
+          fs.writeFileSync(newPath, content, 'utf8')
+          if (newPath !== orig) fs.unlinkSync(orig)
+          usedFileNames.add(newPath)
+          results.push(formatResult(modId, `generated ${path.basename(newPath)}`, ''))
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          results.push(formatResult(modId, `generated ${path.basename(diff.fileName)} (rename failed: ${message})`, ''))
+        }
+      } else {
+        results.push(formatResult(modId, 'no changes', ''))
+      }
+    } finally {
+      await orm.close(true)
+    }
   }
 
   console.log(results.join('\n'))


### PR DESCRIPTION
## Problem

Komenda yarn db:generate wysypywała się z błędem:

```
Only abstract entities were discovered, maybe you forgot to use @Entity() decorator? This can also happen when you have multiple @mikro-orm/core packages installed side by side.
```

...mimo że na dysku była tylko jedna fizyczna kopia @mikro-orm/core, a wszystkie encje miały poprawnie ustawione dekoratory.

## Przyczyna

dbGenerate wywoływało MetadataStorage.clear() na początku każdej iteracji, a potem reimportowało moduł:
```
for (const entry of ordered) {
  MetadataStorage.clear()                          // czyści wszystkie metadane
  const entities = await loadModuleEntities(...)   // reimport → trafienie w cache ESM
  const orm = await MikroORM.init({ entities })    // dostaje "gołe", niedekorowane klasy
}
```

To podejście jest zepsute w ESM. Bootstrap CLI (przez bootstrapFromAppRoot) importuje i wykonuje kilka modułów z encjami z @open-mercato/core jeszcze zanim dbGenerate w ogóle ruszy — ich dekoratory @Entity() odpalają się raz i rejestrują metadane w MetadataStorage.

Kiedy dbGenerate później woła MetadataStorage.clear(), a następnie await import(tenSamyModul), Node zwraca zbuforowany obiekt modułu bez ponownego wykonywania jego kodu. Dekoratory już się nie odpalają.

MikroORM dostaje konstruktory klas bez żadnych powiązanych metadanych i zgłasza je jako abstrakcyjne.
W praktyce dotknięty moduł to entities (custom fields) z @open-mercato/core — pierwszy w posortowanej kolejności moduł, który bootstrap wczytuje — co sprawiło, że błąd wyglądał na ogólny, a nie związany z konkretnym modułem.

## Zmiany

dbGenerate zostało podzielone na dwie wyraźne fazy, które respektują semantykę cache'u modułów ESM:

Faza 1 — jednorazowy load. Wszystkie moduły z encjami są importowane z góry, w jednym przebiegu, zanim cokolwiek wywoła MikroORM.init. MetadataStorage jest pozostawiony sam sobie i naturalnie akumuluje dane — to co zarejestrował bootstrap już tam jest, a nowo importowane moduły tylko dopisują swoje. clear() zniknęło całkowicie.

Faza 2 — inicjalizacja per moduł. Dla każdego modułu MikroORM.init jest wywoływane z jawną listą entities: [...] tylko dla tego modułu. Discovery MikroORMa przechodzi wyłącznie po podanych klasach, dzięki czemu zawartość MetadataStorage z innych modułów nie zatruwa diffa schematu. (To opiera się na istniejącej konwencji projektu zakładającej brak relacji ORM między modułami.)

Dodatkowo: poprzednia logika zmiany nazw używała zwykłego endsWith(suffix) i nie miała żadnego zabezpieczenia przed duplikatami. Gdy kilka modułów generuje migracje w tej samej sekundzie (ten sam prefiks z timestampem), wszystkie próbowały zapisać ten sam plik, a drugi zapis po cichu nadpisywał pierwszy. Ten PR dodaje Set o nazwie usedFileNames z pętlą dodającą numeryczny sufiks (_1, _2, ...), żeby zagwarantować unikalne ścieżki wyjściowe w ramach jednego uruchomienia db:generate.