### PR TITLE
README getting-started grammar: 'a quickest way'

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Architecture in two lines: Vault/KMS (or a derived-key fallback) issues per-tena
 ## Getting Started
 
 
-This is a quickest way to get Open Mercato up and running on your localhost / server - ready for testing / demoing or for `Core development`!
+This is the quickest way to get Open Mercato up and running on your localhost / server - ready for testing / demoing or for `Core development`!
 
 <table>
   <tr>


### PR DESCRIPTION
Source: Repository signal — README getting-started grammar: 'a quickest way'
## Problem Summary
README getting-started grammar: 'a quickest way'
## Expected Behavior
README.md Getting Started section says 'This is a quickest way...' and should read 'This is the quickest way...'.
## Actual Behavior
Current repository state does not satisfy the contribution target.
## What Changed
- README.md
- Diff summary: +1 / -1 (2 total lines)
- Branch head: 1074e0b8c6c22e650e92224b4502256fd84af8f3
## Validation / Tests
- docs-basic
## Expected Contribution Classes
- docs