### PR TITLE
docs: add missing sidebar entry for user-guide/checkout

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -74,6 +74,7 @@ const sidebars: SidebarsConfig = {
             "user-guide/integrations",
             "user-guide/webhooks",
             "user-guide/akeneo-pim",
+            "user-guide/checkout",
             "user-guide/stripe-payments",
             "user-guide/payment-transactions",
           ],


### PR DESCRIPTION
Source: Repository signal — docs: add missing sidebar entry for user-guide/checkout
## Problem Summary
docs: add missing sidebar entry for user-guide/checkout
## Expected Behavior
apps/docs/docs/user-guide/checkout.mdx exists as a documentation page.
## Actual Behavior
apps/docs/sidebars.ts does not reference "user-guide/checkout".
## What Changed
- apps/docs/sidebars.ts
- Diff summary: +1 / -0 (1 total lines)
- Branch head: 0799690a112a3ab418c895f18d2d9f66b0034255
## Validation / Tests
- docs-basic
- docs-app-build
## Expected Contribution Classes
- docs