### PR TITLE
fix(docs): correct outdated statements in README files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,8 @@ We’re excited to collaborate with folks building on top of Open Mercato. This 
 
 Before implementing new features or making significant changes, check for an existing spec in `.ai/specs/`:
 
-1. **Check for a spec**: Look for specs named `SPEC-###-YYYY-MM-DD-{title}.md` related to your feature
-2. **Create or update**: If no spec exists, create one following the naming convention `SPEC-{next-number}-{YYYY-MM-DD}-{title}.md`; if it does, update it with your changes
+1. **Check for a spec**: Look for specs named `{YYYY-MM-DD}-{title}.md` related to your feature
+2. **Create or update**: If no spec exists, create one following the naming convention `{YYYY-MM-DD}-{title}.md`; if it does, update it with your changes
 3. **Maintain the changelog**: Add a dated entry summarizing your changes
 4. **Update the directory**: Add new specs to the table in [`.ai/specs/README.md`](.ai/specs/README.md)
 

--- a/README.md
+++ b/README.md
@@ -499,11 +499,11 @@ Open Mercato follows a **spec-first development approach**. Before implementing 
 
 ### How It Works
 
-1. **Before coding**: Check if a spec exists in `.ai/specs/` (named `SPEC-###-YYYY-MM-DD-title.md`)
+1. **Before coding**: Check if a spec exists in `.ai/specs/` (named `{YYYY-MM-DD}-{title}.md`)
 2. **New features**: Create or update the spec with your design before implementation
 3. **After changes**: Update the spec's changelog with a dated summary
 
-**Naming convention**: Specs use the format `SPEC-{number}-{date}-{title}.md` (e.g., `SPEC-007-2026-01-26-sidebar-reorganization.md`)
+**Naming convention**: Specs use the format `{YYYY-MM-DD}-{title}.md` (e.g., `2026-01-26-sidebar-reorganization.md`)
 
 See [`.ai/specs/README.md`](.ai/specs/README.md) for the full specification directory and [`.ai/specs/AGENTS.md`](.ai/specs/AGENTS.md) for detailed guidelines on maintaining specs.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,7 +38,7 @@ docker compose restart
 
 ## Services
 
-- **PostgreSQL 15** with pgvector extension (port 5432)
+- **PostgreSQL 17** with pgvector extension (port 5432)
 - **Redis 7** for caching and event persistence (port 6379)
 
 ## Database Initialization

--- a/packages/ai-assistant/README.md
+++ b/packages/ai-assistant/README.md
@@ -13,7 +13,7 @@ AI-powered chat and tool execution for Open Mercato, using MCP (Model Context Pr
 
 ### Prerequisites
 
-- Node.js 20+
+- Node.js 24+
 - Docker (for OpenCode)
 - An LLM API key (Anthropic, OpenAI, or Google)
 - An Open Mercato API key (created via Backend > Settings > API Keys)

--- a/packages/create-app/agentic/shared/ai/skills/spec-writing/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/spec-writing/SKILL.md
@@ -10,7 +10,7 @@ Design and review specifications (SPECs) against Open Mercato architecture and q
 ## Workflow
 
 1. **Load Context**: Read `AGENTS.md` for module conventions and `.ai/specs/` for existing specs.
-2. **Initialize**: Create `SPEC-{number}-{date}-{title}.md` in `.ai/specs/`.
+2. **Initialize**: Create `{date}-{title}.md` in `.ai/specs/`.
 3. **Start Minimal**: Write a Skeleton Spec (TLDR + 2-3 key sections). Do NOT write the full spec in one pass.
    - Scan for **critical unknowns** — decisions that block data model, scope, or architecture.
    - If unknowns exist, add a numbered **Open Questions** block (`Q1`, `Q2`, …) after the TLDR.

--- a/packages/create-app/agentic/shared/ai/skills/spec-writing/references/spec-template.md
+++ b/packages/create-app/agentic/shared/ai/skills/spec-writing/references/spec-template.md
@@ -1,4 +1,4 @@
-# SPEC-{number} — {Title}
+# {Title}
 
 **Date**: {YYYY-MM-DD}
 **Status**: Draft

--- a/packages/create-app/agentic/shared/ai/specs/README.md
+++ b/packages/create-app/agentic/shared/ai/specs/README.md
@@ -16,8 +16,8 @@ it's almost certainly an app-level decision.
 
 ## Naming convention
 
-SPEC-{number}-{YYYY-MM-DD}-{slug}.md
-Example: SPEC-001-2026-03-01-inventory-module.md
+{YYYY-MM-DD}-{slug}.md
+Example: 2026-03-01-inventory-module.md
 
 ## Workflow
 

--- a/packages/create-app/agentic/shared/ai/specs/SPEC-000-template.md
+++ b/packages/create-app/agentic/shared/ai/specs/SPEC-000-template.md
@@ -1,4 +1,4 @@
-# SPEC-{number} — {Title}
+# {Title}
 
 **Date**: {YYYY-MM-DD}
 **Status**: Draft


### PR DESCRIPTION
## Summary
- Correct spec file naming convention from legacy SPEC-{number}-{date}
  format to current {YYYY-MM-DD}-{title}.md format across README.md,
  CONTRIBUTING.md, and create-app templates
- Fix Node.js version from "20+" to "24+" in AI Assistant README
- Fix PostgreSQL version from "15" to "17" in docker README

## Context
Several README files contain outdated statements that no longer reflect
the current state of the project. These fixes correct factual
inaccuracies in documentation that could mislead contributors and users.

## Test plan
- [ ] Spec naming matches the format used by all recent specs in .ai/specs/
- [ ] Node.js version matches the version required to run the project
- [ ] PostgreSQL version matches the image used in docker-compose.yml
- [ ] No broken markdown links or formatting issues