### PR TITLE
bug: Custom fields of `kind: relation` render as raw UUIDs instead of entity titles/links in DataGrid

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
@@ -79,4 +79,41 @@ describe('GET /api/entities/relations/options', () => {
       }),
     )
   })
+
+  it('caps pageSize at 200 even when more ids are requested', async () => {
+    const manyIds = Array.from({ length: 300 }, (_, index) => `id-${index}`).join(',')
+    mockQE.query.mockResolvedValueOnce({ items: [] })
+
+    const req = new Request(
+      `http://x/api/entities/relations/options?entityId=virtual:example&labelField=title&ids=${manyIds}`,
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    expect(mockQE.query).toHaveBeenCalledWith(
+      'virtual:example',
+      expect.objectContaining({
+        page: { page: 1, pageSize: 200 },
+      }),
+    )
+  })
+
+  it('defaults to pageSize 50 when no ids are provided', async () => {
+    mockQE.query.mockResolvedValueOnce({ items: [] })
+
+    const req = new Request(
+      'http://x/api/entities/relations/options?entityId=virtual:example&labelField=title',
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    expect(mockQE.query).toHaveBeenCalledWith(
+      'virtual:example',
+      expect.objectContaining({
+        page: { page: 1, pageSize: 50 },
+      }),
+    )
+  })
 })

--- a/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/entities/api/relations/options'
+
+const mockQE = {
+  query: jest.fn(async () => ({
+    items: [
+      { id: 'rec-1', title: 'Alpha' },
+      { id: 'rec-2', title: 'Beta' },
+    ],
+  })),
+}
+
+const mockEm = {}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({ resolve: (key: string) => (key === 'queryEngine' ? mockQE : mockEm) }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: () => ({ orgId: 'org', tenantId: 't1', roles: ['admin'] }),
+}))
+
+describe('GET /api/entities/relations/options', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('supports id-scoped lookups through the existing relation options permission surface', async () => {
+    const req = new Request(
+      'http://x/api/entities/relations/options?entityId=virtual:case_study&labelField=title&ids=rec-1,rec-2',
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      items: [
+        { value: 'rec-1', label: 'Alpha' },
+        { value: 'rec-2', label: 'Beta' },
+      ],
+    })
+    expect(mockQE.query).toHaveBeenCalledWith(
+      'virtual:case_study',
+      expect.objectContaining({
+        tenantId: 't1',
+        organizationId: 'org',
+        fields: ['id', 'title'],
+        filters: { id: { $in: ['rec-1', 'rec-2'] } },
+        page: { page: 1, pageSize: 2 },
+      }),
+    )
+  })
+
+  it('returns only the requested safe route context fields', async () => {
+    mockQE.query.mockResolvedValueOnce({
+      items: [
+        { id: 'rec-1', title: 'Ada Lovelace', kind: 'person' },
+      ],
+    })
+
+    const req = new Request(
+      'http://x/api/entities/relations/options?entityId=customers:customer_entity&labelField=title&ids=rec-1&routeContextFields=kind,email',
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      items: [
+        { value: 'rec-1', label: 'Ada Lovelace', routeContext: { kind: 'person' } },
+      ],
+    })
+    expect(mockQE.query).toHaveBeenCalledWith(
+      'customers:customer_entity',
+      expect.objectContaining({
+        fields: ['id', 'title', 'kind'],
+        filters: { id: 'rec-1' },
+        page: { page: 1, pageSize: 1 },
+      }),
+    )
+  })
+})

--- a/packages/core/src/modules/entities/api/relations/options.ts
+++ b/packages/core/src/modules/entities/api/relations/options.ts
@@ -75,7 +75,7 @@ export async function GET(req: Request) {
     ...(auth.orgId ? { organizationId: auth.orgId } : {}),
     fields,
     filters,
-    page: { page: 1, pageSize: ids.length || 50 },
+    page: { page: 1, pageSize: Math.min(ids.length || 50, 200) },
   })
   const items = (res.items || []).map((it: any) => {
     const routeContext = routeContextFields.reduce<Record<string, unknown>>((acc, field) => {
@@ -117,7 +117,7 @@ export const openApi: OpenApiRouteDoc = {
   methods: {
     GET: {
       summary: 'List relation options',
-      description: 'Returns up to 50 option entries for populating relation dropdowns, automatically resolving label fields when omitted.',
+      description: 'Returns up to 200 option entries for populating relation dropdowns, automatically resolving label fields when omitted.',
       query: relationOptionsQuerySchema,
       responses: [
         {

--- a/packages/core/src/modules/entities/api/relations/options.ts
+++ b/packages/core/src/modules/entities/api/relations/options.ts
@@ -13,11 +13,29 @@ export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['entities.definitions.view'] },
 }
 
+const ALLOWED_ROUTE_CONTEXT_FIELDS = new Set(['kind', 'entity_id', 'product_id'])
+
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const entityId = url.searchParams.get('entityId') || ''
   let labelField = url.searchParams.get('labelField') || ''
   const q = url.searchParams.get('q') || ''
+  const ids = Array.from(
+    new Set(
+      (url.searchParams.get('ids') || '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0),
+    ),
+  )
+  const routeContextFields = Array.from(
+    new Set(
+      (url.searchParams.get('routeContextFields') || '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => ALLOWED_ROUTE_CONTEXT_FIELDS.has(entry)),
+    ),
+  )
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId || (!auth.orgId && !auth.isSuperAdmin)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   if (!entityId) return NextResponse.json({ items: [] })
@@ -47,16 +65,31 @@ export async function GET(req: Request) {
     }
     if (!labelField) labelField = 'id'
   }
-  const filters: any = {}
+  const filters: Record<string, unknown> = {}
+  if (ids.length === 1) filters.id = ids[0]
+  else if (ids.length > 1) filters.id = { $in: ids }
   if (q) filters[labelField] = { $ilike: `%${escapeLikePattern(q)}%` }
+  const fields = Array.from(new Set(['id', labelField, ...routeContextFields]))
   const res = await qe.query(entityId, {
     tenantId: auth.tenantId ?? undefined,
     ...(auth.orgId ? { organizationId: auth.orgId } : {}),
-    fields: ['id', labelField],
+    fields,
     filters,
-    page: { page: 1, pageSize: 50 },
+    page: { page: 1, pageSize: ids.length || 50 },
   })
-  const items = (res.items || []).map((it: any) => ({ value: String(it.id), label: String(it[labelField] ?? it.id) }))
+  const items = (res.items || []).map((it: any) => {
+    const routeContext = routeContextFields.reduce<Record<string, unknown>>((acc, field) => {
+      if (it[field] !== undefined) {
+        acc[field] = it[field]
+      }
+      return acc
+    }, {})
+    return {
+      value: String(it.id),
+      label: String(it[labelField] ?? it.id),
+      ...(Object.keys(routeContext).length > 0 ? { routeContext } : {}),
+    }
+  })
   return NextResponse.json({ items })
 }
 
@@ -64,6 +97,8 @@ const relationOptionsQuerySchema = z.object({
   entityId: z.string().min(1),
   labelField: z.string().optional(),
   q: z.string().optional(),
+  ids: z.string().optional(),
+  routeContextFields: z.string().optional(),
 })
 
 const relationOptionsResponseSchema = z.object({
@@ -71,6 +106,7 @@ const relationOptionsResponseSchema = z.object({
     z.object({
       value: z.string(),
       label: z.string(),
+      routeContext: z.record(z.string(), z.unknown()).optional(),
     })
   ),
 })

--- a/packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
+++ b/packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
@@ -9,6 +9,7 @@ jest.mock('@uiw/react-md-editor', () => ({ __esModule: true, default: () => null
 
 import * as React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
+import { registerEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { CustomDataSection } from '../detail/CustomDataSection'
 import type { CrudField } from '../CrudForm'
@@ -21,6 +22,19 @@ type WindowWithOriginalFetch = Window & {
 describe('CustomDataSection relation display', () => {
   const relationId = '27bf226d-cb46-4535-8181-1a629ebd231b'
 
+  beforeAll(() => {
+    registerEntityIds({
+      customers: {
+        customer_entity: 'customers:customer_entity',
+        customer_person_profile: 'customers:customer_person_profile',
+        customer_company_profile: 'customers:customer_company_profile',
+      },
+      catalog: {
+        catalog_product_variant: 'catalog:catalog_product_variant',
+      },
+    })
+  })
+
   afterEach(() => {
     delete (window as WindowWithOriginalFetch).__omOriginalFetch
     jest.restoreAllMocks()
@@ -29,15 +43,15 @@ describe('CustomDataSection relation display', () => {
   it('resolves relation UUIDs into linked labels in read-only mode', async () => {
     ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
-      expect(url).toContain('/api/entities/records?')
+      expect(url).toContain('/api/entities/relations/options?')
       expect(url).toContain(`entityId=${encodeURIComponent('virtual:case_study')}`)
-      expect(url).toContain(`id=${relationId}`)
+      expect(url).toContain(`ids=${encodeURIComponent(relationId)}`)
       return new Response(
         JSON.stringify({
           items: [
             {
-              id: relationId,
-              title: 'ERP AI w CGE S.A.',
+              value: relationId,
+              label: 'ERP AI w CGE S.A.',
             },
           ],
         }),
@@ -92,5 +106,71 @@ describe('CustomDataSection relation display', () => {
 
     fireEvent.click(relationLink)
     expect(screen.queryByRole('button', { name: 'Save now' })).not.toBeInTheDocument()
+  })
+
+  it('keeps deep links for relation displays that need route context', async () => {
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      expect(url).toContain('/api/entities/relations/options?')
+      expect(url).toContain(`entityId=${encodeURIComponent('customers:customer_entity')}`)
+      expect(url).toContain(`ids=${encodeURIComponent(relationId)}`)
+      expect(url).toContain(`routeContextFields=${encodeURIComponent('kind')}`)
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              value: relationId,
+              label: 'Ada Lovelace',
+              routeContext: { kind: 'person' },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_related_customer',
+        label: 'Customer',
+        type: 'select',
+        options: [{ value: relationId, label: 'Ada Lovelace' }],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'related_customer',
+        kind: 'relation',
+        label: 'Customer',
+        optionsUrl: '/api/entities/relations/options?entityId=customers%3Acustomer_entity&labelField=display_name',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_related_customer: relationId }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data…',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const relationLink = await screen.findByRole('link', { name: 'Ada Lovelace' })
+    expect(relationLink).toHaveAttribute(
+      'href',
+      `/backend/customers/people-v2/${encodeURIComponent(relationId)}`,
+    )
   })
 })

--- a/packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
+++ b/packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
@@ -88,7 +88,7 @@ describe('CustomDataSection relation display', () => {
         title="Custom fields"
         loadFields={async () => ({ fields, definitions })}
         labels={{
-          loading: 'Loading custom data…',
+          loading: 'Loading custom data\u2026',
           emptyValue: 'No value',
           noFields: 'No fields',
           saveShortcut: 'Save now',
@@ -157,7 +157,7 @@ describe('CustomDataSection relation display', () => {
         title="Custom fields"
         loadFields={async () => ({ fields, definitions })}
         labels={{
-          loading: 'Loading custom data…',
+          loading: 'Loading custom data\u2026',
           emptyValue: 'No value',
           noFields: 'No fields',
           saveShortcut: 'Save now',
@@ -172,5 +172,294 @@ describe('CustomDataSection relation display', () => {
       'href',
       `/backend/customers/people-v2/${encodeURIComponent(relationId)}`,
     )
+  })
+
+  it('renders text/richtext fields as markdown even when relation displays are empty', async () => {
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({ items: [] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_notes',
+        label: 'Notes',
+        type: 'richtext',
+      },
+      {
+        id: 'cf_linked_case',
+        label: 'Linked case',
+        type: 'select',
+        options: [],
+        loadOptions: async () => [],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'notes',
+        kind: 'richtext',
+        label: 'Notes',
+      },
+      {
+        key: 'linked_case',
+        kind: 'relation',
+        label: 'Linked case',
+        optionsUrl: '/api/entities/relations/options?entityId=virtual%3Acase_study&labelField=title',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_notes: '**Bold note**', cf_linked_case: relationId }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data\u2026',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const notesContent = await screen.findByText('**Bold note**')
+    expect(notesContent).toBeInTheDocument()
+    expect(notesContent.className).toContain('text-sm')
+  })
+
+  it('resolves customer_person_profile with entity_id route context', async () => {
+    const entityId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+    const profileId = 'pppppppp-1111-2222-3333-444444444444'
+
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              value: profileId,
+              label: 'John Doe Profile',
+              routeContext: { entity_id: entityId },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_person_profile',
+        label: 'Person Profile',
+        type: 'select',
+        options: [],
+        loadOptions: async () => [],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'person_profile',
+        kind: 'relation',
+        label: 'Person Profile',
+        optionsUrl: '/api/entities/relations/options?entityId=customers%3Acustomer_person_profile&labelField=title',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_person_profile: profileId }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data\u2026',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const link = await screen.findByRole('link', { name: 'John Doe Profile' })
+    expect(link).toHaveAttribute(
+      'href',
+      `/backend/customers/people-v2/${encodeURIComponent(entityId)}`,
+    )
+  })
+
+  it('resolves catalog_product_variant with product_id route context', async () => {
+    const productId = 'pppppppp-aaaa-bbbb-cccc-dddddddddddd'
+    const variantId = 'vvvvvvvv-1111-2222-3333-444444444444'
+
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              value: variantId,
+              label: 'Variant XL Red',
+              routeContext: { product_id: productId },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_variant_ref',
+        label: 'Product Variant',
+        type: 'select',
+        options: [],
+        loadOptions: async () => [],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'variant_ref',
+        kind: 'relation',
+        label: 'Product Variant',
+        optionsUrl: '/api/entities/relations/options?entityId=catalog%3Acatalog_product_variant&labelField=title',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_variant_ref: variantId }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data\u2026',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const link = await screen.findByRole('link', { name: 'Variant XL Red' })
+    expect(link).toHaveAttribute(
+      'href',
+      `/backend/catalog/products/${encodeURIComponent(productId)}/variants/${encodeURIComponent(variantId)}`,
+    )
+  })
+
+  it('falls back gracefully on API error', async () => {
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({ error: 'Forbidden' }),
+        { status: 403, headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_some_relation',
+        label: 'Some Relation',
+        type: 'select',
+        options: [],
+        loadOptions: async () => [],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'some_relation',
+        kind: 'relation',
+        label: 'Some Relation',
+        optionsUrl: '/api/entities/relations/options?entityId=virtual%3Aexample&labelField=title',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_some_relation: relationId }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data\u2026',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const fallbackText = await screen.findByText(relationId)
+    expect(fallbackText).toBeInTheDocument()
+  })
+
+  it('resolves multi-value relation fields (array of UUIDs)', async () => {
+    const id1 = 'aaaaaaaa-1111-2222-3333-444444444444'
+    const id2 = 'bbbbbbbb-1111-2222-3333-444444444444'
+
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          items: [
+            { value: id1, label: 'Record Alpha' },
+            { value: id2, label: 'Record Beta' },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_multi_relation',
+        label: 'Multi Relation',
+        type: 'multiselect',
+        options: [],
+        loadOptions: async () => [],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'multi_relation',
+        kind: 'relation',
+        label: 'Multi Relation',
+        optionsUrl: '/api/entities/relations/options?entityId=virtual%3Aexample&labelField=title',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_multi_relation: [id1, id2] }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data\u2026',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const linkAlpha = await screen.findByRole('link', { name: 'Record Alpha' })
+    expect(linkAlpha).toBeInTheDocument()
+    const linkBeta = await screen.findByRole('link', { name: 'Record Beta' })
+    expect(linkBeta).toBeInTheDocument()
   })
 })

--- a/packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
+++ b/packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: {} }))
+jest.mock('@uiw/react-md-editor', () => ({ __esModule: true, default: () => null }))
+
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CustomDataSection } from '../detail/CustomDataSection'
+import type { CrudField } from '../CrudForm'
+import type { CustomFieldDefDto } from '../utils/customFieldDefs'
+
+type WindowWithOriginalFetch = Window & {
+  __omOriginalFetch?: typeof fetch
+}
+
+describe('CustomDataSection relation display', () => {
+  const relationId = '27bf226d-cb46-4535-8181-1a629ebd231b'
+
+  afterEach(() => {
+    delete (window as WindowWithOriginalFetch).__omOriginalFetch
+    jest.restoreAllMocks()
+  })
+
+  it('resolves relation UUIDs into linked labels in read-only mode', async () => {
+    ;(window as WindowWithOriginalFetch).__omOriginalFetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      expect(url).toContain('/api/entities/records?')
+      expect(url).toContain(`entityId=${encodeURIComponent('virtual:case_study')}`)
+      expect(url).toContain(`id=${relationId}`)
+      return new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: relationId,
+              title: 'ERP AI w CGE S.A.',
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        },
+      )
+    })
+
+    const fields: CrudField[] = [
+      {
+        id: 'cf_subject_of_case_study',
+        label: 'Case study',
+        type: 'select',
+        options: [],
+        loadOptions: async () => [],
+      },
+    ]
+    const definitions: CustomFieldDefDto[] = [
+      {
+        key: 'subject_of_case_study',
+        kind: 'relation',
+        label: 'Case study',
+        optionsUrl: '/api/entities/relations/options?entityId=virtual%3Acase_study&labelField=title',
+      },
+    ]
+
+    renderWithProviders(
+      <CustomDataSection
+        entityId="customers:customer_entity"
+        values={{ cf_subject_of_case_study: relationId }}
+        onSubmit={async () => {}}
+        title="Custom fields"
+        loadFields={async () => ({ fields, definitions })}
+        labels={{
+          loading: 'Loading custom data…',
+          emptyValue: 'No value',
+          noFields: 'No fields',
+          saveShortcut: 'Save now',
+          edit: 'Edit',
+          cancel: 'Cancel',
+        }}
+      />,
+    )
+
+    const relationLink = await screen.findByRole('link', { name: 'ERP AI w CGE S.A.' })
+    expect(relationLink).toHaveAttribute(
+      'href',
+      `/backend/entities/user/${encodeURIComponent('virtual:case_study')}/records/${encodeURIComponent(relationId)}`,
+    )
+
+    fireEvent.click(relationLink)
+    expect(screen.queryByRole('button', { name: 'Save now' })).not.toBeInTheDocument()
+  })
+})

--- a/packages/ui/src/backend/detail/CustomDataSection.tsx
+++ b/packages/ui/src/backend/detail/CustomDataSection.tsx
@@ -81,15 +81,14 @@ type ResolvedValueDisplay = {
 
 type RelationOptionsMetadata = {
   entityId: string
-  labelField?: string
 }
 
-type EntityRecordsResponse = {
-  items?: Array<Record<string, unknown>>
-  total?: number
-  page?: number
-  pageSize?: number
-  totalPages?: number
+type RelationOptionsResponse = {
+  items?: Array<{
+    value?: unknown
+    label?: unknown
+    routeContext?: Record<string, unknown>
+  }>
 }
 
 function normalizeTextValue(input: unknown): string | null {
@@ -164,43 +163,6 @@ function readRecordValue(record: Record<string, unknown>, field: string): string
   return normalizeTextValue(record[camel])
 }
 
-function buildRelationLabel(record: Record<string, unknown>, labelField?: string): string | null {
-  if (labelField) {
-    const explicit = readRecordValue(record, labelField)
-    if (explicit) return explicit
-  }
-
-  const labelCandidates = [
-    'label',
-    'title',
-    'name',
-    'display_name',
-    'displayName',
-    'subject',
-    'sku',
-    'handle',
-    'order_number',
-    'quote_number',
-    'invoice_number',
-    'email',
-    'company_name',
-    'legal_name',
-    'brand_name',
-  ]
-
-  for (const candidate of labelCandidates) {
-    const value = readRecordValue(record, candidate)
-    if (value) return value
-  }
-
-  const fullName = [readRecordValue(record, 'first_name'), readRecordValue(record, 'last_name')]
-    .filter((part): part is string => typeof part === 'string' && part.length > 0)
-    .join(' ')
-    .trim()
-
-  return fullName.length ? fullName : null
-}
-
 function parseRelationOptionsMetadata(optionsUrl?: string): RelationOptionsMetadata | null {
   if (!optionsUrl) return null
   try {
@@ -209,11 +171,34 @@ function parseRelationOptionsMetadata(optionsUrl?: string): RelationOptionsMetad
     if (!url.pathname.endsWith('/api/entities/relations/options')) return null
     const entityId = url.searchParams.get('entityId')?.trim()
     if (!entityId) return null
-    const labelField = url.searchParams.get('labelField')?.trim() || undefined
-    return { entityId, labelField }
+    return { entityId }
   } catch {
     return null
   }
+}
+
+function getRelationHrefContextFields(entityId: string): string[] {
+  const trimmedEntityId = entityId.trim()
+  if (!trimmedEntityId) return []
+
+  const knownEntityIds = getEntityIds(false)
+  const customers = knownEntityIds.customers ?? {}
+  const catalog = knownEntityIds.catalog ?? {}
+
+  if (trimmedEntityId === customers.customer_entity) {
+    return ['kind']
+  }
+  if (
+    trimmedEntityId === customers.customer_person_profile
+    || trimmedEntityId === customers.customer_company_profile
+  ) {
+    return ['entity_id']
+  }
+  if (trimmedEntityId === catalog.catalog_product_variant) {
+    return ['product_id']
+  }
+
+  return []
 }
 
 function buildRelationHref(entityId: string, recordId: string, record?: Record<string, unknown>): string | undefined {
@@ -295,12 +280,40 @@ function buildRelationHref(entityId: string, recordId: string, record?: Record<s
   return undefined
 }
 
+function buildRelationLookupUrl(
+  optionsUrl: string,
+  recordIds: string[],
+  routeContextFields: string[] = [],
+): string | null {
+  if (!recordIds.length) return null
+  try {
+    const isAbsolute = /^([a-z][a-z\d+\-.]*:)?\/\//i.test(optionsUrl)
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+    const url = isAbsolute ? new URL(optionsUrl) : new URL(optionsUrl, origin)
+    url.searchParams.set('ids', recordIds.join(','))
+    if (routeContextFields.length > 0) {
+      url.searchParams.set('routeContextFields', routeContextFields.join(','))
+    }
+    if (isAbsolute) return url.toString()
+    return `${url.pathname}${url.search}`
+  } catch {
+    const sep = optionsUrl.includes('?') ? '&' : '?'
+    const params = [`ids=${encodeURIComponent(recordIds.join(','))}`]
+    if (routeContextFields.length > 0) {
+      params.push(`routeContextFields=${encodeURIComponent(routeContextFields.join(','))}`)
+    }
+    return `${optionsUrl}${sep}${params.join('&')}`
+  }
+}
+
 async function fetchRelationRecordDisplays(
+  optionsUrl: string,
   relation: RelationOptionsMetadata,
   recordIds: string[],
 ): Promise<Record<string, ResolvedValueDisplay>> {
   const displays: Record<string, ResolvedValueDisplay> = {}
   if (!recordIds.length) return displays
+  const routeContextFields = getRelationHrefContextFields(relation.entityId)
 
   const uniqueIds = Array.from(new Set(recordIds.map((entry) => entry.trim()).filter((entry) => entry.length > 0)))
   const chunks: string[][] = []
@@ -309,16 +322,19 @@ async function fetchRelationRecordDisplays(
   }
 
   for (const chunk of chunks) {
-    const params = new URLSearchParams({
-      entityId: relation.entityId,
-      id: chunk.join(','),
-      page: '1',
-      pageSize: String(chunk.length),
-      sortField: 'id',
-      sortDir: 'asc',
-    })
-    const response = await readApiResultOrThrow<EntityRecordsResponse>(
-      `/api/entities/records?${params.toString()}`,
+    const url = buildRelationLookupUrl(optionsUrl, chunk, routeContextFields)
+    if (!url) {
+      chunk.forEach((recordId) => {
+        displays[recordId] = {
+          label: recordId,
+          href: buildRelationHref(relation.entityId, recordId),
+        }
+      })
+      continue
+    }
+
+    const response = await readApiResultOrThrow<RelationOptionsResponse>(
+      url,
       undefined,
       {
         errorMessage: 'Failed to resolve relation values',
@@ -326,13 +342,28 @@ async function fetchRelationRecordDisplays(
       },
     )
     const items = Array.isArray(response?.items) ? response.items : []
-    items.forEach((record) => {
-      const recordId = readRecordValue(record, 'id')
+    const resolvedIds = new Set<string>()
+
+    items.forEach((item) => {
+      const recordId = normalizeTextValue(item?.value)
       if (!recordId) return
-      const label = buildRelationLabel(record, relation.labelField) ?? recordId
+      resolvedIds.add(recordId)
+      const label = normalizeTextValue(item?.label) ?? recordId
+      const routeContext =
+        item?.routeContext && typeof item.routeContext === 'object' && !Array.isArray(item.routeContext)
+          ? item.routeContext
+          : undefined
       displays[recordId] = {
         label,
-        href: buildRelationHref(relation.entityId, recordId, record),
+        href: buildRelationHref(relation.entityId, recordId, routeContext),
+      }
+    })
+
+    chunk.forEach((recordId) => {
+      if (resolvedIds.has(recordId) || displays[recordId]) return
+      displays[recordId] = {
+        label: recordId,
+        href: buildRelationHref(relation.entityId, recordId),
       }
     })
   }
@@ -780,11 +811,16 @@ function CustomDataSectionImpl({
               }
             }
 
-            const unresolvedIds = relationIds.filter((relationId) => !displays[relationId])
             const relation = parseRelationOptionsMetadata(definition.optionsUrl)
+            const needsRouteContext = relation ? getRelationHrefContextFields(relation.entityId).length > 0 : false
+            const unresolvedIds = relationIds.filter((relationId) => {
+              const display = displays[relationId]
+              if (!display) return true
+              return needsRouteContext && !display.href
+            })
             if (relation && unresolvedIds.length) {
               try {
-                const fetchedDisplays = await fetchRelationRecordDisplays(relation, unresolvedIds)
+                const fetchedDisplays = await fetchRelationRecordDisplays(definition.optionsUrl!, relation, unresolvedIds)
                 Object.assign(displays, fetchedDisplays)
               } catch {
                 unresolvedIds.forEach((relationId) => {

--- a/packages/ui/src/backend/detail/CustomDataSection.tsx
+++ b/packages/ui/src/backend/detail/CustomDataSection.tsx
@@ -12,13 +12,21 @@ import type { CrudField } from '@open-mercato/ui/backend/CrudForm'
 import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
 import { fetchCustomFieldFormFieldsWithDefinitions } from '@open-mercato/ui/backend/utils/customFieldForms'
 import type { CustomFieldDefDto } from '@open-mercato/ui/backend/utils/customFieldDefs'
-import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import {
   DictionaryValue,
   type DictionaryMap,
 } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import { ensureDictionaryEntries } from '@open-mercato/core/modules/dictionaries/components/hooks/useDictionaryEntries'
-import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
+import {
+  type ResolvedValueDisplay,
+  collectRelationValueIds,
+  extractOptionLookupKey,
+  extractInlineOptionLabel,
+  parseRelationOptionsMetadata,
+  getRelationHrefContextFields,
+  buildRelationHref,
+  fetchRelationRecordDisplays,
+} from '@open-mercato/ui/backend/utils/customFieldRelationDisplay'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { ComponentReplacementHandles } from '@open-mercato/shared/modules/widgets/component-registry'
@@ -72,303 +80,6 @@ function extractDictionaryValue(entry: unknown): string | null {
     return trimmed.length ? trimmed : null
   }
   return null
-}
-
-type ResolvedValueDisplay = {
-  label: string
-  href?: string
-}
-
-type RelationOptionsMetadata = {
-  entityId: string
-}
-
-type RelationOptionsResponse = {
-  items?: Array<{
-    value?: unknown
-    label?: unknown
-    routeContext?: Record<string, unknown>
-  }>
-}
-
-function normalizeTextValue(input: unknown): string | null {
-  if (typeof input === 'string') {
-    const trimmed = input.trim()
-    return trimmed.length ? trimmed : null
-  }
-  if (typeof input === 'number' || typeof input === 'boolean') {
-    return String(input)
-  }
-  return null
-}
-
-function extractOptionLookupKey(entry: unknown): string | null {
-  if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
-    return normalizeTextValue(entry)
-  }
-  if (!entry || typeof entry !== 'object') return null
-  const record = entry as Record<string, unknown>
-  return (
-    normalizeTextValue(record.value)
-    ?? normalizeTextValue(record.id)
-    ?? normalizeTextValue(record.key)
-    ?? normalizeTextValue(record.name)
-    ?? null
-  )
-}
-
-function extractInlineOptionLabel(entry: unknown): string | null {
-  if (!entry || typeof entry !== 'object') return null
-  const record = entry as Record<string, unknown>
-  return (
-    normalizeTextValue(record.label)
-    ?? normalizeTextValue(record.name)
-    ?? null
-  )
-}
-
-function collectRelationValueIds(value: unknown): string[] {
-  if (Array.isArray(value)) {
-    return Array.from(
-      new Set(
-        value
-          .map((entry) => extractOptionLookupKey(entry))
-          .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0),
-      ),
-    )
-  }
-  const single = extractOptionLookupKey(value)
-  return single ? [single] : []
-}
-
-function camelToSnake(value: string): string {
-  return value
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .replace(/[\s-]+/g, '_')
-    .toLowerCase()
-}
-
-function snakeToCamel(value: string): string {
-  return value.replace(/[_-](\w)/g, (_, char: string) => char.toUpperCase())
-}
-
-function readRecordValue(record: Record<string, unknown>, field: string): string | null {
-  if (!field) return null
-  const direct = normalizeTextValue(record[field])
-  if (direct) return direct
-  const snake = camelToSnake(field)
-  const snakeValue = normalizeTextValue(record[snake])
-  if (snakeValue) return snakeValue
-  const camel = snakeToCamel(field)
-  return normalizeTextValue(record[camel])
-}
-
-function parseRelationOptionsMetadata(optionsUrl?: string): RelationOptionsMetadata | null {
-  if (!optionsUrl) return null
-  try {
-    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
-    const url = new URL(optionsUrl, origin)
-    if (!url.pathname.endsWith('/api/entities/relations/options')) return null
-    const entityId = url.searchParams.get('entityId')?.trim()
-    if (!entityId) return null
-    return { entityId }
-  } catch {
-    return null
-  }
-}
-
-function getRelationHrefContextFields(entityId: string): string[] {
-  const trimmedEntityId = entityId.trim()
-  if (!trimmedEntityId) return []
-
-  const knownEntityIds = getEntityIds(false)
-  const customers = knownEntityIds.customers ?? {}
-  const catalog = knownEntityIds.catalog ?? {}
-
-  if (trimmedEntityId === customers.customer_entity) {
-    return ['kind']
-  }
-  if (
-    trimmedEntityId === customers.customer_person_profile
-    || trimmedEntityId === customers.customer_company_profile
-  ) {
-    return ['entity_id']
-  }
-  if (trimmedEntityId === catalog.catalog_product_variant) {
-    return ['product_id']
-  }
-
-  return []
-}
-
-function buildRelationHref(entityId: string, recordId: string, record?: Record<string, unknown>): string | undefined {
-  const trimmedEntityId = entityId.trim()
-  const trimmedRecordId = recordId.trim()
-  if (!trimmedEntityId || !trimmedRecordId) return undefined
-
-  const knownEntityIds = getEntityIds(false)
-  const customers = knownEntityIds.customers ?? {}
-  const catalog = knownEntityIds.catalog ?? {}
-  const sales = knownEntityIds.sales ?? {}
-  const staff = knownEntityIds.staff ?? {}
-  const resources = knownEntityIds.resources ?? {}
-  const knownEntityIdSet = new Set(
-    Object.values(knownEntityIds).flatMap((group) => Object.values(group ?? {})),
-  )
-  const canUseCustomEntityFallback =
-    knownEntityIdSet.size > 0
-      ? !knownEntityIdSet.has(trimmedEntityId)
-      : trimmedEntityId.startsWith('virtual:')
-
-  if (trimmedEntityId === customers.customer_entity) {
-    const kind = (readRecordValue(record ?? {}, 'kind') ?? '').toLowerCase()
-    if (kind === 'person') return `/backend/customers/people-v2/${encodeURIComponent(trimmedRecordId)}`
-    if (kind === 'company') return `/backend/customers/companies-v2/${encodeURIComponent(trimmedRecordId)}`
-    return undefined
-  }
-  if (trimmedEntityId === customers.customer_person_profile) {
-    const linkedId = readRecordValue(record ?? {}, 'entity_id') ?? trimmedRecordId
-    return `/backend/customers/people-v2/${encodeURIComponent(linkedId)}`
-  }
-  if (trimmedEntityId === customers.customer_company_profile) {
-    const linkedId = readRecordValue(record ?? {}, 'entity_id') ?? trimmedRecordId
-    return `/backend/customers/companies-v2/${encodeURIComponent(linkedId)}`
-  }
-  if (trimmedEntityId === customers.customer_deal) {
-    return `/backend/customers/deals/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === catalog.catalog_product) {
-    return `/backend/catalog/products/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === catalog.catalog_category) {
-    return `/backend/catalog/categories/${encodeURIComponent(trimmedRecordId)}/edit`
-  }
-  if (trimmedEntityId === catalog.catalog_product_variant) {
-    const productId = readRecordValue(record ?? {}, 'product_id')
-    if (!productId) return undefined
-    return `/backend/catalog/products/${encodeURIComponent(productId)}/variants/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === sales.sales_quote) {
-    return `/backend/sales/quotes/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === sales.sales_order) {
-    return `/backend/sales/orders/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === sales.sales_channel) {
-    return `/backend/sales/channels/${encodeURIComponent(trimmedRecordId)}/edit`
-  }
-  if (trimmedEntityId === staff.staff_team_member) {
-    return `/backend/staff/team-members/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === staff.staff_team_role) {
-    return `/backend/staff/team-roles/${encodeURIComponent(trimmedRecordId)}/edit`
-  }
-  if (trimmedEntityId === staff.staff_team) {
-    return `/backend/staff/teams/${encodeURIComponent(trimmedRecordId)}/edit`
-  }
-  if (trimmedEntityId === staff.staff_leave_request) {
-    return `/backend/staff/leave-requests/${encodeURIComponent(trimmedRecordId)}`
-  }
-  if (trimmedEntityId === resources.resources_resource) {
-    return `/backend/resources/resources/${encodeURIComponent(trimmedRecordId)}`
-  }
-
-  if (canUseCustomEntityFallback) {
-    return `/backend/entities/user/${encodeURIComponent(trimmedEntityId)}/records/${encodeURIComponent(trimmedRecordId)}`
-  }
-
-  return undefined
-}
-
-function buildRelationLookupUrl(
-  optionsUrl: string,
-  recordIds: string[],
-  routeContextFields: string[] = [],
-): string | null {
-  if (!recordIds.length) return null
-  try {
-    const isAbsolute = /^([a-z][a-z\d+\-.]*:)?\/\//i.test(optionsUrl)
-    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
-    const url = isAbsolute ? new URL(optionsUrl) : new URL(optionsUrl, origin)
-    url.searchParams.set('ids', recordIds.join(','))
-    if (routeContextFields.length > 0) {
-      url.searchParams.set('routeContextFields', routeContextFields.join(','))
-    }
-    if (isAbsolute) return url.toString()
-    return `${url.pathname}${url.search}`
-  } catch {
-    const sep = optionsUrl.includes('?') ? '&' : '?'
-    const params = [`ids=${encodeURIComponent(recordIds.join(','))}`]
-    if (routeContextFields.length > 0) {
-      params.push(`routeContextFields=${encodeURIComponent(routeContextFields.join(','))}`)
-    }
-    return `${optionsUrl}${sep}${params.join('&')}`
-  }
-}
-
-async function fetchRelationRecordDisplays(
-  optionsUrl: string,
-  relation: RelationOptionsMetadata,
-  recordIds: string[],
-): Promise<Record<string, ResolvedValueDisplay>> {
-  const displays: Record<string, ResolvedValueDisplay> = {}
-  if (!recordIds.length) return displays
-  const routeContextFields = getRelationHrefContextFields(relation.entityId)
-
-  const uniqueIds = Array.from(new Set(recordIds.map((entry) => entry.trim()).filter((entry) => entry.length > 0)))
-  const chunks: string[][] = []
-  for (let index = 0; index < uniqueIds.length; index += 100) {
-    chunks.push(uniqueIds.slice(index, index + 100))
-  }
-
-  for (const chunk of chunks) {
-    const url = buildRelationLookupUrl(optionsUrl, chunk, routeContextFields)
-    if (!url) {
-      chunk.forEach((recordId) => {
-        displays[recordId] = {
-          label: recordId,
-          href: buildRelationHref(relation.entityId, recordId),
-        }
-      })
-      continue
-    }
-
-    const response = await readApiResultOrThrow<RelationOptionsResponse>(
-      url,
-      undefined,
-      {
-        errorMessage: 'Failed to resolve relation values',
-        fallback: { items: [] },
-      },
-    )
-    const items = Array.isArray(response?.items) ? response.items : []
-    const resolvedIds = new Set<string>()
-
-    items.forEach((item) => {
-      const recordId = normalizeTextValue(item?.value)
-      if (!recordId) return
-      resolvedIds.add(recordId)
-      const label = normalizeTextValue(item?.label) ?? recordId
-      const routeContext =
-        item?.routeContext && typeof item.routeContext === 'object' && !Array.isArray(item.routeContext)
-          ? item.routeContext
-          : undefined
-      displays[recordId] = {
-        label,
-        href: buildRelationHref(relation.entityId, recordId, routeContext),
-      }
-    })
-
-    chunk.forEach((recordId) => {
-      if (resolvedIds.has(recordId) || displays[recordId]) return
-      displays[recordId] = {
-        label: recordId,
-        href: buildRelationHref(relation.entityId, recordId),
-      }
-    })
-  }
-
-  return displays
 }
 
 export type CustomDataLabels = {
@@ -515,9 +226,11 @@ function formatFieldValue(
     return value ? 'Yes' : 'No'
   }
 
-  const resolvedDisplay = resolveOptionDisplay(value)
-  if (resolvedDisplay) {
-    return renderResolvedDisplay(resolvedDisplay)
+  if (resolvedDisplays && Object.keys(resolvedDisplays).length > 0) {
+    const resolvedDisplay = resolveOptionDisplay(value)
+    if (resolvedDisplay) {
+      return renderResolvedDisplay(resolvedDisplay)
+    }
   }
 
   if (typeof value === 'object') {
@@ -779,7 +492,7 @@ function CustomDataSectionImpl({
       return
     }
 
-    let cancelled = false
+    const abortController = new AbortController()
 
     const load = async () => {
       setRelationLoading(true)
@@ -806,8 +519,8 @@ function CustomDataSectionImpl({
                   })()
                   displays[option.value] = { label: option.label, href }
                 })
-              } catch {
-                // keep static labels only
+              } catch (error) {
+                console.debug('[CustomDataSection] Failed to load remote options for field', field.id, error)
               }
             }
 
@@ -820,9 +533,10 @@ function CustomDataSectionImpl({
             })
             if (relation && unresolvedIds.length) {
               try {
-                const fetchedDisplays = await fetchRelationRecordDisplays(definition.optionsUrl!, relation, unresolvedIds)
+                const fetchedDisplays = await fetchRelationRecordDisplays(definition.optionsUrl!, relation, unresolvedIds, abortController.signal)
                 Object.assign(displays, fetchedDisplays)
-              } catch {
+              } catch (error) {
+                console.debug('[CustomDataSection] Failed to fetch relation record displays for field', field.id, error)
                 unresolvedIds.forEach((relationId) => {
                   if (!displays[relationId]) {
                     displays[relationId] = {
@@ -840,7 +554,7 @@ function CustomDataSectionImpl({
           }),
         )
 
-        if (!cancelled) {
+        if (!abortController.signal.aborted) {
           setResolvedDisplaysByField((prev) => {
             const previousKeys = Object.keys(prev)
             const nextKeys = Object.keys(nextDisplays)
@@ -854,7 +568,7 @@ function CustomDataSectionImpl({
           })
         }
       } finally {
-        if (!cancelled) {
+        if (!abortController.signal.aborted) {
           setRelationLoading(false)
         }
       }
@@ -862,7 +576,7 @@ function CustomDataSectionImpl({
 
     void load()
     return () => {
-      cancelled = true
+      abortController.abort()
     }
   }, [definitions, fields, values])
 

--- a/packages/ui/src/backend/detail/CustomDataSection.tsx
+++ b/packages/ui/src/backend/detail/CustomDataSection.tsx
@@ -12,11 +12,13 @@ import type { CrudField } from '@open-mercato/ui/backend/CrudForm'
 import { CrudForm } from '@open-mercato/ui/backend/CrudForm'
 import { fetchCustomFieldFormFieldsWithDefinitions } from '@open-mercato/ui/backend/utils/customFieldForms'
 import type { CustomFieldDefDto } from '@open-mercato/ui/backend/utils/customFieldDefs'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import {
   DictionaryValue,
   type DictionaryMap,
 } from '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance'
 import { ensureDictionaryEntries } from '@open-mercato/core/modules/dictionaries/components/hooks/useDictionaryEntries'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { ComponentReplacementHandles } from '@open-mercato/shared/modules/widgets/component-registry'
@@ -72,6 +74,272 @@ function extractDictionaryValue(entry: unknown): string | null {
   return null
 }
 
+type ResolvedValueDisplay = {
+  label: string
+  href?: string
+}
+
+type RelationOptionsMetadata = {
+  entityId: string
+  labelField?: string
+}
+
+type EntityRecordsResponse = {
+  items?: Array<Record<string, unknown>>
+  total?: number
+  page?: number
+  pageSize?: number
+  totalPages?: number
+}
+
+function normalizeTextValue(input: unknown): string | null {
+  if (typeof input === 'string') {
+    const trimmed = input.trim()
+    return trimmed.length ? trimmed : null
+  }
+  if (typeof input === 'number' || typeof input === 'boolean') {
+    return String(input)
+  }
+  return null
+}
+
+function extractOptionLookupKey(entry: unknown): string | null {
+  if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+    return normalizeTextValue(entry)
+  }
+  if (!entry || typeof entry !== 'object') return null
+  const record = entry as Record<string, unknown>
+  return (
+    normalizeTextValue(record.value)
+    ?? normalizeTextValue(record.id)
+    ?? normalizeTextValue(record.key)
+    ?? normalizeTextValue(record.name)
+    ?? null
+  )
+}
+
+function extractInlineOptionLabel(entry: unknown): string | null {
+  if (!entry || typeof entry !== 'object') return null
+  const record = entry as Record<string, unknown>
+  return (
+    normalizeTextValue(record.label)
+    ?? normalizeTextValue(record.name)
+    ?? null
+  )
+}
+
+function collectRelationValueIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(
+        value
+          .map((entry) => extractOptionLookupKey(entry))
+          .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0),
+      ),
+    )
+  }
+  const single = extractOptionLookupKey(value)
+  return single ? [single] : []
+}
+
+function camelToSnake(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase()
+}
+
+function snakeToCamel(value: string): string {
+  return value.replace(/[_-](\w)/g, (_, char: string) => char.toUpperCase())
+}
+
+function readRecordValue(record: Record<string, unknown>, field: string): string | null {
+  if (!field) return null
+  const direct = normalizeTextValue(record[field])
+  if (direct) return direct
+  const snake = camelToSnake(field)
+  const snakeValue = normalizeTextValue(record[snake])
+  if (snakeValue) return snakeValue
+  const camel = snakeToCamel(field)
+  return normalizeTextValue(record[camel])
+}
+
+function buildRelationLabel(record: Record<string, unknown>, labelField?: string): string | null {
+  if (labelField) {
+    const explicit = readRecordValue(record, labelField)
+    if (explicit) return explicit
+  }
+
+  const labelCandidates = [
+    'label',
+    'title',
+    'name',
+    'display_name',
+    'displayName',
+    'subject',
+    'sku',
+    'handle',
+    'order_number',
+    'quote_number',
+    'invoice_number',
+    'email',
+    'company_name',
+    'legal_name',
+    'brand_name',
+  ]
+
+  for (const candidate of labelCandidates) {
+    const value = readRecordValue(record, candidate)
+    if (value) return value
+  }
+
+  const fullName = [readRecordValue(record, 'first_name'), readRecordValue(record, 'last_name')]
+    .filter((part): part is string => typeof part === 'string' && part.length > 0)
+    .join(' ')
+    .trim()
+
+  return fullName.length ? fullName : null
+}
+
+function parseRelationOptionsMetadata(optionsUrl?: string): RelationOptionsMetadata | null {
+  if (!optionsUrl) return null
+  try {
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+    const url = new URL(optionsUrl, origin)
+    if (!url.pathname.endsWith('/api/entities/relations/options')) return null
+    const entityId = url.searchParams.get('entityId')?.trim()
+    if (!entityId) return null
+    const labelField = url.searchParams.get('labelField')?.trim() || undefined
+    return { entityId, labelField }
+  } catch {
+    return null
+  }
+}
+
+function buildRelationHref(entityId: string, recordId: string, record?: Record<string, unknown>): string | undefined {
+  const trimmedEntityId = entityId.trim()
+  const trimmedRecordId = recordId.trim()
+  if (!trimmedEntityId || !trimmedRecordId) return undefined
+
+  const knownEntityIds = getEntityIds(false)
+  const customers = knownEntityIds.customers ?? {}
+  const catalog = knownEntityIds.catalog ?? {}
+  const sales = knownEntityIds.sales ?? {}
+  const staff = knownEntityIds.staff ?? {}
+  const resources = knownEntityIds.resources ?? {}
+  const knownEntityIdSet = new Set(
+    Object.values(knownEntityIds).flatMap((group) => Object.values(group ?? {})),
+  )
+  const canUseCustomEntityFallback =
+    knownEntityIdSet.size > 0
+      ? !knownEntityIdSet.has(trimmedEntityId)
+      : trimmedEntityId.startsWith('virtual:')
+
+  if (trimmedEntityId === customers.customer_entity) {
+    const kind = (readRecordValue(record ?? {}, 'kind') ?? '').toLowerCase()
+    if (kind === 'person') return `/backend/customers/people-v2/${encodeURIComponent(trimmedRecordId)}`
+    if (kind === 'company') return `/backend/customers/companies-v2/${encodeURIComponent(trimmedRecordId)}`
+    return undefined
+  }
+  if (trimmedEntityId === customers.customer_person_profile) {
+    const linkedId = readRecordValue(record ?? {}, 'entity_id') ?? trimmedRecordId
+    return `/backend/customers/people-v2/${encodeURIComponent(linkedId)}`
+  }
+  if (trimmedEntityId === customers.customer_company_profile) {
+    const linkedId = readRecordValue(record ?? {}, 'entity_id') ?? trimmedRecordId
+    return `/backend/customers/companies-v2/${encodeURIComponent(linkedId)}`
+  }
+  if (trimmedEntityId === customers.customer_deal) {
+    return `/backend/customers/deals/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === catalog.catalog_product) {
+    return `/backend/catalog/products/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === catalog.catalog_category) {
+    return `/backend/catalog/categories/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === catalog.catalog_product_variant) {
+    const productId = readRecordValue(record ?? {}, 'product_id')
+    if (!productId) return undefined
+    return `/backend/catalog/products/${encodeURIComponent(productId)}/variants/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === sales.sales_quote) {
+    return `/backend/sales/quotes/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === sales.sales_order) {
+    return `/backend/sales/orders/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === sales.sales_channel) {
+    return `/backend/sales/channels/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === staff.staff_team_member) {
+    return `/backend/staff/team-members/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === staff.staff_team_role) {
+    return `/backend/staff/team-roles/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === staff.staff_team) {
+    return `/backend/staff/teams/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === staff.staff_leave_request) {
+    return `/backend/staff/leave-requests/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === resources.resources_resource) {
+    return `/backend/resources/resources/${encodeURIComponent(trimmedRecordId)}`
+  }
+
+  if (canUseCustomEntityFallback) {
+    return `/backend/entities/user/${encodeURIComponent(trimmedEntityId)}/records/${encodeURIComponent(trimmedRecordId)}`
+  }
+
+  return undefined
+}
+
+async function fetchRelationRecordDisplays(
+  relation: RelationOptionsMetadata,
+  recordIds: string[],
+): Promise<Record<string, ResolvedValueDisplay>> {
+  const displays: Record<string, ResolvedValueDisplay> = {}
+  if (!recordIds.length) return displays
+
+  const uniqueIds = Array.from(new Set(recordIds.map((entry) => entry.trim()).filter((entry) => entry.length > 0)))
+  const chunks: string[][] = []
+  for (let index = 0; index < uniqueIds.length; index += 100) {
+    chunks.push(uniqueIds.slice(index, index + 100))
+  }
+
+  for (const chunk of chunks) {
+    const params = new URLSearchParams({
+      entityId: relation.entityId,
+      id: chunk.join(','),
+      page: '1',
+      pageSize: String(chunk.length),
+      sortField: 'id',
+      sortDir: 'asc',
+    })
+    const response = await readApiResultOrThrow<EntityRecordsResponse>(
+      `/api/entities/records?${params.toString()}`,
+      undefined,
+      {
+        errorMessage: 'Failed to resolve relation values',
+        fallback: { items: [] },
+      },
+    )
+    const items = Array.isArray(response?.items) ? response.items : []
+    items.forEach((record) => {
+      const recordId = readRecordValue(record, 'id')
+      if (!recordId) return
+      const label = buildRelationLabel(record, relation.labelField) ?? recordId
+      displays[recordId] = {
+        label,
+        href: buildRelationHref(relation.entityId, recordId, record),
+      }
+    })
+  }
+
+  return displays
+}
+
 export type CustomDataLabels = {
   loading: string
   emptyValue: string
@@ -102,6 +370,7 @@ function formatFieldValue(
   emptyLabel: string,
   dictionaryMap?: DictionaryMap,
   remarkPlugins: PluggableList = [],
+  resolvedDisplays?: Record<string, ResolvedValueDisplay>,
 ): React.ReactNode {
   if (dictionaryMap) {
     if (value === undefined || value === null || value === '') {
@@ -160,23 +429,35 @@ function formatFieldValue(
         }, new Map())
       : null
 
-  const resolveOptionLabel = (entry: unknown): string => {
-    if (entry && typeof entry === 'object') {
-      const record = entry as { label?: unknown; value?: unknown; name?: unknown }
-      const candidateLabel = record.label
-      if (typeof candidateLabel === 'string' && candidateLabel.trim().length) {
-        return candidateLabel.trim()
-      }
-      const candidateValue = record.value ?? record.name
-      if (typeof candidateValue === 'string' && candidateValue.trim().length) {
-        const normalized = candidateValue.trim()
-        return optionMap?.get(normalized) ?? normalized
+  const resolveOptionDisplay = (entry: unknown): ResolvedValueDisplay | null => {
+    const lookupKey = extractOptionLookupKey(entry)
+    if (lookupKey && resolvedDisplays?.[lookupKey]) {
+      return resolvedDisplays[lookupKey]
+    }
+    const inlineLabel = extractInlineOptionLabel(entry)
+    if (lookupKey) {
+      return {
+        label: inlineLabel ?? optionMap?.get(lookupKey) ?? lookupKey,
       }
     }
-    if (entry === undefined || entry === null) return ''
-    const normalized = String(entry)
-    if (!normalized.length) return ''
-    return optionMap?.get(normalized) ?? normalized
+    if (inlineLabel) {
+      return { label: inlineLabel }
+    }
+    return null
+  }
+
+  const renderResolvedDisplay = (display: ResolvedValueDisplay) => {
+    if (!display.href) return display.label
+    return (
+      <Link
+        href={display.href}
+        className="font-medium text-primary underline-offset-2 hover:underline focus-visible:underline"
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => event.stopPropagation()}
+      >
+        {display.label}
+      </Link>
+    )
   }
 
   if (value === undefined || value === null || value === '') {
@@ -190,13 +471,22 @@ function formatFieldValue(
         key={`${field.id}-${index}`}
         className="mr-1 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs"
       >
-        {resolveOptionLabel(entry) || emptyLabel}
+        {(() => {
+          const display = resolveOptionDisplay(entry)
+          if (!display) return emptyLabel
+          return renderResolvedDisplay(display)
+        })()}
       </span>
     ))
   }
 
   if (typeof value === 'boolean') {
     return value ? 'Yes' : 'No'
+  }
+
+  const resolvedDisplay = resolveOptionDisplay(value)
+  if (resolvedDisplay) {
+    return renderResolvedDisplay(resolvedDisplay)
   }
 
   if (typeof value === 'object') {
@@ -207,7 +497,7 @@ function formatFieldValue(
     }
   }
 
-  const resolved = resolveOptionLabel(value)
+  const resolved = optionMap?.get(String(value)) ?? String(value)
   if (typeof value === 'string' && MARKDOWN_FIELD_TYPES.has(field.type)) {
     if (!resolved.trim().length) {
       return <span className="text-muted-foreground">{emptyLabel}</span>
@@ -237,6 +527,7 @@ function CustomDataSectionImpl({
     [scopeVersion],
   )
   const [dictionaryMapsByField, setDictionaryMapsByField] = React.useState<Record<string, DictionaryMap>>({})
+  const [resolvedDisplaysByField, setResolvedDisplaysByField] = React.useState<Record<string, Record<string, ResolvedValueDisplay>>>({})
   const [editing, setEditing] = React.useState(false)
   const sectionRef = React.useRef<HTMLDivElement | null>(null)
   const [markdownPlugins, setMarkdownPlugins] = React.useState<PluggableList>([])
@@ -285,7 +576,8 @@ function CustomDataSectionImpl({
     [customFieldFormsQuery.data],
   )
   const [dictionaryLoading, setDictionaryLoading] = React.useState(false)
-  const loading = customFieldFormsQuery.isLoading || dictionaryLoading
+  const [relationLoading, setRelationLoading] = React.useState(false)
+  const loading = customFieldFormsQuery.isLoading || dictionaryLoading || relationLoading
   const hasFields = fields.length > 0
   const definitionHref = explicitDefinitionHref ?? (primaryEntityId
     ? `/backend/entities/system/${encodeURIComponent(primaryEntityId)}`
@@ -427,6 +719,117 @@ function CustomDataSectionImpl({
     }
   }, [definitions, fields, queryClient, resolvedEntityIds, resolvedScopeVersion])
 
+  React.useEffect(() => {
+    if (!definitions.length || !fields.length) {
+      setRelationLoading((prev) => (prev ? false : prev))
+      setResolvedDisplaysByField((prev) => (Object.keys(prev).length ? {} : prev))
+      return
+    }
+
+    const definitionsByKey = definitions.reduce<Map<string, CustomFieldDefDto>>((acc, definition) => {
+      acc.set(definition.key.toLowerCase(), definition)
+      return acc
+    }, new Map())
+
+    const relationFields = fields
+      .map((field) => {
+        const normalizedKey = field.id.startsWith('cf_') ? field.id.slice(3) : field.id
+        const definition = definitionsByKey.get(normalizedKey.toLowerCase())
+        if (!definition || definition.kind !== 'relation') return null
+        const relationIds = collectRelationValueIds(values?.[field.id])
+        if (!relationIds.length) return null
+        return { field, definition, relationIds }
+      })
+      .filter((entry): entry is { field: CrudField; definition: CustomFieldDefDto; relationIds: string[] } => !!entry)
+
+    if (!relationFields.length) {
+      setRelationLoading((prev) => (prev ? false : prev))
+      setResolvedDisplaysByField((prev) => (Object.keys(prev).length ? {} : prev))
+      return
+    }
+
+    let cancelled = false
+
+    const load = async () => {
+      setRelationLoading(true)
+      try {
+        const nextDisplays: Record<string, Record<string, ResolvedValueDisplay>> = {}
+
+        await Promise.all(
+          relationFields.map(async ({ field, definition, relationIds }) => {
+            const displays: Record<string, ResolvedValueDisplay> = {}
+
+            if ('options' in field && Array.isArray(field.options)) {
+              field.options.forEach((option) => {
+                displays[option.value] = { label: option.label }
+              })
+            }
+
+            if ('loadOptions' in field && typeof field.loadOptions === 'function') {
+              try {
+                const remoteOptions = await field.loadOptions()
+                remoteOptions.forEach((option) => {
+                  const href = (() => {
+                    const relation = parseRelationOptionsMetadata(definition.optionsUrl)
+                    return relation ? buildRelationHref(relation.entityId, option.value) : undefined
+                  })()
+                  displays[option.value] = { label: option.label, href }
+                })
+              } catch {
+                // keep static labels only
+              }
+            }
+
+            const unresolvedIds = relationIds.filter((relationId) => !displays[relationId])
+            const relation = parseRelationOptionsMetadata(definition.optionsUrl)
+            if (relation && unresolvedIds.length) {
+              try {
+                const fetchedDisplays = await fetchRelationRecordDisplays(relation, unresolvedIds)
+                Object.assign(displays, fetchedDisplays)
+              } catch {
+                unresolvedIds.forEach((relationId) => {
+                  if (!displays[relationId]) {
+                    displays[relationId] = {
+                      label: relationId,
+                      href: buildRelationHref(relation.entityId, relationId),
+                    }
+                  }
+                })
+              }
+            }
+
+            if (Object.keys(displays).length > 0) {
+              nextDisplays[field.id] = displays
+            }
+          }),
+        )
+
+        if (!cancelled) {
+          setResolvedDisplaysByField((prev) => {
+            const previousKeys = Object.keys(prev)
+            const nextKeys = Object.keys(nextDisplays)
+            if (
+              previousKeys.length === nextKeys.length &&
+              previousKeys.every((key) => JSON.stringify(prev[key]) === JSON.stringify(nextDisplays[key]))
+            ) {
+              return prev
+            }
+            return nextDisplays
+          })
+        }
+      } finally {
+        if (!cancelled) {
+          setRelationLoading(false)
+        }
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [definitions, fields, values])
+
   const handleSubmit = React.useCallback(
     async (input: Record<string, unknown>) => {
       await onSubmit(input)
@@ -517,6 +920,7 @@ function CustomDataSectionImpl({
                       labels.emptyValue,
                       dictionaryMapsByField[field.id],
                       markdownPlugins,
+                      resolvedDisplaysByField[field.id],
                     )}
                   </div>
                 </div>

--- a/packages/ui/src/backend/utils/customFieldRelationDisplay.ts
+++ b/packages/ui/src/backend/utils/customFieldRelationDisplay.ts
@@ -1,0 +1,302 @@
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+export type ResolvedValueDisplay = {
+  label: string
+  href?: string
+}
+
+export type RelationOptionsMetadata = {
+  entityId: string
+}
+
+export type RelationOptionsResponse = {
+  items?: Array<{
+    value?: unknown
+    label?: unknown
+    routeContext?: Record<string, unknown>
+  }>
+}
+
+export function normalizeTextValue(input: unknown): string | null {
+  if (typeof input === 'string') {
+    const trimmed = input.trim()
+    return trimmed.length ? trimmed : null
+  }
+  if (typeof input === 'number' || typeof input === 'boolean') {
+    return String(input)
+  }
+  return null
+}
+
+export function extractOptionLookupKey(entry: unknown): string | null {
+  if (typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean') {
+    return normalizeTextValue(entry)
+  }
+  if (!entry || typeof entry !== 'object') return null
+  const record = entry as Record<string, unknown>
+  return (
+    normalizeTextValue(record.value)
+    ?? normalizeTextValue(record.id)
+    ?? normalizeTextValue(record.key)
+    ?? normalizeTextValue(record.name)
+    ?? null
+  )
+}
+
+export function extractInlineOptionLabel(entry: unknown): string | null {
+  if (!entry || typeof entry !== 'object') return null
+  const record = entry as Record<string, unknown>
+  return (
+    normalizeTextValue(record.label)
+    ?? normalizeTextValue(record.name)
+    ?? null
+  )
+}
+
+export function collectRelationValueIds(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return Array.from(
+      new Set(
+        value
+          .map((entry) => extractOptionLookupKey(entry))
+          .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0),
+      ),
+    )
+  }
+  const single = extractOptionLookupKey(value)
+  return single ? [single] : []
+}
+
+function camelToSnake(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toLowerCase()
+}
+
+function snakeToCamel(value: string): string {
+  return value.replace(/[_-](\w)/g, (_, char: string) => char.toUpperCase())
+}
+
+export function readRecordValue(record: Record<string, unknown>, field: string): string | null {
+  if (!field) return null
+  const direct = normalizeTextValue(record[field])
+  if (direct) return direct
+  const snake = camelToSnake(field)
+  const snakeValue = normalizeTextValue(record[snake])
+  if (snakeValue) return snakeValue
+  const camel = snakeToCamel(field)
+  return normalizeTextValue(record[camel])
+}
+
+export function parseRelationOptionsMetadata(optionsUrl?: string): RelationOptionsMetadata | null {
+  if (!optionsUrl) return null
+  try {
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+    const url = new URL(optionsUrl, origin)
+    if (!url.pathname.endsWith('/api/entities/relations/options')) return null
+    const entityId = url.searchParams.get('entityId')?.trim()
+    if (!entityId) return null
+    return { entityId }
+  } catch {
+    return null
+  }
+}
+
+export function getRelationHrefContextFields(entityId: string): string[] {
+  const trimmedEntityId = entityId.trim()
+  if (!trimmedEntityId) return []
+
+  const knownEntityIds = getEntityIds(false)
+  const customers = knownEntityIds.customers ?? {}
+  const catalog = knownEntityIds.catalog ?? {}
+
+  if (trimmedEntityId === customers.customer_entity) {
+    return ['kind']
+  }
+  if (
+    trimmedEntityId === customers.customer_person_profile
+    || trimmedEntityId === customers.customer_company_profile
+  ) {
+    return ['entity_id']
+  }
+  if (trimmedEntityId === catalog.catalog_product_variant) {
+    return ['product_id']
+  }
+
+  return []
+}
+
+export function buildRelationHref(entityId: string, recordId: string, record?: Record<string, unknown>): string | undefined {
+  const trimmedEntityId = entityId.trim()
+  const trimmedRecordId = recordId.trim()
+  if (!trimmedEntityId || !trimmedRecordId) return undefined
+
+  const knownEntityIds = getEntityIds(false)
+  const customers = knownEntityIds.customers ?? {}
+  const catalog = knownEntityIds.catalog ?? {}
+  const sales = knownEntityIds.sales ?? {}
+  const staff = knownEntityIds.staff ?? {}
+  const resources = knownEntityIds.resources ?? {}
+  const knownEntityIdSet = new Set(
+    Object.values(knownEntityIds).flatMap((group) => Object.values(group ?? {})),
+  )
+  const canUseCustomEntityFallback =
+    knownEntityIdSet.size > 0
+      ? !knownEntityIdSet.has(trimmedEntityId)
+      : trimmedEntityId.startsWith('virtual:')
+
+  if (trimmedEntityId === customers.customer_entity) {
+    const kind = (readRecordValue(record ?? {}, 'kind') ?? '').toLowerCase()
+    if (kind === 'person') return `/backend/customers/people-v2/${encodeURIComponent(trimmedRecordId)}`
+    if (kind === 'company') return `/backend/customers/companies-v2/${encodeURIComponent(trimmedRecordId)}`
+    return undefined
+  }
+  if (trimmedEntityId === customers.customer_person_profile) {
+    const linkedId = readRecordValue(record ?? {}, 'entity_id') ?? trimmedRecordId
+    return `/backend/customers/people-v2/${encodeURIComponent(linkedId)}`
+  }
+  if (trimmedEntityId === customers.customer_company_profile) {
+    const linkedId = readRecordValue(record ?? {}, 'entity_id') ?? trimmedRecordId
+    return `/backend/customers/companies-v2/${encodeURIComponent(linkedId)}`
+  }
+  if (trimmedEntityId === customers.customer_deal) {
+    return `/backend/customers/deals/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === catalog.catalog_product) {
+    return `/backend/catalog/products/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === catalog.catalog_category) {
+    return `/backend/catalog/categories/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === catalog.catalog_product_variant) {
+    const productId = readRecordValue(record ?? {}, 'product_id')
+    if (!productId) return undefined
+    return `/backend/catalog/products/${encodeURIComponent(productId)}/variants/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === sales.sales_quote) {
+    return `/backend/sales/quotes/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === sales.sales_order) {
+    return `/backend/sales/orders/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === sales.sales_channel) {
+    return `/backend/sales/channels/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === staff.staff_team_member) {
+    return `/backend/staff/team-members/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === staff.staff_team_role) {
+    return `/backend/staff/team-roles/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === staff.staff_team) {
+    return `/backend/staff/teams/${encodeURIComponent(trimmedRecordId)}/edit`
+  }
+  if (trimmedEntityId === staff.staff_leave_request) {
+    return `/backend/staff/leave-requests/${encodeURIComponent(trimmedRecordId)}`
+  }
+  if (trimmedEntityId === resources.resources_resource) {
+    return `/backend/resources/resources/${encodeURIComponent(trimmedRecordId)}`
+  }
+
+  if (canUseCustomEntityFallback) {
+    return `/backend/entities/user/${encodeURIComponent(trimmedEntityId)}/records/${encodeURIComponent(trimmedRecordId)}`
+  }
+
+  return undefined
+}
+
+export function buildRelationLookupUrl(
+  optionsUrl: string,
+  recordIds: string[],
+  routeContextFields: string[] = [],
+): string | null {
+  if (!recordIds.length) return null
+  try {
+    const isAbsolute = /^([a-z][a-z\d+\-.]*:)?\/\//i.test(optionsUrl)
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+    const url = isAbsolute ? new URL(optionsUrl) : new URL(optionsUrl, origin)
+    url.searchParams.set('ids', recordIds.join(','))
+    if (routeContextFields.length > 0) {
+      url.searchParams.set('routeContextFields', routeContextFields.join(','))
+    }
+    if (isAbsolute) return url.toString()
+    return `${url.pathname}${url.search}`
+  } catch {
+    const sep = optionsUrl.includes('?') ? '&' : '?'
+    const params = [`ids=${encodeURIComponent(recordIds.join(','))}`]
+    if (routeContextFields.length > 0) {
+      params.push(`routeContextFields=${encodeURIComponent(routeContextFields.join(','))}`)
+    }
+    return `${optionsUrl}${sep}${params.join('&')}`
+  }
+}
+
+export async function fetchRelationRecordDisplays(
+  optionsUrl: string,
+  relation: RelationOptionsMetadata,
+  recordIds: string[],
+  signal?: AbortSignal,
+): Promise<Record<string, ResolvedValueDisplay>> {
+  const displays: Record<string, ResolvedValueDisplay> = {}
+  if (!recordIds.length) return displays
+  const routeContextFields = getRelationHrefContextFields(relation.entityId)
+
+  const uniqueIds = Array.from(new Set(recordIds.map((entry) => entry.trim()).filter((entry) => entry.length > 0)))
+  const chunks: string[][] = []
+  for (let index = 0; index < uniqueIds.length; index += 100) {
+    chunks.push(uniqueIds.slice(index, index + 100))
+  }
+
+  for (const chunk of chunks) {
+    if (signal?.aborted) break
+
+    const url = buildRelationLookupUrl(optionsUrl, chunk, routeContextFields)
+    if (!url) {
+      chunk.forEach((recordId) => {
+        displays[recordId] = {
+          label: recordId,
+          href: buildRelationHref(relation.entityId, recordId),
+        }
+      })
+      continue
+    }
+
+    const response = await readApiResultOrThrow<RelationOptionsResponse>(
+      url,
+      signal ? { signal } : undefined,
+      {
+        errorMessage: 'Failed to resolve relation values',
+        fallback: { items: [] },
+      },
+    )
+    const items = Array.isArray(response?.items) ? response.items : []
+    const resolvedIds = new Set<string>()
+
+    items.forEach((item) => {
+      const recordId = normalizeTextValue(item?.value)
+      if (!recordId) return
+      resolvedIds.add(recordId)
+      const label = normalizeTextValue(item?.label) ?? recordId
+      const routeContext =
+        item?.routeContext && typeof item.routeContext === 'object' && !Array.isArray(item.routeContext)
+          ? item.routeContext
+          : undefined
+      displays[recordId] = {
+        label,
+        href: buildRelationHref(relation.entityId, recordId, routeContext),
+      }
+    })
+
+    chunk.forEach((recordId) => {
+      if (resolvedIds.has(recordId) || displays[recordId]) return
+      displays[recordId] = {
+        label: recordId,
+        href: buildRelationHref(relation.entityId, recordId),
+      }
+    })
+  }
+
+  return displays
+}


### PR DESCRIPTION
Source: GitHub issue #696
## Problem Summary
bug: Custom fields of `kind: relation` render as raw UUIDs instead of entity titles/links in DataGrid
## Expected Behavior
Custom fields of `kind: relation` correctly store related entity UUIDs in the database and accept properly configured definitions with `optionsUrl` and `labelField` mappings on the backend. However, the frontend`DataGrid` componen
## Actual Behavior
Steps to reproduce
1. Create a `relation` Custom Field Definition via the API (e.g. `subject_of_case_study` linking to `virtual:case_study`).
## What Changed
- packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
- packages/core/src/modules/entities/api/relations/options.ts
- packages/ui/src/backend/__tests__/CustomDataSection.test.tsx
- packages/ui/src/backend/detail/CustomDataSection.tsx
- Diff summary: +756 / -22 (778 total lines)
- Branch head: c1199b28792790731bf08069390ec461ee08d568
## Validation / Tests
- No validation profiles were auto-selected.
## Expected Contribution Classes
- bugfix