### PR TITLE
fix(auth): reset attacker-controlled scope params on resolution failure and add auth.view guard to admin nav endpoint

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/admin-nav.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/admin-nav.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
-import { GET } from '@open-mercato/core/modules/auth/api/admin/nav'
+import { GET, metadata } from '@open-mercato/core/modules/auth/api/admin/nav'
+import * as backendChrome from '@open-mercato/core/modules/auth/lib/backendChrome'
 
 type AuthContext = {
   sub: string
@@ -364,5 +365,83 @@ describe('GET /api/auth/admin/nav', () => {
 
     expect(customerPortalGroup?.items.map((item) => item.href)).toContain('/backend/customer_accounts/users')
     expect(mockUserHasAllFeatures).toHaveBeenCalled()
+  })
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetAuthFromRequest.mockResolvedValue(null)
+    const response = await GET(makeRequest())
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('requires auth.view feature in GET metadata (Finding 2 — CWE-284)', () => {
+    expect(metadata.GET.requireAuth).toBe(true)
+    expect(metadata.GET.requireFeatures).toContain('auth.view')
+  })
+
+  describe('security: scope fallback when resolveFeatureCheckContext throws', () => {
+    const minimalChromePayload = {
+      groups: [],
+      settingsSections: [],
+      settingsPathPrefixes: [],
+      profileSections: [],
+      profilePathPrefixes: [],
+      grantedFeatures: [],
+      roles: [],
+    }
+
+    let resolveBackendChromePayloadSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      mockGetBackendRouteManifests.mockReturnValue([])
+      resolveBackendChromePayloadSpy = jest
+        .spyOn(backendChrome, 'resolveBackendChromePayload')
+        .mockResolvedValue(minimalChromePayload)
+    })
+
+    afterEach(() => {
+      resolveBackendChromePayloadSpy.mockRestore()
+    })
+
+    it('resets attacker-supplied orgId and tenantId to auth values when scope resolution throws', async () => {
+      mockResolveFeatureCheckContext.mockRejectedValueOnce(new Error('scope resolution failed'))
+
+      const req = new Request(
+        'http://localhost/api/auth/admin/nav?orgId=attacker-org&tenantId=attacker-tenant',
+        { method: 'GET' },
+      )
+      const response = await GET(req)
+
+      expect(response.status).toBe(200)
+      expect(resolveBackendChromePayloadSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedOrganizationId: 'org-1',
+          selectedTenantId: 'tenant-1',
+        }),
+      )
+    })
+
+    it('never forwards attacker-controlled tenantId to chrome payload when scope resolution fails', async () => {
+      mockResolveFeatureCheckContext.mockRejectedValueOnce(new Error('db timeout'))
+
+      const req = new Request(
+        'http://localhost/api/auth/admin/nav?orgId=any-org&tenantId=victim-tenant',
+        { method: 'GET' },
+      )
+      await GET(req)
+
+      expect(resolveBackendChromePayloadSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ selectedTenantId: 'victim-tenant' }),
+      )
+    })
+
+    it('still returns a successful response after scope resolution failure', async () => {
+      mockResolveFeatureCheckContext.mockRejectedValueOnce(new Error('network error'))
+
+      const response = await GET(makeRequest())
+
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toMatchObject(minimalChromePayload)
+    })
   })
 })

--- a/packages/core/src/modules/auth/api/admin/nav.ts
+++ b/packages/core/src/modules/auth/api/admin/nav.ts
@@ -9,7 +9,7 @@ import { resolveFeatureCheckContext } from '@open-mercato/core/modules/directory
 import { groupBackendRoutesByModule, resolveBackendChromePayload } from '../../lib/backendChrome'
 
 export const metadata = {
-  GET: { requireAuth: true },
+  GET: { requireAuth: true, requireFeatures: ['auth.view'] },
 }
 
 const sidebarNavItemSchema: z.ZodType<{
@@ -123,6 +123,8 @@ export async function GET(req: Request) {
   } catch {
     cacheScopeOrganizationId = auth.orgId ?? null
     cacheScopeTenantId = auth.tenantId ?? null
+    selectedOrganizationId = auth.orgId ?? null
+    selectedTenantId = auth.tenantId ?? null
   }
 
   const cacheKey = `nav:sidebar:${locale}:${auth.sub}:${cacheScopeTenantId || 'null'}:${cacheScopeOrganizationId || 'null'}`


### PR DESCRIPTION
# Opis problemu
W endpoincie GET /api/auth/admin/nav wykryto dwa problemy bezpieczeństwa:

1. TOCTOU-like scope inconsistency
Parametry orgId i tenantId pobierane z query stringa (attacker-controlled) były przechowywane w zmiennych selectedOrganizationId / selectedTenantId. W bloku catch po nieudanym wywołaniu resolveFeatureCheckContext resetowane były jedynie zmienne używane do budowania klucza cache (cacheScopeOrganizationId, cacheScopeTenantId). Zmienne selectedOrganizationId / selectedTenantId nie były resetowane i trafiały bez zmian do resolveBackendChromePayload.

2. Brak minimalnego guardu uprawnień
Metadata endpointu wymuszała jedynie requireAuth: true. Żaden requireFeatures nie był zadeklarowany, mimo że endpoint serwuje dane bootstrap admina (lista przyznanych feature'ów, role). Każdy uwierzytelniony użytkownik — niezależnie od uprawnień — mógł wywołać endpoint.

# Konsekwencje problemu
Ad. 1 — Jeśli resolveFeatureCheckContext rzuciło wyjątek z dowolnego powodu (timeout bazy, nieistniejąca org, celowe wyczerpanie zasobu), payload nawigacji był obliczany dla organizacji / tenanta dostarczonego przez atakującego, nie dla kontekstu zalogowanego użytkownika. Wynik nie trafiał do cache pod kluczem atakowanego tenanta, więc atak nie zostawiał śladów. Scenariusz pozwala na cross-tenant information disclosure — ujawnienie struktury modułów, ścieżek routingu i nazw sekcji innego tenanta.

Ad. 2 — Użytkownicy z minimalnym dostępem (np. read-only, konta portalu klienckiego z tokenem backendu) mogli enumerować pełną listę grantedFeatures i roles swojego konta poprzez ten endpoint.

# Zaaplikowana poprawka
Ad. 1 — W bloku catch po nieudanym resolveFeatureCheckContext dodano reset selectedOrganizationId i selectedTenantId do wartości z zweryfikowanego obiektu auth:


```
} catch {
  cacheScopeOrganizationId = auth.orgId ?? null
  cacheScopeTenantId = auth.tenantId ?? null
  selectedOrganizationId = auth.orgId ?? null   // ← dodane
  selectedTenantId = auth.tenantId ?? null       // ← dodane
}
```

Ad. 2 — Do metadata endpointu dodano requireFeatures: ['auth.view'], ograniczając dostęp do użytkowników z uprawnieniem backendowym:


```
export const metadata = {
  GET: { requireAuth: true, requireFeatures: ['auth.view'] },
}
```

Obu poprawkom towarzyszą testy jednostkowe weryfikujące: reset scope'u do wartości auth przy błędzie resolution, brak forwarding attacker-controlled tenantId do payloadu oraz poprawność deklaracji requireFeatures w metadata.