### PR TITLE
fix/Jwt not expired

### DIFF
--- a/.ai/specs/implemented/SPEC-060-2026-03-04-customer-identity-portal-auth.md
+++ b/.ai/specs/implemented/SPEC-060-2026-03-04-customer-identity-portal-auth.md
@@ -418,6 +418,7 @@ Workers are idempotent: they delete rows matching `expires_at < now()` or `used_
 | `failed_login_attempts` | integer | NOT NULL, DEFAULT 0 | Reset on successful login |
 | `locked_until` | timestamptz | NULL | NULL = not locked |
 | `last_login_at` | timestamptz | NULL | Updated on each successful login |
+| `sessions_revoked_at` | timestamptz | NULL | Set by `revokeAllUserSessions`. JWTs with `iat` before this timestamp are rejected. |
 | `person_entity_id` | uuid | NULL, INDEX | FK to `customer_entities.id` (kind='person'). Who this user IS in CRM |
 | `customer_entity_id` | uuid | NULL, INDEX | FK to `customer_entities.id` (kind='company'). Which company they represent. NULL for B2C |
 | `is_active` | boolean | NOT NULL, DEFAULT true | Soft disable by staff |
@@ -1636,6 +1637,12 @@ The following capabilities are explicitly deferred from the current scope. They 
 - **No changes to `customer_accounts` RBAC needed**: Purchase limits are separate from feature-based RBAC. They operate on financial thresholds, not access permissions.
 
 ## Changelog
+
+### 2026-04-11 (v4 — Immediate JWT Invalidation via `sessions_revoked_at`)
+- **Added `sessions_revoked_at` column** to `CustomerUser`: nullable timestamp set by `revokeAllUserSessions()`. When set, any JWT whose `iat` (issued-at) precedes this timestamp is rejected by `getCustomerAuthFromRequest()`.
+- **Modified `getCustomerAuthFromRequest()`**: After JWT signature verification, performs a lightweight DB lookup (`em.findOne(CustomerUser, { id }, { fields: ['sessionsRevokedAt'] })`) to compare `jwt.iat` against `sessions_revoked_at`. Follows the staff auth pattern (`resolveCanonicalInteractiveAuthContext` in `server.ts`). Fail-closed: container or DB errors return `null` (unauthenticated).
+- **Modified `revokeAllUserSessions()`**: In addition to soft-deleting session rows, stamps `sessions_revoked_at = now()` on the `CustomerUser` record. Both operations use the same `Date` instance for timestamp consistency.
+- **Security impact**: Closes the window where a revoked session's already-issued JWT remained valid until expiry (up to 8 hours). After this change, JWTs issued before session revocation are immediately rejected on next API call.
 
 ### 2026-03-05 (v3 — Enterprise Architecture Review)
 - **Enterprise architecture review**: Evaluated against SAP Commerce Cloud (B2BCustomer/B2BUnit hierarchy, purchase-threshold RBAC, OAuth 2.0), OroCommerce (Customer/CustomerUser composition, 4-level entity ACL, `selfManaged`/`public` role flags), and Magento 2 / Adobe Commerce (company linkage model, per-company resource-permission roles, company registration approval).

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-AUTH-024.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-AUTH-024.spec.ts
@@ -2,19 +2,18 @@ import { expect, test } from '@playwright/test'
 import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api'
 
 /**
- * TC-AUTH-023: Admin password reset revokes customer session tokens
+ * TC-AUTH-024: Customer JWT is rejected after sessions_revoked_at is set
  *
- * Regression test for: admin-initiated password reset did not invalidate
- * active portal sessions, allowing a stolen session token to remain usable
- * for up to 30 days after the password was changed.
+ * Verifies that a JWT issued before admin password reset is blocked by the
+ * sessionsRevokedAt check in getCustomerAuthFromRequest, even without a
+ * session refresh — the JWT itself becomes invalid at the portal boundary.
  *
- * After revokeAllUserSessions, sessions-refresh must return 401.
- * JWT invalidation via sessionsRevokedAt is covered by TC-AUTH-024.
+ * Complements TC-AUTH-023 which covers session token revocation.
  */
-test.describe('TC-AUTH-023: Admin password reset revokes customer session tokens', () => {
-  test('sessions-refresh should be blocked after admin resets the password', async ({ request }) => {
+test.describe('TC-AUTH-024: Customer JWT rejected after sessions_revoked_at is set', () => {
+  test('portal endpoint returns 401 for JWT issued before admin password reset', async ({ request }) => {
     const stamp = Date.now()
-    const customerEmail = `qa-auth-023-${stamp}@test.local`
+    const customerEmail = `qa-auth-024-${stamp}@test.local`
     const initialPassword = `InitialPass${stamp}!`
     const newPassword = `NewPass${stamp}!`
 
@@ -22,16 +21,15 @@ test.describe('TC-AUTH-023: Admin password reset revokes customer session tokens
     let customerId: string | null = null
 
     try {
-      // 1. Authenticate as admin (staff)
       adminToken = await getAuthToken(request, 'admin')
 
-      // 2. Create a customer user via admin API
+      // 1. Create a customer user
       const createRes = await apiRequest(request, 'POST', '/api/customer_accounts/admin/users', {
         token: adminToken,
         data: {
           email: customerEmail,
           password: initialPassword,
-          displayName: `QA Auth 023 ${stamp}`,
+          displayName: `QA Auth 024 ${stamp}`,
         },
       })
       expect(createRes.status(), 'Customer user should be created').toBe(201)
@@ -39,7 +37,7 @@ test.describe('TC-AUTH-023: Admin password reset revokes customer session tokens
       customerId = createBody.user?.id ?? null
       expect(customerId, 'Created user id should be returned').toBeTruthy()
 
-      // 3. Decode admin JWT to get tenantId for portal login
+      // 2. Decode tenantId from admin JWT
       const adminJwtParts = adminToken.split('.')
       const adminClaims = JSON.parse(
         Buffer.from(
@@ -53,7 +51,7 @@ test.describe('TC-AUTH-023: Admin password reset revokes customer session tokens
       const tenantId = adminClaims.tenantId
       expect(tenantId, 'tenantId must be decodable from admin JWT').toBeTruthy()
 
-      // 4. Login as the customer user → capture session cookies
+      // 3. Login as customer — capture JWT cookie only (isolates JWT path from session path)
       const portalLoginRes = await request.post('/api/customer_accounts/login', {
         data: { email: customerEmail, password: initialPassword, tenantId },
         headers: { 'Content-Type': 'application/json' },
@@ -62,19 +60,18 @@ test.describe('TC-AUTH-023: Admin password reset revokes customer session tokens
 
       const setCookieHeader = portalLoginRes.headers()['set-cookie'] ?? ''
       const jwtCookieMatch = setCookieHeader.match(/customer_auth_token=([^;]+)/)
-      const sessionCookieMatch = setCookieHeader.match(/customer_session_token=([^;]+)/)
       expect(jwtCookieMatch, 'customer_auth_token cookie must be set').toBeTruthy()
-      expect(sessionCookieMatch, 'customer_session_token cookie must be set').toBeTruthy()
 
-      const authCookie = `customer_auth_token=${jwtCookieMatch![1]}; customer_session_token=${sessionCookieMatch![1]}`
+      const jwtOnlyCookie = `customer_auth_token=${jwtCookieMatch![1]}`
 
-      // 5. Verify sessions-refresh works before reset
-      const refreshBeforeRes = await request.post('/api/customer_accounts/portal/sessions-refresh', {
-        headers: { Cookie: authCookie },
+      // 4. Confirm JWT is accepted before reset
+      const beforeRes = await request.post('/api/customer_accounts/portal/feature-check', {
+        data: { features: ['portal.view'] },
+        headers: { Cookie: jwtOnlyCookie, 'Content-Type': 'application/json' },
       })
-      expect(refreshBeforeRes.status(), 'sessions-refresh should succeed with active session').toBe(200)
+      expect(beforeRes.status(), 'feature-check should succeed with valid JWT before reset').toBe(200)
 
-      // 6. Admin resets the customer user's password (also revokes all sessions)
+      // 5. Admin resets the customer password — sets sessionsRevokedAt on CustomerUser
       const resetRes = await apiRequest(
         request,
         'POST',
@@ -83,24 +80,20 @@ test.describe('TC-AUTH-023: Admin password reset revokes customer session tokens
       )
       expect(resetRes.ok(), 'Admin password reset should succeed').toBeTruthy()
 
-      // 7. sessions-refresh must now be rejected — this is the regression assertion.
-      // The session token is revoked in DB. JWT invalidation is tested in TC-AUTH-024.
-      const refreshAfterRes = await request.post('/api/customer_accounts/portal/sessions-refresh', {
-        headers: { Cookie: authCookie },
+      // 6. Same JWT (issued before sessionsRevokedAt) must now be rejected
+      const afterRes = await request.post('/api/customer_accounts/portal/feature-check', {
+        data: { features: ['portal.view'] },
+        headers: { Cookie: jwtOnlyCookie, 'Content-Type': 'application/json' },
       })
       expect(
-        refreshAfterRes.status(),
-        'sessions-refresh must be blocked after admin password reset',
+        afterRes.status(),
+        'portal endpoint must return 401 for JWT issued before sessionsRevokedAt',
       ).toBe(401)
     } finally {
-      // Cleanup: delete the customer user
       if (adminToken && customerId) {
-        await apiRequest(
-          request,
-          'DELETE',
-          `/api/customer_accounts/admin/users/${customerId}`,
-          { token: adminToken },
-        ).catch(() => {})
+        await apiRequest(request, 'DELETE', `/api/customer_accounts/admin/users/${customerId}`, {
+          token: adminToken,
+        }).catch(() => {})
       }
     }
   })

--- a/packages/core/src/modules/customer_accounts/__integration__/TC-AUTH-025.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-AUTH-025.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken, apiRequest } from '@open-mercato/core/helpers/integration/api'
+
+/**
+ * TC-AUTH-025: Sessions and JWT are both revoked after admin user deletion
+ *
+ * Verifies that when an admin deletes a customer user, revokeAllUserSessions
+ * is called which both soft-deletes active sessions and sets sessionsRevokedAt.
+ * This prevents a deleted user's stolen JWT from remaining usable.
+ */
+test.describe('TC-AUTH-025: Sessions and JWT revoked after admin user deletion', () => {
+  test('sessions-refresh and JWT-only requests are blocked after admin deletes the user', async ({ request }) => {
+    const stamp = Date.now()
+    const customerEmail = `qa-auth-025-${stamp}@test.local`
+    const password = `InitialPass${stamp}!`
+
+    let adminToken: string | null = null
+    let customerId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+
+      // 1. Create a customer user
+      const createRes = await apiRequest(request, 'POST', '/api/customer_accounts/admin/users', {
+        token: adminToken,
+        data: {
+          email: customerEmail,
+          password,
+          displayName: `QA Auth 025 ${stamp}`,
+        },
+      })
+      expect(createRes.status(), 'Customer user should be created').toBe(201)
+      const createBody = (await createRes.json()) as { user?: { id?: string } }
+      customerId = createBody.user?.id ?? null
+      expect(customerId, 'Created user id should be returned').toBeTruthy()
+
+      // 2. Decode tenantId from admin JWT
+      const adminJwtParts = adminToken.split('.')
+      const adminClaims = JSON.parse(
+        Buffer.from(
+          adminJwtParts[1].replace(/-/g, '+').replace(/_/g, '/').padEnd(
+            Math.ceil(adminJwtParts[1].length / 4) * 4,
+            '=',
+          ),
+          'base64',
+        ).toString('utf8'),
+      ) as { tenantId?: string }
+      const tenantId = adminClaims.tenantId
+      expect(tenantId, 'tenantId must be decodable from admin JWT').toBeTruthy()
+
+      // 3. Login as customer — capture both JWT and session cookies
+      const portalLoginRes = await request.post('/api/customer_accounts/login', {
+        data: { email: customerEmail, password, tenantId },
+        headers: { 'Content-Type': 'application/json' },
+      })
+      expect(portalLoginRes.ok(), 'Customer portal login should succeed').toBeTruthy()
+
+      const setCookieHeader = portalLoginRes.headers()['set-cookie'] ?? ''
+      const jwtCookieMatch = setCookieHeader.match(/customer_auth_token=([^;]+)/)
+      const sessionCookieMatch = setCookieHeader.match(/customer_session_token=([^;]+)/)
+      expect(jwtCookieMatch, 'customer_auth_token cookie must be set').toBeTruthy()
+      expect(sessionCookieMatch, 'customer_session_token cookie must be set').toBeTruthy()
+
+      const sessionCookie = `customer_auth_token=${jwtCookieMatch![1]}; customer_session_token=${sessionCookieMatch![1]}`
+      const jwtOnlyCookie = `customer_auth_token=${jwtCookieMatch![1]}`
+
+      // 4. Verify both access paths work before deletion
+      const refreshBeforeRes = await request.post('/api/customer_accounts/portal/sessions-refresh', {
+        headers: { Cookie: sessionCookie },
+      })
+      expect(refreshBeforeRes.status(), 'sessions-refresh should succeed before deletion').toBe(200)
+
+      const jwtBeforeRes = await request.post('/api/customer_accounts/portal/feature-check', {
+        data: { features: ['portal.view'] },
+        headers: { Cookie: jwtOnlyCookie, 'Content-Type': 'application/json' },
+      })
+      expect(jwtBeforeRes.status(), 'feature-check should succeed with valid JWT before deletion').toBe(200)
+
+      // 5. Admin deletes the customer user → calls revokeAllUserSessions → sets sessionsRevokedAt
+      const deleteRes = await apiRequest(
+        request,
+        'DELETE',
+        `/api/customer_accounts/admin/users/${customerId}`,
+        { token: adminToken },
+      )
+      expect(deleteRes.ok(), 'Admin user deletion should succeed').toBeTruthy()
+      customerId = null // already deleted, skip cleanup
+
+      // 6. Session token path must be blocked
+      const refreshAfterRes = await request.post('/api/customer_accounts/portal/sessions-refresh', {
+        headers: { Cookie: sessionCookie },
+      })
+      expect(
+        refreshAfterRes.status(),
+        'sessions-refresh must be blocked after admin user deletion',
+      ).toBe(401)
+
+      // 7. JWT-only path must also be blocked via sessionsRevokedAt check
+      const jwtAfterRes = await request.post('/api/customer_accounts/portal/feature-check', {
+        data: { features: ['portal.view'] },
+        headers: { Cookie: jwtOnlyCookie, 'Content-Type': 'application/json' },
+      })
+      expect(
+        jwtAfterRes.status(),
+        'JWT must be rejected after admin user deletion sets sessionsRevokedAt',
+      ).toBe(401)
+    } finally {
+      if (adminToken && customerId) {
+        await apiRequest(request, 'DELETE', `/api/customer_accounts/admin/users/${customerId}`, {
+          token: adminToken,
+        }).catch(() => {})
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
@@ -1,6 +1,6 @@
 const verifyJwt = jest.fn()
 const createRequestContainer = jest.fn()
-const findOneMock = jest.fn()
+const findOneWithDecryptionMock = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({
   verifyJwt: (...args: unknown[]) => verifyJwt(...args),
@@ -18,11 +18,15 @@ jest.mock('@open-mercato/shared/lib/auth/featureMatch', () => ({
   hasAllFeatures: jest.fn(() => true),
 }))
 
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+}))
+
 jest.mock('next/server', () => ({
   NextResponse: { json: jest.fn((body: unknown, init?: unknown) => ({ body, init })) },
 }))
 
-const em = { findOne: findOneMock }
+const em = {}
 
 function makeRequest(token: string, via: 'cookie' | 'bearer' = 'cookie'): Request {
   const headers: Record<string, string> = via === 'cookie'
@@ -49,19 +53,14 @@ describe('getCustomerAuthFromRequest — sessions_revoked_at check', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.resetModules()
-    createRequestContainer.mockResolvedValue({
-      resolve: (name: string) => {
-        if (name === 'em') return em
-        return null
-      },
-    })
+    createRequestContainer.mockResolvedValue({ resolve: () => em })
   })
 
   it('returns auth context when sessionsRevokedAt is null', async () => {
     const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
 
     verifyJwt.mockReturnValue(validPayload)
-    findOneMock.mockResolvedValue({ sessionsRevokedAt: null })
+    findOneWithDecryptionMock.mockResolvedValue({ sessionsRevokedAt: null })
 
     const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
     expect(auth).not.toBeNull()
@@ -72,7 +71,7 @@ describe('getCustomerAuthFromRequest — sessions_revoked_at check', () => {
     const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
 
     verifyJwt.mockReturnValue({ ...validPayload, iat: 1000 })
-    findOneMock.mockResolvedValue({
+    findOneWithDecryptionMock.mockResolvedValue({
       sessionsRevokedAt: new Date(2000 * 1000), // epoch 2000
     })
 
@@ -84,7 +83,7 @@ describe('getCustomerAuthFromRequest — sessions_revoked_at check', () => {
     const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
 
     verifyJwt.mockReturnValue({ ...validPayload, iat: 3000 })
-    findOneMock.mockResolvedValue({
+    findOneWithDecryptionMock.mockResolvedValue({
       sessionsRevokedAt: new Date(2000 * 1000), // epoch 2000
     })
 
@@ -97,7 +96,7 @@ describe('getCustomerAuthFromRequest — sessions_revoked_at check', () => {
     const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
 
     verifyJwt.mockReturnValue(validPayload)
-    findOneMock.mockResolvedValue(null)
+    findOneWithDecryptionMock.mockResolvedValue(null)
 
     const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
     expect(auth).toBeNull()

--- a/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
@@ -1,0 +1,115 @@
+const verifyJwt = jest.fn()
+const createRequestContainer = jest.fn()
+const findOneMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({
+  verifyJwt: (...args: unknown[]) => verifyJwt(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => createRequestContainer(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/data/entities', () => ({
+  CustomerUser: 'CustomerUser',
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/featureMatch', () => ({
+  hasAllFeatures: jest.fn(() => true),
+}))
+
+jest.mock('next/server', () => ({
+  NextResponse: { json: jest.fn((body: unknown, init?: unknown) => ({ body, init })) },
+}))
+
+const em = { findOne: findOneMock }
+
+function makeRequest(token: string, via: 'cookie' | 'bearer' = 'cookie'): Request {
+  const headers: Record<string, string> = via === 'cookie'
+    ? { cookie: `customer_auth_token=${token}` }
+    : { authorization: `Bearer ${token}` }
+  return new Request('https://example.test/api/portal/test', { headers })
+}
+
+const validPayload = {
+  sub: '11111111-1111-4111-8111-111111111111',
+  type: 'customer',
+  tenantId: '22222222-2222-4222-8222-222222222222',
+  orgId: '33333333-3333-4333-8333-333333333333',
+  email: 'customer@example.com',
+  displayName: 'Test Customer',
+  customerEntityId: null,
+  personEntityId: null,
+  resolvedFeatures: ['portal.view'],
+  iat: 1000,
+  exp: 9999999999,
+}
+
+describe('getCustomerAuthFromRequest — sessions_revoked_at check', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+    createRequestContainer.mockResolvedValue({
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        return null
+      },
+    })
+  })
+
+  it('returns auth context when sessionsRevokedAt is null', async () => {
+    const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
+
+    verifyJwt.mockReturnValue(validPayload)
+    findOneMock.mockResolvedValue({ sessionsRevokedAt: null })
+
+    const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
+    expect(auth).not.toBeNull()
+    expect(auth!.sub).toBe(validPayload.sub)
+  })
+
+  it('returns null when jwt.iat is before sessionsRevokedAt', async () => {
+    const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
+
+    verifyJwt.mockReturnValue({ ...validPayload, iat: 1000 })
+    findOneMock.mockResolvedValue({
+      sessionsRevokedAt: new Date(2000 * 1000), // epoch 2000
+    })
+
+    const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
+    expect(auth).toBeNull()
+  })
+
+  it('returns auth context when jwt.iat is after sessionsRevokedAt', async () => {
+    const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
+
+    verifyJwt.mockReturnValue({ ...validPayload, iat: 3000 })
+    findOneMock.mockResolvedValue({
+      sessionsRevokedAt: new Date(2000 * 1000), // epoch 2000
+    })
+
+    const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
+    expect(auth).not.toBeNull()
+    expect(auth!.sub).toBe(validPayload.sub)
+  })
+
+  it('returns null when user is not found in DB', async () => {
+    const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
+
+    verifyJwt.mockReturnValue(validPayload)
+    findOneMock.mockResolvedValue(null)
+
+    const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
+    expect(auth).toBeNull()
+  })
+
+  it('returns null when container creation fails (fail-closed)', async () => {
+    const { getCustomerAuthFromRequest } = await import('../lib/customerAuth')
+
+    verifyJwt.mockReturnValue(validPayload)
+    createRequestContainer.mockRejectedValue(new Error('DI unavailable'))
+
+    const auth = await getCustomerAuthFromRequest(makeRequest('jwt-token'))
+    expect(auth).toBeNull()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__tests__/customerSessionService.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerSessionService.test.ts
@@ -1,0 +1,46 @@
+jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({
+  signJwt: jest.fn(() => 'mock-jwt'),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/tokenGenerator', () => ({
+  generateSecureToken: jest.fn(() => 'mock-token'),
+  hashToken: jest.fn(() => 'mock-hash'),
+}))
+
+const nativeUpdateMock = jest.fn()
+
+const em = {
+  nativeUpdate: nativeUpdateMock,
+} as any
+
+describe('CustomerSessionService.revokeAllUserSessions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('soft-deletes sessions and stamps sessionsRevokedAt on the user', async () => {
+    const { CustomerSessionService } = await import('../services/customerSessionService')
+    const { CustomerUser, CustomerUserSession } = await import('../data/entities')
+    const service = new CustomerSessionService(em)
+    const userId = '11111111-1111-4111-8111-111111111111'
+
+    await service.revokeAllUserSessions(userId)
+
+    expect(nativeUpdateMock).toHaveBeenCalledTimes(2)
+
+    // First call: soft-delete sessions
+    const [sessionEntity, sessionFilter, sessionUpdate] = nativeUpdateMock.mock.calls[0]
+    expect(sessionEntity).toBe(CustomerUserSession)
+    expect(sessionFilter).toEqual({ user: userId, deletedAt: null })
+    expect(sessionUpdate.deletedAt).toBeInstanceOf(Date)
+
+    // Second call: stamp sessionsRevokedAt on user
+    const [userEntity, userFilter, userUpdate] = nativeUpdateMock.mock.calls[1]
+    expect(userEntity).toBe(CustomerUser)
+    expect(userFilter).toEqual({ id: userId })
+    expect(userUpdate.sessionsRevokedAt).toBeInstanceOf(Date)
+
+    // Both timestamps should use the same instant
+    expect(sessionUpdate.deletedAt.getTime()).toBe(userUpdate.sessionsRevokedAt.getTime())
+  })
+})

--- a/packages/core/src/modules/customer_accounts/data/entities.ts
+++ b/packages/core/src/modules/customer_accounts/data/entities.ts
@@ -37,6 +37,9 @@ export class CustomerUser {
   @Property({ name: 'last_login_at', type: Date, nullable: true })
   lastLoginAt?: Date | null
 
+  @Property({ name: 'sessions_revoked_at', type: Date, nullable: true })
+  sessionsRevokedAt?: Date | null
+
   @Property({ name: 'person_entity_id', type: 'uuid', nullable: true })
   @Index({ name: 'customer_users_person_entity_idx' })
   personEntityId?: string | null

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
 import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 export interface CustomerAuthContext {
   sub: string
@@ -24,6 +25,19 @@ export function readCookieFromHeader(header: string | null | undefined, name: st
     }
   }
   return undefined
+}
+
+async function isSessionRevoked(sub: string, iat: unknown): Promise<boolean> {
+  const [{ createRequestContainer }, { CustomerUser }] = await Promise.all([
+    import('@open-mercato/shared/lib/di/container'),
+    import('@open-mercato/core/modules/customer_accounts/data/entities'),
+  ])
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
+  const user = await findOneWithDecryption(em, CustomerUser, { id: sub }, { fields: ['sessionsRevokedAt'] })
+  if (!user) return true
+  if (!user.sessionsRevokedAt || typeof iat !== 'number') return false
+  return iat < Math.floor(user.sessionsRevokedAt.getTime() / 1000)
 }
 
 export async function getCustomerAuthFromRequest(req: Request): Promise<CustomerAuthContext | null> {
@@ -53,21 +67,7 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
     if (payload.type !== 'customer') return null
 
     try {
-      const [{ createRequestContainer }, { CustomerUser }] = await Promise.all([
-        import('@open-mercato/shared/lib/di/container'),
-        import('@open-mercato/core/modules/customer_accounts/data/entities'),
-      ])
-      const container = await createRequestContainer()
-      const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
-      const user = await em.findOne(CustomerUser, { id: payload.sub }, { fields: ['sessionsRevokedAt'] })
-      if (!user) return null
-      if (
-        user.sessionsRevokedAt &&
-        typeof payload.iat === 'number' &&
-        payload.iat < Math.floor(user.sessionsRevokedAt.getTime() / 1000)
-      ) {
-        return null
-      }
+      if (await isSessionRevoked(String(payload.sub), payload.iat)) return null
     } catch {
       return null
     }

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -37,7 +37,7 @@ async function isSessionRevoked(sub: string, iat: unknown): Promise<boolean> {
   const user = await findOneWithDecryption(em, CustomerUser, { id: sub }, { fields: ['sessionsRevokedAt'] })
   if (!user) return true
   if (!user.sessionsRevokedAt || typeof iat !== 'number') return false
-  return iat < Math.floor(user.sessionsRevokedAt.getTime() / 1000)
+  return iat * 1000 < user.sessionsRevokedAt.getTime()
 }
 
 export async function getCustomerAuthFromRequest(req: Request): Promise<CustomerAuthContext | null> {

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -52,6 +52,26 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
     if (!payload) return null
     if (payload.type !== 'customer') return null
 
+    try {
+      const [{ createRequestContainer }, { CustomerUser }] = await Promise.all([
+        import('@open-mercato/shared/lib/di/container'),
+        import('@open-mercato/core/modules/customer_accounts/data/entities'),
+      ])
+      const container = await createRequestContainer()
+      const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
+      const user = await em.findOne(CustomerUser, { id: payload.sub }, { fields: ['sessionsRevokedAt'] })
+      if (!user) return null
+      if (
+        user.sessionsRevokedAt &&
+        typeof payload.iat === 'number' &&
+        payload.iat < Math.floor(user.sessionsRevokedAt.getTime() / 1000)
+      ) {
+        return null
+      }
+    } catch {
+      return null
+    }
+
     return {
       sub: String(payload.sub),
       type: 'customer',

--- a/packages/core/src/modules/customer_accounts/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/customer_accounts/migrations/.snapshot-open-mercato.json
@@ -11,9 +11,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "tenant_id": {
@@ -23,6 +29,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "organization_id": {
@@ -32,6 +45,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "name": {
@@ -41,6 +61,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "slug": {
@@ -50,6 +77,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "description": {
@@ -59,6 +93,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "is_default": {
@@ -68,7 +109,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "false",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "is_system": {
@@ -78,7 +125,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "false",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "customer_assignable": {
@@ -88,7 +141,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "false",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "created_at": {
@@ -98,7 +157,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -108,7 +173,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -118,7 +189,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -158,9 +235,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "role_id": {
@@ -170,6 +253,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "tenant_id": {
@@ -179,6 +269,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "features_json": {
@@ -188,6 +285,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "json"
         },
         "is_portal_admin": {
@@ -197,7 +301,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "false",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "created_at": {
@@ -207,7 +317,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -217,7 +333,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -227,7 +349,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -280,9 +408,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "tenant_id": {
@@ -292,6 +426,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "organization_id": {
@@ -301,6 +442,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "email": {
@@ -310,6 +458,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "email_hash": {
@@ -319,6 +474,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "password_hash": {
@@ -328,6 +490,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "display_name": {
@@ -337,6 +506,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "email_verified_at": {
@@ -346,7 +522,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "failed_login_attempts": {
@@ -356,7 +538,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "0",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "integer"
         },
         "locked_until": {
@@ -366,7 +554,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "last_login_at": {
@@ -376,7 +570,29 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "sessions_revoked_at": {
+          "name": "sessions_revoked_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "person_entity_id": {
@@ -386,6 +602,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "customer_entity_id": {
@@ -395,6 +618,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "is_active": {
@@ -404,7 +634,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "true",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "created_at": {
@@ -414,7 +650,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -424,7 +666,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -434,7 +682,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -504,9 +758,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "user_id": {
@@ -516,6 +776,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "tenant_id": {
@@ -525,6 +792,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "features_json": {
@@ -534,6 +808,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "json"
         },
         "is_portal_admin": {
@@ -543,7 +824,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "false",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "boolean"
         },
         "created_at": {
@@ -553,7 +840,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "updated_at": {
@@ -563,7 +856,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -573,7 +872,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -626,9 +931,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "user_id": {
@@ -638,6 +949,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "token": {
@@ -647,6 +965,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "purpose": {
@@ -656,7 +981,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "'email_verification'",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "expires_at": {
@@ -666,7 +997,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "used_at": {
@@ -676,7 +1013,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "created_at": {
@@ -686,7 +1029,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -738,9 +1087,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "tenant_id": {
@@ -750,6 +1105,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "organization_id": {
@@ -759,6 +1121,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "email": {
@@ -768,6 +1137,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "email_hash": {
@@ -777,6 +1153,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "token": {
@@ -786,6 +1169,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "customer_entity_id": {
@@ -795,6 +1185,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "role_ids_json": {
@@ -804,6 +1201,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "json"
         },
         "invited_by_user_id": {
@@ -813,6 +1217,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "invited_by_customer_user_id": {
@@ -822,6 +1233,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "display_name": {
@@ -831,6 +1249,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "expires_at": {
@@ -840,7 +1265,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "accepted_at": {
@@ -850,7 +1281,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "cancelled_at": {
@@ -860,7 +1297,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "created_at": {
@@ -870,7 +1313,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -920,9 +1369,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "user_id": {
@@ -932,6 +1387,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "token": {
@@ -941,6 +1403,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "expires_at": {
@@ -950,7 +1419,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "used_at": {
@@ -960,7 +1435,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "created_at": {
@@ -970,7 +1451,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -1022,9 +1509,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "user_id": {
@@ -1034,6 +1527,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "role_id": {
@@ -1043,6 +1543,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "created_at": {
@@ -1052,7 +1559,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -1062,7 +1575,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },
@@ -1127,9 +1646,15 @@
           "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
-          "primary": false,
+          "primary": true,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
           "default": "gen_random_uuid()",
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "user_id": {
@@ -1139,6 +1664,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "uuid"
         },
         "token_hash": {
@@ -1148,6 +1680,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "ip_address": {
@@ -1157,6 +1696,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "user_agent": {
@@ -1166,6 +1712,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "text"
         },
         "expires_at": {
@@ -1175,7 +1728,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "last_used_at": {
@@ -1185,7 +1744,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "created_at": {
@@ -1195,7 +1760,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         },
         "deleted_at": {
@@ -1205,7 +1776,13 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "unique": false,
           "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
           "mappedType": "datetime"
         }
       },

--- a/packages/core/src/modules/customer_accounts/migrations/Migration20260411113503.ts
+++ b/packages/core/src/modules/customer_accounts/migrations/Migration20260411113503.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260411113503 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "customer_users" add column "sessions_revoked_at" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "customer_users" drop column "sessions_revoked_at";`);
+  }
+
+}

--- a/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
@@ -81,10 +81,16 @@ export class CustomerSessionService {
   }
 
   async revokeAllUserSessions(userId: string): Promise<void> {
+    const now = new Date()
     await this.em.nativeUpdate(
       CustomerUserSession,
       { user: userId as any, deletedAt: null },
-      { deletedAt: new Date() },
+      { deletedAt: now },
+    )
+    await this.em.nativeUpdate(
+      CustomerUser,
+      { id: userId },
+      { sessionsRevokedAt: now },
     )
   }
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                         
  Customer portal JWTs issued before session revocation remained valid for up to                                                                   
  8 hours after `revokeAllUserSessions()` was called (admin password reset, admin
  user deletion, self-service password reset). An attacker holding a stolen JWT  
  could continue using the portal until natural token expiry.                  
                                                                                                                                                     
  This PR closes that window by stamping a `sessions_revoked_at` timestamp on
  `CustomerUser` during revocation and rejecting JWTs whose `iat` (issued-at)                                                                        
  precedes that timestamp at every portal API call. Follows the existing staff                                                                     
  auth DB-validation pattern (fail-closed on any DB/DI error).                
                                                              
  ## Changes
            
  - Added `sessions_revoked_at` column to `CustomerUser`; `revokeAllUserSessions()`
    now stamps this timestamp alongside the existing session soft-delete                                                                             
  - `getCustomerAuthFromRequest()` performs a lightweight DB lookup after JWT
    signature verification and rejects tokens issued before `sessions_revoked_at`                                                                    
  - Fail-closed: any DB or DI error during the revocation check returns 401                                                                        
                                                                                                                                                     
  ## Specification                                                                                                                                   
                                                                                                                                                     
  **Does a spec exist for this feature/module?**                                                                                                     
  - [x] Yes                                                                                                                                        
           
  **Spec file path:**
  `.ai/specs/implemented/SPEC-060-2026-03-04-customer-identity-portal-auth.md`
                                                                              
  ## Testing
            
  ```bash
  yarn test
  yarn typecheck
  yarn test:integration --grep "TC-AUTH-02[345]"
                                                
  Checklist
                                                                                                                                                     
  - This pull request targets develop.
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).                                                         
  - I updated documentation, locales, or generators if the change requires it.                                                                     
  - I added or adjusted tests that cover the change.
  - I added or updated integration tests in .ai/qa/tests/ (or documented why
  integration coverage is not required).
    - TC-AUTH-024: JWT invalidation via sessions_revoked_at after admin password reset
    - TC-AUTH-025: Both session and JWT blocked after admin user deletion
    - Note: self-service reset path shares the same codepath; integration test
  requires out-of-band token retrieval not available via HTTP API — covered at unit level
  - I created or updated the spec in .ai/specs/ with a changelog entry (if applicable).
  
##  Notes for reviewer                                                                                                                                 
                                                                                                                                                     
  .snapshot-open-mercato.json has a large diff (~595 lines) unrelated to this                                                                        
  change. The previous snapshot was last committed in 9c8ba9e (15 Mar 2026) with
  an older MikroORM version that did not record unique, scale, precision,                                                                            
  comment, and enumItems fields per column. The current MikroORM version                                                                           
  emits them — this PR is the first db:generate run since that upgrade, so the                                                                       
  drift is flushed here. The generated migration contains only the expected                                                                          
  ADD COLUMN sessions_revoked_at statement.  