### PR TITLE
add Tenant org/scoped to all nativeDelete calls

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/nativedelete-scoping.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/nativedelete-scoping.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests that every em.nativeDelete call in the people command handlers
+ * includes organizationId + tenantId scope where the entity schema supports it.
+ *
+ * Regression coverage for: fix/customers-data-integrity
+ *   – delete execute:  CustomerAddress/Comment/Activity/Interaction/TodoLink/TagAssignment
+ *   – create undo:     CustomerTagAssignment
+ *   – delete undo:     CustomerActivity/Comment/Address/TodoLink/Interaction
+ *
+ * CustomerDealPersonLink is intentionally NOT scoped: it has no org/tenant columns.
+ */
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+import '@open-mercato/core/modules/customers/commands'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  CustomerEntity,
+  CustomerPersonProfile,
+  CustomerAddress,
+  CustomerComment,
+  CustomerActivity,
+  CustomerInteraction,
+  CustomerTodoLink,
+  CustomerTagAssignment,
+  CustomerDealPersonLink,
+} from '../../data/entities'
+
+const ORG_ID = 'org-aaa'
+const TENANT_ID = 'tenant-bbb'
+const ENTITY_ID = 'entity-111'
+
+function makeEntity(overrides: Partial<CustomerEntity> = {}): CustomerEntity {
+  return {
+    id: ENTITY_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    kind: 'person',
+    displayName: 'Test Person',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    personProfile: undefined,
+    companyProfile: undefined,
+    addresses: [] as any,
+    activities: [] as any,
+    comments: [] as any,
+    tagAssignments: [] as any,
+    todoLinks: [] as any,
+    dealPersonLinks: [] as any,
+    dealCompanyLinks: [] as any,
+    companyMembers: [] as any,
+    ...overrides,
+  }
+}
+
+function makeEm(entity: CustomerEntity): jest.Mocked<Pick<EntityManager,
+  'fork' | 'findOne' | 'find' | 'nativeDelete' | 'remove' | 'flush' | 'create' | 'persist' | 'getReference'
+>> {
+  const em: any = {
+    fork: jest.fn().mockReturnThis(),
+    findOne: jest.fn(async (ctor: any) => {
+      if (ctor === CustomerEntity) return entity
+      return null
+    }),
+    find: jest.fn(async () => []),
+    nativeDelete: jest.fn(async () => undefined),
+    remove: jest.fn().mockReturnValue({ flush: jest.fn().mockResolvedValue(undefined) }),
+    flush: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn((_ctor: any, data: any) => ({ id: 'new-id', ...data })),
+    persist: jest.fn(),
+    getReference: jest.fn((_ctor: any, id: string) => ({ id })),
+  }
+  return em
+}
+
+function makeCtx(em: any): CommandRuntimeContext {
+  const queue: any[] = []
+  const dataEngine: any = {
+    setCustomFields: jest.fn(async () => {}),
+    emitOrmEntityEvent: jest.fn(async () => {}),
+    markOrmEntityChange: jest.fn((entry: any) => { if (entry?.entity) queue.push(entry) }),
+    flushOrmEntityChanges: jest.fn(async () => {
+      while (queue.length) await dataEngine.emitOrmEntityEvent(queue.shift())
+    }),
+  }
+  return {
+    container: {
+      resolve: (token: string): any => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return dataEngine
+        throw new Error(`Unexpected DI token: ${token}`)
+      },
+    } as any,
+    auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID } as any,
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: undefined as any,
+  }
+}
+
+describe('people commands — nativeDelete tenant/org scoping', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  describe('customers.people.delete execute', () => {
+    it('scopes nativeDelete with organizationId + tenantId for all tenant-aware child entities', async () => {
+      const entity = makeEntity()
+      const em = makeEm(entity)
+      const ctx = makeCtx(em)
+      const handler = commandRegistry.get('customers.people.delete') as CommandHandler
+      expect(handler).toBeDefined()
+
+      await handler.execute({ body: { id: ENTITY_ID } }, ctx)
+
+      const scope = { organizationId: ORG_ID, tenantId: TENANT_ID }
+
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerAddress,     expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerComment,     expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerActivity,    expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerInteraction, expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerTodoLink,    expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerTagAssignment, expect.objectContaining({ entity, ...scope }))
+    })
+
+    it('does NOT add organizationId/tenantId scope to CustomerDealPersonLink (join table has no tenant columns)', async () => {
+      const entity = makeEntity()
+      const em = makeEm(entity)
+      const ctx = makeCtx(em)
+      const handler = commandRegistry.get('customers.people.delete') as CommandHandler
+
+      await handler.execute({ body: { id: ENTITY_ID } }, ctx)
+
+      const dealPersonLinkCalls = (em.nativeDelete as jest.Mock).mock.calls.filter(
+        ([ctor]: [any]) => ctor === CustomerDealPersonLink,
+      )
+      expect(dealPersonLinkCalls).toHaveLength(1)
+      expect(dealPersonLinkCalls[0][1]).not.toHaveProperty('organizationId')
+      expect(dealPersonLinkCalls[0][1]).not.toHaveProperty('tenantId')
+    })
+  })
+
+  describe('customers.people.create undo', () => {
+    it('scopes nativeDelete(CustomerTagAssignment) with organizationId + tenantId', async () => {
+      const entity = makeEntity()
+      const em = makeEm(entity)
+      const ctx = makeCtx(em)
+      const handler = commandRegistry.get('customers.people.create') as CommandHandler
+      expect(handler).toBeDefined()
+      expect(handler.undo).toBeDefined()
+
+      const logEntry = {
+        resourceId: ENTITY_ID,
+        commandPayload: {
+          undo: {
+            after: {
+              entity: {
+                id: ENTITY_ID,
+                organizationId: ORG_ID,
+                tenantId: TENANT_ID,
+              },
+              profile: { id: 'profile-1' },
+              tagIds: [],
+            },
+          },
+        },
+      }
+
+      await handler.undo!({ input: undefined, logEntry: logEntry as any, ctx })
+
+      expect(em.nativeDelete).toHaveBeenCalledWith(
+        CustomerTagAssignment,
+        expect.objectContaining({ entity, organizationId: ORG_ID, tenantId: TENANT_ID }),
+      )
+    })
+  })
+
+  describe('customers.people.delete undo', () => {
+    it('scopes nativeDelete with organizationId + tenantId for all tenant-aware child entities', async () => {
+      const entity = makeEntity()
+      const em = makeEm(entity)
+      const ctx = makeCtx(em)
+      const handler = commandRegistry.get('customers.people.delete') as CommandHandler
+      expect(handler).toBeDefined()
+      expect(handler.undo).toBeDefined()
+
+      const before = {
+        entity: {
+          id: ENTITY_ID,
+          organizationId: ORG_ID,
+          tenantId: TENANT_ID,
+          kind: 'person' as const,
+          displayName: 'Test Person',
+          description: null,
+          ownerUserId: null,
+          primaryEmail: null,
+          primaryPhone: null,
+          status: null,
+          lifecycleStage: null,
+          source: null,
+          nextInteractionAt: null,
+          nextInteractionName: null,
+          nextInteractionRefId: null,
+          isActive: true,
+        },
+        profile: {
+          id: 'profile-1',
+          firstName: 'Test',
+          lastName: 'Person',
+          preferredName: null,
+          jobTitle: null,
+          department: null,
+          seniority: null,
+          timezone: null,
+          linkedInUrl: null,
+          twitterUrl: null,
+          companyEntityId: null,
+        },
+        deals: [],
+        comments: [],
+        addresses: [],
+        tagIds: [],
+        custom: {},
+      }
+
+      const logEntry = {
+        commandPayload: { undo: { before } },
+      }
+
+      await handler.undo!({ input: undefined, logEntry: logEntry as any, ctx })
+
+      const scope = { organizationId: ORG_ID, tenantId: TENANT_ID }
+
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerActivity,    expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerComment,     expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerAddress,     expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerTodoLink,    expect.objectContaining({ entity, ...scope }))
+      expect(em.nativeDelete).toHaveBeenCalledWith(CustomerInteraction, expect.objectContaining({ entity, ...scope }))
+    })
+
+    it('does NOT add organizationId/tenantId scope to CustomerDealPersonLink in undo path', async () => {
+      const entity = makeEntity()
+      const em = makeEm(entity)
+      const ctx = makeCtx(em)
+      const handler = commandRegistry.get('customers.people.delete') as CommandHandler
+
+      const before = {
+        entity: {
+          id: ENTITY_ID,
+          organizationId: ORG_ID,
+          tenantId: TENANT_ID,
+          kind: 'person' as const,
+          displayName: 'Test Person',
+          description: null,
+          ownerUserId: null,
+          primaryEmail: null,
+          primaryPhone: null,
+          status: null,
+          lifecycleStage: null,
+          source: null,
+          nextInteractionAt: null,
+          nextInteractionName: null,
+          nextInteractionRefId: null,
+          isActive: true,
+        },
+        profile: {
+          id: 'profile-1',
+          firstName: 'Test',
+          lastName: 'Person',
+          preferredName: null,
+          jobTitle: null,
+          department: null,
+          seniority: null,
+          timezone: null,
+          linkedInUrl: null,
+          twitterUrl: null,
+          companyEntityId: null,
+        },
+        deals: [],
+        comments: [],
+        addresses: [],
+        tagIds: [],
+        custom: {},
+      }
+
+      await handler.undo!({ input: undefined, logEntry: { commandPayload: { undo: { before } } } as any, ctx })
+
+      const dealPersonLinkCalls = (em.nativeDelete as jest.Mock).mock.calls.filter(
+        ([ctor]: [any]) => ctor === CustomerDealPersonLink,
+      )
+      expect(dealPersonLinkCalls).toHaveLength(1)
+      expect(dealPersonLinkCalls[0][1]).not.toHaveProperty('organizationId')
+      expect(dealPersonLinkCalls[0][1]).not.toHaveProperty('tenantId')
+    })
+  })
+})

--- a/packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts
@@ -1628,7 +1628,7 @@ describe('customers commands undo custom fields', () => {
     const ctx = createMockContext({ em, dataEngine })
     await handler.execute({ query: { id: entity.id } }, ctx)
 
-    expect(em.nativeDelete).toHaveBeenCalledWith(CustomerInteraction, { entity })
+    expect(em.nativeDelete).toHaveBeenCalledWith(CustomerInteraction, expect.objectContaining({ entity, organizationId: entity.organizationId, tenantId: entity.tenantId }))
     const interactionDeleteOrder = em.nativeDelete.mock.invocationCallOrder[
       em.nativeDelete.mock.calls.findIndex(([ctor]) => ctor === CustomerInteraction)
     ]
@@ -1738,7 +1738,7 @@ describe('customers commands undo custom fields', () => {
     const ctx = createMockContext({ em, dataEngine })
     await handler.execute({ query: { id: entity.id } }, ctx)
 
-    expect(em.nativeDelete).toHaveBeenCalledWith(CustomerInteraction, { entity })
+    expect(em.nativeDelete).toHaveBeenCalledWith(CustomerInteraction, expect.objectContaining({ entity, organizationId: entity.organizationId, tenantId: entity.tenantId }))
     const interactionDeleteOrder = em.nativeDelete.mock.invocationCallOrder[
       em.nativeDelete.mock.calls.findIndex(([ctor]) => ctor === CustomerInteraction)
     ]

--- a/packages/core/src/modules/customers/commands/companies.ts
+++ b/packages/core/src/modules/customers/commands/companies.ts
@@ -509,8 +509,8 @@ const createCompanyCommand: CommandHandler<CompanyCreateInput, { entityId: strin
       organizationId: entity.organizationId,
       tenantId: entity.tenantId,
     }
-    await em.nativeDelete(CustomerCompanyProfile, { entity })
-    await em.nativeDelete(CustomerTagAssignment, { entity })
+    await em.nativeDelete(CustomerCompanyProfile, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
+    await em.nativeDelete(CustomerTagAssignment, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
     em.remove(entity)
     await em.flush()
 
@@ -787,13 +787,13 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const profile = await em.findOne(CustomerCompanyProfile, { entity: record })
       await em.nativeUpdate(CustomerPersonProfile, { company: record }, { company: null })
       await em.nativeDelete(CustomerDealCompanyLink, { company: record })
-      await em.nativeDelete(CustomerActivity, { entity: record })
-      await em.nativeDelete(CustomerInteraction, { entity: record })
-      await em.nativeDelete(CustomerTodoLink, { entity: record })
-      await em.nativeDelete(CustomerCompanyProfile, { entity: record })
-      await em.nativeDelete(CustomerAddress, { entity: record })
-      await em.nativeDelete(CustomerComment, { entity: record })
-      await em.nativeDelete(CustomerTagAssignment, { entity: record })
+      await em.nativeDelete(CustomerActivity, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerInteraction, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerTodoLink, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerCompanyProfile, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerAddress, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerComment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerTagAssignment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
       em.remove(record)
       await em.flush()
 
@@ -1033,7 +1033,7 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
         await em.flush()
       }
 
-      await em.nativeDelete(CustomerActivity, { entity })
+      await em.nativeDelete(CustomerActivity, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const activity of beforeActivities) {
         const restoredActivity = em.create(CustomerActivity, {
           id: activity.id,
@@ -1055,7 +1055,7 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerComment, { entity })
+      await em.nativeDelete(CustomerComment, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const comment of beforeComments) {
         const restoredComment = em.create(CustomerComment, {
           id: comment.id,
@@ -1075,7 +1075,7 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerAddress, { entity })
+      await em.nativeDelete(CustomerAddress, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const address of beforeAddresses) {
         const restoredAddress = em.create(CustomerAddress, {
           id: address.id,
@@ -1098,7 +1098,7 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerTodoLink, { entity })
+      await em.nativeDelete(CustomerTodoLink, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const todo of beforeTodos) {
         const restoredTodo = em.create(CustomerTodoLink, {
           id: todo.id,
@@ -1115,7 +1115,7 @@ const deleteCompanyCommand: CommandHandler<{ body?: Record<string, unknown>; que
       await em.flush()
 
       const de = (ctx.container.resolve('dataEngine') as DataEngine)
-      await em.nativeDelete(CustomerInteraction, { entity })
+      await em.nativeDelete(CustomerInteraction, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const interaction of beforeInteractions) {
         const restoredInteraction = em.create(CustomerInteraction, {
           id: interaction.id,

--- a/packages/core/src/modules/customers/commands/people.ts
+++ b/packages/core/src/modules/customers/commands/people.ts
@@ -638,7 +638,7 @@ const createPersonCommand: CommandHandler<PersonCreateInput, { entityId: string;
       organizationId: entity.organizationId,
       tenantId: entity.tenantId,
     }
-    await em.nativeDelete(CustomerTagAssignment, { entity })
+    await em.nativeDelete(CustomerTagAssignment, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
     if (profile) {
       await em.remove(profile).flush()
     }
@@ -951,12 +951,12 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       ensureOrganizationScope(ctx, record.organizationId)
       const profile = await em.findOne(CustomerPersonProfile, { entity: record })
       if (profile) em.remove(profile)
-      await em.nativeDelete(CustomerAddress, { entity: record })
-      await em.nativeDelete(CustomerComment, { entity: record })
-      await em.nativeDelete(CustomerActivity, { entity: record })
-      await em.nativeDelete(CustomerInteraction, { entity: record })
-      await em.nativeDelete(CustomerTodoLink, { entity: record })
-      await em.nativeDelete(CustomerTagAssignment, { entity: record })
+      await em.nativeDelete(CustomerAddress, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerComment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerActivity, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerInteraction, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerTodoLink, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
+      await em.nativeDelete(CustomerTagAssignment, { entity: record, organizationId: record.organizationId, tenantId: record.tenantId })
       await em.nativeDelete(CustomerDealPersonLink, { person: record })
       em.remove(record)
       await em.flush()
@@ -1180,7 +1180,7 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerActivity, { entity })
+      await em.nativeDelete(CustomerActivity, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const activity of beforeActivities) {
         const restoredActivity = em.create(CustomerActivity, {
           id: activity.id,
@@ -1202,7 +1202,7 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerComment, { entity })
+      await em.nativeDelete(CustomerComment, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const comment of before.comments) {
         const restoredComment = em.create(CustomerComment, {
           id: comment.id,
@@ -1222,7 +1222,7 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerAddress, { entity })
+      await em.nativeDelete(CustomerAddress, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const address of before.addresses) {
         const restoredAddress = em.create(CustomerAddress, {
           id: address.id,
@@ -1245,7 +1245,7 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       }
       await em.flush()
 
-      await em.nativeDelete(CustomerTodoLink, { entity })
+      await em.nativeDelete(CustomerTodoLink, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const todo of beforeTodos) {
         const restoredTodo = em.create(CustomerTodoLink, {
           id: todo.id,
@@ -1262,7 +1262,7 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       await em.flush()
 
       const de = (ctx.container.resolve('dataEngine') as DataEngine)
-      await em.nativeDelete(CustomerInteraction, { entity })
+      await em.nativeDelete(CustomerInteraction, { entity, organizationId: entity.organizationId, tenantId: entity.tenantId })
       for (const interaction of beforeInteractions) {
         const restoredInteraction = em.create(CustomerInteraction, {
           id: interaction.id,


### PR DESCRIPTION
I've checked with Claude whether there is something like findOneWithDecryption for this, but there isn't.

## fix(customers): add tenant/org scope to all nativeDelete calls in people command                                                            
                                                                                                                                                 
  ### Problem                                                                                                                                    
                                                                                                                                                 
  The `people.ts` command file contained `em.nativeDelete` calls on related entities                                                             
  (`CustomerTagAssignment`, `CustomerAddress`, `CustomerComment`, `CustomerActivity`,                                                            
  `CustomerInteraction`, `CustomerTodoLink`) that used only the entity FK as the WHERE                                                           
  filter — no `organizationId` or `tenantId` scope was applied.                                                                                  
   
  In a multi-tenant environment, if the same entity FK value appears across tenants                                                              
  (which is possible without unique cross-tenant DB constraints), these deletes could
  silently remove records belonging to a different organization.                                                                                 
                                                                  
  The issue was present in three separate code paths:                                                                                            
                                                                  
  1. **`create` undo** (line 641) — deleting `CustomerTagAssignment` when undoing a                                                              
     person creation.                                             
  2. **`delete` execute** (lines 954–959) — bulk-deleting all related records when                                                               
     deleting a person.                                                                                                                          
  3. **`delete` undo** (lines 1183, 1205, 1225, 1248, 1265) — clearing related records                                                           
     before restoring a snapshot when undoing a person deletion.                                                                                 
                                                                  
  ### Changes                                                                                                                                    
                                                                  
  #### `packages/core/src/modules/customers/commands/people.ts`                                                                                  
   
  Ten `nativeDelete` calls scoped with `organizationId` and `tenantId` sourced from                                                              
  the already-authenticated parent entity (`record` / `entity`):  
                                                                                                                                                 
  | Entity | Call site | Scope added |
  |--------|-----------|-------------|                                                                                                           
  | `CustomerTagAssignment` | `create` undo, `delete` execute | `entity.organizationId`, `entity.tenantId` |
  | `CustomerAddress` | `delete` execute, `delete` undo | same |                                                                                 
  | `CustomerComment` | `delete` execute, `delete` undo | same |                                                                                 
  | `CustomerActivity` | `delete` execute, `delete` undo | same |                                                                                
  | `CustomerInteraction` | `delete` execute, `delete` undo | same |                                                                             
  | `CustomerTodoLink` | `delete` execute, `delete` undo | same |                                                                                
   
  `CustomerDealPersonLink` (lines 960, 1168) is intentionally left without org/tenant                                                            
  scope — that join table has no `organization_id` or `tenant_id` columns in its schema,
  so adding scope would cause a runtime error.                                                                                                   
                                                                                                                                                 
  No business logic was changed. The additions are purely additive filter arguments to                                                           
  existing `nativeDelete` calls.                                                                                                                 
                                                                                                                                                 
  ### Tests                                                                                                                                      
   
  **New file: `commands/__tests__/nativedelete-scoping.test.ts`** (5 tests)                                                                      
                                                                  
  | Test | What it asserts |                                                                                                                     
  |------|----------------|                                       
  | `delete execute` — scoped entities | All 6 tenant-aware `nativeDelete` calls include `organizationId` + `tenantId` |
  | `delete execute` — join table | `CustomerDealPersonLink` call has no `organizationId`/`tenantId` (intentional) |                             
  | `create undo` — `CustomerTagAssignment` | Scoped with `organizationId` + `tenantId` |                                                        
  | `delete undo` — scoped entities | All 5 tenant-aware `nativeDelete` calls in the undo path include scope |                                   
  | `delete undo` — join table | `CustomerDealPersonLink` call has no scope (intentional) |                                                      
                                                                                                                                                 
  All 5 tests pass. The core package builds cleanly. 
  
  
 