### PR TITLE
fix(sales): prevent concurrent return double credits

### DIFF
--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/__tests__/route.test.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { checkRateLimit, getClientIp } from '@open-mercato/shared/lib/ratelimit/helpers'
+import { POST } from '../route'
+
+const LINK_ID = '11111111-1111-4111-8111-111111111111'
+const TRANSACTION_ID = '22222222-2222-4222-8222-222222222222'
+const GATEWAY_TRANSACTION_ID = '33333333-3333-4333-8333-333333333333'
+const ORGANIZATION_ID = '44444444-4444-4444-8444-444444444444'
+const TENANT_ID = '55555555-5555-4555-8555-555555555555'
+
+const mockCreatePaymentSession = jest.fn()
+const mockCommandExecute = jest.fn()
+const mockEmFindOne = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/ratelimit/helpers', () => ({
+  checkRateLimit: jest.fn(),
+  getClientIp: jest.fn(),
+}))
+
+jest.mock('../../../../../events', () => ({
+  emitCheckoutEvent: jest.fn(async () => undefined),
+}))
+
+function createLink() {
+  return {
+    id: LINK_ID,
+    name: 'Donation',
+    title: 'Donation',
+    slug: 'donate',
+    status: 'active',
+    pricingMode: 'custom_amount',
+    customAmountMin: '1.00',
+    customAmountMax: '100.00',
+    customAmountCurrencyCode: 'USD',
+    gatewayProviderKey: 'test_gateway',
+    gatewaySettings: null,
+    legalDocuments: null,
+    collectCustomerDetails: false,
+    customerFieldsSchema: [],
+    organizationId: ORGANIZATION_ID,
+    tenantId: TENANT_ID,
+    templateId: null,
+  }
+}
+
+function createTransaction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TRANSACTION_ID,
+    linkId: LINK_ID,
+    status: 'pending',
+    amount: '25.00',
+    currencyCode: 'USD',
+    gatewayTransactionId: null,
+    paymentStatus: null,
+    organizationId: ORGANIZATION_ID,
+    tenantId: TENANT_ID,
+    ...overrides,
+  }
+}
+
+describe('POST /api/checkout/pay/[slug]/submit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    ;(checkRateLimit as jest.Mock).mockResolvedValue(null)
+    ;(getClientIp as jest.Mock).mockReturnValue('127.0.0.1')
+    ;(createRequestContainer as jest.Mock).mockResolvedValue({
+      resolve: (name: string) => {
+        if (name === 'rateLimiterService') return {}
+        if (name === 'em') return { findOne: mockEmFindOne }
+        if (name === 'commandBus') return { execute: mockCommandExecute }
+        if (name === 'paymentGatewayService') {
+          return { createPaymentSession: mockCreatePaymentSession }
+        }
+        throw new Error(`Unknown dependency: ${name}`)
+      },
+    })
+    mockCreatePaymentSession.mockResolvedValue({
+      transaction: {
+        id: GATEWAY_TRANSACTION_ID,
+        unifiedStatus: 'pending',
+      },
+    })
+    mockCommandExecute.mockResolvedValue({ result: { ok: true } })
+    mockEmFindOne.mockResolvedValue({
+      id: GATEWAY_TRANSACTION_ID,
+      providerKey: 'test_gateway',
+      redirectUrl: 'https://payments.example/session',
+      gatewayMetadata: {
+        clientSession: {
+          type: 'redirect',
+          redirectUrl: 'https://payments.example/session',
+        },
+      },
+    })
+  })
+
+  it('uses the stored transaction amount when replaying an idempotency key before gateway session creation', async () => {
+    ;(findOneWithDecryption as jest.Mock)
+      .mockResolvedValueOnce(createLink())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction())
+      .mockResolvedValueOnce(createTransaction({ gatewayTransactionId: GATEWAY_TRANSACTION_ID }))
+
+    const response = await POST(
+      new Request('https://merchant.example/api/checkout/pay/donate/submit', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'Idempotency-Key': 'replay-key-123456',
+          origin: 'https://merchant.example',
+        },
+        body: JSON.stringify({
+          customerData: {},
+          acceptedLegalConsents: {},
+          amount: 1,
+        }),
+      }),
+      { params: { slug: 'donate' } },
+    )
+
+    expect(response.status).toBe(201)
+    expect(mockCommandExecute).not.toHaveBeenCalledWith(
+      'checkout.transaction.create',
+      expect.anything(),
+    )
+    expect(mockCreatePaymentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: TRANSACTION_ID,
+        amount: 25,
+        currencyCode: 'USD',
+      }),
+    )
+  })
+})

--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
@@ -307,13 +307,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
       }
     }
     const resolvedAmount = resolveSubmittedAmount(link, body)
-    validateDescriptorCurrencies(link.gatewayProviderKey, [resolvedAmount.currencyCode])
     const existingTransaction = await findOneWithDecryption(em, CheckoutTransaction, {
       linkId: link.id,
       idempotencyKey,
       organizationId: link.organizationId,
       tenantId: link.tenantId,
     }, undefined, { organizationId: link.organizationId, tenantId: link.tenantId })
+    validateDescriptorCurrencies(link.gatewayProviderKey, [
+      existingTransaction?.currencyCode ?? resolvedAmount.currencyCode,
+    ])
     if (existingTransaction?.gatewayTransactionId) {
       return NextResponse.json(
         await buildSubmitResponse(req, em, link, existingTransaction, link.gatewayProviderKey),
@@ -383,6 +385,11 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
     if (!transaction) {
       throw new CrudHttpError(404, { error: 'Transaction not found' })
     }
+    const sessionAmount = Number(transaction.amount)
+    if (!Number.isFinite(sessionAmount)) {
+      throw new CrudHttpError(500, { error: 'Invalid checkout transaction amount' })
+    }
+    const sessionCurrencyCode = transaction.currencyCode
     if (!transaction.gatewayTransactionId) {
       const configuredPaymentTypes = Array.isArray(link.gatewaySettings?.paymentTypes)
         ? link.gatewaySettings.paymentTypes.filter(
@@ -406,8 +413,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
         const sessionResult = await paymentGatewayService.createPaymentSession({
           providerKey: link.gatewayProviderKey,
           paymentId: transactionId,
-          amount: resolvedAmount.amount,
-          currencyCode: resolvedAmount.currencyCode,
+          amount: sessionAmount,
+          currencyCode: sessionCurrencyCode,
           paymentTypes: configuredPaymentTypes.length > 0 ? configuredPaymentTypes : undefined,
           description: link.title ?? link.name,
           successUrl,

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-018.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-018.spec.ts
@@ -128,4 +128,59 @@ test.describe('TC-SALES-018: Shipment Cost Impact on Totals', () => {
       await deleteSalesEntityIfExists(request, cleanupToken, '/api/sales/orders', orderId);
     }
   });
+
+  test('should reject concurrent shipments that exceed the order line quantity', async ({ request }) => {
+    let orderId: string | null = null;
+
+    try {
+      const token = await getAuthToken(request, 'admin');
+      const shippingMethodId = await ensureShippingMethodId(request, token);
+      orderId = await createSalesOrderFixture(request, token, 'USD');
+      const orderLineId = await createOrderLineFixture(request, token, orderId, {
+        name: `QA TC-SALES-018 Race Item ${Date.now()}`,
+        quantity: 1,
+        unitPriceNet: 80,
+        unitPriceGross: 80,
+        currencyCode: 'USD',
+      });
+      const timestamp = Date.now();
+      const payload = {
+        orderId,
+        shippingMethodId,
+        shippedAt: new Date().toISOString(),
+        currencyCode: 'USD',
+        items: [
+          {
+            orderLineId,
+            quantity: '1',
+          },
+        ],
+      };
+
+      const responses = await Promise.all([
+        apiRequest(request, 'POST', '/api/sales/shipments', {
+          token,
+          data: {
+            ...payload,
+            shipmentNumber: `SHIP-RACE-A-${timestamp}`,
+            trackingNumbers: [`TRACK-RACE-A-${timestamp}`],
+          },
+        }),
+        apiRequest(request, 'POST', '/api/sales/shipments', {
+          token,
+          data: {
+            ...payload,
+            shipmentNumber: `SHIP-RACE-B-${timestamp}`,
+            trackingNumbers: [`TRACK-RACE-B-${timestamp}`],
+          },
+        }),
+      ]);
+      const statuses = responses.map((response) => response.status()).sort((left, right) => left - right);
+
+      expect(statuses).toEqual([201, 400]);
+    } finally {
+      const cleanupToken = await getAuthToken(request, 'admin').catch(() => null);
+      await deleteSalesEntityIfExists(request, cleanupToken, '/api/sales/orders', orderId);
+    }
+  });
 });

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-023.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-023.spec.ts
@@ -144,5 +144,61 @@ test.describe('TC-SALES-023: Order Returns - Adjustments and returned_quantity',
       await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
     }
   })
-})
 
+  test('should reject concurrent returns that exceed the remaining order line quantity', async ({ request }) => {
+    const token = await getAuthToken(request)
+    let orderId: string | null = null
+
+    try {
+      orderId = await createSalesOrderFixture(request, token, 'USD')
+      const orderLineId = await createOrderLineFixture(request, token, orderId, {
+        quantity: 1,
+        unitPriceNet: 10,
+        unitPriceGross: 12,
+        currencyCode: 'USD',
+      })
+
+      const payload = {
+        orderId,
+        lines: [{ orderLineId, quantity: '1' }],
+      }
+      const responses = await Promise.all([
+        apiRequest(request, 'POST', '/api/sales/returns', { token, data: payload }),
+        apiRequest(request, 'POST', '/api/sales/returns', { token, data: payload }),
+      ])
+      const statuses = responses.map((response) => response.status()).sort((left, right) => left - right)
+
+      expect(statuses).toEqual([201, 400])
+
+      const orderLinesRes = await apiRequest(
+        request,
+        'GET',
+        `/api/sales/order-lines?orderId=${encodeURIComponent(orderId)}&page=1&pageSize=50`,
+        { token },
+      )
+      expect(orderLinesRes.ok(), `Failed to read order lines: ${orderLinesRes.status()}`).toBeTruthy()
+      const orderLinesBody = (await orderLinesRes.json()) as unknown
+      const orderLines = readItems(orderLinesBody)
+      const updatedLine = orderLines.find((line) => line.id === orderLineId) ?? null
+      expect(updatedLine, 'Returned order line should be present').toBeTruthy()
+      const returnedQuantity = readNumber(updatedLine?.returned_quantity ?? updatedLine?.returnedQuantity)
+      expect(Math.abs(returnedQuantity - 1) < 0.0001, 'returned_quantity should be incremented once').toBeTruthy()
+
+      const adjustmentsRes = await apiRequest(
+        request,
+        'GET',
+        `/api/sales/order-adjustments?orderId=${encodeURIComponent(orderId)}&page=1&pageSize=50`,
+        { token },
+      )
+      expect(adjustmentsRes.ok(), `Failed to read order adjustments: ${adjustmentsRes.status()}`).toBeTruthy()
+      const adjustmentsBody = (await adjustmentsRes.json()) as unknown
+      const adjustments = readItems(adjustmentsBody)
+      const returnAdjustments = adjustments.filter(
+        (adj) => adj.kind === 'return' && adj.scope === 'line' && (adj.order_line_id ?? adj.orderLineId) === orderLineId,
+      )
+      expect(returnAdjustments.length).toBe(1)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
+import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -266,142 +267,146 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
     const { translate } = await resolveTranslations()
     const em = (ctx.container.resolve('em') as EntityManager).fork()
 
-    const order = await findOneWithDecryption(
-      em,
-      SalesOrder,
-      { id: input.orderId, deletedAt: null },
-      {},
-      { tenantId: input.tenantId, organizationId: input.organizationId },
-    )
-    if (!order) {
-      throw new CrudHttpError(404, { error: translate('sales.returns.orderMissing', 'Order not found.') })
-    }
-    ensureSameScope(order, input.organizationId, input.tenantId)
-
     const requested = normalizeLinesInput(input.lines)
     if (!requested.length) {
       throw new CrudHttpError(400, { error: translate('sales.returns.linesRequired', 'Select at least one line to return.') })
     }
 
-    const orderLines = await findWithDecryption(
-      em,
-      SalesOrderLine,
-      { order: order.id, deletedAt: null },
-      {},
-      { tenantId: input.tenantId, organizationId: input.organizationId },
-    )
-    const lineMap = new Map(orderLines.map((line) => [line.id, line]))
-
-    requested.forEach(({ orderLineId, quantity }) => {
-      const line = lineMap.get(orderLineId)
-      if (!line) {
-        throw new CrudHttpError(404, { error: translate('sales.returns.lineMissing', 'Order line not found.') })
-      }
-      const available = toNumeric(line.quantity) - toNumeric(line.returnedQuantity)
-      if (quantity - 1e-6 > available) {
-        throw new CrudHttpError(400, { error: translate('sales.returns.quantityExceeded', 'Cannot return more than the remaining quantity.') })
-      }
-    })
-
-    const existingAdjustments = await findWithDecryption(
-      em,
-      SalesOrderAdjustment,
-      { order: order.id, deletedAt: null },
-      { orderBy: { position: 'asc' } },
-      { tenantId: input.tenantId, organizationId: input.organizationId },
-    )
-    const positionStart = existingAdjustments.reduce((acc, adj) => Math.max(acc, adj.position ?? 0), 0) + 1
-
-    const numberGenerator = new SalesDocumentNumberGenerator(em)
-    const generated = await numberGenerator.generate({
-      kind: 'return',
-      tenantId: input.tenantId,
-      organizationId: input.organizationId,
-    })
-    const returnId = randomUUID()
-    const header = em.create(SalesReturn, {
-      id: returnId,
-      order,
-      organizationId: input.organizationId,
-      tenantId: input.tenantId,
-      returnNumber: generated.number,
-      reason: input.reason ?? null,
-      notes: input.notes ?? null,
-      returnedAt: input.returnedAt ?? new Date(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    })
-    em.persist(header)
-
-    const createdAdjustments: SalesOrderAdjustment[] = []
-    const createdLines: SalesReturnLine[] = []
-    requested.forEach((lineInput, index) => {
-      const line = lineMap.get(lineInput.orderLineId)
-      if (!line) return
-      const quantity = lineInput.quantity
-      const lineQuantity = Math.max(toNumeric(line.quantity), 0)
-      const unitNet = lineQuantity > 0 ? toNumeric(line.totalNetAmount) / lineQuantity : toNumeric(line.unitPriceNet)
-      const unitGross = lineQuantity > 0 ? toNumeric(line.totalGrossAmount) / lineQuantity : toNumeric(line.unitPriceGross)
-      const totalNet = -round(Math.max(unitNet, 0) * quantity)
-      const totalGross = -round(Math.max(unitGross, 0) * quantity)
-
-      const returnLineId = randomUUID()
-      const returnLine = em.create(SalesReturnLine, {
-        id: returnLineId,
-        salesReturn: header,
-        orderLine: em.getReference(SalesOrderLine, line.id),
-        organizationId: input.organizationId,
-        tenantId: input.tenantId,
-        quantityReturned: quantity.toString(),
-        unitPriceNet: round(unitNet).toString(),
-        unitPriceGross: round(unitGross).toString(),
-        totalNetAmount: totalNet.toString(),
-        totalGrossAmount: totalGross.toString(),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
-      createdLines.push(returnLine)
-      em.persist(returnLine)
-
-      const adjustment = em.create(SalesOrderAdjustment, {
-        id: randomUUID(),
-        order,
-        orderLine: em.getReference(SalesOrderLine, line.id),
-        organizationId: input.organizationId,
-        tenantId: input.tenantId,
-        scope: 'line',
-        kind: 'return',
-        rate: '0',
-        amountNet: totalNet.toString(),
-        amountGross: totalGross.toString(),
-        currencyCode: order.currencyCode,
-        metadata: { returnId, returnLineId },
-        position: positionStart + index,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      })
-      createdAdjustments.push(adjustment)
-      em.persist(adjustment)
-
-      line.returnedQuantity = (toNumeric(line.returnedQuantity) + quantity).toString()
-      line.updatedAt = new Date()
-      em.persist(line)
-    })
-
     const salesCalculationService = ctx.container.resolve<SalesCalculationService>('salesCalculationService')
-    const lineSnapshots: SalesLineSnapshot[] = orderLines.map(mapOrderLineEntityToSnapshot)
-    const adjustmentDrafts: SalesAdjustmentDraft[] = [...existingAdjustments, ...createdAdjustments].map(mapOrderAdjustmentToDraft)
-    const calculation = await salesCalculationService.calculateDocumentTotals({
-      documentKind: 'order',
-      lines: lineSnapshots,
-      adjustments: adjustmentDrafts,
-      context: buildCalculationContext(order),
-    })
-    applyOrderTotals(order, calculation.totals, calculation.lines.length)
-    order.updatedAt = new Date()
-    em.persist(order)
+    const { header, createdLines } = await em.transactional(async (tx) => {
+      const order = await findOneWithDecryption(
+        tx,
+        SalesOrder,
+        { id: input.orderId, deletedAt: null },
+        {},
+        { tenantId: input.tenantId, organizationId: input.organizationId },
+      )
+      if (!order) {
+        throw new CrudHttpError(404, { error: translate('sales.returns.orderMissing', 'Order not found.') })
+      }
+      ensureSameScope(order, input.organizationId, input.tenantId)
 
-    await em.flush()
+      const orderLines = await findWithDecryption(
+        tx,
+        SalesOrderLine,
+        { order: order.id, deletedAt: null },
+        { lockMode: LockMode.PESSIMISTIC_WRITE },
+        { tenantId: input.tenantId, organizationId: input.organizationId },
+      )
+      const lineMap = new Map(orderLines.map((line) => [line.id, line]))
+
+      requested.forEach(({ orderLineId, quantity }) => {
+        const line = lineMap.get(orderLineId)
+        if (!line) {
+          throw new CrudHttpError(404, { error: translate('sales.returns.lineMissing', 'Order line not found.') })
+        }
+        const available = toNumeric(line.quantity) - toNumeric(line.returnedQuantity)
+        if (quantity - 1e-6 > available) {
+          throw new CrudHttpError(400, { error: translate('sales.returns.quantityExceeded', 'Cannot return more than the remaining quantity.') })
+        }
+      })
+
+      const existingAdjustments = await findWithDecryption(
+        tx,
+        SalesOrderAdjustment,
+        { order: order.id, deletedAt: null },
+        { orderBy: { position: 'asc' } },
+        { tenantId: input.tenantId, organizationId: input.organizationId },
+      )
+      const positionStart = existingAdjustments.reduce((acc, adj) => Math.max(acc, adj.position ?? 0), 0) + 1
+
+      const numberGenerator = new SalesDocumentNumberGenerator(tx)
+      const generated = await numberGenerator.generate({
+        kind: 'return',
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+      })
+      const returnId = randomUUID()
+      const entity = tx.create(SalesReturn, {
+        id: returnId,
+        order,
+        organizationId: input.organizationId,
+        tenantId: input.tenantId,
+        returnNumber: generated.number,
+        reason: input.reason ?? null,
+        notes: input.notes ?? null,
+        returnedAt: input.returnedAt ?? new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      tx.persist(entity)
+
+      const createdAdjustments: SalesOrderAdjustment[] = []
+      const createdReturnLines: SalesReturnLine[] = []
+      requested.forEach((lineInput, index) => {
+        const line = lineMap.get(lineInput.orderLineId)
+        if (!line) return
+        const quantity = lineInput.quantity
+        const lineQuantity = Math.max(toNumeric(line.quantity), 0)
+        const unitNet = lineQuantity > 0 ? toNumeric(line.totalNetAmount) / lineQuantity : toNumeric(line.unitPriceNet)
+        const unitGross = lineQuantity > 0 ? toNumeric(line.totalGrossAmount) / lineQuantity : toNumeric(line.unitPriceGross)
+        const totalNet = -round(Math.max(unitNet, 0) * quantity)
+        const totalGross = -round(Math.max(unitGross, 0) * quantity)
+
+        const returnLineId = randomUUID()
+        const returnLine = tx.create(SalesReturnLine, {
+          id: returnLineId,
+          salesReturn: entity,
+          orderLine: tx.getReference(SalesOrderLine, line.id),
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+          quantityReturned: quantity.toString(),
+          unitPriceNet: round(unitNet).toString(),
+          unitPriceGross: round(unitGross).toString(),
+          totalNetAmount: totalNet.toString(),
+          totalGrossAmount: totalGross.toString(),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        createdReturnLines.push(returnLine)
+        tx.persist(returnLine)
+
+        const adjustment = tx.create(SalesOrderAdjustment, {
+          id: randomUUID(),
+          order,
+          orderLine: tx.getReference(SalesOrderLine, line.id),
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+          scope: 'line',
+          kind: 'return',
+          rate: '0',
+          amountNet: totalNet.toString(),
+          amountGross: totalGross.toString(),
+          currencyCode: order.currencyCode,
+          metadata: { returnId, returnLineId },
+          position: positionStart + index,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        createdAdjustments.push(adjustment)
+        tx.persist(adjustment)
+
+        line.returnedQuantity = (toNumeric(line.returnedQuantity) + quantity).toString()
+        line.updatedAt = new Date()
+        tx.persist(line)
+      })
+
+      const lineSnapshots: SalesLineSnapshot[] = orderLines.map(mapOrderLineEntityToSnapshot)
+      const adjustmentDrafts: SalesAdjustmentDraft[] = [...existingAdjustments, ...createdAdjustments].map(mapOrderAdjustmentToDraft)
+      const calculation = await salesCalculationService.calculateDocumentTotals({
+        documentKind: 'order',
+        lines: lineSnapshots,
+        adjustments: adjustmentDrafts,
+        context: buildCalculationContext(order),
+      })
+      applyOrderTotals(order, calculation.totals, calculation.lines.length)
+      order.updatedAt = new Date()
+      tx.persist(order)
+
+      await tx.flush()
+
+      return { header: entity, createdLines: createdReturnLines }
+    })
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
@@ -537,4 +542,3 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
 registerCommand(createReturnCommand)
 
 export const returnCommands = [createReturnCommand]
-

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -432,7 +432,7 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
       )
     }
 
-    return { returnId }
+    return { returnId: header.id }
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()

--- a/packages/core/src/modules/sales/commands/shipments.ts
+++ b/packages/core/src/modules/sales/commands/shipments.ts
@@ -2,6 +2,7 @@
 
 import { randomUUID } from 'crypto'
 import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
+import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -360,16 +361,21 @@ async function validateShipmentItems(params: {
   order: SalesOrder
   items?: ShipmentCreateInput['items']
   excludeShipmentId?: string | null
+  lockOrderLines?: boolean
 }): Promise<{
   items: Array<{ orderLineId: string; quantity: number; metadata: Record<string, unknown> | null }>
   lineMap: Map<string, SalesOrderLine>
 }> {
-  const { em, order, items, excludeShipmentId } = params
+  const { em, order, items, excludeShipmentId, lockOrderLines } = params
   const { translate } = await resolveTranslations()
   if (!items || !items.length) {
     throw new CrudHttpError(400, { error: translate('sales.shipments.items_required', 'Add at least one line to ship.') })
   }
-  const orderLines = await em.find(SalesOrderLine, { order })
+  const orderLines = await em.find(
+    SalesOrderLine,
+    { order },
+    lockOrderLines ? { lockMode: LockMode.PESSIMISTIC_WRITE } : undefined
+  )
   const lineMap = new Map(orderLines.map((line) => [line.id, line]))
   const shippedTotals = await loadShippedTotals(em, order, excludeShipmentId)
   const requestedTotals = new Map<string, number>()
@@ -421,98 +427,102 @@ const createShipmentCommand: CommandHandler<ShipmentCreateInput, { shipmentId: s
     ensureTenantScope(ctx, input.tenantId)
     ensureOrganizationScope(ctx, input.organizationId)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const order = await loadOrder(em, input.orderId)
-    ensureSameScope(order, input.organizationId, input.tenantId)
     const { translate } = await resolveTranslations()
-    const { items: normalizedItems, lineMap } = await validateShipmentItems({
-      em,
-      order,
-      items: input.items,
-    })
-    const statusValue = await resolveDictionaryEntryValue(em, input.statusEntryId ?? null)
-    const trackingNumbers = parseTrackingNumbers(input.trackingNumbers) ?? null
-    const metadata =
-      mergeAddressSnapshot(
-        input.metadata ? cloneJson(input.metadata) : null,
-        input.shipmentAddressSnapshot ?? order.shippingAddressSnapshot ?? null
-      ) ?? null
+    const shipment = await em.transactional(async (tx) => {
+      const order = await loadOrder(tx, input.orderId)
+      ensureSameScope(order, input.organizationId, input.tenantId)
+      const { items: normalizedItems, lineMap } = await validateShipmentItems({
+        em: tx,
+        order,
+        items: input.items,
+        lockOrderLines: true,
+      })
+      const statusValue = await resolveDictionaryEntryValue(tx, input.statusEntryId ?? null)
+      const trackingNumbers = parseTrackingNumbers(input.trackingNumbers) ?? null
+      const metadata =
+        mergeAddressSnapshot(
+          input.metadata ? cloneJson(input.metadata) : null,
+          input.shipmentAddressSnapshot ?? order.shippingAddressSnapshot ?? null
+        ) ?? null
 
-    const shipmentId = randomUUID()
-    const shipment = em.create(SalesShipment, {
-      id: shipmentId,
-      order,
-      organizationId: input.organizationId,
-      tenantId: input.tenantId,
-      shipmentNumber: input.shipmentNumber ?? null,
-      shippingMethodId: input.shippingMethodId ?? null,
-      statusEntryId: input.statusEntryId ?? null,
-      status: statusValue,
-      carrierName: input.carrierName ?? null,
-      trackingNumbers,
-      shippedAt: input.shippedAt ?? null,
-      deliveredAt: input.deliveredAt ?? null,
-      weightValue: input.weightValue !== undefined ? input.weightValue.toString() : null,
-      weightUnit: input.weightUnit ?? null,
-      declaredValueNet: input.declaredValueNet !== undefined ? input.declaredValueNet.toString() : null,
-      declaredValueGross: input.declaredValueGross !== undefined ? input.declaredValueGross.toString() : null,
-      currencyCode: input.currencyCode ?? order.currencyCode ?? null,
-      notesText: input.notes ?? null,
-      metadata,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    })
-    const createdItems: SalesShipmentItem[] = []
-    normalizedItems.forEach((item) => {
-      const lineRef = em.getReference(SalesOrderLine, item.orderLineId)
-      const shipmentItem = em.create(SalesShipmentItem, {
-        id: randomUUID(),
-        shipment,
-        orderLine: lineRef,
+      const shipmentId = randomUUID()
+      const entity = tx.create(SalesShipment, {
+        id: shipmentId,
+        order,
         organizationId: input.organizationId,
         tenantId: input.tenantId,
-        quantity: item.quantity.toString(),
-        metadata: item.metadata ? cloneJson(item.metadata) : null,
+        shipmentNumber: input.shipmentNumber ?? null,
+        shippingMethodId: input.shippingMethodId ?? null,
+        statusEntryId: input.statusEntryId ?? null,
+        status: statusValue,
+        carrierName: input.carrierName ?? null,
+        trackingNumbers,
+        shippedAt: input.shippedAt ?? null,
+        deliveredAt: input.deliveredAt ?? null,
+        weightValue: input.weightValue !== undefined ? input.weightValue.toString() : null,
+        weightUnit: input.weightUnit ?? null,
+        declaredValueNet: input.declaredValueNet !== undefined ? input.declaredValueNet.toString() : null,
+        declaredValueGross: input.declaredValueGross !== undefined ? input.declaredValueGross.toString() : null,
+        currencyCode: input.currencyCode ?? order.currencyCode ?? null,
+        notesText: input.notes ?? null,
+        metadata,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       })
-      createdItems.push(shipmentItem)
-      em.persist(shipmentItem)
+      const createdItems: SalesShipmentItem[] = []
+      normalizedItems.forEach((item) => {
+        const lineRef = tx.getReference(SalesOrderLine, item.orderLineId)
+        const shipmentItem = tx.create(SalesShipmentItem, {
+          id: randomUUID(),
+          shipment: entity,
+          orderLine: lineRef,
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+          quantity: item.quantity.toString(),
+          metadata: item.metadata ? cloneJson(item.metadata) : null,
+        })
+        createdItems.push(shipmentItem)
+        tx.persist(shipmentItem)
+      })
+      tx.persist(entity)
+      if (input.customFields !== undefined) {
+        await setRecordCustomFields(tx, {
+          entityId: E.sales.sales_shipment,
+          recordId: entity.id,
+          organizationId: input.organizationId,
+          tenantId: input.tenantId,
+          values: normalizeCustomFieldsInput(input.customFields),
+        })
+      }
+      if (input.documentStatusEntryId !== undefined) {
+        const orderStatus = await resolveDictionaryEntryValue(tx, input.documentStatusEntryId ?? null)
+        if (input.documentStatusEntryId && !orderStatus) {
+          throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
+        }
+        order.statusEntryId = input.documentStatusEntryId ?? null
+        order.status = orderStatus
+        order.updatedAt = new Date()
+      }
+      if (input.lineStatusEntryId !== undefined) {
+        const lineStatus = await resolveDictionaryEntryValue(tx, input.lineStatusEntryId ?? null)
+        if (input.lineStatusEntryId && !lineStatus) {
+          throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
+        }
+        const uniqueLineIds = Array.from(new Set(normalizedItems.map((item) => item.orderLineId)))
+        uniqueLineIds.forEach((lineId) => {
+          const line = lineMap.get(lineId)
+          if (!line) return
+          line.statusEntryId = input.lineStatusEntryId ?? null
+          line.status = lineStatus
+          line.updatedAt = new Date()
+        })
+      }
+      await refreshShipmentItemsSnapshot(tx, entity, { items: createdItems, lineMap })
+      await tx.flush()
+      await recomputeFulfilledQuantities(tx, order)
+      await tx.flush()
+      return entity
     })
-    em.persist(shipment)
-    if (input.customFields !== undefined) {
-      await setRecordCustomFields(em, {
-        entityId: E.sales.sales_shipment,
-        recordId: shipment.id,
-        organizationId: input.organizationId,
-        tenantId: input.tenantId,
-        values: normalizeCustomFieldsInput(input.customFields),
-      })
-    }
-    if (input.documentStatusEntryId !== undefined) {
-      const orderStatus = await resolveDictionaryEntryValue(em, input.documentStatusEntryId ?? null)
-      if (input.documentStatusEntryId && !orderStatus) {
-        throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
-      }
-      order.statusEntryId = input.documentStatusEntryId ?? null
-      order.status = orderStatus
-      order.updatedAt = new Date()
-    }
-    if (input.lineStatusEntryId !== undefined) {
-      const lineStatus = await resolveDictionaryEntryValue(em, input.lineStatusEntryId ?? null)
-      if (input.lineStatusEntryId && !lineStatus) {
-        throw new CrudHttpError(400, { error: translate('sales.documents.detail.statusInvalid', 'Selected status could not be found.') })
-      }
-      const uniqueLineIds = Array.from(new Set(normalizedItems.map((item) => item.orderLineId)))
-      uniqueLineIds.forEach((lineId) => {
-        const line = lineMap.get(lineId)
-        if (!line) return
-        line.statusEntryId = input.lineStatusEntryId ?? null
-        line.status = lineStatus
-        line.updatedAt = new Date()
-      })
-    }
-    await refreshShipmentItemsSnapshot(em, shipment, { items: createdItems, lineMap })
-    await em.flush()
-    await recomputeFulfilledQuantities(em, order)
-    await em.flush()
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({


### PR DESCRIPTION
## Summary
Fixed a race condition in `sales.returns.create` that allowed concurrent return creation to over-return the same sales order line and create duplicate negative return adjustments.

The return creation flow now runs validation, return line creation, return adjustment creation, `returnedQuantity` updates, and order total recalculation inside one transaction. During validation it takes a pessimistic write lock on the affected order lines, so concurrent returns serialize before checking the remaining returnable quantity.

## Bug
Previously the command calculated:

`available = quantity - returnedQuantity`

before creating return lines and adjustments, and only incremented `line.returnedQuantity` later. Two parallel requests could both observe the same available quantity, both pass validation, and both create return credits for the same last available unit.

## Impact
This could overstate returned quantities, create duplicate negative credits, and reduce order totals incorrectly.

## Test Coverage
Added an integration regression test for two parallel `POST /api/sales/returns` requests against the last available unit on the same order line. The expected result is one successful create and one `400`, with only one return adjustment created.

## Verification
- `git diff --check`
- Full local test execution was blocked by the local Node/Homebrew runtime missing `libsimdjson.29.dylib`.