### PR TITLE
Fix missing tenant scope on public quote endpoints (Sales Module)

### DIFF
--- a/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/quotes.acceptance.test.ts
@@ -108,6 +108,7 @@ describe('quote send + accept flow', () => {
   test('public view returns expired flag', async () => {
     const quote = {
       id: 'q-1',
+      tenantId: '00000000-0000-4000-8000-000000000000',
       quoteNumber: 'SQ-1',
       currencyCode: 'USD',
       status: 'sent',
@@ -158,6 +159,164 @@ describe('quote send + accept flow', () => {
       'sales.quotes.convert_to_order',
       expect.objectContaining({ input: { quoteId: quote.id } })
     )
+  })
+})
+
+describe('public view - tenant isolation (fix: cross-tenant auth returns 404)', () => {
+  const TENANT_ID = '00000000-0000-4000-8000-000000000000'
+  const OTHER_TENANT_ID = 'ffffffff-ffff-4fff-bfff-ffffffffffff'
+  const TOKEN = '00000000-0000-4000-8000-000000000001'
+
+  const baseQuote = {
+    id: 'q-tenant-test',
+    tenantId: TENANT_ID,
+    quoteNumber: 'SQ-T1',
+    currencyCode: 'USD',
+    status: 'sent',
+    validFrom: null,
+    validUntil: null,
+    subtotalNetAmount: '0',
+    subtotalGrossAmount: '0',
+    discountTotalAmount: '0',
+    taxTotalAmount: '0',
+    grandTotalNetAmount: '0',
+    grandTotalGrossAmount: '0',
+  }
+
+  function makePublicReq() {
+    return new Request(`http://localhost/api/sales/quotes/public/${TOKEN}`)
+  }
+
+  function makePublicCtx() {
+    return { params: { token: TOKEN } } as any
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockEm.findOne.mockResolvedValue({ ...baseQuote })
+    mockEm.find.mockResolvedValue([])
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue(null)
+  })
+
+  test('unauthenticated request returns quote (200)', async () => {
+    const res = await getPublicQuote(makePublicReq(), makePublicCtx())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.quote.quoteNumber).toBe('SQ-T1')
+  })
+
+  test('authenticated same-tenant request returns quote (200)', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: TENANT_ID })
+
+    const res = await getPublicQuote(makePublicReq(), makePublicCtx())
+    expect(res.status).toBe(200)
+  })
+
+  test('authenticated cross-tenant request returns 404', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: OTHER_TENANT_ID })
+
+    const res = await getPublicQuote(makePublicReq(), makePublicCtx())
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBeTruthy()
+  })
+})
+
+describe('accept - tenant isolation (fix: tenantId scoped in lookup + encryption scope)', () => {
+  const TENANT_ID = '00000000-0000-4000-8000-000000000000'
+  const OTHER_TENANT_ID = 'ffffffff-ffff-4fff-bfff-ffffffffffff'
+  const ACCEPTANCE_TOKEN = '00000000-0000-4000-8000-000000000002'
+
+  // Fresh quote per test — the route mutates quote.status to 'confirmed' so it must not be shared
+  let quote: Record<string, unknown>
+
+  function makeAcceptReq() {
+    return new Request('http://localhost/api/sales/quotes/accept', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: ACCEPTANCE_TOKEN }),
+    })
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockCommandBus.execute.mockResolvedValue({ result: { orderId: 'order-sec-1' } })
+    // Recreate quote each test so route mutations (status → 'confirmed') don't leak
+    quote = {
+      id: '55555555-5555-4555-8555-555555555555',
+      tenantId: TENANT_ID,
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      quoteNumber: 'SQ-SEC-1',
+      status: 'sent',
+      statusEntryId: null,
+      validUntil: new Date(Date.now() + 60_000),
+      updatedAt: new Date(),
+    }
+    // Simulate DB: honour tenantId in where clause (cross-tenant lookup returns null)
+    mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
+      if (cls === SalesQuote) {
+        if (where?.tenantId && where.tenantId !== TENANT_ID) return null
+        return where?.acceptanceToken === ACCEPTANCE_TOKEN ? quote : null
+      }
+      if (cls === Dictionary) return { id: 'dict-1' }
+      if (cls === DictionaryEntry) return { id: 'entry-confirmed' }
+      if (cls === SalesOrder) return { id: 'order-sec-1', orderNumber: 'SO-SEC-1', deletedAt: null }
+      return null
+    })
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue(null)
+  })
+
+  test('unauthenticated accept succeeds (no tenantId filter applied)', async () => {
+    const res = await acceptQuote(makeAcceptReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.orderId).toBe('order-sec-1')
+  })
+
+  test('same-tenant auth accepts quote (200)', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: TENANT_ID })
+
+    const res = await acceptQuote(makeAcceptReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.orderId).toBe('order-sec-1')
+  })
+
+  test('cross-tenant auth returns 404 — tenantId included in lookup filter', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: OTHER_TENANT_ID })
+
+    const res = await acceptQuote(makeAcceptReq())
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBeTruthy()
+  })
+
+  test('authenticated accept passes tenantId in the em.findOne where clause', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: TENANT_ID })
+
+    let capturedWhere: Record<string, unknown> | null = null
+    mockEm.findOne.mockImplementation(async (cls: any, where: any) => {
+      if (cls === SalesQuote) {
+        capturedWhere = where
+        return where?.acceptanceToken === ACCEPTANCE_TOKEN ? quote : null
+      }
+      if (cls === Dictionary) return { id: 'dict-1' }
+      if (cls === DictionaryEntry) return { id: 'entry-confirmed' }
+      if (cls === SalesOrder) return { id: 'order-sec-1', orderNumber: 'SO-SEC-1', deletedAt: null }
+      return null
+    })
+
+    await acceptQuote(makeAcceptReq())
+    expect(capturedWhere?.tenantId).toBe(TENANT_ID)
   })
 })
 

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -6,6 +6,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { SalesOrder, SalesQuote } from '../../../data/entities'
 import { quoteAcceptSchema } from '../../../data/validators'
 import { sendEmail } from '@open-mercato/shared/lib/email/send'
@@ -24,11 +25,16 @@ export const metadata = {
 export async function POST(req: Request) {
   try {
     const { token } = quoteAcceptSchema.parse(await req.json().catch(() => ({})))
+    const auth = await getAuthFromRequest(req)
     const container = await createRequestContainer()
     const em = (container.resolve('em') as EntityManager).fork()
     const { translate } = await resolveTranslations()
 
-    const quote = await em.findOne(SalesQuote, { acceptanceToken: token, deletedAt: null })
+    const quote = await em.findOne(SalesQuote, {
+      acceptanceToken: token,
+      ...(auth?.tenantId ? { tenantId: auth.tenantId } : {}),
+      deletedAt: null,
+    } as any)
     if (!quote) {
       throw new CrudHttpError(404, { error: translate('sales.quotes.accept.notFound', 'Quote not found.') })
     }

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -7,6 +7,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SalesOrder, SalesQuote } from '../../../data/entities'
 import { quoteAcceptSchema } from '../../../data/validators'
 import { sendEmail } from '@open-mercato/shared/lib/email/send'
@@ -30,11 +31,17 @@ export async function POST(req: Request) {
     const em = (container.resolve('em') as EntityManager).fork()
     const { translate } = await resolveTranslations()
 
-    const quote = await em.findOne(SalesQuote, {
-      acceptanceToken: token,
-      ...(auth?.tenantId ? { tenantId: auth.tenantId } : {}),
-      deletedAt: null,
-    } as any)
+    const quote = await findOneWithDecryption(
+      em,
+      SalesQuote,
+      {
+        acceptanceToken: token,
+        ...(auth?.tenantId ? { tenantId: auth.tenantId } : {}),
+        deletedAt: null,
+      } as any,
+      undefined,
+      auth?.tenantId ? { tenantId: auth.tenantId } : undefined,
+    )
     if (!quote) {
       throw new CrudHttpError(404, { error: translate('sales.quotes.accept.notFound', 'Quote not found.') })
     }

--- a/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
@@ -12,6 +12,7 @@ import {
   SalesQuoteAdjustment,
 } from "../../../../data/entities";
 import { canonicalizeUnitCode } from "@open-mercato/shared/lib/units/unitCodes";
+import { getAuthFromRequest } from "@open-mercato/shared/lib/auth/server";
 
 const paramsSchema = z.object({
   token: z.string().uuid(),
@@ -21,7 +22,7 @@ export const metadata = {
   GET: { requireAuth: false },
 };
 
-export async function GET(_req: Request, ctx: { params: { token: string } }) {
+export async function GET(req: Request, ctx: { params: { token: string } }) {
   try {
     const { token } = paramsSchema.parse(ctx.params ?? {});
     const container = await createRequestContainer();
@@ -32,6 +33,13 @@ export async function GET(_req: Request, ctx: { params: { token: string } }) {
     });
     const { translate } = await resolveTranslations();
     if (!quote) {
+      throw new CrudHttpError(404, {
+        error: translate("sales.quotes.public.notFound", "Quote not found."),
+      });
+    }
+
+    const auth = await getAuthFromRequest(req);
+    if (auth?.tenantId && quote.tenantId !== auth.tenantId) {
       throw new CrudHttpError(404, {
         error: translate("sales.quotes.public.notFound", "Quote not found."),
       });


### PR DESCRIPTION
Fix missing tenant scope on public quote endpoints (sales module)
Problem
Two public endpoints in the sales module — view a quote and accept a quote — queried SalesQuote by acceptanceToken alone, with no tenant boundary enforced at the query level:

// public/[token]/route.ts
await findOneWithDecryption(em, SalesQuote, { acceptanceToken: token, deletedAt: null })

// accept/route.ts
await em.findOne(SalesQuote, { acceptanceToken: token, deletedAt: null })
Both routes carry requireAuth: false, so the standard auth middleware does not apply. This means there was no server-side mechanism to prevent a leaked acceptanceToken from being used across tenant boundaries — a tenant A token could be submitted against tenant B's deployment with no rejection.

What was changed
Both fixes use the same pattern: attempt to resolve a tenant context from the incoming request via getAuthFromRequest(req). If the caller is authenticated (staff session cookie or API key), the resolved tenantId is used to scope the operation. If no credentials are present — the normal case for customers clicking an emailed quote link — the endpoints are unaffected and continue to work as before. The acceptanceToken UUID remains the primary authentication mechanism for anonymous access.

api/quotes/public/[token]/route.ts — post-fetch tenant validation
After the quote is retrieved and confirmed to exist, a defence-in-depth check is applied: if auth.tenantId is available and does not match quote.tenantId, the endpoint returns 404. The error message is identical to "quote not found" so no information about the mismatch is leaked.

api/quotes/accept/route.ts — tenant-scoped query
Rather than validating after the fact, the tenantId is injected directly into the findOne WHERE clause when available:

const auth = await getAuthFromRequest(req)

await em.findOne(SalesQuote, {
acceptanceToken: token,
...(auth?.tenantId ? { tenantId: auth.tenantId } : {}),
deletedAt: null,
})
This ensures the database query itself is scoped to the correct tenant, rather than relying on a post-fetch comparison.

Files changed

api/quotes/public/[token]/route.ts -> Import getAuthFromRequest; add post-fetch tenant mismatch check
api/quotes/accept/route.ts -> Import getAuthFromRequest; inject tenantId into findOne filter when auth context is available