### PR TITLE
fix(auth): reject non-superadmin actors with null tenant in roleTenan…

### DIFF
--- a/packages/core/src/modules/auth/lib/__tests__/roleTenantGuard.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/roleTenantGuard.test.ts
@@ -1,0 +1,137 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { enforceRoleTenantAccess } from '@open-mercato/core/modules/auth/lib/roleTenantGuard'
+
+const tenantA = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const tenantB = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const roleId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+const makeFindOne = (role: object | null) => jest.fn().mockResolvedValue(role)
+
+function makeCtx({
+  isSuperAdmin = false,
+  tenantId = tenantA as string | null,
+  role = { id: roleId, tenantId: tenantA } as object | null,
+}: {
+  isSuperAdmin?: boolean
+  tenantId?: string | null
+  role?: object | null
+} = {}) {
+  const findOne = makeFindOne(role)
+  const em = { findOne } as unknown as EntityManager
+  const rbacService = { loadAcl: jest.fn().mockResolvedValue({ isSuperAdmin }) }
+  return {
+    ctx: {
+      auth: { sub: 'user-1', tenantId, isSuperAdmin },
+      container: {
+        resolve: (name: string) => {
+          if (name === 'em') return em
+          if (name === 'rbacService') return rbacService
+          throw new Error(`Unexpected service: ${name}`)
+        },
+      },
+    },
+    findOne,
+  }
+}
+
+describe('enforceRoleTenantAccess — update mode', () => {
+  describe('null-null tenant bypass (CWE-284 fix)', () => {
+    it('rejects a non-superadmin with no tenant (null) attempting to update a global/system role (tenantId null)', async () => {
+      const { ctx } = makeCtx({ tenantId: null, role: { id: roleId, tenantId: null } })
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx),
+      ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+    })
+
+    it('rejects a non-superadmin with a blank tenant string attempting to update a global role', async () => {
+      const { ctx } = makeCtx({ tenantId: '   ', role: { id: roleId, tenantId: null } })
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx),
+      ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+    })
+  })
+
+  describe('cross-tenant isolation', () => {
+    it('rejects a non-superadmin updating a role owned by a different tenant', async () => {
+      const { ctx } = makeCtx({ tenantId: tenantA, role: { id: roleId, tenantId: tenantB } })
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx),
+      ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+    })
+
+    it('allows a non-superadmin to update their own tenant role', async () => {
+      const { ctx } = makeCtx({ tenantId: tenantA, role: { id: roleId, tenantId: tenantA } })
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx),
+      ).resolves.toEqual({ id: roleId })
+    })
+  })
+
+  describe('superadmin bypass', () => {
+    it('allows a superadmin with null tenantId to update a global/system role', async () => {
+      const { ctx } = makeCtx({ isSuperAdmin: true, tenantId: null, role: { id: roleId, tenantId: null } })
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx),
+      ).resolves.toEqual({ id: roleId })
+    })
+
+    it('allows a superadmin to update a role in any tenant', async () => {
+      const { ctx } = makeCtx({ isSuperAdmin: true, tenantId: tenantA, role: { id: roleId, tenantId: tenantB } })
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx),
+      ).resolves.toEqual({ id: roleId })
+    })
+  })
+
+  describe('guard short-circuits', () => {
+    it('returns input unchanged when no roleId is provided', async () => {
+      const { ctx } = makeCtx()
+      const input = { name: 'some-role' }
+
+      await expect(enforceRoleTenantAccess('update', input, ctx)).resolves.toBe(input)
+    })
+
+    it('returns input unchanged when the role does not exist in the database', async () => {
+      const { ctx } = makeCtx({ role: null })
+      const input = { id: roleId }
+
+      await expect(enforceRoleTenantAccess('update', input, ctx)).resolves.toBe(input)
+    })
+
+    it('throws 403 when auth context is missing', async () => {
+      const ctx = {
+        auth: null,
+        container: { resolve: () => ({}) },
+      }
+
+      await expect(
+        enforceRoleTenantAccess('update', { id: roleId }, ctx as never),
+      ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+    })
+  })
+})
+
+describe('enforceRoleTenantAccess — create mode', () => {
+  it('passes tenantId through enforceTenantSelection for a non-superadmin creating in their own tenant', async () => {
+    const { ctx } = makeCtx({ tenantId: tenantA })
+
+    const result = await enforceRoleTenantAccess('create', { name: 'new-role', tenantId: tenantA }, ctx)
+
+    expect(result).toMatchObject({ name: 'new-role', tenantId: tenantA })
+  })
+
+  it('rejects a non-superadmin trying to create a role in a different tenant', async () => {
+    const { ctx } = makeCtx({ tenantId: tenantA })
+
+    await expect(
+      enforceRoleTenantAccess('create', { name: 'new-role', tenantId: tenantB }, ctx),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+  })
+})

--- a/packages/core/src/modules/auth/lib/roleTenantGuard.ts
+++ b/packages/core/src/modules/auth/lib/roleTenantGuard.ts
@@ -44,6 +44,10 @@ export async function enforceRoleTenantAccess(
   const actorTenant = normalizeTenantId(auth.tenantId ?? null) ?? null
   const existingTenantId = normalizeTenantId(existing.tenantId ?? null) ?? null
 
+  if (!isSuperAdmin && !actorTenant) {
+    throw forbidden('Not authorized')
+  }
+
   if (!isSuperAdmin && existingTenantId !== actorTenant) {
     throw forbidden('Not authorized')
   }


### PR DESCRIPTION
                                                                                                                                                                                                                                                             ## Summary                                                                                                                                         
                                                            
  `enforceRoleTenantAccess` (update mode) compared actor tenant ID to the target role's tenant ID using `!==`. When both resolved to `null` (actor   
  has no tenant scope, role is a global/system role), `null !== null` returned `false` and the guard silently passed — allowing a non-superadmin to
  modify system-level roles and escalate privileges for all users assigned to them.                                                                  
                                                            
  The fix adds an explicit fail-closed guard before the existing comparison: if a non-superadmin has no tenant scope, the request is rejected        
  regardless of the target role's tenantId.
                                                                                                                                                     
  ## Changes                                                

  - `packages/core/src/modules/auth/lib/roleTenantGuard.ts` — added explicit `!actorTenant` check for non-superadmin actors before the `!==` tenant  
  comparison
  - `packages/core/src/modules/auth/lib/__tests__/roleTenantGuard.test.ts` — new test file with 11 unit tests covering the null-null bypass scenario,
   cross-tenant isolation, superadmin bypass, guard short-circuits, and create mode                                                                  
  
  ## Specification                                                                                                                                   
                                                            
  **Does a spec exist for this feature/module?**
  - [x] N/A (minor change, no spec needed)
                                                                                                                                                     
  ## Testing
                                                                                                                                                     
  ```bash                                                   
  # Unit tests — all 11 pass
  npx jest src/modules/auth/lib/__tests__/roleTenantGuard.test.ts                                                                                    
  
  # Full CI gates                                                                                                                                    
  yarn build:packages   # PASS — 18/18                      
  yarn generate         # PASS                                                                                                                       
  yarn typecheck        # PASS — 18/18                                                                                                               
  yarn i18n:check-sync  # PASS — all 4 locales in sync                                                                                               
  yarn test             # PASS — 259 suites, 2409 tests                                                                                              
                                                            
  Checklist                                                                                                                                          
                                                            
  - This pull request targets develop.                                                                                                               
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
  - I updated documentation, locales, or generators if the change requires it.                                                                       
  - I added or adjusted tests that cover the change.                                                                                                 
  - I added or updated integration tests in .ai/qa/tests/ (or documented why integration coverage is not required): guard is a pure in-process
  authorization helper with no HTTP surface of its own; the calling route (/api/auth/roles) is covered by existing roles.route.test.ts.              
  - I created or updated the spec in .ai/specs/ with a changelog entry (if applicable): N/A.