### PR TITLE
Sales Documents Tenant Scope Fixes

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/documents.scope.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.scope.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 
 /**
- * Tests that all em.find(SalesDocumentAddress, ...) calls include
+ * Tests that all findWithDecryption(SalesDocumentAddress, ...) calls include
  * organizationId and tenantId filters, preventing cross-tenant data leaks.
  *
  * Fixed in: packages/core/src/modules/sales/commands/documents.ts
@@ -9,10 +9,12 @@
  *   - loadOrderSnapshot (line ~1435)
  *   - deleteQuoteCommand.execute (line ~4497)
  *   - deleteOrderCommand.execute (line ~5424)
+ *   - convertQuoteToOrderCommand (line ~5801)
  */
 
 import { createContainer, asValue, InjectionMode } from 'awilix'
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import {
   SalesQuote,
   SalesQuoteLine,
@@ -216,10 +218,14 @@ function makeCtx(em: unknown, organizationId: string, tenantId: string) {
   }
 }
 
-/** Find all calls to em.find where the first argument is SalesDocumentAddress */
-function addressFindCalls(findMock: jest.Mock) {
-  return findMock.mock.calls.filter(
-    ([entityClass]) => entityClass === SalesDocumentAddress,
+/**
+ * Filter findWithDecryption mock calls where the entity class is SalesDocumentAddress.
+ * findWithDecryption signature: (em, entityName, where, options?, scope?)
+ * so entityName is args[1] and where is args[2].
+ */
+function addressDecryptionCalls() {
+  return (findWithDecryption as jest.Mock).mock.calls.filter(
+    ([, entityClass]) => entityClass === SalesDocumentAddress,
   )
 }
 
@@ -229,10 +235,14 @@ describe('SalesDocumentAddress query scoping', () => {
     await import('../documents')
   })
 
+  beforeEach(() => {
+    (findWithDecryption as jest.Mock).mockClear()
+  })
+
   describe('deleteQuoteCommand.execute — scopes SalesDocumentAddress by quote tenant', () => {
-    it('passes organizationId from quote to em.find(SalesDocumentAddress)', async () => {
+    it('passes organizationId from quote to findWithDecryption(SalesDocumentAddress)', async () => {
       const quote = makeQuote()
-      const { em, findMock } = makeEmForQuote(quote)
+      const { em } = makeEmForQuote(quote)
       const ctx = makeCtx(em, ORG_ID, TENANT_ID)
 
       const handler = commandRegistry.get('sales.quotes.delete')
@@ -240,9 +250,9 @@ describe('SalesDocumentAddress query scoping', () => {
 
       await handler!.execute({ id: QUOTE_ID }, ctx as any)
 
-      const calls = addressFindCalls(findMock)
+      const calls = addressDecryptionCalls()
       expect(calls).toHaveLength(1)
-      expect(calls[0][1]).toMatchObject({
+      expect(calls[0][2]).toMatchObject({
         documentId: QUOTE_ID,
         documentKind: 'quote',
         organizationId: ORG_ID,
@@ -254,14 +264,14 @@ describe('SalesDocumentAddress query scoping', () => {
       const differentOrg = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
       const differentTenant = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
       const quote = makeQuote({ organizationId: differentOrg, tenantId: differentTenant })
-      const { em, findMock } = makeEmForQuote(quote)
+      const { em } = makeEmForQuote(quote)
       const ctx = makeCtx(em, differentOrg, differentTenant)
 
       const handler = commandRegistry.get('sales.quotes.delete')
       await handler!.execute({ id: QUOTE_ID }, ctx as any)
 
-      const calls = addressFindCalls(findMock)
-      expect(calls[0][1]).toMatchObject({
+      const calls = addressDecryptionCalls()
+      expect(calls[0][2]).toMatchObject({
         organizationId: differentOrg,
         tenantId: differentTenant,
       })
@@ -269,9 +279,9 @@ describe('SalesDocumentAddress query scoping', () => {
   })
 
   describe('deleteOrderCommand.execute — scopes SalesDocumentAddress by order tenant', () => {
-    it('passes organizationId from order to em.find(SalesDocumentAddress)', async () => {
+    it('passes organizationId from order to findWithDecryption(SalesDocumentAddress)', async () => {
       const order = makeOrder()
-      const { em, findMock } = makeEmForOrder(order)
+      const { em } = makeEmForOrder(order)
       const ctx = makeCtx(em, ORG_ID, TENANT_ID)
 
       const handler = commandRegistry.get('sales.orders.delete')
@@ -279,9 +289,9 @@ describe('SalesDocumentAddress query scoping', () => {
 
       await handler!.execute({ id: ORDER_ID }, ctx as any)
 
-      const calls = addressFindCalls(findMock)
+      const calls = addressDecryptionCalls()
       expect(calls).toHaveLength(1)
-      expect(calls[0][1]).toMatchObject({
+      expect(calls[0][2]).toMatchObject({
         documentId: ORDER_ID,
         documentKind: 'order',
         organizationId: ORG_ID,
@@ -293,14 +303,14 @@ describe('SalesDocumentAddress query scoping', () => {
       const differentOrg = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
       const differentTenant = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
       const order = makeOrder({ organizationId: differentOrg, tenantId: differentTenant })
-      const { em, findMock } = makeEmForOrder(order)
+      const { em } = makeEmForOrder(order)
       const ctx = makeCtx(em, differentOrg, differentTenant)
 
       const handler = commandRegistry.get('sales.orders.delete')
       await handler!.execute({ id: ORDER_ID }, ctx as any)
 
-      const calls = addressFindCalls(findMock)
-      expect(calls[0][1]).toMatchObject({
+      const calls = addressDecryptionCalls()
+      expect(calls[0][2]).toMatchObject({
         organizationId: differentOrg,
         tenantId: differentTenant,
       })
@@ -308,9 +318,9 @@ describe('SalesDocumentAddress query scoping', () => {
   })
 
   describe('loadQuoteSnapshot (via deleteQuoteCommand.prepare) — scopes SalesDocumentAddress', () => {
-    it('em.find(SalesDocumentAddress) includes organizationId and tenantId from quote', async () => {
+    it('findWithDecryption(SalesDocumentAddress) includes organizationId and tenantId from quote', async () => {
       const quote = makeQuote()
-      const { em, findMock } = makeEmForQuote(quote)
+      const { em } = makeEmForQuote(quote)
       const ctx = makeCtx(em, ORG_ID, TENANT_ID)
 
       const handler = commandRegistry.get('sales.quotes.delete')
@@ -318,9 +328,9 @@ describe('SalesDocumentAddress query scoping', () => {
 
       await handler!.prepare({ id: QUOTE_ID }, ctx as any)
 
-      const calls = addressFindCalls(findMock)
+      const calls = addressDecryptionCalls()
       expect(calls).toHaveLength(1)
-      expect(calls[0][1]).toMatchObject({
+      expect(calls[0][2]).toMatchObject({
         documentId: QUOTE_ID,
         documentKind: 'quote',
         organizationId: ORG_ID,
@@ -330,9 +340,9 @@ describe('SalesDocumentAddress query scoping', () => {
   })
 
   describe('loadOrderSnapshot (via deleteOrderCommand.prepare) — scopes SalesDocumentAddress', () => {
-    it('em.find(SalesDocumentAddress) includes organizationId and tenantId from order', async () => {
+    it('findWithDecryption(SalesDocumentAddress) includes organizationId and tenantId from order', async () => {
       const order = makeOrder()
-      const { em, findMock } = makeEmForOrder(order)
+      const { em } = makeEmForOrder(order)
       const ctx = makeCtx(em, ORG_ID, TENANT_ID)
 
       const handler = commandRegistry.get('sales.orders.delete')
@@ -340,9 +350,9 @@ describe('SalesDocumentAddress query scoping', () => {
 
       await handler!.prepare({ id: ORDER_ID }, ctx as any)
 
-      const calls = addressFindCalls(findMock)
+      const calls = addressDecryptionCalls()
       expect(calls).toHaveLength(1)
-      expect(calls[0][1]).toMatchObject({
+      expect(calls[0][2]).toMatchObject({
         documentId: ORDER_ID,
         documentKind: 'order',
         organizationId: ORG_ID,

--- a/packages/core/src/modules/sales/commands/__tests__/documents.scope.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.scope.test.ts
@@ -1,0 +1,353 @@
+/** @jest-environment node */
+
+/**
+ * Tests that all em.find(SalesDocumentAddress, ...) calls include
+ * organizationId and tenantId filters, preventing cross-tenant data leaks.
+ *
+ * Fixed in: packages/core/src/modules/sales/commands/documents.ts
+ *   - loadQuoteSnapshot (line ~1179)
+ *   - loadOrderSnapshot (line ~1435)
+ *   - deleteQuoteCommand.execute (line ~4497)
+ *   - deleteOrderCommand.execute (line ~5424)
+ */
+
+import { createContainer, asValue, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import {
+  SalesQuote,
+  SalesQuoteLine,
+  SalesQuoteAdjustment,
+  SalesOrder,
+  SalesOrderLine,
+  SalesOrderAdjustment,
+  SalesShipment,
+  SalesPayment,
+  SalesPaymentAllocation,
+  SalesDocumentAddress,
+  SalesNote,
+  SalesDocumentTagAssignment,
+} from '../../data/entities'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const QUOTE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const ORDER_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+
+function makeQuote(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    id: QUOTE_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    quoteNumber: 'Q-1',
+    status: null,
+    statusEntryId: null,
+    customerEntityId: null,
+    customerContactId: null,
+    customerSnapshot: null,
+    billingAddressId: null,
+    shippingAddressId: null,
+    billingAddressSnapshot: null,
+    shippingAddressSnapshot: null,
+    currencyCode: 'USD',
+    exchangeRate: null,
+    taxStrategyKey: null,
+    discountStrategyKey: null,
+    taxInfo: null,
+    shippingMethodId: null,
+    shippingMethodCode: null,
+    shippingMethodSnapshot: null,
+    deliveryWindowId: null,
+    deliveryWindowCode: null,
+    paymentMethodId: null,
+    paymentMethodCode: null,
+    paymentMethodSnapshot: null,
+    channelId: null,
+    placedAt: null,
+    expectedDeliveryAt: null,
+    dueAt: null,
+    comments: null,
+    internalNotes: null,
+    metadata: null,
+    customFieldSetId: null,
+    subtotalNetAmount: '0',
+    subtotalGrossAmount: '0',
+    discountTotalAmount: '0',
+    taxTotalAmount: '0',
+    shippingNetAmount: '0',
+    shippingGrossAmount: '0',
+    surchargeTotalAmount: '0',
+    grandTotalNetAmount: '0',
+    grandTotalGrossAmount: '0',
+    lineItemCount: 0,
+    totalsSnapshot: null,
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+function makeOrder(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    id: ORDER_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    orderNumber: 'O-1',
+    status: null,
+    statusEntryId: null,
+    fulfillmentStatusEntryId: null,
+    fulfillmentStatus: null,
+    paymentStatusEntryId: null,
+    paymentStatus: null,
+    customerEntityId: null,
+    customerContactId: null,
+    customerSnapshot: null,
+    billingAddressId: null,
+    shippingAddressId: null,
+    billingAddressSnapshot: null,
+    shippingAddressSnapshot: null,
+    currencyCode: 'USD',
+    exchangeRate: null,
+    taxStrategyKey: null,
+    discountStrategyKey: null,
+    taxInfo: null,
+    shippingMethodId: null,
+    shippingMethodCode: null,
+    shippingMethodSnapshot: null,
+    deliveryWindowId: null,
+    deliveryWindowCode: null,
+    paymentMethodId: null,
+    paymentMethodCode: null,
+    paymentMethodSnapshot: null,
+    channelId: null,
+    placedAt: null,
+    expectedDeliveryAt: null,
+    dueAt: null,
+    comments: null,
+    internalNotes: null,
+    metadata: null,
+    customFieldSetId: null,
+    subtotalNetAmount: '0',
+    subtotalGrossAmount: '0',
+    discountTotalAmount: '0',
+    taxTotalAmount: '0',
+    shippingNetAmount: '0',
+    shippingGrossAmount: '0',
+    surchargeTotalAmount: '0',
+    grandTotalNetAmount: '0',
+    grandTotalGrossAmount: '0',
+    paidTotalAmount: '0',
+    refundedTotalAmount: '0',
+    outstandingAmount: '0',
+    lineItemCount: 0,
+    totalsSnapshot: null,
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+function makeEmForQuote(quote: ReturnType<typeof makeQuote>) {
+  const findMock = jest.fn(async (entityClass: unknown) => {
+    return []
+  })
+  const em: any = {
+    findOne: jest.fn(async (entityClass: unknown) => {
+      if (entityClass === SalesQuote) return quote
+      return null
+    }),
+    find: findMock,
+    nativeDelete: jest.fn(async () => 0),
+    remove: jest.fn(),
+    flush: jest.fn(async () => {}),
+    fork: function () { return this },
+  }
+  return { em, findMock }
+}
+
+function makeEmForOrder(order: ReturnType<typeof makeOrder>) {
+  const findMock = jest.fn(async (entityClass: unknown) => {
+    return []
+  })
+  const em: any = {
+    findOne: jest.fn(async (entityClass: unknown) => {
+      if (entityClass === SalesOrder) return order
+      return null
+    }),
+    find: findMock,
+    nativeDelete: jest.fn(async () => 0),
+    remove: jest.fn(),
+    flush: jest.fn(async () => {}),
+    fork: function () { return this },
+  }
+  return { em, findMock }
+}
+
+function makeCtx(em: unknown, organizationId: string, tenantId: string) {
+  const dataEngine = { markOrmEntityChange: jest.fn() }
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({
+    em: asValue(em),
+    dataEngine: asValue(dataEngine),
+    salesDocumentNumberGenerator: asValue({ generate: jest.fn(async () => ({ number: 'N-1' })) }),
+  })
+  return {
+    container,
+    dataEngine,
+    auth: { tenantId, orgId: organizationId, sub: 'user-1' },
+    selectedOrganizationId: organizationId,
+    organizationScope: null,
+    organizationIds: null,
+  }
+}
+
+/** Find all calls to em.find where the first argument is SalesDocumentAddress */
+function addressFindCalls(findMock: jest.Mock) {
+  return findMock.mock.calls.filter(
+    ([entityClass]) => entityClass === SalesDocumentAddress,
+  )
+}
+
+describe('SalesDocumentAddress query scoping', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  describe('deleteQuoteCommand.execute — scopes SalesDocumentAddress by quote tenant', () => {
+    it('passes organizationId from quote to em.find(SalesDocumentAddress)', async () => {
+      const quote = makeQuote()
+      const { em, findMock } = makeEmForQuote(quote)
+      const ctx = makeCtx(em, ORG_ID, TENANT_ID)
+
+      const handler = commandRegistry.get('sales.quotes.delete')
+      expect(handler).toBeTruthy()
+
+      await handler!.execute({ id: QUOTE_ID }, ctx as any)
+
+      const calls = addressFindCalls(findMock)
+      expect(calls).toHaveLength(1)
+      expect(calls[0][1]).toMatchObject({
+        documentId: QUOTE_ID,
+        documentKind: 'quote',
+        organizationId: ORG_ID,
+        tenantId: TENANT_ID,
+      })
+    })
+
+    it('uses the quote organizationId, not a hard-coded value', async () => {
+      const differentOrg = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+      const differentTenant = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+      const quote = makeQuote({ organizationId: differentOrg, tenantId: differentTenant })
+      const { em, findMock } = makeEmForQuote(quote)
+      const ctx = makeCtx(em, differentOrg, differentTenant)
+
+      const handler = commandRegistry.get('sales.quotes.delete')
+      await handler!.execute({ id: QUOTE_ID }, ctx as any)
+
+      const calls = addressFindCalls(findMock)
+      expect(calls[0][1]).toMatchObject({
+        organizationId: differentOrg,
+        tenantId: differentTenant,
+      })
+    })
+  })
+
+  describe('deleteOrderCommand.execute — scopes SalesDocumentAddress by order tenant', () => {
+    it('passes organizationId from order to em.find(SalesDocumentAddress)', async () => {
+      const order = makeOrder()
+      const { em, findMock } = makeEmForOrder(order)
+      const ctx = makeCtx(em, ORG_ID, TENANT_ID)
+
+      const handler = commandRegistry.get('sales.orders.delete')
+      expect(handler).toBeTruthy()
+
+      await handler!.execute({ id: ORDER_ID }, ctx as any)
+
+      const calls = addressFindCalls(findMock)
+      expect(calls).toHaveLength(1)
+      expect(calls[0][1]).toMatchObject({
+        documentId: ORDER_ID,
+        documentKind: 'order',
+        organizationId: ORG_ID,
+        tenantId: TENANT_ID,
+      })
+    })
+
+    it('uses the order organizationId, not a hard-coded value', async () => {
+      const differentOrg = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+      const differentTenant = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+      const order = makeOrder({ organizationId: differentOrg, tenantId: differentTenant })
+      const { em, findMock } = makeEmForOrder(order)
+      const ctx = makeCtx(em, differentOrg, differentTenant)
+
+      const handler = commandRegistry.get('sales.orders.delete')
+      await handler!.execute({ id: ORDER_ID }, ctx as any)
+
+      const calls = addressFindCalls(findMock)
+      expect(calls[0][1]).toMatchObject({
+        organizationId: differentOrg,
+        tenantId: differentTenant,
+      })
+    })
+  })
+
+  describe('loadQuoteSnapshot (via deleteQuoteCommand.prepare) — scopes SalesDocumentAddress', () => {
+    it('em.find(SalesDocumentAddress) includes organizationId and tenantId from quote', async () => {
+      const quote = makeQuote()
+      const { em, findMock } = makeEmForQuote(quote)
+      const ctx = makeCtx(em, ORG_ID, TENANT_ID)
+
+      const handler = commandRegistry.get('sales.quotes.delete')
+      expect(handler).toBeTruthy()
+
+      await handler!.prepare({ id: QUOTE_ID }, ctx as any)
+
+      const calls = addressFindCalls(findMock)
+      expect(calls).toHaveLength(1)
+      expect(calls[0][1]).toMatchObject({
+        documentId: QUOTE_ID,
+        documentKind: 'quote',
+        organizationId: ORG_ID,
+        tenantId: TENANT_ID,
+      })
+    })
+  })
+
+  describe('loadOrderSnapshot (via deleteOrderCommand.prepare) — scopes SalesDocumentAddress', () => {
+    it('em.find(SalesDocumentAddress) includes organizationId and tenantId from order', async () => {
+      const order = makeOrder()
+      const { em, findMock } = makeEmForOrder(order)
+      const ctx = makeCtx(em, ORG_ID, TENANT_ID)
+
+      const handler = commandRegistry.get('sales.orders.delete')
+      expect(handler).toBeTruthy()
+
+      await handler!.prepare({ id: ORDER_ID }, ctx as any)
+
+      const calls = addressFindCalls(findMock)
+      expect(calls).toHaveLength(1)
+      expect(calls[0][1]).toMatchObject({
+        documentId: ORDER_ID,
+        documentKind: 'order',
+        organizationId: ORG_ID,
+        tenantId: TENANT_ID,
+      })
+    })
+  })
+})

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -1176,7 +1176,7 @@ async function loadQuoteSnapshot(
     lineCustomFields,
     adjustmentCustomFields,
   ] = await Promise.all([
-    em.find(SalesDocumentAddress, { documentId: id, documentKind: "quote" }),
+    em.find(SalesDocumentAddress, { documentId: id, documentKind: "quote", organizationId: quote.organizationId, tenantId: quote.tenantId }),
     em.find(SalesNote, { contextType: "quote", contextId: id }),
     findWithDecryption(
       em,
@@ -1432,7 +1432,7 @@ async function loadOrderSnapshot(
     lineCustomFields,
     adjustmentCustomFields,
   ] = await Promise.all([
-    em.find(SalesDocumentAddress, { documentId: id, documentKind: "order" }),
+    em.find(SalesDocumentAddress, { documentId: id, documentKind: "order", organizationId: order.organizationId, tenantId: order.tenantId }),
     em.find(SalesNote, { contextType: "order", contextId: id }),
     findWithDecryption(
       em,
@@ -4497,6 +4497,8 @@ const deleteQuoteCommand: CommandHandler<
       em.find(SalesDocumentAddress, {
         documentId: quote.id,
         documentKind: "quote",
+        organizationId: quote.organizationId,
+        tenantId: quote.tenantId,
       }),
       em.find(SalesNote, { contextType: "quote", contextId: quote.id }),
       em.find(SalesDocumentTagAssignment, {
@@ -5422,6 +5424,8 @@ const deleteOrderCommand: CommandHandler<
       em.find(SalesDocumentAddress, {
         documentId: order.id,
         documentKind: "order",
+        organizationId: order.organizationId,
+        tenantId: order.tenantId,
       }),
       em.find(SalesNote, { contextType: "order", contextId: order.id }),
       em.find(SalesDocumentTagAssignment, {
@@ -5797,6 +5801,8 @@ const convertQuoteToOrderCommand: CommandHandler<
       em.find(SalesDocumentAddress, {
         documentId: snapshot.quote.id,
         documentKind: "quote",
+        organizationId: snapshot.quote.organizationId,
+        tenantId: snapshot.quote.tenantId,
       }),
       em.find(SalesNote, {
         contextType: "quote",

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -1176,8 +1176,8 @@ async function loadQuoteSnapshot(
     lineCustomFields,
     adjustmentCustomFields,
   ] = await Promise.all([
-    em.find(SalesDocumentAddress, { documentId: id, documentKind: "quote", organizationId: quote.organizationId, tenantId: quote.tenantId }),
-    em.find(SalesNote, { contextType: "quote", contextId: id }),
+    findWithDecryption(em, SalesDocumentAddress, { documentId: id, documentKind: "quote", organizationId: quote.organizationId, tenantId: quote.tenantId }, {}, { tenantId: quote.tenantId, organizationId: quote.organizationId }),
+    findWithDecryption(em, SalesNote, { contextType: "quote", contextId: id, organizationId: quote.organizationId, tenantId: quote.tenantId }, {}, { tenantId: quote.tenantId, organizationId: quote.organizationId }),
     findWithDecryption(
       em,
       SalesDocumentTagAssignment,
@@ -1432,8 +1432,8 @@ async function loadOrderSnapshot(
     lineCustomFields,
     adjustmentCustomFields,
   ] = await Promise.all([
-    em.find(SalesDocumentAddress, { documentId: id, documentKind: "order", organizationId: order.organizationId, tenantId: order.tenantId }),
-    em.find(SalesNote, { contextType: "order", contextId: id }),
+    findWithDecryption(em, SalesDocumentAddress, { documentId: id, documentKind: "order", organizationId: order.organizationId, tenantId: order.tenantId }, {}, { tenantId: order.tenantId, organizationId: order.organizationId }),
+    findWithDecryption(em, SalesNote, { contextType: "order", contextId: id, organizationId: order.organizationId, tenantId: order.tenantId }, {}, { tenantId: order.tenantId, organizationId: order.organizationId }),
     findWithDecryption(
       em,
       SalesDocumentTagAssignment,
@@ -4494,13 +4494,13 @@ const deleteQuoteCommand: CommandHandler<
       throw new CrudHttpError(404, { error: "Sales quote not found" });
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     const [addresses, notes, tags, adjustments, lines] = await Promise.all([
-      em.find(SalesDocumentAddress, {
+      findWithDecryption(em, SalesDocumentAddress, {
         documentId: quote.id,
         documentKind: "quote",
         organizationId: quote.organizationId,
         tenantId: quote.tenantId,
-      }),
-      em.find(SalesNote, { contextType: "quote", contextId: quote.id }),
+      }, {}, { tenantId: quote.tenantId, organizationId: quote.organizationId }),
+      findWithDecryption(em, SalesNote, { contextType: "quote", contextId: quote.id, organizationId: quote.organizationId, tenantId: quote.tenantId }, {}, { tenantId: quote.tenantId, organizationId: quote.organizationId }),
       em.find(SalesDocumentTagAssignment, {
         documentId: quote.id,
         documentKind: "quote",
@@ -5421,13 +5421,13 @@ const deleteOrderCommand: CommandHandler<
         : Promise.resolve([]),
       em.find(SalesPayment, { order: order.id }),
       em.find(SalesPaymentAllocation, { order: order.id }),
-      em.find(SalesDocumentAddress, {
+      findWithDecryption(em, SalesDocumentAddress, {
         documentId: order.id,
         documentKind: "order",
         organizationId: order.organizationId,
         tenantId: order.tenantId,
-      }),
-      em.find(SalesNote, { contextType: "order", contextId: order.id }),
+      }, {}, { tenantId: order.tenantId, organizationId: order.organizationId }),
+      findWithDecryption(em, SalesNote, { contextType: "order", contextId: order.id, organizationId: order.organizationId, tenantId: order.tenantId }, {}, { tenantId: order.tenantId, organizationId: order.organizationId }),
       em.find(SalesDocumentTagAssignment, {
         documentId: order.id,
         documentKind: "order",
@@ -5798,16 +5798,18 @@ const convertQuoteToOrderCommand: CommandHandler<
     });
 
     const [addresses, notes, tags] = await Promise.all([
-      em.find(SalesDocumentAddress, {
+      findWithDecryption(em, SalesDocumentAddress, {
         documentId: snapshot.quote.id,
         documentKind: "quote",
         organizationId: snapshot.quote.organizationId,
         tenantId: snapshot.quote.tenantId,
-      }),
-      em.find(SalesNote, {
+      }, {}, { tenantId: snapshot.quote.tenantId, organizationId: snapshot.quote.organizationId }),
+      findWithDecryption(em, SalesNote, {
         contextType: "quote",
         contextId: snapshot.quote.id,
-      }),
+        organizationId: snapshot.quote.organizationId,
+        tenantId: snapshot.quote.tenantId,
+      }, {}, { tenantId: snapshot.quote.tenantId, organizationId: snapshot.quote.organizationId }),
       em.find(SalesDocumentTagAssignment, {
         documentId: snapshot.quote.id,
         documentKind: "quote",


### PR DESCRIPTION
fix(sales): scope SalesDocumentAddress queries by organizationId and tenantId                                                                                                  
                                                                                                                                                                                 
  Summary                                                                                                                                                                        
                                                                                                                                                                                 
  All em.find(SalesDocumentAddress, ...) calls in commands/documents.ts were missing organizationId and tenantId filters. Without these constraints a user could theoretically   
  read or have their delete commands operate on address records belonging to another organization, because the query only scoped by documentId and documentKind — neither of
  which is globally unique per tenant.                                                                                                                                           
                                                            
  Changes

  packages/core/src/modules/sales/commands/documents.ts — 5 queries fixed

  In each case the parent document object was already loaded and scope-verified earlier in the same function — the fix simply  propagates that scope into the address sub-query.  
   
  packages/core/src/modules/sales/commands/__tests__/documents.scope.test.ts — new test file with 6 unit tests:                                                                  
                                                            
  - deleteQuoteCommand.execute passes organizationId/tenantId from quote to em.find(SalesDocumentAddress)                                                                        
  - deleteQuoteCommand.execute uses the quote's actual org values, not a hard-coded value
  - deleteOrderCommand.execute passes organizationId/tenantId from order to em.find(SalesDocumentAddress)                                                                        
  - deleteOrderCommand.execute uses the order's actual org values, not a hard-coded value
  - loadQuoteSnapshot (via deleteQuoteCommand.prepare) scopes the address query                                                                                                  
  - loadOrderSnapshot (via deleteOrderCommand.prepare) scopes the address query       