### PR TITLE
Fix markAllAsRead to emit read + SSE events per notification

### DIFF
--- a/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
@@ -2,10 +2,15 @@ import { createNotificationService } from '../lib/notificationService'
 import { NOTIFICATION_EVENTS, NOTIFICATION_SSE_EVENTS } from '../lib/events'
 import type { Notification } from '../data/entities'
 import { getRecipientUserIdsForFeature } from '../lib/notificationRecipients'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 jest.mock('../lib/notificationRecipients', () => ({
   getRecipientUserIdsForRole: jest.fn(),
   getRecipientUserIdsForFeature: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
 }))
 
 const baseNotificationInput = {
@@ -221,7 +226,7 @@ describe('notification service', () => {
       },
     ] as Notification[]
 
-    em.find.mockResolvedValue(notifications)
+    ;(findWithDecryption as jest.Mock).mockResolvedValue(notifications)
 
     const knexUpdate = jest.fn().mockResolvedValue(notifications.length)
     const knexSelect = jest.fn().mockResolvedValue(
@@ -263,6 +268,13 @@ describe('notification service', () => {
       status: 'unread',
     })
     expect(knexBuilder.where).toHaveBeenCalledWith('organization_id', 'org-1')
+    expect(findWithDecryption).toHaveBeenCalledWith(
+      em,
+      expect.anything(),
+      { id: { $in: ['note-11', 'note-12'] } },
+      undefined,
+      { tenantId: baseCtx.tenantId, organizationId: 'org-1' },
+    )
     expect(eventBus.emit).toHaveBeenCalledTimes(4)
     for (const note of notifications) {
       expect(eventBus.emit).toHaveBeenCalledWith(

--- a/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
@@ -193,6 +193,94 @@ describe('notification service', () => {
     )
   })
 
+  it('marks all as read, scopes by org, and emits events per notification', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const notifications = [
+      {
+        id: 'note-11',
+        recipientUserId: baseCtx.userId,
+        tenantId: baseCtx.tenantId,
+        organizationId: 'org-1',
+        status: 'read',
+        readAt: new Date('2026-03-01T00:00:00Z'),
+        createdAt: new Date('2026-02-28T00:00:00Z'),
+        type: 'system',
+        title: 'Hello',
+      },
+      {
+        id: 'note-12',
+        recipientUserId: baseCtx.userId,
+        tenantId: baseCtx.tenantId,
+        organizationId: 'org-1',
+        status: 'read',
+        readAt: new Date('2026-03-01T00:00:01Z'),
+        createdAt: new Date('2026-02-28T00:00:01Z'),
+        type: 'system',
+        title: 'Hi again',
+      },
+    ] as Notification[]
+
+    em.find.mockResolvedValue(notifications)
+
+    const knexUpdate = jest.fn().mockResolvedValue(notifications.length)
+    const knexSelect = jest.fn().mockResolvedValue(
+      notifications.map((n) => ({
+        id: n.id,
+        organization_id: n.organizationId,
+        recipient_user_id: n.recipientUserId,
+      }))
+    )
+
+    const knexBuilder: any = {
+      where: jest.fn().mockReturnThis(),
+      whereNull: jest.fn().mockReturnThis(),
+      select: knexSelect,
+      update: knexUpdate,
+      clone: jest.fn(function clone() {
+        return this
+      }),
+      fn: { now: jest.fn(() => 'now') },
+    }
+
+    const knexMock = Object.assign(
+      jest.fn().mockReturnValue(knexBuilder),
+      { fn: knexBuilder.fn },
+    )
+
+    em.getConnection.mockReturnValue({
+      getKnex: () => knexMock,
+    })
+
+    const service = createNotificationService({ em, eventBus })
+
+    const count = await service.markAllAsRead({ ...baseCtx, organizationId: 'org-1' })
+
+    expect(count).toBe(2)
+    expect(knexBuilder.where).toHaveBeenCalledWith({
+      recipient_user_id: baseCtx.userId,
+      tenant_id: baseCtx.tenantId,
+      status: 'unread',
+    })
+    expect(knexBuilder.where).toHaveBeenCalledWith('organization_id', 'org-1')
+    expect(eventBus.emit).toHaveBeenCalledTimes(4)
+    for (const note of notifications) {
+      expect(eventBus.emit).toHaveBeenCalledWith(
+        NOTIFICATION_EVENTS.READ,
+        expect.objectContaining({ notificationId: note.id, userId: baseCtx.userId, tenantId: baseCtx.tenantId })
+      )
+      expect(eventBus.emit).toHaveBeenCalledWith(
+        NOTIFICATION_SSE_EVENTS.CREATED,
+        expect.objectContaining({
+          tenantId: note.tenantId,
+          organizationId: note.organizationId,
+          recipientUserId: note.recipientUserId,
+          notification: expect.objectContaining({ id: note.id, status: 'read' }),
+        })
+      )
+    }
+  })
+
   it('executes notification action via command bus', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -1,4 +1,4 @@
-import type { EntityManager } from '@mikro-orm/core'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import type { Knex } from 'knex'
 import { Notification, type NotificationStatus } from '../data/entities'
 import type { CreateNotificationInput, CreateBatchNotificationInput, CreateRoleNotificationInput, CreateFeatureNotificationInput, ExecuteActionInput } from '../data/validators'

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -4,6 +4,7 @@ import { Notification, type NotificationStatus } from '../data/entities'
 import type { CreateNotificationInput, CreateBatchNotificationInput, CreateRoleNotificationInput, CreateFeatureNotificationInput, ExecuteActionInput } from '../data/validators'
 import type { NotificationPollData } from '@open-mercato/shared/modules/notifications/types'
 import { NOTIFICATION_EVENTS, NOTIFICATION_SSE_EVENTS } from './events'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import {
   buildNotificationEntity,
   emitNotificationCreated,
@@ -332,8 +333,11 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
         read_at: knex.fn.now(),
       })
 
-      const notifications = await em.find(Notification, {
+      const notifications = await findWithDecryption(em, Notification, {
         id: { $in: targetRows.map((row) => row.id) },
+      }, undefined, {
+        tenantId: ctx.tenantId,
+        organizationId: ctx.organizationId ?? null,
       })
 
       for (const notification of notifications) {

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -309,17 +309,47 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
     async markAllAsRead(ctx) {
       const em = rootEm.fork()
       const knex = getKnex(em)
-
-      const result = await knex('notifications')
+      const baseQuery = knex('notifications')
         .where({
           recipient_user_id: ctx.userId,
           tenant_id: ctx.tenantId,
           status: 'unread',
         })
-        .update({
-          status: 'read',
-          read_at: knex.fn.now(),
+
+      if (ctx.organizationId) {
+        baseQuery.where('organization_id', ctx.organizationId)
+      }
+
+      const targetRows = await baseQuery.clone()
+        .select('id', 'organization_id', 'recipient_user_id')
+
+      if (!targetRows.length) {
+        return 0
+      }
+
+      const result = await baseQuery.clone().update({
+        status: 'read',
+        read_at: knex.fn.now(),
+      })
+
+      const notifications = await em.find(Notification, {
+        id: { $in: targetRows.map((row) => row.id) },
+      })
+
+      for (const notification of notifications) {
+        await eventBus.emit(NOTIFICATION_EVENTS.READ, {
+          notificationId: notification.id,
+          userId: ctx.userId,
+          tenantId: ctx.tenantId,
         })
+
+        await eventBus.emit(NOTIFICATION_SSE_EVENTS.CREATED, {
+          tenantId: notification.tenantId,
+          organizationId: notification.organizationId ?? null,
+          recipientUserId: notification.recipientUserId,
+          notification: toNotificationDto(notification),
+        })
+      }
 
       return result
     },


### PR DESCRIPTION
Summary:
- Ensure markAllAsRead selects affected notifications, respects org scope, updates statuses, and emits both NOTIFICATION_EVENTS.READ and SSE CREATED events so realtime badges refresh.

Add unit test covering org-scoped bulk read and per-notification event emission.