### PR TITLE
tests: add low-level coverage for inspect.ts

### DIFF
--- a/apps/mercato/src/modules/example/__integration__/TC-UMES-011.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/TC-UMES-011.spec.ts
@@ -7,7 +7,7 @@
  * Spec reference: SPEC-041k — DevTools + Conflict Detection (TC-UMES-DT02)
  */
 import { test, expect } from '@playwright/test'
-import { execSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import {
@@ -28,27 +28,42 @@ function findProjectRoot(): string {
 }
 
 const ROOT = findProjectRoot()
-const MERCATO_BIN = path.join(ROOT, 'node_modules/.bin/mercato')
 
-function runMercato(args: string): { stdout: string; exitCode: number } {
-  const cmd = `"${MERCATO_BIN}" ${args} 2>/dev/null`
-  try {
-    const stdout = execSync(cmd, {
-      cwd: ROOT,
-      encoding: 'utf-8',
-      timeout: 60_000,
-      env: { ...process.env, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
-    })
-    return { stdout, exitCode: 0 }
-  } catch (err) {
-    const error = err as { stdout?: string; status?: number | null }
-    return { stdout: error.stdout ?? '', exitCode: error.status ?? 1 }
+function resolveMercatoBin(): string {
+  const candidates = [
+    path.join(ROOT, 'node_modules/.bin/mercato'),
+    path.join(ROOT, 'node_modules/@open-mercato/cli/bin/mercato'),
+    path.join(ROOT, 'packages/cli/bin/mercato'),
+  ]
+
+  const match = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!match) {
+    throw new Error(`Could not find mercato bin. Checked: ${candidates.join(', ')}`)
+  }
+
+  return match
+}
+
+const MERCATO_BIN = resolveMercatoBin()
+
+function runMercato(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync(MERCATO_BIN, args, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 60_000,
+    env: { ...process.env, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
+  })
+
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
   }
 }
 
 test.describe('TC-UMES-011: CLI commands', () => {
   test('umes:list shows registered extensions from example module', () => {
-    const { stdout, exitCode } = runMercato('umes:list')
+    const { stdout, exitCode } = runMercato(['umes:list'])
     expect(exitCode).toBe(0)
 
     // Should list example module extensions in the output
@@ -59,7 +74,7 @@ test.describe('TC-UMES-011: CLI commands', () => {
   })
 
   test('umes:inspect shows extension tree for example module', () => {
-    const { stdout, exitCode } = runMercato('umes:inspect --module example')
+    const { stdout, exitCode } = runMercato(['umes:inspect', '--module', 'example'])
     expect(exitCode).toBe(0)
 
     // Should show the example module header
@@ -69,8 +84,16 @@ test.describe('TC-UMES-011: CLI commands', () => {
     expect(stdout).toMatch(/Injection Widgets|Component Overrides|Declared Features/)
   })
 
+  test('umes:inspect reports missing modules on stderr and exits non-zero', () => {
+    const { stderr, exitCode } = runMercato(['umes:inspect', '--module', 'missing-module'])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Module "missing-module" not found.')
+    expect(stderr).toContain('Available modules:')
+    expect(stderr).toContain('example')
+  })
+
   test('umes:check exits 0 with no conflicts', () => {
-    const { stdout, exitCode } = runMercato('umes:check')
+    const { stdout, exitCode } = runMercato(['umes:check'])
     expect(exitCode).toBe(0)
 
     // Should indicate no errors found

--- a/packages/cli/src/lib/umes/__tests__/inspect.test.ts
+++ b/packages/cli/src/lib/umes/__tests__/inspect.test.ts
@@ -1,0 +1,179 @@
+import type { PackageResolver } from '../../resolver'
+import { createResolver } from '../../resolver'
+import { collectUmesData, type UmesModuleData } from '../collector'
+import { runUmesInspect } from '../inspect'
+
+jest.mock('../../resolver', () => ({
+  createResolver: jest.fn(),
+}))
+
+jest.mock('../collector', () => ({
+  collectUmesData: jest.fn(),
+}))
+
+const mockedCreateResolver = createResolver as jest.MockedFunction<typeof createResolver>
+const mockedCollectUmesData = collectUmesData as jest.MockedFunction<typeof collectUmesData>
+
+function createConsoleRecorder() {
+  const logLines: string[] = []
+  const errorLines: string[] = []
+
+  const logSpy = jest.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    logLines.push(args.map((arg) => String(arg)).join(' '))
+  })
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    errorLines.push(args.map((arg) => String(arg)).join(' '))
+  })
+
+  return {
+    errorLines,
+    errorSpy,
+    logLines,
+    logSpy,
+  }
+}
+
+describe('runUmesInspect', () => {
+  let previousExitCode: number | undefined
+  let resolver: PackageResolver
+
+  beforeEach(() => {
+    previousExitCode = process.exitCode
+    process.exitCode = undefined
+    jest.clearAllMocks()
+    resolver = {} as PackageResolver
+    mockedCreateResolver.mockReturnValue(resolver)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    process.exitCode = previousExitCode
+  })
+
+  it('prints grouped UMES sections and skips falsey detail fields', async () => {
+    const recorder = createConsoleRecorder()
+    const modulesData: UmesModuleData[] = [
+      {
+        moduleId: 'example',
+        declaredFeatures: ['example.view', 'example.manage'],
+        extensions: [
+          {
+            moduleId: 'example',
+            type: 'enricher',
+            id: 'example.person.enricher',
+            target: 'customers.person',
+            priority: 10,
+            features: ['example.view'],
+            details: {
+              critical: true,
+              hasCache: false,
+              timeout: 5_000,
+            },
+          },
+          {
+            moduleId: 'example',
+            type: 'interceptor',
+            id: 'example.people.list',
+            target: 'GET /api/customers/people',
+            priority: 20,
+            features: ['example.manage'],
+            details: {
+              hasAfter: false,
+              hasBefore: true,
+              methods: 'GET',
+              targetRoute: '/api/customers/people',
+            },
+          },
+          {
+            moduleId: 'example',
+            type: 'component-override',
+            id: 'example.page.dashboard',
+            target: 'page:dashboard',
+            priority: 30,
+            details: {
+              overrideKind: 'wrapper',
+            },
+          },
+          {
+            moduleId: 'example',
+            type: 'injection-widget',
+            id: 'example.customer_badge',
+            target: 'customer:header',
+            priority: 40,
+          },
+        ],
+      },
+    ]
+    mockedCollectUmesData.mockReturnValue(modulesData)
+
+    await runUmesInspect('example')
+
+    expect(mockedCreateResolver).toHaveBeenCalledTimes(1)
+    expect(mockedCollectUmesData).toHaveBeenCalledWith(resolver)
+    expect(recorder.errorSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBeUndefined()
+
+    const output = recorder.logLines.join('\n')
+    expect(output).toContain('UMES Extensions for module: example')
+    expect(output).toContain('Declared Features (2):')
+    expect(output).toContain('  - example.view')
+    expect(output).toContain('  - example.manage')
+    expect(output).toContain('Response Enrichers (1):')
+    expect(output).toContain('API Interceptors (1):')
+    expect(output).toContain('Component Overrides (1):')
+    expect(output).toContain('Injection Widgets (1):')
+    expect(output).toContain('features: example.view')
+    expect(output).toContain('features: example.manage')
+    expect(output).toContain('critical: true')
+    expect(output).toContain('timeout: 5000')
+    expect(output).toContain('hasBefore: true')
+    expect(output).toContain('targetRoute: /api/customers/people')
+    expect(output).toContain('overrideKind: wrapper')
+    expect(output).not.toContain('hasAfter: false')
+    expect(output).not.toContain('hasCache: false')
+    expect(output.indexOf('Response Enrichers')).toBeLessThan(output.indexOf('API Interceptors'))
+    expect(output.indexOf('API Interceptors')).toBeLessThan(output.indexOf('Component Overrides'))
+    expect(output.indexOf('Component Overrides')).toBeLessThan(output.indexOf('Injection Widgets'))
+  })
+
+  it('prints an empty-state message when a module has no UMES extensions', async () => {
+    const recorder = createConsoleRecorder()
+    mockedCollectUmesData.mockReturnValue([
+      {
+        moduleId: 'empty_module',
+        declaredFeatures: [],
+        extensions: [],
+      },
+    ])
+
+    await runUmesInspect('empty_module')
+
+    expect(recorder.errorSpy).not.toHaveBeenCalled()
+    expect(recorder.logLines.join('\n')).toContain('No UMES extensions found for this module.')
+    expect(recorder.logLines.join('\n')).not.toContain('Declared Features')
+  })
+
+  it('sets exit code and reports available modules when the target module is missing', async () => {
+    const recorder = createConsoleRecorder()
+    mockedCollectUmesData.mockReturnValue([
+      {
+        moduleId: 'customers',
+        declaredFeatures: [],
+        extensions: [],
+      },
+      {
+        moduleId: 'example',
+        declaredFeatures: [],
+        extensions: [],
+      },
+    ])
+
+    await runUmesInspect('missing_module')
+
+    expect(recorder.logSpy).not.toHaveBeenCalled()
+    expect(process.exitCode).toBe(1)
+    expect(recorder.errorLines).toEqual([
+      'Module "missing_module" not found. Available modules: customers, example',
+    ])
+  })
+})

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -20,6 +20,18 @@ import fs from 'node:fs'
 
 let envLoaded = false
 
+async function runWithCapturedExitCode(action: () => Promise<void>): Promise<number> {
+  const previousExitCode = process.exitCode
+  process.exitCode = undefined
+
+  try {
+    await action()
+    return process.exitCode ?? 0
+  } finally {
+    process.exitCode = previousExitCode
+  }
+}
+
 function getRegisteredCliWorkers(modules: Module[] = getCliModules()): ModuleWorker[] {
   const allWorkers: ModuleWorker[] = []
   for (const mod of modules) {
@@ -862,14 +874,12 @@ export async function run(argv = process.argv) {
       return 1
     }
     const { runUmesInspect } = await import('./lib/umes/inspect')
-    await runUmesInspect(moduleArg)
-    return 0
+    return runWithCapturedExitCode(() => runUmesInspect(moduleArg))
   }
 
   if (first === 'umes:check') {
     const { runUmesCheck } = await import('./lib/umes/check')
-    await runUmesCheck()
-    return 0
+    return runWithCapturedExitCode(() => runUmesCheck())
   }
 
   if (first === 'seed:defaults') {

--- a/packages/create-app/template/src/modules/example/__integration__/TC-UMES-011.spec.ts
+++ b/packages/create-app/template/src/modules/example/__integration__/TC-UMES-011.spec.ts
@@ -7,7 +7,7 @@
  * Spec reference: SPEC-041k — DevTools + Conflict Detection (TC-UMES-DT02)
  */
 import { test, expect } from '@playwright/test'
-import { execSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import {
@@ -28,27 +28,42 @@ function findProjectRoot(): string {
 }
 
 const ROOT = findProjectRoot()
-const MERCATO_BIN = path.join(ROOT, 'node_modules/.bin/mercato')
 
-function runMercato(args: string): { stdout: string; exitCode: number } {
-  const cmd = `"${MERCATO_BIN}" ${args} 2>/dev/null`
-  try {
-    const stdout = execSync(cmd, {
-      cwd: ROOT,
-      encoding: 'utf-8',
-      timeout: 60_000,
-      env: { ...process.env, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
-    })
-    return { stdout, exitCode: 0 }
-  } catch (err) {
-    const error = err as { stdout?: string; status?: number | null }
-    return { stdout: error.stdout ?? '', exitCode: error.status ?? 1 }
+function resolveMercatoBin(): string {
+  const candidates = [
+    path.join(ROOT, 'node_modules/.bin/mercato'),
+    path.join(ROOT, 'node_modules/@open-mercato/cli/bin/mercato'),
+    path.join(ROOT, 'packages/cli/bin/mercato'),
+  ]
+
+  const match = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!match) {
+    throw new Error(`Could not find mercato bin. Checked: ${candidates.join(', ')}`)
+  }
+
+  return match
+}
+
+const MERCATO_BIN = resolveMercatoBin()
+
+function runMercato(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const result = spawnSync(MERCATO_BIN, args, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+    timeout: 60_000,
+    env: { ...process.env, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
+  })
+
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    exitCode: result.status ?? 1,
   }
 }
 
 test.describe('TC-UMES-011: CLI commands', () => {
   test('umes:list shows registered extensions from example module', () => {
-    const { stdout, exitCode } = runMercato('umes:list')
+    const { stdout, exitCode } = runMercato(['umes:list'])
     expect(exitCode).toBe(0)
 
     // Should list example module extensions in the output
@@ -59,7 +74,7 @@ test.describe('TC-UMES-011: CLI commands', () => {
   })
 
   test('umes:inspect shows extension tree for example module', () => {
-    const { stdout, exitCode } = runMercato('umes:inspect --module example')
+    const { stdout, exitCode } = runMercato(['umes:inspect', '--module', 'example'])
     expect(exitCode).toBe(0)
 
     // Should show the example module header
@@ -69,8 +84,16 @@ test.describe('TC-UMES-011: CLI commands', () => {
     expect(stdout).toMatch(/Injection Widgets|Component Overrides|Declared Features/)
   })
 
+  test('umes:inspect reports missing modules on stderr and exits non-zero', () => {
+    const { stderr, exitCode } = runMercato(['umes:inspect', '--module', 'missing-module'])
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Module "missing-module" not found.')
+    expect(stderr).toContain('Available modules:')
+    expect(stderr).toContain('example')
+  })
+
   test('umes:check exits 0 with no conflicts', () => {
-    const { stdout, exitCode } = runMercato('umes:check')
+    const { stdout, exitCode } = runMercato(['umes:check'])
     expect(exitCode).toBe(0)
 
     // Should indicate no errors found


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for inspect.ts
## Problem Summary
tests: add low-level coverage for inspect.ts
## Expected Behavior
packages/cli/src/lib/umes/inspect.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/cli/src/lib/umes/inspect.ts.
Checked: packages/cli/src/lib/umes/inspect.test.ts
packages/cli/src/lib/umes/__tests__/inspect.test.ts
packages/cli/src/lib/umes/inspect.spec.ts
packages/cli/src/lib/umes/__tests__/inspect.spec.ts ...
## What Changed
- apps/mercato/src/modules/example/__integration__/TC-UMES-011.spec.ts
- packages/cli/src/lib/umes/__tests__/inspect.test.ts
- packages/cli/src/mercato.ts
- packages/create-app/template/src/modules/example/__integration__/TC-UMES-011.spec.ts
- Diff summary: +277 / -42 (319 total lines)
- Branch head: 10e23259ae8aec76e1d57583fa5b9add3d4e1167
## Validation / Tests
- cli-package-checks
## Expected Contribution Classes
- tests
- bugfix