### PR TITLE
Block enterprise tests when OM_ENABLE_ENTERPRISE_MODULES is false

### DIFF
--- a/packages/enterprise/src/modules/security/__integration__/meta.ts
+++ b/packages/enterprise/src/modules/security/__integration__/meta.ts
@@ -1,0 +1,4 @@
+export const integrationMeta = {
+  description: 'Security enterprise integration coverage',
+  dependsOnModules: ['security'],
+}

--- a/packages/ui/src/backend/notifications/NotificationDispatcher.ts
+++ b/packages/ui/src/backend/notifications/NotificationDispatcher.ts
@@ -99,11 +99,18 @@ class NotificationDispatcher {
     for (const notification of notifications) {
       if (this.handledIds.has(notification.id)) continue
 
+      let handlerRan = false
+      let hadFeatureBlockedHandler = false
+
       for (const entry of sortedEntries) {
         const handler = entry.handler
         if (!matchesType(handler.notificationType, notification.type)) continue
-        if (!matchesFeatures(handler.features, runtime.features)) continue
+        if (!matchesFeatures(handler.features, runtime.features)) {
+          hadFeatureBlockedHandler = true
+          continue
+        }
         if (this.shouldDebounce(handler, notification.id)) continue
+        handlerRan = true
         try {
           void Promise.resolve(handler.handle(notification, context))
         } catch (error) {
@@ -113,6 +120,7 @@ class NotificationDispatcher {
 
       for (const listener of this.listeners.values()) {
         if (!matchesType(listener.pattern, notification.type)) continue
+        handlerRan = true
         try {
           listener.effect(notification)
         } catch (error) {
@@ -120,7 +128,14 @@ class NotificationDispatcher {
         }
       }
 
-      this.markHandled(notification.id)
+      // Only mark as permanently handled when something actually ran, or when no handler
+      // was blocked by missing features. This prevents a race where the initial notification
+      // fetch completes before the feature-check API resolves (features: []), causing all
+      // feature-gated handlers to be skipped — but the notification gets permanently
+      // deduped so it never fires when features are available on the next dispatch.
+      if (handlerRan || !hadFeatureBlockedHandler) {
+        this.markHandled(notification.id)
+      }
     }
   }
 


### PR DESCRIPTION
I started from the point that test TC-LOCK-008 was failing after one of my changes, and the agent suggested setting the OM_ENABLE_ENTERPRISE_MODULES flag to true, which didn’t seem like something that should happen.

During the discussion, the plan was to block enterprise tests if the flag is set to false, but it turned out this had already been implemented. However, two additional issues were discovered.

1. Created packages/enterprise/src/modules/security/__integration__/meta.ts

The security module's integration test folder was the only one under packages/enterprise/ missing a meta.ts. Without it, the discovery code's requiredModules filter couldn't exclude these tests when OM_ENABLE_ENTERPRISE_MODULES is false. It now declares dependsOnModules: ['security'], which causes discoverIntegrationSpecFiles() to skip all TC-SEC-* tests when the enterprise flag is off.

2. Fixed the race condition in NotificationDispatcher.ts

The root cause of TC-LOCK-008: useNotificationsSse fires two concurrent useEffects on mount — one to fetch existing notifications, one to call /api/auth/feature-check. The fetch races and typically wins, so dispatch() is called with runtime.features = []. The record_locks.record-deleted-event handler (which requires record_locks.view) gets skipped due to the empty features array, but markHandled(notification.id) was still called — permanently deduplicating the notification so it never fires when features are loaded.

The fix: track handlerRan and hadFeatureBlockedHandler per notification. Only call markHandled when handlerRan || !hadFeatureBlockedHandler. When all handlers were blocked by features (and no listeners ran), the notification remains unhandled and gets re-dispatched on the next call — which happens after the feature-check resolves and grantedFeaturesRef.current is populated.