### PR TITLE
bug: Logout from develop environment redirects to demo environment

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/logout.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/logout.test.ts
@@ -1,0 +1,42 @@
+/** @jest-environment node */
+import { POST } from '@open-mercato/core/modules/auth/api/logout'
+
+const deleteSessionByToken = jest.fn()
+const originalAppUrl = process.env.APP_URL
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (_name: string) => ({
+      deleteSessionByToken: (...args: unknown[]) => deleteSessionByToken(...args),
+    }),
+  }),
+}))
+
+describe('/api/auth/logout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.APP_URL = 'https://demo.openmercato.com'
+  })
+
+  afterAll(() => {
+    if (originalAppUrl === undefined) {
+      delete process.env.APP_URL
+      return
+    }
+    process.env.APP_URL = originalAppUrl
+  })
+
+  it('redirects to the request host login page and clears auth cookies', async () => {
+    const response = await POST(new Request('https://develop.openmercato.com/api/auth/logout', {
+      method: 'POST',
+    }))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/login')
+
+    const setCookie = response.headers.get('set-cookie') || ''
+    expect(setCookie).toContain('auth_token=;')
+    expect(setCookie).toContain('session_token=;')
+    expect(deleteSessionByToken).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts
@@ -2,6 +2,7 @@
 import { GET, POST } from '@open-mercato/core/modules/auth/api/session/refresh'
 
 const refreshFromSessionToken = jest.fn()
+const originalAppUrl = process.env.APP_URL
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   resolveTranslations: async () => ({
@@ -21,19 +22,54 @@ jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({
   signJwt: () => 'jwt-token',
 }))
 
+jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
+  checkAuthRateLimit: async () => ({ error: null }),
+}))
+
 describe('/api/auth/session/refresh', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env.APP_URL = 'https://demo.openmercato.com'
   })
 
-  it('GET clears cookies when session cookie is missing', async () => {
-    const response = await GET(new Request('http://localhost/api/auth/session/refresh?redirect=%2Fbackend'))
+  afterAll(() => {
+    if (originalAppUrl === undefined) {
+      delete process.env.APP_URL
+      return
+    }
+    process.env.APP_URL = originalAppUrl
+  })
+
+  it('GET clears cookies and redirects to the request host when session cookie is missing', async () => {
+    const response = await GET(new Request('https://develop.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend'))
 
     expect(response.status).toBe(307)
-    expect(response.headers.get('location')).toContain('/login?redirect=%2Fbackend')
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/login?redirect=%2Fbackend')
     const setCookie = response.headers.get('set-cookie') || ''
     expect(setCookie).toContain('auth_token=;')
     expect(setCookie).toContain('session_token=;')
+  })
+
+  it('GET redirects valid browser refreshes to the request host', async () => {
+    refreshFromSessionToken.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        email: 'admin@acme.com',
+      },
+      roles: ['admin'],
+    })
+
+    const response = await GET(new Request('https://develop.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend', {
+      headers: {
+        cookie: 'session_token=refresh-token',
+      },
+    }))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/backend')
+    expect(refreshFromSessionToken).toHaveBeenCalledWith('refresh-token')
   })
 
   it('POST clears cookies when refresh token is invalid', async () => {

--- a/packages/core/src/modules/auth/api/logout.ts
+++ b/packages/core/src/modules/auth/api/logout.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { toAbsoluteUrl } from '@open-mercato/shared/lib/url'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
+import { buildRequestOriginUrl } from '@open-mercato/core/modules/auth/lib/requestRedirect'
 
 function parseCookie(req: Request, name: string): string | null {
   const cookie = req.headers.get('cookie') || ''
@@ -15,7 +15,7 @@ export async function POST(req: Request) {
   if (sessToken) {
     try { const c = await createRequestContainer(); const auth = c.resolve<AuthService>('authService'); await auth.deleteSessionByToken(sessToken) } catch {}
   }
-  const res = NextResponse.redirect(toAbsoluteUrl(req, '/login'))
+  const res = NextResponse.redirect(buildRequestOriginUrl(req, '/login'))
   res.cookies.set('auth_token', '', { path: '/', maxAge: 0 })
   res.cookies.set('session_token', '', { path: '/', maxAge: 0 })
   return res

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { toAbsoluteUrl } from '@open-mercato/shared/lib/url'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
 import { signJwt } from '@open-mercato/shared/lib/auth/jwt'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { refreshSessionRequestSchema } from '@open-mercato/core/modules/auth/data/validators'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
+import { buildRequestOriginUrl } from '@open-mercato/core/modules/auth/lib/requestRedirect'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { z } from 'zod'
@@ -61,7 +61,7 @@ export async function GET(req: Request) {
   const token = parseCookie(req, 'session_token')
   if (!token) {
     return clearStaffAuthCookies(
-      NextResponse.redirect(toAbsoluteUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
+      NextResponse.redirect(buildRequestOriginUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
     )
   }
   const c = await createRequestContainer()
@@ -69,12 +69,12 @@ export async function GET(req: Request) {
   const ctx = await auth.refreshFromSessionToken(token)
   if (!ctx) {
     return clearStaffAuthCookies(
-      NextResponse.redirect(toAbsoluteUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
+      NextResponse.redirect(buildRequestOriginUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
     )
   }
   const { user, roles } = ctx
   const jwt = signJwt({ sub: String(user.id), tenantId: String(user.tenantId), orgId: String(user.organizationId), email: user.email, roles })
-  const res = NextResponse.redirect(toAbsoluteUrl(req, redirectTo))
+  const res = NextResponse.redirect(buildRequestOriginUrl(req, redirectTo))
   res.cookies.set('auth_token', jwt, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
   return res
 }

--- a/packages/core/src/modules/auth/lib/requestRedirect.ts
+++ b/packages/core/src/modules/auth/lib/requestRedirect.ts
@@ -1,0 +1,4 @@
+export function buildRequestOriginUrl(req: Request, path: string): string {
+  const url = new URL(req.url)
+  return new URL(path, `${url.protocol}//${url.host}`).toString()
+}


### PR DESCRIPTION
Source: GitHub issue #967

## Problem Summary
Logging out from the develop environment redirects the user to the demo environment login page.

## Steps to reproduce
1. Open https://develop.openmercato.com
2. Login
3. Click Logout

## Expected result
User should be redirected to:
https://develop.openmercato.com/login

## Actual result
User is redirected to:
https://demo.openmercato.com/login

## Implemented fix
- Added an auth-local request-origin helper for browser redirects.
- Updated the logout redirect to build the login URL from the incoming request host instead of APP_URL.
- Updated the browser redirect path in session refresh to use the incoming request host as well.
- Added focused auth tests covering the develop-vs-demo host mismatch and cookie clearing.

## Validation / Tests
- yarn workspace @open-mercato/core test --runTestsByPath src/modules/auth/api/__tests__/logout.test.ts src/modules/auth/api/__tests__/session.refresh.test.ts

## Expected Contribution Classes
- bugfix
