### PR TITLE
fix #902: keep product list actions column visible without horizontal scroll

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/products/__tests__/ProductsDataTable.test.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/__tests__/ProductsDataTable.test.tsx
@@ -28,6 +28,7 @@ jest.mock('@open-mercato/ui/backend/DataTable', () => ({
     <div data-testid="data-table-mock">
       <div data-testid="data-table-title">{props.title}</div>
       <div data-testid="data-table-cache-status">{props.pagination?.cacheStatus ?? ''}</div>
+      <div data-testid="data-table-sticky-actions">{String(Boolean(props.stickyActionsColumn))}</div>
       <button data-testid="search-trigger" onClick={() => props.onSearchChange?.('widgets')}>
         trigger-search
       </button>
@@ -153,6 +154,7 @@ describe('ProductsDataTable', () => {
       expect(screen.getByTestId('data-table-cache-status')).toHaveTextContent('hit')
     })
     expect(screen.getByTestId('data-table-title')).toHaveTextContent('Products & services')
+    expect(screen.getByTestId('data-table-sticky-actions')).toHaveTextContent('true')
     expect((apiCall as jest.Mock).mock.calls[0][0]).toContain('/api/catalog/products?page=1&pageSize=25')
     expect(applyCustomFieldVisibility).toHaveBeenCalled()
   })

--- a/packages/core/src/modules/catalog/components/products/ProductsDataTable.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductsDataTable.tsx
@@ -661,6 +661,7 @@ export default function ProductsDataTable() {
         exporter={exportConfig}
         isLoading={isLoading}
         perspective={{ tableId: 'catalog.products.list' }}
+        stickyActionsColumn
         rowActions={(row) => (
           <RowActions
             items={[

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -62,6 +62,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { cn } from '@open-mercato/shared/lib/utils'
 
 let refreshScheduled = false
 
@@ -223,6 +224,7 @@ export type DataTableProps<T> = {
   injectionContext?: Record<string, unknown>
   replacementHandle?: string
   stickyFirstColumn?: boolean
+  stickyActionsColumn?: boolean
   virtualized?: boolean
   virtualizedMaxHeight?: number | string
   virtualizedOverscan?: number
@@ -755,6 +757,7 @@ export function DataTable<T>({
   injectionContext,
   replacementHandle,
   stickyFirstColumn = false,
+  stickyActionsColumn = false,
   virtualized = false,
   virtualizedMaxHeight,
   virtualizedOverscan = 10,
@@ -2318,7 +2321,12 @@ export function DataTable<T>({
                   )
                 })}
                 {rowActions || injectedRowActions.length > 0 ? (
-                  <TableHead className="w-0 text-right">
+                  <TableHead
+                    className={cn(
+                      'w-0 text-right',
+                      stickyActionsColumn && 'sticky right-0 z-20 bg-background',
+                    )}
+                  >
                     {t('ui.dataTable.actionsColumn', 'Actions')}
                   </TableHead>
                 ) : null}
@@ -2438,7 +2446,13 @@ export function DataTable<T>({
                       )
                     })}
                     {rowActions || injectedRowActions.length > 0 ? (
-                      <TableCell className="text-right whitespace-nowrap" data-actions-cell>
+                      <TableCell
+                        className={cn(
+                          'text-right whitespace-nowrap',
+                          stickyActionsColumn && 'sticky right-0 z-10 bg-background',
+                        )}
+                        data-actions-cell
+                      >
                         {rowActionsElement}
                       </TableCell>
                     ) : null}


### PR DESCRIPTION
Closes #902

## Summary

This MR keeps the actions column visible on the products list page, so users can access `Edit` and `Delete` without horizontal scrolling.

## Changes

- added an opt-in `stickyActionsColumn` prop to the shared `DataTable`
- enabled `stickyActionsColumn` for `/backend/catalog/products`
- kept the existing shared `RowActions` menu pattern unchanged
- added focused test coverage for the products table configuration

## Problem

On wide product tables, the actions column was rendered at the far right and could move out of the visible area. That made the delete action easy to miss.

## Solution

The shared `DataTable` now supports pinning the actions column to the right edge when explicitly enabled. The products list opts into that behavior.

## Scope / BC

- additive shared UI change
- no behavior change for existing tables unless they opt in
- no API or data contract changes

## Verification

- verified with focused Jest test:
  `yarn jest packages/core/src/modules/catalog/backend/catalog/products/__tests__/ProductsDataTable.test.tsx --runInBand`
- negative check performed:
  temporarily removed `stickyActionsColumn` from the products page, confirmed the focused test failed, then restored the change and confirmed the suite passed again

## Follow-up

Should we create a separate issue to roll this pattern out more broadly across analogous list views where the actions column can scroll out of view?