### PR TITLE
fix(dev): splash stuck on "preparing" when warmup login returns 401

### DIFF
--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -684,7 +684,9 @@ async function runTargetedRouteWarmup() {
           throw createWarmupTransientError('login warmup required tenant selection')
         }
       }
-      throw new Error(`login warmup failed: ${failure}`)
+      const loginError = new Error(`login warmup failed: ${failure}`)
+      loginError.warmupLoginStatus = loginResponse.status
+      throw loginError
     }
 
     const cookieHeader = buildCookieHeader(loginResponse)
@@ -793,21 +795,45 @@ async function runTargetedRouteWarmup() {
       return
     }
 
-    const warmupWarning = `⚠️ Warmup incomplete: ${error instanceof Error ? error.message : 'unknown error'}`
+    const errorMessage = error instanceof Error ? error.message : 'unknown error'
+    const loginStatus = error && typeof error === 'object' ? error.warmupLoginStatus : undefined
+    const isCredentialsFailure = loginStatus === 401
+    const warmupWarning = `⚠️ Warmup incomplete: ${errorMessage}`
+    const loginUrl = runtimeWarmupState.baseUrl
+      ? `${runtimeWarmupState.baseUrl}/login`
+      : null
+    const failureLines = isCredentialsFailure
+      ? [
+          'Warmup login failed with HTTP 401 — the app is running but warmup credentials are invalid.',
+          'Set OM_INIT_SUPERADMIN_EMAIL and OM_INIT_SUPERADMIN_PASSWORD in .env,',
+          'or run: yarn initialize  (to seed demo data with default credentials).',
+        ]
+      : []
+    runtimeWarmupState.completed = true
+    runtimeWarmupState.failed = false
     updateSplashState({
       phase: 'App is ready',
       detail: warmupWarning,
       failed: false,
-      failureLines: [],
+      failureLines,
       failureCommand: null,
       ready: true,
+      loginUrl,
       progressCurrent: runtimeReadyProgressCurrent,
       progressTotal: startupProgress.total,
       progressPercent: resolveProgressPercent(runtimeReadyProgressCurrent, startupProgress.total),
       progressLabel: 'App is ready',
       activity: warmupWarning,
     })
-    console.log(formatStatusOutput(warmupWarning, runtimeReadyProgressCurrent, 'App is ready'))
+    if (isCredentialsFailure) {
+      console.log(formatStatusOutput(
+        '⚠️ Warmup login returned 401 — credentials invalid. Set OM_INIT_SUPERADMIN_EMAIL/PASSWORD in .env or run: yarn initialize',
+        runtimeReadyProgressCurrent,
+        'App is ready',
+      ))
+    } else {
+      console.log(formatStatusOutput(warmupWarning, runtimeReadyProgressCurrent, 'App is ready'))
+    }
   }
 }
 

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -336,6 +336,14 @@ function publishRuntimeFailure(detail, options = {}) {
     ? options.progressLabel
     : (startupProgress.current >= runtimeProgressCurrent ? startupProgress.label : 'Starting app server')
 
+  if (runtimeWarmupState.completed) {
+    updateSplashState({
+      detail: failureDetail,
+      activity: failureDetail,
+    })
+    return
+  }
+
   updateSplashState({
     phase: 'Runtime error detected',
     detail: failureDetail,

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -336,14 +336,6 @@ function publishRuntimeFailure(detail, options = {}) {
     ? options.progressLabel
     : (startupProgress.current >= runtimeProgressCurrent ? startupProgress.label : 'Starting app server')
 
-  if (runtimeWarmupState.completed) {
-    updateSplashState({
-      detail: failureDetail,
-      activity: failureDetail,
-    })
-    return
-  }
-
   updateSplashState({
     phase: 'Runtime error detected',
     detail: failureDetail,
@@ -437,6 +429,14 @@ function resolveWarmupCredentials() {
   return {
     email: readNonEmptyEnvValue('OM_INIT_SUPERADMIN_EMAIL') ?? 'superadmin@acme.com',
     password: readNonEmptyEnvValue('OM_INIT_SUPERADMIN_PASSWORD') ?? 'secret',
+  }
+}
+
+class LoginError extends Error {
+  constructor(message, status) {
+    super(message)
+    this.name = 'LoginError'
+    this.status = status
   }
 }
 
@@ -692,9 +692,7 @@ async function runTargetedRouteWarmup() {
           throw createWarmupTransientError('login warmup required tenant selection')
         }
       }
-      const loginError = new Error(`login warmup failed: ${failure}`)
-      loginError.warmupLoginStatus = loginResponse.status
-      throw loginError
+      throw new LoginError(`login warmup failed: ${failure}`, loginResponse.status)
     }
 
     const cookieHeader = buildCookieHeader(loginResponse)
@@ -804,8 +802,7 @@ async function runTargetedRouteWarmup() {
     }
 
     const errorMessage = error instanceof Error ? error.message : 'unknown error'
-    const loginStatus = error && typeof error === 'object' ? error.warmupLoginStatus : undefined
-    const isCredentialsFailure = loginStatus === 401
+    const isCredentialsFailure = error instanceof LoginError && error.status === 401
     const warmupWarning = `⚠️ Warmup incomplete: ${errorMessage}`
     const loginUrl = runtimeWarmupState.baseUrl
       ? `${runtimeWarmupState.baseUrl}/login`

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -684,7 +684,9 @@ async function runTargetedRouteWarmup() {
           throw createWarmupTransientError('login warmup required tenant selection')
         }
       }
-      throw new Error(`login warmup failed: ${failure}`)
+      const loginError = new Error(`login warmup failed: ${failure}`)
+      loginError.warmupLoginStatus = loginResponse.status
+      throw loginError
     }
 
     const cookieHeader = buildCookieHeader(loginResponse)
@@ -793,21 +795,45 @@ async function runTargetedRouteWarmup() {
       return
     }
 
-    const warmupWarning = `⚠️ Warmup incomplete: ${error instanceof Error ? error.message : 'unknown error'}`
+    const errorMessage = error instanceof Error ? error.message : 'unknown error'
+    const loginStatus = error && typeof error === 'object' ? error.warmupLoginStatus : undefined
+    const isCredentialsFailure = loginStatus === 401
+    const warmupWarning = `⚠️ Warmup incomplete: ${errorMessage}`
+    const loginUrl = runtimeWarmupState.baseUrl
+      ? `${runtimeWarmupState.baseUrl}/login`
+      : null
+    const failureLines = isCredentialsFailure
+      ? [
+          'Warmup login failed with HTTP 401 — the app is running but warmup credentials are invalid.',
+          'Set OM_INIT_SUPERADMIN_EMAIL and OM_INIT_SUPERADMIN_PASSWORD in .env,',
+          'or run: yarn initialize  (to seed demo data with default credentials).',
+        ]
+      : []
+    runtimeWarmupState.completed = true
+    runtimeWarmupState.failed = false
     updateSplashState({
       phase: 'App is ready',
       detail: warmupWarning,
       failed: false,
-      failureLines: [],
+      failureLines,
       failureCommand: null,
       ready: true,
+      loginUrl,
       progressCurrent: runtimeReadyProgressCurrent,
       progressTotal: startupProgress.total,
       progressPercent: resolveProgressPercent(runtimeReadyProgressCurrent, startupProgress.total),
       progressLabel: 'App is ready',
       activity: warmupWarning,
     })
-    console.log(formatStatusOutput(warmupWarning, runtimeReadyProgressCurrent, 'App is ready'))
+    if (isCredentialsFailure) {
+      console.log(formatStatusOutput(
+        '⚠️ Warmup login returned 401 — credentials invalid. Set OM_INIT_SUPERADMIN_EMAIL/PASSWORD in .env or run: yarn initialize',
+        runtimeReadyProgressCurrent,
+        'App is ready',
+      ))
+    } else {
+      console.log(formatStatusOutput(warmupWarning, runtimeReadyProgressCurrent, 'App is ready'))
+    }
   }
 }
 

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -336,6 +336,14 @@ function publishRuntimeFailure(detail, options = {}) {
     ? options.progressLabel
     : (startupProgress.current >= runtimeProgressCurrent ? startupProgress.label : 'Starting app server')
 
+  if (runtimeWarmupState.completed) {
+    updateSplashState({
+      detail: failureDetail,
+      activity: failureDetail,
+    })
+    return
+  }
+
   updateSplashState({
     phase: 'Runtime error detected',
     detail: failureDetail,

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -336,14 +336,6 @@ function publishRuntimeFailure(detail, options = {}) {
     ? options.progressLabel
     : (startupProgress.current >= runtimeProgressCurrent ? startupProgress.label : 'Starting app server')
 
-  if (runtimeWarmupState.completed) {
-    updateSplashState({
-      detail: failureDetail,
-      activity: failureDetail,
-    })
-    return
-  }
-
   updateSplashState({
     phase: 'Runtime error detected',
     detail: failureDetail,
@@ -437,6 +429,14 @@ function resolveWarmupCredentials() {
   return {
     email: readNonEmptyEnvValue('OM_INIT_SUPERADMIN_EMAIL') ?? 'superadmin@acme.com',
     password: readNonEmptyEnvValue('OM_INIT_SUPERADMIN_PASSWORD') ?? 'secret',
+  }
+}
+
+class LoginError extends Error {
+  constructor(message, status) {
+    super(message)
+    this.name = 'LoginError'
+    this.status = status
   }
 }
 
@@ -692,9 +692,7 @@ async function runTargetedRouteWarmup() {
           throw createWarmupTransientError('login warmup required tenant selection')
         }
       }
-      const loginError = new Error(`login warmup failed: ${failure}`)
-      loginError.warmupLoginStatus = loginResponse.status
-      throw loginError
+      throw new LoginError(`login warmup failed: ${failure}`, loginResponse.status)
     }
 
     const cookieHeader = buildCookieHeader(loginResponse)
@@ -804,8 +802,7 @@ async function runTargetedRouteWarmup() {
     }
 
     const errorMessage = error instanceof Error ? error.message : 'unknown error'
-    const loginStatus = error && typeof error === 'object' ? error.warmupLoginStatus : undefined
-    const isCredentialsFailure = loginStatus === 401
+    const isCredentialsFailure = error instanceof LoginError && error.status === 401
     const warmupWarning = `⚠️ Warmup incomplete: ${errorMessage}`
     const loginUrl = runtimeWarmupState.baseUrl
       ? `${runtimeWarmupState.baseUrl}/login`


### PR DESCRIPTION
## Summary

- When warmup login gets a 401 (invalid credentials), the dev splash page was stuck on "App is preparing..." indefinitely even though the app was running fine on localhost:3000
- Root cause: `runtimeWarmupState.completed` was never set to `true`, so subsequent request log lines kept overwriting `ready=true` back to `false`. Also `loginUrl` was never set, so the splash button stayed disabled
- Now the splash correctly transitions to "App is ready, open login" with a clickable button, and prints a terminal hint about setting `OM_INIT_SUPERADMIN_EMAIL`/`OM_INIT_SUPERADMIN_PASSWORD` or running `yarn initialize`
- Only triggers on HTTP 401 specifically — 5xx errors still go through the existing transient retry path

## Test plan

- [ ] Run `yarn dev` with invalid/missing warmup credentials → splash should show "App is ready, open login" button
- [ ] Run `yarn dev` with valid credentials → warmup completes normally as before
- [ ] Verify terminal shows helpful hint about credentials when 401 occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)