### PR TITLE
Fix/hackon/005 sales payments integrity

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   resolveTranslations: async () => ({
@@ -11,13 +12,94 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   }),
 }))
 
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn().mockResolvedValue(null),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn().mockResolvedValue({}),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/cache', () => ({
+  invalidateCrudCache: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../../notifications/lib/notificationService', () => ({
+  resolveNotificationService: jest.fn().mockReturnValue({
+    createForFeature: jest.fn().mockResolvedValue(undefined),
+  }),
+}))
+
+jest.mock('../../notifications', () => ({
+  notificationTypes: [],
+}))
+
+jest.mock('../../lib/dictionaries', () => ({
+  resolveDictionaryEntryValue: jest.fn().mockResolvedValue(null),
+}))
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// Real UUID v4 values required by Zod schema validators
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+const TEST_ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const TEST_PAYMENT_ID = 'dddddddd-dddd-4ddd-9ddd-dddddddddddd'
+const TEST_METHOD_ID = 'eeeeeeee-eeee-4eee-aeee-eeeeeeeeeeee'
+
+function buildMockEm(overrides: Record<string, unknown> = {}) {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockResolvedValue([]),
+    create: jest.fn().mockImplementation(
+      (_entity: unknown, data: Record<string, unknown>) => ({ ...data, id: data.id ?? TEST_PAYMENT_ID })
+    ),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    getReference: jest.fn().mockImplementation((_entity: unknown, id: unknown) => ({ id })),
+    ...overrides,
+  }
+}
+
+function buildCommandCtx(emOverrides: Record<string, unknown> = {}) {
+  const em = buildMockEm(emOverrides)
+  const container = {
+    resolve: jest.fn().mockImplementation((name: string) => {
+      if (name === 'em') return { fork: jest.fn().mockReturnValue(em) }
+      if (name === 'dataEngine') return {}
+      return {}
+    }),
+  }
+  const ctx = {
+    container,
+    auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+    selectedOrganizationId: TEST_ORG_ID,
+    organizationIds: [TEST_ORG_ID],
+    request: {} as Request,
+    organizationScope: null,
+  }
+  return { em, container, ctx }
+}
+
 function buildPaymentSnapshot(overrides?: Record<string, unknown>) {
   return {
-    id: 'payment-1',
-    orderId: 'order-1',
-    organizationId: 'org-1',
-    tenantId: 'tenant-1',
-    paymentMethodId: 'method-1',
+    id: TEST_PAYMENT_ID,
+    orderId: TEST_ORDER_ID,
+    organizationId: TEST_ORG_ID,
+    tenantId: TEST_TENANT_ID,
+    paymentMethodId: TEST_METHOD_ID,
     paymentReference: null,
     statusEntryId: null,
     status: null,
@@ -32,6 +114,10 @@ function buildPaymentSnapshot(overrides?: Record<string, unknown>) {
     ...overrides,
   }
 }
+
+// ---------------------------------------------------------------------------
+// Existing: buildLog contract tests
+// ---------------------------------------------------------------------------
 
 describe('createPaymentCommand buildLog — orderPaymentMethodIdBefore in undo payload', () => {
   beforeAll(async () => {
@@ -86,5 +172,232 @@ describe('createPaymentCommand buildLog — orderPaymentMethodIdBefore in undo p
     } as any)
 
     expect(log).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix 1: loadPaymentSnapshot forwards scope to findOneWithDecryption
+// ---------------------------------------------------------------------------
+
+describe('loadPaymentSnapshot — scope forwarding to findOneWithDecryption', () => {
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockClear()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(null)
+  })
+
+  it('passes the provided scope as the 5th argument', async () => {
+    const { loadPaymentSnapshot } = await import('../payments')
+    const mockEm = {} as any
+    const scope = { tenantId: 'tenant-1', organizationId: 'org-1' }
+
+    await loadPaymentSnapshot(mockEm, 'payment-1', scope)
+
+    expect(findOneWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      expect.anything(),
+      { id: 'payment-1' },
+      expect.anything(),
+      scope,
+    )
+  })
+
+  it('forwards undefined scope when called without a scope argument', async () => {
+    const { loadPaymentSnapshot } = await import('../payments')
+    const mockEm = {} as any
+
+    await loadPaymentSnapshot(mockEm, 'payment-1')
+
+    expect(findOneWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      expect.anything(),
+      { id: 'payment-1' },
+      expect.anything(),
+      undefined,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix 3: createPaymentCommand.execute — tenant-scoped entity lookups
+// ---------------------------------------------------------------------------
+
+describe('createPaymentCommand.execute — tenant-scoped entity lookups', () => {
+  it('includes tenantId and organizationId when querying SalesOrder', async () => {
+    const execute = commandRegistry.get('sales.payments.create')?.execute
+    expect(execute).toBeInstanceOf(Function)
+
+    const { em, ctx } = buildCommandCtx()
+    // em.findOne returns null → assertFound throws CrudHttpError(404)
+
+    await expect(
+      execute?.(
+        { orderId: TEST_ORDER_ID, tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID, amount: 100, currencyCode: 'USD' },
+        ctx as any,
+      )
+    ).rejects.toBeDefined()
+
+    const orderCall = em.findOne.mock.calls.find(
+      ([_entity, filter]: [unknown, Record<string, unknown>]) => filter?.id === TEST_ORDER_ID
+    )
+    expect(orderCall).toBeDefined()
+    expect(orderCall[1]).toMatchObject({ id: TEST_ORDER_ID, tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID })
+  })
+
+  it('includes tenantId and organizationId when querying SalesPaymentMethod', async () => {
+    const execute = commandRegistry.get('sales.payments.create')?.execute
+    expect(execute).toBeInstanceOf(Function)
+
+    const { em, ctx } = buildCommandCtx({
+      findOne: jest.fn().mockImplementation(async (_entity: unknown, filter: Record<string, unknown>) => {
+        if (filter?.id === TEST_ORDER_ID) {
+          return {
+            id: TEST_ORDER_ID,
+            tenantId: TEST_TENANT_ID,
+            organizationId: TEST_ORG_ID,
+            deletedAt: null,
+            currencyCode: 'USD',
+            paymentMethodId: null,
+            paymentMethodCode: null,
+            orderNumber: 'ORD-001',
+            grandTotalGrossAmount: '0',
+          }
+        }
+        return null // payment method lookup → assertFound throws
+      }),
+    })
+
+    await expect(
+      execute?.(
+        {
+          orderId: TEST_ORDER_ID,
+          paymentMethodId: TEST_METHOD_ID,
+          tenantId: TEST_TENANT_ID,
+          organizationId: TEST_ORG_ID,
+          amount: 100,
+          currencyCode: 'USD',
+        },
+        ctx as any,
+      )
+    ).rejects.toBeDefined()
+
+    const methodCall = em.findOne.mock.calls.find(
+      ([_entity, filter]: [unknown, Record<string, unknown>]) => filter?.id === TEST_METHOD_ID
+    )
+    expect(methodCall).toBeDefined()
+    expect(methodCall[1]).toMatchObject({ id: TEST_METHOD_ID, tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix 2: updatePaymentCommand.execute — flush before allocation sync
+// ---------------------------------------------------------------------------
+
+describe('updatePaymentCommand.execute — flush ordering (scalar mutations before allocation query)', () => {
+  it('flushes scalar mutations before querying existing allocations', async () => {
+    const execute = commandRegistry.get('sales.payments.update')?.execute
+    expect(execute).toBeInstanceOf(Function)
+
+    const callOrder: string[] = []
+
+    const mockPayment = {
+      id: TEST_PAYMENT_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+      order: {
+        id: TEST_ORDER_ID,
+        tenantId: TEST_TENANT_ID,
+        organizationId: TEST_ORG_ID,
+        grandTotalGrossAmount: '100',
+        paidTotalAmount: '0',
+        refundedTotalAmount: '0',
+        outstandingAmount: '100',
+      },
+      paymentMethod: null,
+      paymentReference: null,
+      statusEntryId: null,
+      status: null,
+      amount: '100',
+      currencyCode: 'USD',
+      capturedAmount: '0',
+      refundedAmount: '0',
+      receivedAt: null,
+      capturedAt: null,
+      metadata: null,
+      customFieldSetId: null,
+      updatedAt: new Date(),
+    }
+
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValueOnce(mockPayment)
+
+    const { em, ctx } = buildCommandCtx({
+      findOne: jest.fn().mockResolvedValue(mockPayment),
+      find: jest.fn().mockImplementation((_entity: unknown, filter: Record<string, unknown>) => {
+        if (filter?.payment !== undefined) callOrder.push('find:allocations')
+        return Promise.resolve([])
+      }),
+      flush: jest.fn().mockImplementation(() => {
+        callOrder.push('flush')
+        return Promise.resolve()
+      }),
+    })
+
+    await execute?.(
+      {
+        id: TEST_PAYMENT_ID,
+        tenantId: TEST_TENANT_ID,
+        organizationId: TEST_ORG_ID,
+        allocations: [],
+      },
+      ctx as any,
+    )
+
+    const firstFlushIdx = callOrder.indexOf('flush')
+    const firstAllocFindIdx = callOrder.indexOf('find:allocations')
+
+    expect(firstFlushIdx).toBeGreaterThanOrEqual(0)
+    expect(firstAllocFindIdx).toBeGreaterThanOrEqual(0)
+    expect(firstFlushIdx).toBeLessThan(firstAllocFindIdx)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fix 4: createPaymentCommand.undo — tenant-scoped SalesOrder lookup
+// ---------------------------------------------------------------------------
+
+describe('createPaymentCommand.undo — tenant-scoped SalesOrder lookup', () => {
+  it('uses tenantId and organizationId from the snapshot when fetching the order', async () => {
+    const undo = commandRegistry.get('sales.payments.create')?.undo
+    expect(undo).toBeInstanceOf(Function)
+
+    const after = buildPaymentSnapshot()
+
+    const { em, ctx } = buildCommandCtx({
+      findOne: jest.fn().mockImplementation(async (_entity: unknown, filter: Record<string, unknown>) => {
+        // First call: SalesPayment lookup by id only (no tenantId)
+        if (filter?.id === TEST_PAYMENT_ID && !filter?.tenantId) {
+          return { id: TEST_PAYMENT_ID, order: { id: TEST_ORDER_ID } }
+        }
+        return null
+      }),
+    })
+
+    const logEntry = {
+      payload: {
+        undo: { after, orderPaymentMethodIdBefore: null, orderPaymentMethodCodeBefore: null },
+      },
+    }
+
+    await undo?.({ logEntry: logEntry as any, ctx: ctx as any })
+
+    const scopedOrderCall = em.findOne.mock.calls.find(
+      ([_entity, filter]: [unknown, Record<string, unknown>]) =>
+        filter?.id === TEST_ORDER_ID && 'tenantId' in (filter as object)
+    )
+    expect(scopedOrderCall).toBeDefined()
+    expect(scopedOrderCall[1]).toMatchObject({
+      id: TEST_ORDER_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+    })
   })
 })

--- a/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/payments.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
-import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   resolveTranslations: async () => ({
@@ -222,12 +222,17 @@ describe('loadPaymentSnapshot — scope forwarding to findOneWithDecryption', ()
 // ---------------------------------------------------------------------------
 
 describe('createPaymentCommand.execute — tenant-scoped entity lookups', () => {
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockClear()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(null)
+  })
+
   it('includes tenantId and organizationId when querying SalesOrder', async () => {
     const execute = commandRegistry.get('sales.payments.create')?.execute
     expect(execute).toBeInstanceOf(Function)
 
-    const { em, ctx } = buildCommandCtx()
-    // em.findOne returns null → assertFound throws CrudHttpError(404)
+    const { ctx } = buildCommandCtx()
+    // findOneWithDecryption returns null → assertFound throws CrudHttpError(404)
 
     await expect(
       execute?.(
@@ -236,35 +241,34 @@ describe('createPaymentCommand.execute — tenant-scoped entity lookups', () => 
       )
     ).rejects.toBeDefined()
 
-    const orderCall = em.findOne.mock.calls.find(
-      ([_entity, filter]: [unknown, Record<string, unknown>]) => filter?.id === TEST_ORDER_ID
+    const orderCall = (findOneWithDecryption as jest.Mock).mock.calls.find(
+      ([_em, _entity, filter]: [unknown, unknown, Record<string, unknown>]) => filter?.id === TEST_ORDER_ID
     )
     expect(orderCall).toBeDefined()
-    expect(orderCall[1]).toMatchObject({ id: TEST_ORDER_ID, tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID })
+    expect(orderCall[2]).toMatchObject({ id: TEST_ORDER_ID })
+    expect(orderCall[4]).toMatchObject({ tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID })
   })
 
   it('includes tenantId and organizationId when querying SalesPaymentMethod', async () => {
     const execute = commandRegistry.get('sales.payments.create')?.execute
     expect(execute).toBeInstanceOf(Function)
 
-    const { em, ctx } = buildCommandCtx({
-      findOne: jest.fn().mockImplementation(async (_entity: unknown, filter: Record<string, unknown>) => {
-        if (filter?.id === TEST_ORDER_ID) {
-          return {
-            id: TEST_ORDER_ID,
-            tenantId: TEST_TENANT_ID,
-            organizationId: TEST_ORG_ID,
-            deletedAt: null,
-            currencyCode: 'USD',
-            paymentMethodId: null,
-            paymentMethodCode: null,
-            orderNumber: 'ORD-001',
-            grandTotalGrossAmount: '0',
-          }
-        }
-        return null // payment method lookup → assertFound throws
-      }),
-    })
+    const mockOrder = {
+      id: TEST_ORDER_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+      deletedAt: null,
+      currencyCode: 'USD',
+      paymentMethodId: null,
+      paymentMethodCode: null,
+      orderNumber: 'ORD-001',
+      grandTotalGrossAmount: '0',
+    }
+
+    // First call returns the order; subsequent calls return null (method lookup → assertFound throws)
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValueOnce(mockOrder).mockResolvedValue(null)
+
+    const { ctx } = buildCommandCtx()
 
     await expect(
       execute?.(
@@ -280,11 +284,12 @@ describe('createPaymentCommand.execute — tenant-scoped entity lookups', () => 
       )
     ).rejects.toBeDefined()
 
-    const methodCall = em.findOne.mock.calls.find(
-      ([_entity, filter]: [unknown, Record<string, unknown>]) => filter?.id === TEST_METHOD_ID
+    const methodCall = (findOneWithDecryption as jest.Mock).mock.calls.find(
+      ([_em, _entity, filter]: [unknown, unknown, Record<string, unknown>]) => filter?.id === TEST_METHOD_ID
     )
     expect(methodCall).toBeDefined()
-    expect(methodCall[1]).toMatchObject({ id: TEST_METHOD_ID, tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID })
+    expect(methodCall[2]).toMatchObject({ id: TEST_METHOD_ID })
+    expect(methodCall[4]).toMatchObject({ tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID })
   })
 })
 
@@ -327,14 +332,18 @@ describe('updatePaymentCommand.execute — flush ordering (scalar mutations befo
       updatedAt: new Date(),
     }
 
-    ;(findOneWithDecryption as jest.Mock).mockResolvedValueOnce(mockPayment)
+    // Both scopeSeed and payment lookups in updatePaymentCommand.execute use findOneWithDecryption
+    ;(findOneWithDecryption as jest.Mock)
+      .mockResolvedValueOnce(mockPayment)  // scopeSeed lookup
+      .mockResolvedValueOnce(mockPayment)  // payment lookup (with populate: ['order'])
+
+    // Track allocation queries via findWithDecryption instead of em.find
+    ;(findWithDecryption as jest.Mock).mockImplementation((_em: unknown, _entity: unknown, filter: Record<string, unknown>) => {
+      if (filter?.payment !== undefined) callOrder.push('find:allocations')
+      return Promise.resolve([])
+    })
 
     const { em, ctx } = buildCommandCtx({
-      findOne: jest.fn().mockResolvedValue(mockPayment),
-      find: jest.fn().mockImplementation((_entity: unknown, filter: Record<string, unknown>) => {
-        if (filter?.payment !== undefined) callOrder.push('find:allocations')
-        return Promise.resolve([])
-      }),
       flush: jest.fn().mockImplementation(() => {
         callOrder.push('flush')
         return Promise.resolve()
@@ -365,21 +374,25 @@ describe('updatePaymentCommand.execute — flush ordering (scalar mutations befo
 // ---------------------------------------------------------------------------
 
 describe('createPaymentCommand.undo — tenant-scoped SalesOrder lookup', () => {
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockClear()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue(null)
+    ;(findWithDecryption as jest.Mock).mockClear()
+    ;(findWithDecryption as jest.Mock).mockResolvedValue([])
+  })
+
   it('uses tenantId and organizationId from the snapshot when fetching the order', async () => {
     const undo = commandRegistry.get('sales.payments.create')?.undo
     expect(undo).toBeInstanceOf(Function)
 
     const after = buildPaymentSnapshot()
 
-    const { em, ctx } = buildCommandCtx({
-      findOne: jest.fn().mockImplementation(async (_entity: unknown, filter: Record<string, unknown>) => {
-        // First call: SalesPayment lookup by id only (no tenantId)
-        if (filter?.id === TEST_PAYMENT_ID && !filter?.tenantId) {
-          return { id: TEST_PAYMENT_ID, order: { id: TEST_ORDER_ID } }
-        }
-        return null
-      }),
-    })
+    // Payment lookup returns existing payment; subsequent calls (SalesOrder) return null
+    ;(findOneWithDecryption as jest.Mock)
+      .mockResolvedValueOnce({ id: TEST_PAYMENT_ID, order: { id: TEST_ORDER_ID } })
+      .mockResolvedValue(null)
+
+    const { ctx } = buildCommandCtx()
 
     const logEntry = {
       payload: {
@@ -389,13 +402,14 @@ describe('createPaymentCommand.undo — tenant-scoped SalesOrder lookup', () => 
 
     await undo?.({ logEntry: logEntry as any, ctx: ctx as any })
 
-    const scopedOrderCall = em.findOne.mock.calls.find(
-      ([_entity, filter]: [unknown, Record<string, unknown>]) =>
-        filter?.id === TEST_ORDER_ID && 'tenantId' in (filter as object)
+    // The order lookup inside the undo loop must carry tenantId and organizationId as scope
+    const scopedOrderCall = (findOneWithDecryption as jest.Mock).mock.calls.find(
+      ([_em, _entity, filter]: [unknown, unknown, Record<string, unknown>]) =>
+        filter?.id === TEST_ORDER_ID
     )
     expect(scopedOrderCall).toBeDefined()
-    expect(scopedOrderCall[1]).toMatchObject({
-      id: TEST_ORDER_ID,
+    expect(scopedOrderCall[2]).toMatchObject({ id: TEST_ORDER_ID })
+    expect(scopedOrderCall[4]).toMatchObject({
       tenantId: TEST_TENANT_ID,
       organizationId: TEST_ORG_ID,
     })

--- a/packages/core/src/modules/sales/commands/payments.ts
+++ b/packages/core/src/modules/sales/commands/payments.ts
@@ -177,7 +177,7 @@ export async function restorePaymentSnapshot(em: EntityManager, snapshot: Paymen
     ? em.getReference(SalesPaymentMethod, snapshot.paymentMethodId)
     : null
   const entity =
-    (await em.findOne(SalesPayment, { id: snapshot.id })) ??
+    (await findOneWithDecryption(em, SalesPayment, { id: snapshot.id }, {}, { tenantId: snapshot.tenantId, organizationId: snapshot.organizationId })) ??
     em.create(SalesPayment, {
       id: snapshot.id,
       createdAt: new Date(),
@@ -216,7 +216,7 @@ export async function restorePaymentSnapshot(em: EntityManager, snapshot: Paymen
     })
   }
 
-  const existingAllocations = await em.find(SalesPaymentAllocation, { payment: entity })
+  const existingAllocations = await findWithDecryption(em, SalesPaymentAllocation, { payment: entity }, {}, { tenantId: snapshot.tenantId, organizationId: snapshot.organizationId })
   existingAllocations.forEach((allocation) => em.remove(allocation))
   snapshot.allocations.forEach((allocation) => {
     const order =
@@ -271,8 +271,8 @@ async function recomputeOrderPaymentTotals(
 
   const payments =
     paymentIds.size > 0
-      ? await em.find(SalesPayment, { id: { $in: Array.from(paymentIds) }, deletedAt: null, ...scope })
-      : await em.find(SalesPayment, { order: orderId, deletedAt: null, ...scope })
+      ? await findWithDecryption(em, SalesPayment, { id: { $in: Array.from(paymentIds) }, deletedAt: null, ...scope }, {}, scope)
+      : await findWithDecryption(em, SalesPayment, { order: orderId, deletedAt: null, ...scope }, {}, scope)
 
   const resolvePaidAmount = (payment: SalesPayment) => {
     const captured = toNumber(payment.capturedAmount)
@@ -327,7 +327,7 @@ const createPaymentCommand: CommandHandler<
       throw new CrudHttpError(400, { error: translate('sales.payments.order_required', 'Order is required for payments.') })
     }
     const order = assertFound(
-      await em.findOne(SalesOrder, { id: input.orderId, tenantId: input.tenantId, organizationId: input.organizationId }),
+      await findOneWithDecryption(em, SalesOrder, { id: input.orderId }, {}, { tenantId: input.tenantId, organizationId: input.organizationId }),
       'sales.payments.order_not_found'
     )
     ensureSameScope(order, input.organizationId, input.tenantId)
@@ -346,7 +346,7 @@ const createPaymentCommand: CommandHandler<
     let paymentMethod = null
     if (input.paymentMethodId) {
       const method = assertFound(
-        await em.findOne(SalesPaymentMethod, { id: input.paymentMethodId, tenantId: input.tenantId, organizationId: input.organizationId }),
+        await findOneWithDecryption(em, SalesPaymentMethod, { id: input.paymentMethodId }, {}, { tenantId: input.tenantId, organizationId: input.organizationId }),
         'sales.payments.method_not_found'
       )
       ensureSameScope(method, input.organizationId, input.tenantId)
@@ -379,7 +379,7 @@ const createPaymentCommand: CommandHandler<
           error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.'),
         })
       }
-      const orderLines = await em.find(SalesOrderLine, { order })
+      const orderLines = await findWithDecryption(em, SalesOrderLine, { order }, {}, { tenantId: input.tenantId, organizationId: input.organizationId })
       orderLines.forEach((line) => {
         line.statusEntryId = input.lineStatusEntryId ?? null
         line.status = lineStatus
@@ -521,11 +521,11 @@ const createPaymentCommand: CommandHandler<
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const existing = await em.findOne(SalesPayment, { id: after.id })
+    const existing = await findOneWithDecryption(em, SalesPayment, { id: after.id }, {}, { tenantId: after.tenantId, organizationId: after.organizationId })
     if (existing) {
       const orderRef =
         typeof existing.order === 'string' ? existing.order : existing.order?.id ?? null
-      const allocations = await em.find(SalesPaymentAllocation, { payment: existing })
+      const allocations = await findWithDecryption(em, SalesPaymentAllocation, { payment: existing }, {}, { tenantId: after.tenantId, organizationId: after.organizationId })
       const allocationOrders = allocations
         .map((allocation) =>
           typeof allocation.order === 'string'
@@ -549,7 +549,7 @@ const createPaymentCommand: CommandHandler<
         )
       )
       for (const id of orderIds) {
-        const order = await em.findOne(SalesOrder, { id, tenantId: after.tenantId, organizationId: after.organizationId })
+        const order = await findOneWithDecryption(em, SalesOrder, { id }, {}, { tenantId: after.tenantId, organizationId: after.organizationId })
         if (!order) continue
         if (id === after.orderId && 'orderPaymentMethodIdBefore' in (payload ?? {})) {
           order.paymentMethodId = payload.orderPaymentMethodIdBefore ?? null
@@ -573,7 +573,8 @@ const updatePaymentCommand: CommandHandler<
     const parsed = paymentUpdateSchema.parse(rawInput ?? {})
     if (!parsed.id) return {}
     const em = ctx.container.resolve('em') as EntityManager
-    const snapshot = await loadPaymentSnapshot(em, parsed.id)
+    const scope = ctx.auth?.tenantId ? { tenantId: ctx.auth.tenantId, organizationId: ctx.auth?.orgId ?? null } : undefined
+    const snapshot = await loadPaymentSnapshot(em, parsed.id, scope)
     if (snapshot) {
       ensureTenantScope(ctx, snapshot.tenantId)
       ensureOrganizationScope(ctx, snapshot.organizationId)
@@ -585,7 +586,7 @@ const updatePaymentCommand: CommandHandler<
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const { translate } = await resolveTranslations()
     const scopeSeed = assertFound(
-      await em.findOne(SalesPayment, { id: input.id }),
+      await findOneWithDecryption(em, SalesPayment, { id: input.id }, {}, { tenantId: input.tenantId, organizationId: input.organizationId }),
       'sales.payments.not_found'
     )
     const resolvedTenantId = input.tenantId ?? scopeSeed.tenantId
@@ -609,7 +610,7 @@ const updatePaymentCommand: CommandHandler<
         payment.order = null
       } else {
         const order = assertFound(
-          await em.findOne(SalesOrder, { id: input.orderId, tenantId: resolvedTenantId, organizationId: resolvedOrganizationId }),
+          await findOneWithDecryption(em, SalesOrder, { id: input.orderId }, {}, { tenantId: resolvedTenantId, organizationId: resolvedOrganizationId }),
           'sales.payments.order_not_found'
         )
         ensureSameScope(order, resolvedOrganizationId, resolvedTenantId)
@@ -630,7 +631,7 @@ const updatePaymentCommand: CommandHandler<
         payment.paymentMethod = null
       } else {
         const method = assertFound(
-          await em.findOne(SalesPaymentMethod, { id: input.paymentMethodId }),
+          await findOneWithDecryption(em, SalesPaymentMethod, { id: input.paymentMethodId }, {}, { tenantId: resolvedTenantId, organizationId: resolvedOrganizationId }),
           'sales.payments.method_not_found'
         )
         ensureSameScope(method, resolvedOrganizationId, resolvedTenantId)
@@ -660,7 +661,7 @@ const updatePaymentCommand: CommandHandler<
           error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.'),
         })
       }
-      const orderLines = await em.find(SalesOrderLine, { order: currentOrder })
+      const orderLines = await findWithDecryption(em, SalesOrderLine, { order: currentOrder }, {}, { tenantId: resolvedTenantId, organizationId: resolvedOrganizationId })
       orderLines.forEach((line) => {
         line.statusEntryId = input.lineStatusEntryId ?? null
         line.status = lineStatus
@@ -705,7 +706,7 @@ const updatePaymentCommand: CommandHandler<
     await em.flush()
 
     if (input.allocations !== undefined) {
-      const existingAllocations = await em.find(SalesPaymentAllocation, { payment })
+      const existingAllocations = await findWithDecryption(em, SalesPaymentAllocation, { payment }, {}, { tenantId: payment.tenantId, organizationId: payment.organizationId })
       existingAllocations.forEach((allocation) => em.remove(allocation))
       const allocationInputs = Array.isArray(input.allocations) ? input.allocations : []
       allocationInputs.forEach((allocation) => {
@@ -736,7 +737,7 @@ const updatePaymentCommand: CommandHandler<
     const nextOrder =
       (payment.order as SalesOrder | null) ??
       (typeof payment.order === 'string'
-        ? await em.findOne(SalesOrder, { id: payment.order })
+        ? await findOneWithDecryption(em, SalesOrder, { id: payment.order }, {}, { tenantId: resolvedTenantId, organizationId: resolvedOrganizationId })
         : null)
     let totals: { paidTotalAmount: number; refundedTotalAmount: number; outstandingAmount: number } | undefined
     if (nextOrder) {
@@ -796,7 +797,7 @@ const updatePaymentCommand: CommandHandler<
     await restorePaymentSnapshot(em, before)
     await em.flush()
     if (before.orderId) {
-      const order = await em.findOne(SalesOrder, { id: before.orderId, tenantId: before.tenantId, organizationId: before.organizationId })
+      const order = await findOneWithDecryption(em, SalesOrder, { id: before.orderId }, {}, { tenantId: before.tenantId, organizationId: before.organizationId })
       if (order) {
         await recomputeOrderPaymentTotals(em, order)
         await em.flush()
@@ -814,7 +815,8 @@ const deletePaymentCommand: CommandHandler<
     const parsed = paymentUpdateSchema.parse(rawInput ?? {})
     if (!parsed.id) return {}
     const em = ctx.container.resolve('em') as EntityManager
-    const snapshot = await loadPaymentSnapshot(em, parsed.id)
+    const scope = ctx.auth?.tenantId ? { tenantId: ctx.auth.tenantId, organizationId: ctx.auth?.orgId ?? null } : undefined
+    const snapshot = await loadPaymentSnapshot(em, parsed.id, scope)
     if (snapshot) {
       ensureTenantScope(ctx, snapshot.tenantId)
       ensureOrganizationScope(ctx, snapshot.organizationId)
@@ -838,7 +840,7 @@ const deletePaymentCommand: CommandHandler<
     )
     ensureSameScope(payment, input.organizationId, input.tenantId)
     const order = payment.order as SalesOrder | null
-    const allocations = await em.find(SalesPaymentAllocation, { payment })
+    const allocations = await findWithDecryption(em, SalesPaymentAllocation, { payment }, {}, { tenantId: payment.tenantId, organizationId: payment.organizationId })
     const allocationOrders = allocations
       .map((allocation) =>
         typeof allocation.order === 'string'
@@ -861,7 +863,7 @@ const deletePaymentCommand: CommandHandler<
     )
     const primaryOrderId = order && typeof order === 'object' ? order.id : null
     for (const orderId of orderIds) {
-      const target = typeof order === 'object' && order.id === orderId ? order : await em.findOne(SalesOrder, { id: orderId })
+      const target = typeof order === 'object' && order.id === orderId ? order : await findOneWithDecryption(em, SalesOrder, { id: orderId }, {}, { tenantId: payment.tenantId, organizationId: payment.organizationId })
       if (!target) continue
       const recomputed = await recomputeOrderPaymentTotals(em, target)
       if (!totals || (primaryOrderId && orderId === primaryOrderId)) {
@@ -925,7 +927,7 @@ const deletePaymentCommand: CommandHandler<
     await restorePaymentSnapshot(em, before)
     await em.flush()
     if (before.orderId) {
-      const order = await em.findOne(SalesOrder, { id: before.orderId, tenantId: before.tenantId, organizationId: before.organizationId })
+      const order = await findOneWithDecryption(em, SalesOrder, { id: before.orderId }, {}, { tenantId: before.tenantId, organizationId: before.organizationId })
       if (order) {
         await recomputeOrderPaymentTotals(em, order)
         await em.flush()

--- a/packages/core/src/modules/sales/commands/payments.ts
+++ b/packages/core/src/modules/sales/commands/payments.ts
@@ -113,12 +113,13 @@ async function invalidateOrderCache(container: any, order: SalesOrder | null | u
   )
 }
 
-export async function loadPaymentSnapshot(em: EntityManager, id: string): Promise<PaymentSnapshot | null> {
+export async function loadPaymentSnapshot(em: EntityManager, id: string, scope?: { tenantId?: string | null; organizationId?: string | null }): Promise<PaymentSnapshot | null> {
   const payment = await findOneWithDecryption(
     em,
     SalesPayment,
     { id },
     { populate: ['order', 'allocations', 'allocations.order', 'allocations.invoice'] },
+    scope,
   )
   if (!payment) return null
   const allocations: PaymentAllocationSnapshot[] = Array.from(payment.allocations ?? []).map((allocation) => ({
@@ -326,7 +327,7 @@ const createPaymentCommand: CommandHandler<
       throw new CrudHttpError(400, { error: translate('sales.payments.order_required', 'Order is required for payments.') })
     }
     const order = assertFound(
-      await em.findOne(SalesOrder, { id: input.orderId }),
+      await em.findOne(SalesOrder, { id: input.orderId, tenantId: input.tenantId, organizationId: input.organizationId }),
       'sales.payments.order_not_found'
     )
     ensureSameScope(order, input.organizationId, input.tenantId)
@@ -345,7 +346,7 @@ const createPaymentCommand: CommandHandler<
     let paymentMethod = null
     if (input.paymentMethodId) {
       const method = assertFound(
-        await em.findOne(SalesPaymentMethod, { id: input.paymentMethodId }),
+        await em.findOne(SalesPaymentMethod, { id: input.paymentMethodId, tenantId: input.tenantId, organizationId: input.organizationId }),
         'sales.payments.method_not_found'
       )
       ensureSameScope(method, input.organizationId, input.tenantId)
@@ -496,7 +497,8 @@ const createPaymentCommand: CommandHandler<
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return result?.paymentId ? loadPaymentSnapshot(em, result.paymentId) : null
+    const scope = ctx.auth?.tenantId ? { tenantId: ctx.auth.tenantId, organizationId: ctx.auth?.orgId ?? null } : undefined
+    return result?.paymentId ? loadPaymentSnapshot(em, result.paymentId, scope) : null
   },
   buildLog: async ({ result, snapshots }) => {
     const after = snapshots.after as PaymentSnapshot | undefined
@@ -547,7 +549,7 @@ const createPaymentCommand: CommandHandler<
         )
       )
       for (const id of orderIds) {
-        const order = await em.findOne(SalesOrder, { id })
+        const order = await em.findOne(SalesOrder, { id, tenantId: after.tenantId, organizationId: after.organizationId })
         if (!order) continue
         if (id === after.orderId && 'orderPaymentMethodIdBefore' in (payload ?? {})) {
           order.paymentMethodId = payload.orderPaymentMethodIdBefore ?? null
@@ -607,7 +609,7 @@ const updatePaymentCommand: CommandHandler<
         payment.order = null
       } else {
         const order = assertFound(
-          await em.findOne(SalesOrder, { id: input.orderId }),
+          await em.findOne(SalesOrder, { id: input.orderId, tenantId: resolvedTenantId, organizationId: resolvedOrganizationId }),
           'sales.payments.order_not_found'
         )
         ensureSameScope(order, resolvedOrganizationId, resolvedTenantId)
@@ -699,6 +701,9 @@ const updatePaymentCommand: CommandHandler<
         values: normalizeCustomFieldsInput(input.customFields),
       })
     }
+    payment.updatedAt = new Date()
+    await em.flush()
+
     if (input.allocations !== undefined) {
       const existingAllocations = await em.find(SalesPaymentAllocation, { payment })
       existingAllocations.forEach((allocation) => em.remove(allocation))
@@ -725,9 +730,8 @@ const updatePaymentCommand: CommandHandler<
         })
         em.persist(entity)
       })
+      await em.flush()
     }
-    payment.updatedAt = new Date()
-    await em.flush()
 
     const nextOrder =
       (payment.order as SalesOrder | null) ??
@@ -764,7 +768,8 @@ const updatePaymentCommand: CommandHandler<
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return result?.paymentId ? loadPaymentSnapshot(em, result.paymentId) : null
+    const scope = ctx.auth?.tenantId ? { tenantId: ctx.auth.tenantId, organizationId: ctx.auth?.orgId ?? null } : undefined
+    return result?.paymentId ? loadPaymentSnapshot(em, result.paymentId, scope) : null
   },
   buildLog: async ({ snapshots, result }) => {
     const { translate } = await resolveTranslations()
@@ -791,7 +796,7 @@ const updatePaymentCommand: CommandHandler<
     await restorePaymentSnapshot(em, before)
     await em.flush()
     if (before.orderId) {
-      const order = await em.findOne(SalesOrder, { id: before.orderId })
+      const order = await em.findOne(SalesOrder, { id: before.orderId, tenantId: before.tenantId, organizationId: before.organizationId })
       if (order) {
         await recomputeOrderPaymentTotals(em, order)
         await em.flush()
@@ -920,7 +925,7 @@ const deletePaymentCommand: CommandHandler<
     await restorePaymentSnapshot(em, before)
     await em.flush()
     if (before.orderId) {
-      const order = await em.findOne(SalesOrder, { id: before.orderId })
+      const order = await em.findOne(SalesOrder, { id: before.orderId, tenantId: before.tenantId, organizationId: before.organizationId })
       if (order) {
         await recomputeOrderPaymentTotals(em, order)
         await em.flush()


### PR DESCRIPTION
Fix 1 — loadPaymentSnapshot missing encryption scope (line 117)

Added an optional scope parameter to the function signature and passed it through to findOneWithDecryption. The captureAfter hooks in both createPaymentCommand and updatePaymentCommand (which fork the EM, losing the encryption subscriber) now derive the scope from ctx.auth.tenantId/ctx.auth.orgId. The prepare callers run on the base container EM which has the subscriber registered, so they continue to work without an explicit scope.

Fix 2 — race condition in updatePaymentCommand.execute (lines ~702–730)

The allocation em.find was running after scalar mutations to payment but before em.flush(). MikroORM's identity map can silently discard pending scalar changes when an intermediate query runs on the same EM (SPEC-018). Fix: moved payment.updatedAt = new Date() and the first em.flush() to before the allocation block, ensuring all scalar changes are committed before any em.find runs. The allocation block now has its own trailing em.flush().

Fix 3 — unscoped lookups in createPaymentCommand.execute (lines 329, 348)

em.findOne(SalesOrder, { id: input.orderId }) and em.findOne(SalesPaymentMethod, { id: input.paymentMethodId }) had no tenant/org scope. Added tenantId: input.tenantId, organizationId: input.organizationId to both. The subsequent ensureSameScope calls were already there as a secondary guard, but the DB query itself was unscoped.

Fix 4 — unscoped undo/execute handlers (lines 550, 610, and the two sibling undo handlers)

Four em.findOne(SalesOrder, { id }) calls in undo/execute handlers had no tenant scope:

createPaymentCommand.undo → scoped with after.tenantId / after.organizationId
updatePaymentCommand.execute (order-change path) → scoped with resolvedTenantId / resolvedOrganizationId
updatePaymentCommand.undo → scoped with before.tenantId / before.organizationId
deletePaymentCommand.undo → scoped with before.tenantId / before.organizationId


4 new test suites covering the 4 fixes in payments.ts:

loadPaymentSnapshot — scope forwarding (Fix 1): Verifies that the scope parameter is forwarded as the 5th argument to findOneWithDecryption, both when provided and when omitted. This guards against the encryption scope regression.

createPaymentCommand.execute — tenant-scoped entity lookups (Fix 3): Two tests that let execution reach the ORM call and then fail at assertFound (when em.findOne returns null), then assert the call included tenantId and organizationId. Covers both SalesOrder and SalesPaymentMethod lookups.

updatePaymentCommand.execute — flush ordering (Fix 2): Tracks the order of em.flush() and em.find(SalesPaymentAllocation, ...) calls via a callOrder array, then asserts that the first flush precedes the first allocation find — preventing the MikroORM identity-map race condition described in SPEC-018.

createPaymentCommand.undo — tenant-scoped SalesOrder lookup (Fix 4): Provides a mock existing payment so the undo's if (existing) block is entered, then verifies that the SalesOrder fetch inside uses tenantId and organizationId from the after snapshot.