### PR TITLE
fix: yarn dev doesn't work out of the box in devcontainer. command fails when opening splash

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,9 +9,10 @@
   "postCreateCommand": "bash .devcontainer/scripts/post-create.sh",
   "postStartCommand": "bash .devcontainer/scripts/post-start.sh",
 
-  "forwardPorts": [3000, "postgres:5432", "redis:6379", "meilisearch:7700"],
+  "forwardPorts": [3000, 4000, "postgres:5432", "redis:6379", "meilisearch:7700"],
   "portsAttributes": {
     "3000": { "label": "App", "onAutoForward": "notify" },
+    "4000": { "label": "Dev Splash", "onAutoForward": "notify" },
     "5432": { "label": "PostgreSQL", "onAutoForward": "silent" },
     "6379": { "label": "Redis", "onAutoForward": "silent" },
     "7700": { "label": "Meilisearch", "onAutoForward": "silent" }

--- a/packages/create-app/template/scripts/dev.mjs
+++ b/packages/create-app/template/scripts/dev.mjs
@@ -942,19 +942,15 @@ function closeSplashServer() {
 
 function openBrowser(url) {
   try {
+    let child
     if (process.platform === 'darwin') {
-      const child = spawn('open', [url], { detached: true, stdio: 'ignore' })
-      child.unref()
-      return
+      child = spawn('open', [url], { detached: true, stdio: 'ignore' })
+    } else if (process.platform === 'win32') {
+      child = spawn('cmd', ['/c', 'start', '', url], { detached: true, stdio: 'ignore' })
+    } else {
+      child = spawn('xdg-open', [url], { detached: true, stdio: 'ignore' })
     }
-
-    if (process.platform === 'win32') {
-      const child = spawn('cmd', ['/c', 'start', '', url], { detached: true, stdio: 'ignore' })
-      child.unref()
-      return
-    }
-
-    const child = spawn('xdg-open', [url], { detached: true, stdio: 'ignore' })
+    child.on('error', () => { /* best-effort: browser open is non-critical */ })
     child.unref()
   } catch { /* best-effort: browser open is non-critical */ }
 }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -942,19 +942,15 @@ function closeSplashServer() {
 
 function openBrowser(url) {
   try {
+    let child
     if (process.platform === 'darwin') {
-      const child = spawn('open', [url], { detached: true, stdio: 'ignore' })
-      child.unref()
-      return
+      child = spawn('open', [url], { detached: true, stdio: 'ignore' })
+    } else if (process.platform === 'win32') {
+      child = spawn('cmd', ['/c', 'start', '', url], { detached: true, stdio: 'ignore' })
+    } else {
+      child = spawn('xdg-open', [url], { detached: true, stdio: 'ignore' })
     }
-
-    if (process.platform === 'win32') {
-      const child = spawn('cmd', ['/c', 'start', '', url], { detached: true, stdio: 'ignore' })
-      child.unref()
-      return
-    }
-
-    const child = spawn('xdg-open', [url], { detached: true, stdio: 'ignore' })
+    child.on('error', () => { /* best-effort: browser open is non-critical */ })
     child.unref()
   } catch { /* best-effort: browser open is non-critical */ }
 }


### PR DESCRIPTION
  ---
##  Summary                                                                                                                                            
   
  - Fix unhandled ENOENT crash when yarn dev tries to auto-open a browser inside a Dev Container (or any headless Linux environment) where xdg-open  
  is not installed
  - Forward the Dev Splash port (4000) in devcontainer.json so the startup status page is accessible from the host browser                           
                                                                                                                                                     
##  Problem
                                                                                                                                                     
  Running yarn dev inside the VS Code Dev Container crashes immediately with:

  Error: spawn xdg-open ENOENT
  Emitted 'error' event on ChildProcess instance
                                                                                                                                                     
  The openBrowser() helper wraps spawn() in a try/catch, but spawn emits ENOENT as an async 'error' event on the ChildProcess — the synchronous      
  try/catch never catches it, and with no .on('error') listener, Node.js treats it as an unhandled error and terminates the process.                 
                                                                                                                                                     
  This breaks the out-of-the-box Dev Container experience: a new contributor cloning the repo, opening in VS Code, and running the documented yarn   
  dev command gets an immediate crash with no workaround other than reading the source.
                                                                                                                                                     
##  Fix             

  Added .on('error', ...) listener to the spawned child process so a missing browser opener is silently ignored — consistent with the existing       
  "best-effort: browser open is non-critical" intent in the code.
                                                                                                                                                     
##  Changes         

  - scripts/dev.mjs — refactored openBrowser() to attach .on('error') handler on the spawned child process, catching async ENOENT from missing       
  xdg-open
  - packages/create-app/template/scripts/dev.mjs — same fix mirrored to the app template                                                             
  - .devcontainer/devcontainer.json — added port 4000 (Dev Splash) to forwardPorts and portsAttributes
                                                                                                                                                     
##  Specification
                                                                                                                                                     
  Does a spec exist for this feature/module?
  - N/A (minor change, no spec needed)
                                      
##  Testing
                                                                                                                                                     
  - Reproduced the crash by running yarn dev inside a VS Code Dev Container (Linux, no xdg-open)
  - Confirmed the error no longer appears after the fix                                                                                              
  - Verified yarn dev starts normally on macOS (unaffected path)

##  Checklist                                                                                                                                          
  
  - This pull request targets develop.                                                                                                               
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
  - I updated documentation, locales, or generators if the change requires it.
  - I added or adjusted tests that cover the change — N/A, dev script startup behaviour is not covered by automated tests.                           
  - I added or updated integration tests in .ai/qa/tests/ — N/A (see above).                                                                         
  - I created or updated the spec in .ai/specs/ — N/A (minor fix). 