### PR TITLE
fix(auth): apply input validation to feature-check endpoint to prevent DoS

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
@@ -38,7 +38,7 @@ describe('POST /api/auth/feature-check', () => {
     ;(getAuthFromRequest as jest.Mock).mockReturnValue({ sub: 'u1', tenantId: 't1', orgId: 'o1' })
     const res = await POST(makeReq({ features: [] }))
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ ok: true, granted: [] })
+    await expect(res.json()).resolves.toEqual({ ok: true, granted: [], userId: 'u1' })
   })
 
   it('returns ok true when RBAC grants all features', async () => {
@@ -47,7 +47,7 @@ describe('POST /api/auth/feature-check', () => {
     mockRbac.userHasAllFeatures.mockResolvedValueOnce(true)
     const res = await POST(makeReq({ features: ['a.b'] }))
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ ok: true, granted: ['a.b'] })
+    await expect(res.json()).resolves.toEqual({ ok: true, granted: ['a.b'], userId: 'u1' })
   })
 
   it('returns ok false when RBAC denies features', async () => {

--- a/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
@@ -38,7 +38,7 @@ describe('POST /api/auth/feature-check', () => {
     ;(getAuthFromRequest as jest.Mock).mockReturnValue({ sub: 'u1', tenantId: 't1', orgId: 'o1' })
     const res = await POST(makeReq({ features: [] }))
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ ok: true, granted: [], userId: 'u1' })
+    await expect(res.json()).resolves.toEqual({ ok: true, granted: [] })
   })
 
   it('returns ok true when RBAC grants all features', async () => {
@@ -47,7 +47,7 @@ describe('POST /api/auth/feature-check', () => {
     mockRbac.userHasAllFeatures.mockResolvedValueOnce(true)
     const res = await POST(makeReq({ features: ['a.b'] }))
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toEqual({ ok: true, granted: ['a.b'], userId: 'u1' })
+    await expect(res.json()).resolves.toEqual({ ok: true, granted: ['a.b'] })
   })
 
   it('returns ok false when RBAC denies features', async () => {

--- a/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
@@ -12,7 +12,7 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: async () => ({ resolve: (k: string) => (k === 'rbacService' ? mockRbac : null) }),
 }))
 
-function makeReq(body: any) {
+function makeReq(body: unknown) {
   return new Request('http://localhost/api/auth/feature-check', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
@@ -60,6 +60,56 @@ describe('POST /api/auth/feature-check', () => {
     expect(data.ok).toBe(false)
     expect(Array.isArray(data.granted)).toBe(true)
   })
+
+  describe('input validation — returns 400', () => {
+    beforeEach(async () => {
+      const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+      ;(getAuthFromRequest as jest.Mock).mockReturnValue({ sub: 'u1', tenantId: 't1', orgId: 'o1' })
+    })
+
+    it('rejects request with more than 50 features', async () => {
+      const features = Array.from({ length: 51 }, (_, i) => `module.feature${i}`)
+      const res = await POST(makeReq({ features }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ ok: false, error: expect.any(String) })
+    })
+
+    it('rejects feature string longer than 128 characters', async () => {
+      const res = await POST(makeReq({ features: ['a'.repeat(129)] }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ ok: false })
+    })
+
+    it('rejects non-string elements in features array', async () => {
+      const res = await POST(makeReq({ features: [123, true] }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ ok: false })
+    })
+
+    it('rejects missing features field', async () => {
+      const res = await POST(makeReq({}))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ ok: false })
+    })
+
+    it('rejects non-object body', async () => {
+      const res = await POST(new Request('http://localhost/api/auth/feature-check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify('invalid'),
+      }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ ok: false })
+    })
+
+    it('rejects malformed JSON body', async () => {
+      const res = await POST(new Request('http://localhost/api/auth/feature-check', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: 'not-json{{{',
+      }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ ok: false })
+    })
+  })
 })
-
-

--- a/packages/core/src/modules/auth/api/feature-check.ts
+++ b/packages/core/src/modules/auth/api/feature-check.ts
@@ -15,6 +15,7 @@ const featureCheckRequestSchema = z.object({
 const featureCheckResponseSchema = z.object({
   ok: z.boolean().describe('Indicates whether all requested features are granted'),
   granted: z.array(z.string()).describe('Features the current user may access'),
+  userId: z.string().describe('ID of the authenticated user'),
 })
 
 export async function POST(req: Request) {
@@ -35,7 +36,7 @@ export async function POST(req: Request) {
 
   const features = parsed.data.features
   if (!features.length) {
-    return NextResponse.json({ ok: true, granted: [] })
+    return NextResponse.json({ ok: true, granted: [], userId: auth.sub })
   }
 
   const container = await createRequestContainer()
@@ -43,7 +44,7 @@ export async function POST(req: Request) {
   const ok = await rbac.userHasAllFeatures(auth.sub, features, { tenantId: auth.tenantId, organizationId: auth.orgId })
   // Return which features the user has (for batch checking)
   if (ok) {
-    return NextResponse.json({ ok: true, granted: features })
+    return NextResponse.json({ ok: true, granted: features, userId: auth.sub })
   }
 
   // Check individually to see which features are granted
@@ -53,7 +54,7 @@ export async function POST(req: Request) {
     if (hasFeature) granted.push(f)
   }
 
-  return NextResponse.json({ ok: false, granted })
+  return NextResponse.json({ ok: false, granted, userId: auth.sub })
 }
 
 const featureCheckMethodDoc: OpenApiMethodDoc = {

--- a/packages/core/src/modules/auth/api/feature-check.ts
+++ b/packages/core/src/modules/auth/api/feature-check.ts
@@ -8,38 +8,53 @@ export const metadata = {
   POST: { requireAuth: true },
 }
 
+const featureCheckRequestSchema = z.object({
+  features: z.array(z.string().max(128)).max(50).describe('Feature identifiers to check'),
+}).describe('Batch feature check payload')
+
+const featureCheckResponseSchema = z.object({
+  ok: z.boolean().describe('Indicates whether all requested features are granted'),
+  granted: z.array(z.string()).describe('Features the current user may access'),
+})
+
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth) return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
-  let body: any = {}
-  try { body = await req.json() } catch {}
-  const features: string[] = Array.isArray(body?.features) ? body.features : []
-  if (!features.length) return NextResponse.json({ ok: true, granted: [], userId: auth.sub })
+  if (!auth) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown = {}
+  try {
+    body = await req.json()
+  } catch { }
+
+  const parsed = featureCheckRequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: 'Invalid request' }, { status: 400 })
+  }
+
+  const features = parsed.data.features
+  if (!features.length) {
+    return NextResponse.json({ ok: true, granted: [] })
+  }
+
   const container = await createRequestContainer()
   const rbac = (container.resolve('rbacService') as any)
   const ok = await rbac.userHasAllFeatures(auth.sub, features, { tenantId: auth.tenantId, organizationId: auth.orgId })
   // Return which features the user has (for batch checking)
   if (ok) {
-    return NextResponse.json({ ok: true, granted: features, userId: auth.sub })
+    return NextResponse.json({ ok: true, granted: features })
   }
+
   // Check individually to see which features are granted
   const granted: string[] = []
   for (const f of features) {
     const hasFeature = await rbac.userHasAllFeatures(auth.sub, [f], { tenantId: auth.tenantId, organizationId: auth.orgId })
     if (hasFeature) granted.push(f)
   }
-  return NextResponse.json({ ok: false, granted, userId: auth.sub })
+
+  return NextResponse.json({ ok: false, granted })
 }
-
-const featureCheckRequestSchema = z.object({
-  features: z.array(z.string()).describe('Feature identifiers to check'),
-}).describe('Batch feature check payload')
-
-const featureCheckResponseSchema = z.object({
-  ok: z.boolean().describe('Indicates whether all requested features are granted'),
-  granted: z.array(z.string()).describe('Features the current user may access'),
-  userId: z.string().describe('Identifier of the authenticated user'),
-})
 
 const featureCheckMethodDoc: OpenApiMethodDoc = {
   summary: 'Check feature grants for the current user',

--- a/packages/core/src/modules/auth/api/feature-check.ts
+++ b/packages/core/src/modules/auth/api/feature-check.ts
@@ -3,14 +3,11 @@ import { z } from 'zod'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { featureCheckRequestSchema } from '../data/validators'
 
 export const metadata = {
   POST: { requireAuth: true },
 }
-
-const featureCheckRequestSchema = z.object({
-  features: z.array(z.string().max(128)).max(50).describe('Feature identifiers to check'),
-}).describe('Batch feature check payload')
 
 const featureCheckResponseSchema = z.object({
   ok: z.boolean().describe('Indicates whether all requested features are granted'),
@@ -27,7 +24,7 @@ export async function POST(req: Request) {
   let body: unknown = {}
   try {
     body = await req.json()
-  } catch { }
+  } catch { /* malformed JSON — safeParse below will reject */ }
 
   const parsed = featureCheckRequestSchema.safeParse(body)
   if (!parsed.success) {
@@ -42,7 +39,6 @@ export async function POST(req: Request) {
   const container = await createRequestContainer()
   const rbac = (container.resolve('rbacService') as any)
   const ok = await rbac.userHasAllFeatures(auth.sub, features, { tenantId: auth.tenantId, organizationId: auth.orgId })
-  // Return which features the user has (for batch checking)
   if (ok) {
     return NextResponse.json({ ok: true, granted: features, userId: auth.sub })
   }
@@ -74,6 +70,11 @@ const featureCheckMethodDoc: OpenApiMethodDoc = {
     },
   ],
   errors: [
+    {
+      status: 400,
+      description: 'Invalid request — features array missing, too large, or contains invalid entries',
+      schema: z.object({ ok: z.literal(false), error: z.string() }),
+    },
     {
       status: 401,
       description: 'Authentication required',

--- a/packages/core/src/modules/auth/data/validators.ts
+++ b/packages/core/src/modules/auth/data/validators.ts
@@ -47,9 +47,14 @@ export const userCreateSchema = z.object({
   { message: 'Either password or sendInviteEmail is required', path: ['password'] },
 )
 
+export const featureCheckRequestSchema = z.object({
+  features: z.array(z.string().max(128)).max(50).describe('Feature identifiers to check'),
+}).describe('Batch feature check payload')
+
 export type UserLoginInput = z.infer<typeof userLoginSchema>
 export type RequestPasswordResetInput = z.infer<typeof requestPasswordResetSchema>
 export type ConfirmPasswordResetInput = z.infer<typeof confirmPasswordResetSchema>
 export type RefreshSessionRequestInput = z.infer<typeof refreshSessionRequestSchema>
 export type SidebarPreferencesInput = z.infer<typeof sidebarPreferencesInputSchema>
 export type UserCreateInput = z.infer<typeof userCreateSchema>
+export type FeatureCheckRequestInput = z.infer<typeof featureCheckRequestSchema>


### PR DESCRIPTION
1. Opis problemu
Endpoint POST /api/auth/feature-check przyjmował dowolnie dużą tablicę features bez żadnej walidacji rozmiaru ani długości poszczególnych elementów. Pomimo że w pliku istniał schemat Zod (featureCheckRequestSchema), był on używany wyłącznie w dokumentacji OpenAPI — nigdy nie był stosowany do walidacji rzeczywistego ciała żądania. Handler odczytywał body jako typ any i sprawdzał jedynie, czy pole features jest tablicą, po czym przekazywał je bezpośrednio do serwisu RBAC.

2. Konsekwencje wystąpienia problemu
Brak walidacji tablicy.
Każdy zalogowany użytkownik — nawet z najniższymi uprawnieniami (rola employee) — mógł wysłać żądanie z tablicą zawierającą dziesiątki tysięcy fikcyjnych identyfikatorów funkcji. Gdy żadna z nich nie jest przyznana (przypadek typowy dla losowych ciągów), handler wchodzi w pętlę O(N), w której dla każdego elementu wykonywane jest osobne zapytanie do serwisu RBAC, a tym samym do bazy danych. Przy jednoczesnym wywołaniu kilku takich żądań przez różnych użytkowników możliwe było wyczerpanie puli połączeń do bazy danych i wywołanie efektywnego DoS dla całej aplikacji. Długie ciągi znaków (np. 1 MB na element) dodatkowo zwiększały zużycie pamięci procesu.

3. Zaaplikowana poprawka
Schemat Zod przeniesiony przed handler i faktycznie stosowany do walidacji ciała żądania przez safeParse — nieprawidłowe żądania są odrzucane odpowiedzią 400 Invalid request.
Dodane twarde limity w schemacie: maksymalnie 50 elementów w tablicy oraz maksymalnie 128 znaków na pojedynczy identyfikator funkcji.
