### PR TITLE
fix(sales): reorder document detail tabs

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-020.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-020.spec.ts
@@ -224,6 +224,10 @@ test.describe('TC-SALES-020b: Document History Widget', () => {
       await page.goto(`/backend/sales/documents/${orderId}?kind=order`);
       await page.waitForLoadState('domcontentloaded');
 
+      const tabButtons = page.locator('[data-tab-id]');
+      await expect(tabButtons.first()).toHaveAttribute('data-tab-id', 'items');
+      await expect(page.locator('[data-tab-id="items"]')).toHaveAttribute('data-active', 'true');
+
       // Open History tab
       const historyButton = page.getByRole('button', { name: 'History', exact: true });
       await expect(historyButton).toBeVisible({ timeout: WIDGET_LOAD_TIMEOUT });

--- a/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
@@ -1871,7 +1871,7 @@ export default function SalesDocumentDetailPage({
   const [kind, setKind] = React.useState<'order' | 'quote'>('quote')
   const [error, setError] = React.useState<string | null>(null)
   const [reloadKey, setReloadKey] = React.useState(0)
-  const [activeTab, setActiveTab] = React.useState<string>('comments')
+  const [activeTab, setActiveTab] = React.useState<string>('items')
   const [sectionAction, setSectionAction] = React.useState<SectionAction | null>(null)
   const detailSectionRef = React.useRef<HTMLDivElement | null>(null)
   const [generating, setGenerating] = React.useState(false)
@@ -3938,10 +3938,10 @@ export default function SalesDocumentDetailPage({
   const tabButtons = React.useMemo<Array<{ id: string; label: string }>>(
     () => {
       const tabs: Array<{ id: string; label: string }> = [
-        { id: 'comments', label: t('sales.documents.detail.tabs.comments', 'Comments') },
-        { id: 'addresses', label: t('sales.documents.detail.tabs.addresses', 'Addresses') },
         { id: 'items', label: t('sales.documents.detail.tabs.items', 'Items') },
+        { id: 'addresses', label: t('sales.documents.detail.tabs.addresses', 'Addresses') },
       ]
+      tabs.push({ id: 'adjustments', label: t('sales.documents.detail.tabs.adjustments', 'Adjustments') })
       if (kind === 'order') {
         tabs.push(
           { id: 'shipments', label: t('sales.documents.detail.tabs.shipments', 'Shipments') },
@@ -3949,10 +3949,10 @@ export default function SalesDocumentDetailPage({
           { id: 'returns', label: t('sales.documents.detail.tabs.returns', 'Returns') },
         )
       }
-      tabs.push({ id: 'adjustments', label: t('sales.documents.detail.tabs.adjustments', 'Adjustments') })
       injectedTabs.forEach((tab) => {
         tabs.push({ id: tab.id, label: tab.label })
       })
+      tabs.push({ id: 'comments', label: t('sales.documents.detail.tabs.comments', 'Comments') })
       return tabs
     },
     [injectedTabs, kind, t],
@@ -4736,19 +4736,23 @@ export default function SalesDocumentDetailPage({
           <div className="mb-3 flex flex-wrap items-center justify-between gap-2 pb-2">
             <div className="flex flex-wrap items-center gap-2">
               {tabButtons.map((tab) => (
-                <button
+                <Button
                   key={tab.id}
                   type="button"
+                  variant="ghost"
+                  size="sm"
+                  data-tab-id={tab.id}
+                  data-active={activeTab === tab.id ? 'true' : 'false'}
                   className={cn(
-                    'px-3 py-2 text-sm font-medium transition-colors',
+                    'h-auto rounded-none border-b-2 px-3 py-2 text-sm font-medium transition-colors hover:bg-transparent',
                     activeTab === tab.id
                       ? 'border-b-2 border-primary text-primary'
-                      : 'text-muted-foreground hover:text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
                   )}
                   onClick={() => setActiveTab(tab.id)}
                 >
                   {tab.label}
-                </button>
+                </Button>
               ))}
             </div>
             {sectionAction ? (


### PR DESCRIPTION
## Summary

Fixes #922

This changes the shared sales document detail page used by both orders and quotes so the tab flow better matches the primary editing workflow.

### What changed

- make `Items` the default active tab for sales document detail pages
- reorder built-in tabs so `Items` appears first
- keep injected tabs, including `History`, before `Comments`
- move `Comments` to the end of the tab strip
- replace raw tab buttons with the shared `Button` primitive
- add stable `data-tab-id` / `data-active` attributes for verification

## Scope

This affects only sales document detail views:

- `/backend/sales/orders/:id`
- `/backend/sales/quotes/:id`
- `/backend/sales/documents/:id?kind=order`
- `/backend/sales/documents/:id?kind=quote`

No API, schema, or non-sales pages were changed.

## Test coverage

Updated existing sales integration tests coverage in:

- `packages/core/src/modules/sales/__integration__/TC-SALES-020.spec.ts`

Added assertions that verify:
- `Items` is the first tab on order detail
- `Items` is active by default before opening `History`

## Verification

Ran:

```bash
npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/sales/__integration__/TC-SALES-020.spec.ts
```

Result:
- `2 passed`