### PR TITLE
feat(cli): add seed:defaults command for existing databases (#1099)

### DIFF
--- a/apps/mercato/package.json
+++ b/apps/mercato/package.json
@@ -17,7 +17,8 @@
     "db:migrate": "mercato db migrate",
     "db:greenfield": "mercato db greenfield",
     "initialize": "mercato init",
-    "reinstall": "mercato init --reinstall"
+    "reinstall": "mercato init --reinstall",
+    "seed:defaults": "mercato seed:defaults"
   },
   "engines": {
     "node": "24.x"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "db:migrate": "turbo run db:migrate --filter=@open-mercato/app",
     "db:greenfield": "turbo run db:greenfield --filter=@open-mercato/app",
     "initialize": "turbo run initialize --filter=@open-mercato/app",
+    "seed:defaults": "yarn workspace @open-mercato/app seed:defaults",
     "docker:up": "docker compose -f docker-compose.fullapp.yml up --build -d",
     "docker:down": "docker compose -f docker-compose.fullapp.yml down",
     "docker:dev:up": "docker compose -f docker-compose.fullapp.dev.yml up --build -d",

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -872,6 +872,68 @@ export async function run(argv = process.argv) {
     return 0
   }
 
+  if (first === 'seed:defaults') {
+    await ensureEnvLoaded()
+    const moduleFilter = parts.includes('--module') ? parts[parts.indexOf('--module') + 1] : null
+
+    try {
+      const [{ bootstrapFromAppRoot }, { createResolver }] = await Promise.all([
+        import('@open-mercato/shared/lib/bootstrap/dynamicLoader'),
+        import('./lib/resolver'),
+      ])
+      const resolver = createResolver()
+      const data = await bootstrapFromAppRoot(resolver.getAppDir())
+      registerCliModules(data.modules)
+      const allModules = data.modules
+
+      const modulesToSeed = moduleFilter
+        ? allModules.filter((mod) => mod.id === moduleFilter)
+        : allModules
+
+      if (moduleFilter && modulesToSeed.length === 0) {
+        console.error(`❌ Module "${moduleFilter}" not found.`)
+        return 1
+      }
+
+      const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+      const seedContainer = await createRequestContainer()
+      const seedEm = seedContainer.resolve('em') as any
+
+      const { Organization } = await import('@open-mercato/core/modules/directory/data/entities')
+      const orgs = await seedEm.find(Organization, { deletedAt: null }, { populate: ['tenant'] as const })
+
+      if (orgs.length === 0) {
+        console.error('❌ No organizations found. Run yarn initialize first.')
+        return 1
+      }
+
+      console.log(`📚 Running seed:defaults for ${orgs.length} org(s)...\n`)
+      for (const org of orgs) {
+        const tenantId = String(org.tenant.id)
+        const organizationId = String(org.id)
+        const seedCtx = { em: seedEm, tenantId, organizationId, container: seedContainer }
+
+        console.log(`  🏢 org=${organizationId} tenant=${tenantId}`)
+        for (const mod of modulesToSeed) {
+          if (mod.setup?.seedDefaults) {
+            console.log(`    📦 ${mod.id}...`)
+            await mod.setup.seedDefaults(seedCtx)
+          }
+        }
+
+        const { ensureCustomRoleAcls } = await import('@open-mercato/core/modules/auth/lib/setup-app')
+        await ensureCustomRoleAcls(seedEm, tenantId, allModules)
+      }
+
+      console.log('\n✅ seed:defaults complete.')
+      return 0
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      console.error(`❌ seed:defaults failed: ${message}`)
+      return 1
+    }
+  }
+
   let modName = first
   let cmdName = second
   let rest = remaining

--- a/turbo.json
+++ b/turbo.json
@@ -60,6 +60,10 @@
     "initialize": {
       "cache": false,
       "outputs": []
+    },
+    "seed:defaults": {
+      "cache": false,
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `mercato seed:defaults` CLI command that re-runs all module `seedDefaults` without the "users exist" guard that blocks `yarn initialize`
- Iterates every registered module with a `seedDefaults` in its `ModuleSetupConfig` across all tenant/org pairs
- Supports `--module <id>` flag to target a single module
- Wires `yarn seed:defaults` shortcut in root and app `package.json`, with a no-cache Turbo pipeline entry

## Motivation

When new seeders are added to modules after a database is already initialized, those seeders never execute on existing databases. The only escape hatches were `--reinstall` (destroys all data) or per-module CLI commands requiring manual tenant/org IDs. This command closes that gap — since all seeders are already idempotent, re-running them is always safe.

Fixes #1099.

## Usage

```bash
yarn seed:defaults                        # re-seed all modules across all orgs
yarn seed:defaults --module currencies    # single module only