### PR TITLE
fix #1229: roll out sticky actions column to wide backend lists

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -1050,6 +1050,7 @@ export function AttachmentLibrary() {
   return (
     <>
       <DataTable<AttachmentRow>
+        stickyActionsColumn
         title={t('attachments.library.title', 'Attachments')}
         refreshButton={{
           label: t('attachments.library.actions.refresh', 'Refresh'),

--- a/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/page.tsx
+++ b/packages/core/src/modules/customer_accounts/backend/customer_accounts/users/page.tsx
@@ -522,6 +522,7 @@ export default function CustomerAccountsPage() {
           </div>
         </div>
         <DataTable<UserRow>
+          stickyActionsColumn
           title={t('customer_accounts.admin.title', 'Users')}
           actions={(
             <Button onClick={() => setCreateDialogOpen(true)}>

--- a/packages/core/src/modules/customers/backend/customers/companies/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/page.tsx
@@ -732,6 +732,7 @@ export default function CustomersCompaniesPage() {
       <PageBody>
         <DataTable<CompanyRow>
           stickyFirstColumn
+          stickyActionsColumn
           title={t('customers.companies.list.title')}
           refreshButton={{
             label: t('customers.companies.list.actions.refresh'),

--- a/packages/core/src/modules/customers/backend/customers/deals/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/page.tsx
@@ -968,6 +968,7 @@ export default function CustomersDealsPage() {
       <PageBody>
         <DataTable<DealRow>
           stickyFirstColumn
+          stickyActionsColumn
           title={t('customers.deals.list.title')}
           actions={(
             <Button asChild>

--- a/packages/core/src/modules/customers/backend/customers/people/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people/page.tsx
@@ -755,6 +755,7 @@ export default function CustomersPeoplePage() {
       <PageBody>
         <DataTable<PersonRow>
           stickyFirstColumn
+          stickyActionsColumn
           title={t('customers.people.list.title')}
           refreshButton={{
             label: t('customers.people.list.actions.refresh'),

--- a/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/page.tsx
@@ -956,6 +956,7 @@ export default function SyncRunsDashboardPage() {
         </Card>
 
         <DataTable
+          stickyActionsColumn
           title={t('data_sync.dashboard.title')}
           columns={columns}
           data={rows}

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
@@ -328,6 +328,7 @@ export RECORD_ID="<record uuid>"`}</code></pre>
           </div>
         </ContextHelp>
         <DataTable
+          stickyActionsColumn
           title={`Records: ${entityId}`}
           entityId={entityId}
           actions={actions}

--- a/packages/core/src/modules/inbox_ops/backend/inbox-ops/page.tsx
+++ b/packages/core/src/modules/inbox_ops/backend/inbox-ops/page.tsx
@@ -323,6 +323,7 @@ export default function InboxOpsProposalsPage() {
     <Page>
       <PageBody>
         <DataTable<ProposalRow>
+          stickyActionsColumn
           title={t('inbox_ops.title', 'AI Inbox Actions')}
           refreshButton={{
             label: t('inbox_ops.list.actions.refresh', 'Refresh'),

--- a/packages/core/src/modules/payment_gateways/backend/payment-gateways/page.tsx
+++ b/packages/core/src/modules/payment_gateways/backend/payment-gateways/page.tsx
@@ -452,6 +452,7 @@ export default function PaymentTransactionsPage() {
       />
       <PageBody className="space-y-6">
         <DataTable
+          stickyActionsColumn
           title={t('payment_gateways.transactions.tableTitle', 'Transactions')}
           columns={columns}
           data={rows}

--- a/packages/core/src/modules/resources/backend/resources/resources/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resources/page.tsx
@@ -468,6 +468,7 @@ export default function ResourcesResourcesPage() {
     <Page>
       <PageBody>
         <DataTable
+          stickyActionsColumn
           title={t('resources.resources.page.title', 'Resources')}
           actions={canManage ? (
             <Button asChild>

--- a/packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentsTable.tsx
@@ -657,6 +657,7 @@ export function SalesDocumentsTable({ kind }: { kind: SalesDocumentKind }) {
     <Page>
       <PageBody>
         <DataTable<SalesDocumentRow>
+          stickyActionsColumn
           title={(
             <div className="flex flex-col">
               <span>{title}</span>

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -124,6 +124,7 @@ import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 ## DataTable Guidelines
 
 - Use `DataTable` as the default list view.
+- For wide list views where rightmost `rowActions` can scroll out of view, enable `stickyActionsColumn` on the host `DataTable`; keep it opt-in instead of making all actions columns sticky by default.
 - DataTable extension spots include: `data-table:<tableId>:columns`, `:row-actions`, `:bulk-actions`, `:filters` (in addition to `:header`/`:footer`).
 - Populate `columns` with explicit renderers and set `meta.truncate`/`meta.maxWidth` where truncation is needed.
 - For filters, use `FilterBar`/`FilterOverlay` with async option loaders; keep `pageSize` at or below 100.

--- a/packages/ui/src/backend/__tests__/DataTable.extensions.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.extensions.test.tsx
@@ -314,4 +314,26 @@ describe('DataTable extensions', () => {
       rendered.cleanupQueryClient()
     }
   })
+
+  it('applies sticky positioning to the actions column when enabled', () => {
+    const rendered = renderTable({
+      columns: [{ accessorKey: 'name', header: 'Name' }],
+      data: [{ id: 'r1', name: 'Alice' }],
+      rowActions: () => <button type="button">Open</button>,
+      stickyActionsColumn: true,
+    })
+
+    try {
+      const actionsHeader = screen.getByRole('columnheader', { name: 'Actions' })
+      expect(actionsHeader.className).toContain('sticky')
+      expect(actionsHeader.className).toContain('right-0')
+
+      const actionsCell = rendered.container.querySelector('[data-actions-cell]')
+      expect(actionsCell).not.toBeNull()
+      expect(actionsCell?.className).toContain('sticky')
+      expect(actionsCell?.className).toContain('right-0')
+    } finally {
+      rendered.cleanupQueryClient()
+    }
+  })
 })


### PR DESCRIPTION
Closes #1229

## Summary

This PR rolls out the opt-in `stickyActionsColumn` pattern from PR #1186 to additional wide backend list views where row actions can scroll out of view.

It also adds a short UI guideline for when to use the prop and one shared `DataTable` behavioral test, instead of duplicating the same host-level assertion across multiple pages.

## Changes

- enabled `stickyActionsColumn` on additional wide backend tables:
  - customers people / companies / deals
  - sales documents
  - attachments library
  - customer accounts users
  - data sync runs
  - user entity records
  - inbox ops proposals
  - payment transactions
  - resources
- documented the pattern in `packages/ui/AGENTS.md`
- added a shared `DataTable` behavioral test covering sticky actions column rendering

## Scope / BC

- additive UI-only change
- no API or data contract changes
- no behavior change for tables that do not opt in

## Verification

- `yarn jest packages/ui/src/backend/__tests__/DataTable.extensions.test.tsx --runInBand`