### PR TITLE
Fix organization tenant selection and switcher refresh for issue #959

### DIFF
--- a/apps/mercato/src/components/OrganizationSwitcher.tsx
+++ b/apps/mercato/src/components/OrganizationSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client"
 import * as React from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { emitOrganizationScopeChanged } from '@open-mercato/shared/lib/frontend/organizationEvents'
@@ -120,6 +120,7 @@ type OrganizationSwitcherExternalProps = {
 
 export default function OrganizationSwitcher({ compact }: OrganizationSwitcherExternalProps = {}) {
   const router = useRouter()
+  const pathname = usePathname()
   const t = useT()
   const [state, setState] = React.useState<SwitcherState>({ status: 'loading' })
   const [cookieState, setCookieState] = React.useState<SelectedCookieState>(() => readSelectedOrganizationCookie())
@@ -289,7 +290,7 @@ export default function OrganizationSwitcher({ compact }: OrganizationSwitcherEx
     const abortRef = { current: false }
     load({ abortRef })
     return () => { abortRef.current = true }
-  }, [load])
+  }, [load, pathname])
 
   const nodes = React.useMemo<OrganizationTreeNode[]>(() => {
     if (state.status !== 'ready') return []

--- a/packages/core/src/modules/auth/lib/__tests__/tenantAccess.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/tenantAccess.test.ts
@@ -1,0 +1,72 @@
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { enforceTenantSelection } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+
+describe('enforceTenantSelection', () => {
+  it('allows superadmin to target a tenant different from the current header tenant', async () => {
+    const resolve = jest.fn(() => ({
+      loadAcl: jest.fn(),
+    }))
+
+    await expect(
+      enforceTenantSelection(
+        {
+          auth: {
+            sub: 'user-1',
+            tenantId: 'tenant-header',
+            orgId: 'org-header',
+            isSuperAdmin: true,
+          },
+          container: { resolve },
+        },
+        'tenant-form',
+      ),
+    ).resolves.toBe('tenant-form')
+
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('rejects non-superadmin targeting a tenant different from the current header tenant', async () => {
+    const resolve = jest.fn(() => ({
+      loadAcl: jest.fn(),
+    }))
+
+    await expect(
+      enforceTenantSelection(
+        {
+          auth: {
+            sub: 'user-1',
+            tenantId: 'tenant-header',
+            orgId: 'org-header',
+            isSuperAdmin: false,
+          },
+          container: { resolve },
+        },
+        'tenant-form',
+      ),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({
+      status: 403,
+      body: { error: 'Not authorized to target this tenant.' },
+    })
+  })
+
+  it('falls back to the current tenant when non-superadmin omits tenant selection', async () => {
+    const resolve = jest.fn(() => ({
+      loadAcl: jest.fn(),
+    }))
+
+    await expect(
+      enforceTenantSelection(
+        {
+          auth: {
+            sub: 'user-1',
+            tenantId: 'tenant-header',
+            orgId: 'org-header',
+            isSuperAdmin: false,
+          },
+          container: { resolve },
+        },
+        undefined,
+      ),
+    ).resolves.toBe('tenant-header')
+  })
+})

--- a/packages/core/src/modules/directory/__integration__/TC-DIR-004.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-004.spec.ts
@@ -1,0 +1,154 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import {
+  deleteGeneralEntityIfExists,
+  expectId,
+  getTokenContext,
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures';
+
+type SwitcherPayload = {
+  items?: Array<{
+    id?: string;
+    name?: string;
+    children?: Array<unknown>;
+  }>;
+  tenants?: Array<{
+    id?: string;
+    name?: string;
+  }>;
+};
+
+function buildSuperAdminCookie(tenantId: string, organizationId: string | null): string {
+  const parts = [`om_selected_tenant=${encodeURIComponent(tenantId)}`];
+  if (organizationId) {
+    parts.push(`om_selected_org=${encodeURIComponent(organizationId)}`);
+  }
+  return parts.join('; ');
+}
+
+function buildSwitcherCookie(tenantId: string): string {
+  return `om_selected_tenant=${encodeURIComponent(tenantId)}; om_selected_org=__all__`;
+}
+
+async function apiRequestWithCookie(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  options: { token: string; cookie: string; data?: unknown },
+) {
+  return request.fetch(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      'Content-Type': 'application/json',
+      Cookie: options.cookie,
+    },
+    data: options.data,
+  });
+}
+
+function flattenNames(items: Array<{ name?: string; children?: Array<unknown> }> | undefined): string[] {
+  if (!Array.isArray(items)) return [];
+  const result: string[] = [];
+  const walk = (nodes: Array<{ name?: string; children?: Array<unknown> }>) => {
+    for (const node of nodes) {
+      if (typeof node.name === 'string' && node.name.length > 0) result.push(node.name);
+      const children = Array.isArray(node.children)
+        ? (node.children.filter((child): child is { name?: string; children?: Array<unknown> } => !!child && typeof child === 'object'))
+        : [];
+      if (children.length > 0) walk(children);
+    }
+  };
+  walk(items);
+  return result;
+}
+
+/**
+ * TC-DIR-004: Superadmin tenant override and switcher freshness
+ * Covers: POST /api/directory/organizations, GET /api/directory/organization-switcher
+ */
+test.describe('TC-DIR-004: Superadmin tenant override and switcher freshness', () => {
+  test('should honor form tenant selection and expose new tenant and organization in switcher payloads immediately', async ({ request }) => {
+    let token: string | null = null;
+    let tenantId: string | null = null;
+    let organizationId: string | null = null;
+
+    const tenantName = `QA TC-DIR-004 Tenant ${Date.now()}`;
+    const organizationName = `QA TC-DIR-004 Org ${Date.now()}`;
+
+    try {
+      token = await getAuthToken(request, 'superadmin');
+      const { tenantId: actorTenantId, organizationId: actorOrganizationId } = getTokenContext(token);
+      expect(actorTenantId, 'Superadmin token should include a tenant context').toBeTruthy();
+
+      const staleHeaderCookie = buildSuperAdminCookie(actorTenantId, actorOrganizationId || null);
+
+      const createTenantResponse = await apiRequest(request, 'POST', '/api/directory/tenants', {
+        token,
+        data: { name: tenantName },
+      });
+      expect(createTenantResponse.status(), 'POST /api/directory/tenants should return 201').toBe(201);
+      const createTenantBody = await readJsonSafe<{ id?: string }>(createTenantResponse);
+      tenantId = expectId(createTenantBody?.id, 'Tenant create response should contain an id');
+
+      const staleTenantSwitcherResponse = await apiRequestWithCookie(
+        request,
+        'GET',
+        '/api/directory/organization-switcher',
+        {
+          token,
+          cookie: staleHeaderCookie,
+        },
+      );
+      expect(staleTenantSwitcherResponse.status(), 'GET /api/directory/organization-switcher should return 200').toBe(200);
+      const staleTenantSwitcherBody = await readJsonSafe<SwitcherPayload>(staleTenantSwitcherResponse);
+      const tenantNames = Array.isArray(staleTenantSwitcherBody?.tenants)
+        ? staleTenantSwitcherBody.tenants
+          .map((entry) => (typeof entry?.name === 'string' ? entry.name : null))
+          .filter((entry): entry is string => !!entry)
+        : [];
+      expect(tenantNames, 'Switcher tenant list should include the newly created tenant immediately').toContain(tenantName);
+
+      const createOrganizationResponse = await apiRequestWithCookie(
+        request,
+        'POST',
+        '/api/directory/organizations',
+        {
+          token,
+          cookie: staleHeaderCookie,
+          data: {
+            name: organizationName,
+            tenantId,
+          },
+        },
+      );
+      expect(
+        createOrganizationResponse.status(),
+        'POST /api/directory/organizations should allow a superadmin to target the form-selected tenant even when the header tenant differs',
+      ).toBe(201);
+      const createOrganizationBody = await readJsonSafe<{ id?: string }>(createOrganizationResponse);
+      organizationId = expectId(createOrganizationBody?.id, 'Organization create response should contain an id');
+
+      const targetTenantSwitcherResponse = await apiRequestWithCookie(
+        request,
+        'GET',
+        '/api/directory/organization-switcher',
+        {
+          token,
+          cookie: buildSwitcherCookie(tenantId),
+        },
+      );
+      expect(targetTenantSwitcherResponse.status(), 'GET /api/directory/organization-switcher should return 200').toBe(200);
+      const targetTenantSwitcherBody = await readJsonSafe<SwitcherPayload>(targetTenantSwitcherResponse);
+      const organizationNames = flattenNames(targetTenantSwitcherBody?.items);
+      expect(
+        organizationNames,
+        'Switcher organization tree should include the newly created organization immediately for the selected tenant',
+      ).toContain(organizationName);
+    } finally {
+      await deleteGeneralEntityIfExists(request, token, '/api/directory/organizations', organizationId);
+      await deleteGeneralEntityIfExists(request, token, '/api/directory/tenants', tenantId);
+    }
+  });
+});

--- a/packages/core/src/modules/directory/commands/organizations.ts
+++ b/packages/core/src/modules/directory/commands/organizations.ts
@@ -639,8 +639,8 @@ const deleteOrganizationCommand: CommandHandler<{ body: any; query: Record<strin
     const existing = await em.findOne(Organization, { id, deletedAt: null })
     if (!existing) throw new CrudHttpError(404, { error: 'Not found' })
 
-    const authTenantId = ctx.auth?.tenantId ?? null
-    const tenantId = requireTenantScope(authTenantId, resolveTenantIdFromEntity(existing))
+    const tenantId = await enforceTenantSelection(ctx, resolveTenantIdFromEntity(existing))
+    if (!tenantId) throw new CrudHttpError(400, { error: 'Tenant scope required' })
 
     const parentId = existing.parentId ?? null
     const childSnapshotsBefore = await loadChildParentSnapshots(

--- a/packages/core/src/modules/directory/commands/organizations.ts
+++ b/packages/core/src/modules/directory/commands/organizations.ts
@@ -6,6 +6,7 @@ import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import { Organization, Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import { organizationCreateSchema, organizationUpdateSchema } from '@open-mercato/core/modules/directory/data/validators'
 import { rebuildHierarchyForTenant } from '@open-mercato/core/modules/directory/lib/hierarchy'
+import { enforceTenantSelection } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { E } from '#generated/entities.ids.generated'
 import type { CrudEmitContext, CrudEventsConfig, CrudIndexerConfig } from '@open-mercato/shared/lib/crud/types'
 import {
@@ -19,7 +20,6 @@ import {
   setCustomFieldsIfAny,
   emitCrudSideEffects,
   emitCrudUndoSideEffects,
-  requireTenantScope,
   requireId,
   buildChanges,
 } from '@open-mercato/shared/lib/commands/helpers'
@@ -274,8 +274,8 @@ const createOrganizationCommand: CommandHandler<Record<string, unknown>, Organiz
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(organizationCreateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const authTenantId = ctx.auth?.tenantId ?? null
-    const tenantId = requireTenantScope(authTenantId, parsed.tenantId ?? null)
+    const tenantId = await enforceTenantSelection(ctx, parsed.tenantId ?? null)
+    if (!tenantId) throw new CrudHttpError(400, { error: 'Tenant scope required' })
 
     const parentId = parsed.parentId ?? null
     if (parentId) {
@@ -431,8 +431,8 @@ const updateOrganizationCommand: CommandHandler<Record<string, unknown>, Organiz
     const existing = await em.findOne(Organization, { id: parsed.id, deletedAt: null })
     if (!existing) throw new CrudHttpError(404, { error: 'Not found' })
 
-    const authTenantId = ctx.auth?.tenantId ?? null
-    const tenantId = requireTenantScope(authTenantId, parsed.tenantId ?? resolveTenantIdFromEntity(existing))
+    const tenantId = await enforceTenantSelection(ctx, parsed.tenantId ?? resolveTenantIdFromEntity(existing))
+    if (!tenantId) throw new CrudHttpError(400, { error: 'Tenant scope required' })
 
     const parentId = parsed.parentId ?? null
     if (parentId) {

--- a/packages/create-app/template/src/components/OrganizationSwitcher.tsx
+++ b/packages/create-app/template/src/components/OrganizationSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client"
 import * as React from 'react'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { emitOrganizationScopeChanged } from '@open-mercato/shared/lib/frontend/organizationEvents'
@@ -120,6 +120,7 @@ type OrganizationSwitcherExternalProps = {
 
 export default function OrganizationSwitcher({ compact }: OrganizationSwitcherExternalProps = {}) {
   const router = useRouter()
+  const pathname = usePathname()
   const t = useT()
   const [state, setState] = React.useState<SwitcherState>({ status: 'loading' })
   const [cookieState, setCookieState] = React.useState<SelectedCookieState>(() => readSelectedOrganizationCookie())
@@ -289,7 +290,7 @@ export default function OrganizationSwitcher({ compact }: OrganizationSwitcherEx
     const abortRef = { current: false }
     load({ abortRef })
     return () => { abortRef.current = true }
-  }, [load])
+  }, [load, pathname])
 
   const nodes = React.useMemo<OrganizationTreeNode[]>(() => {
     if (state.status !== 'ready') return []


### PR DESCRIPTION
## Summary

Fixes issue #959

This branch makes tenant selection in the organization flow behave consistently for superadmins and improves switcher freshness after tenant and organization changes.

## Changes

- organization create/update tenant handling now uses the form-selected tenant for superadmin flows instead of requiring the header tenant to match
- organization/tenant switcher state refresh was updated so newly created tenants and organizations are reflected without requiring a manual page refresh
- organization delete was aligned with the same tenant-selection guard and no longer uses the removed `requireTenantScope(...)`
- added integration coverage for the issue 959 scenarios around tenant selection and switcher freshness

## Verification

Passed:
- `yarn workspace @open-mercato/core test --runInBand src/modules/auth/lib/__tests__/tenantAccess.test.ts`
- `node_modules/typescript/bin/tsc -p packages/core/tsconfig.json --noEmit`

Added:
- `packages/core/src/modules/directory/__integration__/TC-DIR-004.spec.ts`

## Note

A separate follow-up ticket will cover the pre-existing edit/update behavior where the organization edit UI exposes tenant change even though update does not actually move the record across tenants.