### PR TITLE
fix(progress): enforce tenant isolation in isCancellationRequested

### DIFF
--- a/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
@@ -56,7 +56,7 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
     } catch (error) {
       const job = await progressService.getJob(run.progressJobId, progressCtx)
       const cancelRequested = job && (job.status === 'running' || job.status === 'cancelled')
-        ? await progressService.isCancellationRequested(run.progressJobId)
+        ? await progressService.isCancellationRequested(run.progressJobId, progressCtx.tenantId)
         : false
 
       if (job?.status !== 'cancelled' && !cancelRequested) {

--- a/packages/core/src/modules/data_sync/lib/sync-engine.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-engine.ts
@@ -299,7 +299,7 @@ export function createSyncEngine(deps: EngineDeps) {
           mapping,
           scope: { organizationId: scope.organizationId, tenantId: scope.tenantId },
         })) {
-          if (run.progressJobId && await progressService.isCancellationRequested(run.progressJobId)) {
+          if (run.progressJobId && await progressService.isCancellationRequested(run.progressJobId, scope.tenantId)) {
             await finalizeRun(run.id, 'cancelled', scope)
             return
           }
@@ -427,7 +427,7 @@ export function createSyncEngine(deps: EngineDeps) {
           mapping,
           scope: { organizationId: scope.organizationId, tenantId: scope.tenantId },
         })) {
-          if (run.progressJobId && await progressService.isCancellationRequested(run.progressJobId)) {
+          if (run.progressJobId && await progressService.isCancellationRequested(run.progressJobId, scope.tenantId)) {
             await finalizeRun(run.id, 'cancelled', scope)
             return
           }

--- a/packages/core/src/modules/progress/__tests__/progressService.test.ts
+++ b/packages/core/src/modules/progress/__tests__/progressService.test.ts
@@ -352,6 +352,60 @@ describe('progress service', () => {
     )
   })
 
+  it('isCancellationRequested — returns true when cancelRequestedAt is set for matching tenant', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = {
+      id: 'job-1',
+      tenantId: baseCtx.tenantId,
+      cancelRequestedAt: new Date(),
+    } as unknown as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.isCancellationRequested('job-1', baseCtx.tenantId)
+
+    expect(result).toBe(true)
+    expect(em.findOne).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId })
+    )
+  })
+
+  it('isCancellationRequested — returns false when job belongs to a different tenant', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    em.findOne.mockResolvedValue(null)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.isCancellationRequested('job-1', 'other-tenant-id')
+
+    expect(result).toBe(false)
+    expect(em.findOne).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', tenantId: 'other-tenant-id' })
+    )
+  })
+
+  it('isCancellationRequested — returns false when cancelRequestedAt is null', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = {
+      id: 'job-1',
+      tenantId: baseCtx.tenantId,
+      cancelRequestedAt: null,
+    } as unknown as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.isCancellationRequested('job-1', baseCtx.tenantId)
+
+    expect(result).toBe(false)
+  })
+
   it('getRecentlyCompletedJobs — queries completed/failed jobs with tenant scope', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }

--- a/packages/core/src/modules/progress/__tests__/progressService.test.ts
+++ b/packages/core/src/modules/progress/__tests__/progressService.test.ts
@@ -3,6 +3,14 @@ import { PROGRESS_EVENTS } from '../lib/events'
 import { calculateEta, calculateProgressPercent } from '../lib/progressService'
 import type { ProgressJob } from '../data/entities'
 
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+const mockFindOneWithDecryption = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
 const baseCtx = {
   tenantId: '7f4c85ef-f8f7-4e53-9df1-42e95bd8d48e',
   organizationId: null,
@@ -24,6 +32,7 @@ const buildEm = () => {
 describe('progress service', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockFindOneWithDecryption.mockReset()
   })
 
   it('createJob — creates entity, persists, emits JOB_CREATED', async () => {
@@ -361,13 +370,14 @@ describe('progress service', () => {
       tenantId: baseCtx.tenantId,
       cancelRequestedAt: new Date(),
     } as unknown as ProgressJob
-    em.findOne.mockResolvedValue(job)
+    mockFindOneWithDecryption.mockResolvedValue(job)
 
     const service = createProgressService(em as never, eventBus)
     const result = await service.isCancellationRequested('job-1', baseCtx.tenantId)
 
     expect(result).toBe(true)
-    expect(em.findOne).toHaveBeenCalledWith(
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      em,
       expect.anything(),
       expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId })
     )
@@ -377,13 +387,14 @@ describe('progress service', () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
-    em.findOne.mockResolvedValue(null)
+    mockFindOneWithDecryption.mockResolvedValue(null)
 
     const service = createProgressService(em as never, eventBus)
     const result = await service.isCancellationRequested('job-1', 'other-tenant-id')
 
     expect(result).toBe(false)
-    expect(em.findOne).toHaveBeenCalledWith(
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      em,
       expect.anything(),
       expect.objectContaining({ id: 'job-1', tenantId: 'other-tenant-id' })
     )
@@ -398,7 +409,7 @@ describe('progress service', () => {
       tenantId: baseCtx.tenantId,
       cancelRequestedAt: null,
     } as unknown as ProgressJob
-    em.findOne.mockResolvedValue(job)
+    mockFindOneWithDecryption.mockResolvedValue(job)
 
     const service = createProgressService(em as never, eventBus)
     const result = await service.isCancellationRequested('job-1', baseCtx.tenantId)

--- a/packages/core/src/modules/progress/di.ts
+++ b/packages/core/src/modules/progress/di.ts
@@ -1,5 +1,5 @@
 import type { AppContainer } from '@open-mercato/shared/lib/di/container'
-import type { EntityManager } from '@mikro-orm/core'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import { createProgressService } from './lib/progressServiceImpl'
 
 export function register(container: AppContainer) {

--- a/packages/core/src/modules/progress/lib/progressService.ts
+++ b/packages/core/src/modules/progress/lib/progressService.ts
@@ -16,7 +16,7 @@ export interface ProgressService {
   failJob(jobId: string, input: FailJobInput, ctx: ProgressServiceContext): Promise<ProgressJob>
   cancelJob(jobId: string, ctx: ProgressServiceContext): Promise<ProgressJob>
   markCancelled(jobId: string, ctx: ProgressServiceContext): Promise<ProgressJob>
-  isCancellationRequested(jobId: string): Promise<boolean>
+  isCancellationRequested(jobId: string, tenantId: string): Promise<boolean>
   getActiveJobs(ctx: ProgressServiceContext): Promise<ProgressJob[]>
   getRecentlyCompletedJobs(ctx: ProgressServiceContext, sinceSeconds?: number): Promise<ProgressJob[]>
   getJob(jobId: string, ctx: ProgressServiceContext): Promise<ProgressJob | null>

--- a/packages/core/src/modules/progress/lib/progressServiceImpl.ts
+++ b/packages/core/src/modules/progress/lib/progressServiceImpl.ts
@@ -1,4 +1,4 @@
-import type { EntityManager } from '@mikro-orm/core'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import { ProgressJob } from '../data/entities'
 import type { ProgressService } from './progressService'
 import { calculateEta, calculateProgressPercent, STALE_JOB_TIMEOUT_SECONDS } from './progressService'

--- a/packages/core/src/modules/progress/lib/progressServiceImpl.ts
+++ b/packages/core/src/modules/progress/lib/progressServiceImpl.ts
@@ -3,6 +3,7 @@ import { ProgressJob } from '../data/entities'
 import type { ProgressService } from './progressService'
 import { calculateEta, calculateProgressPercent, STALE_JOB_TIMEOUT_SECONDS } from './progressService'
 import { PROGRESS_EVENTS } from './events'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 function buildJobPayload(job: ProgressJob): Record<string, unknown> {
   return {
@@ -244,7 +245,7 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
     },
 
     async isCancellationRequested(jobId, tenantId) {
-      const job = await em.findOne(ProgressJob, { id: jobId, tenantId })
+      const job = await findOneWithDecryption(em, ProgressJob, { id: jobId, tenantId })
       return job?.cancelRequestedAt != null
     },
 

--- a/packages/core/src/modules/progress/lib/progressServiceImpl.ts
+++ b/packages/core/src/modules/progress/lib/progressServiceImpl.ts
@@ -243,8 +243,8 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
       return job
     },
 
-    async isCancellationRequested(jobId) {
-      const job = await em.findOne(ProgressJob, { id: jobId })
+    async isCancellationRequested(jobId, tenantId) {
+      const job = await em.findOne(ProgressJob, { id: jobId, tenantId })
       return job?.cancelRequestedAt != null
     },
 


### PR DESCRIPTION
  ---                                                                                                                                                
  Summary
                                                                                                                                                     
  ProgressService.isCancellationRequested was the only method in the service that did not filter by tenantId, allowing callers to check the
  cancellation status of a job belonging to another tenant if its UUID was known (information leakage). All other methods in the same service        
  correctly scope queries to the authenticated tenant.
                                                                                                                                                     
  Changes                                                   

  - Added required tenantId: string parameter to ProgressService.isCancellationRequested interface                                                   
  - Updated progressServiceImpl to include tenantId in the findOne filter
  - Updated all three call sites to pass tenant from existing scope context: sync-engine.ts (×2, scope.tenantId) and data_sync cancel endpoint       
  (progressCtx.tenantId)                                                                                                                             
  - Added three unit tests: matching tenant + cancelRequestedAt set → true, cross-tenant query → false, cancelRequestedAt null → false
                                                                                                                                                     
  Specification                                             
                                                                                                                                                     
  Does a spec exist for this feature/module?                
  - N/A (minor change, no spec needed)
                                                                                                                                                     
  Testing
                                                                                                                                                     
  yarn jest packages/core/src/modules/progress/__tests__/progressService.test.ts --no-coverage
  # 22 passed

  Checklist

  - This pull request targets develop.                                                                                                               
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
  - I added or adjusted tests that cover the change.                                                                                                 
  - I added or updated integration tests in .ai/qa/tests/ (integration coverage not required — isCancellationRequested is an internal service method
  not exposed via API; tenant scoping is enforced at the DB query level and covered by unit tests)                                                   
   
  Breaking change note                                                                                                                               
                                                            
  ProgressService.isCancellationRequested signature change is technically breaking under the BC contract (Function signatures — STABLE). Practical   
  risk is zero: no external module has a legitimate reason to call this method without knowing its own tenantId. The parameter is intentionally
  required (not optional) so the compiler enforces correct usage going forward. 