### PR TITLE
fix(customers): return 422 for deal UUID passed as timeline entityId

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/shared.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/shared.test.ts
@@ -1,7 +1,9 @@
 import * as shared from '../shared'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import {
+  CustomerDeal,
   CustomerDictionaryEntry,
+  CustomerEntity,
   CustomerTag,
   CustomerTagAssignment,
 } from '../../data/entities'
@@ -12,6 +14,7 @@ const {
   ensureSameScope,
   extractUndoPayload,
   assertFound,
+  requireTimelineParentEntity,
   ensureDictionaryEntry,
   loadEntityTagIds,
   syncEntityTags,
@@ -61,6 +64,58 @@ describe('customers commands shared utilities', () => {
       const record = { id: '123' }
       expect(assertFound(record, 'Missing')).toBe(record)
       expect(() => assertFound(null, 'Missing')).toThrow(CrudHttpError)
+    })
+  })
+
+  describe('requireTimelineParentEntity', () => {
+    const personEntity = Object.assign(new CustomerEntity(), { id: 'person-1', kind: 'person' as const })
+    const companyEntity = Object.assign(new CustomerEntity(), { id: 'company-1', kind: 'company' as const })
+    const invalidKindEntity = Object.assign(new CustomerEntity(), { id: 'weird-1', kind: 'lead' as any })
+    const dealRecord = Object.assign(new CustomerDeal(), { id: 'deal-1' })
+
+    function makeEm(lookups: { entity?: unknown; deal?: unknown }) {
+      return {
+        findOne: jest.fn(async (cls: unknown) => {
+          if (cls === CustomerEntity) return lookups.entity ?? null
+          if (cls === CustomerDeal) return lookups.deal ?? null
+          return null
+        }),
+      }
+    }
+
+    it('returns a person or company entity', async () => {
+      const personEm = makeEm({ entity: personEntity })
+      const companyEm = makeEm({ entity: companyEntity })
+
+      await expect(requireTimelineParentEntity(personEm as any, 'person-1')).resolves.toBe(personEntity)
+      await expect(requireTimelineParentEntity(companyEm as any, 'company-1')).resolves.toBe(companyEntity)
+    })
+
+    it('throws 422 when entityId belongs to a deal record', async () => {
+      const em = makeEm({ deal: dealRecord })
+
+      await expect(requireTimelineParentEntity(em as any, 'deal-1')).rejects.toMatchObject({
+        status: 422,
+        body: { error: 'entityId must reference a person or company, not a deal' },
+      })
+    })
+
+    it('throws 404 when neither a customer entity nor a deal exists', async () => {
+      const em = makeEm({})
+
+      await expect(requireTimelineParentEntity(em as any, 'missing-1')).rejects.toMatchObject({
+        status: 404,
+        body: { error: 'Customer not found' },
+      })
+    })
+
+    it('throws 422 when the customer entity exists with an unsupported kind', async () => {
+      const em = makeEm({ entity: invalidKindEntity })
+
+      await expect(requireTimelineParentEntity(em as any, 'weird-1')).rejects.toMatchObject({
+        status: 422,
+        body: { error: 'entityId must reference a person or company' },
+      })
     })
   })
 
@@ -260,4 +315,3 @@ describe('customers commands shared utilities', () => {
     })
   })
 })
-

--- a/packages/core/src/modules/customers/commands/comments.ts
+++ b/packages/core/src/modules/customers/commands/comments.ts
@@ -8,7 +8,7 @@ import { commentCreateSchema, commentUpdateSchema, type CommentCreateInput, type
 import {
   ensureOrganizationScope,
   ensureTenantScope,
-  requireCustomerEntity,
+  requireTimelineParentEntity,
   ensureSameScope,
   extractUndoPayload,
   requireDealInScope,
@@ -82,7 +82,7 @@ const createCommentCommand: CommandHandler<CommentCreateInput, { commentId: stri
     const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId, ctx.auth)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entity = await requireCustomerEntity(em, parsed.entityId, undefined, 'Customer not found')
+    const entity = await requireTimelineParentEntity(em, parsed.entityId)
     ensureSameScope(entity, parsed.organizationId, parsed.tenantId)
     const deal = await requireDealInScope(em, parsed.dealId, parsed.tenantId, parsed.organizationId)
 
@@ -169,7 +169,7 @@ const updateCommentCommand: CommandHandler<CommentUpdateInput, { commentId: stri
     ensureOrganizationScope(ctx, comment.organizationId)
 
     if (parsed.entityId !== undefined) {
-      const entity = await requireCustomerEntity(em, parsed.entityId, undefined, 'Customer not found')
+      const entity = await requireTimelineParentEntity(em, parsed.entityId)
       ensureSameScope(entity, comment.organizationId, comment.tenantId)
       comment.entity = entity
     }
@@ -241,7 +241,7 @@ const updateCommentCommand: CommandHandler<CommentUpdateInput, { commentId: stri
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let comment = await em.findOne(CustomerComment, { id: before.id })
-    const entity = await requireCustomerEntity(em, before.entityId, undefined, 'Customer not found')
+    const entity = await requireTimelineParentEntity(em, before.entityId)
     const deal = await requireDealInScope(em, before.dealId, before.tenantId, before.organizationId)
 
     if (!comment) {
@@ -344,7 +344,7 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const entity = await requireCustomerEntity(em, before.entityId, undefined, 'Customer not found')
+      const entity = await requireTimelineParentEntity(em, before.entityId)
       const deal = await requireDealInScope(em, before.dealId, before.tenantId, before.organizationId)
       let comment = await em.findOne(CustomerComment, { id: before.id })
       if (!comment) {

--- a/packages/core/src/modules/customers/commands/interactions.ts
+++ b/packages/core/src/modules/customers/commands/interactions.ts
@@ -26,7 +26,7 @@ import {
 import {
   ensureOrganizationScope,
   ensureTenantScope,
-  requireCustomerEntity,
+  requireTimelineParentEntity,
   extractUndoPayload,
   emitQueryIndexUpsertEvents,
   requireDealInScope,
@@ -259,7 +259,7 @@ const createInteractionCommand: CommandHandler<InteractionCreateInput, { interac
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId ?? null, ctx.auth)
     const { interaction, entityId } = await runInTransaction(em, async (trx) => {
-      const entity = await requireCustomerEntity(trx, parsed.entityId, undefined, 'Customer not found')
+      const entity = await requireTimelineParentEntity(trx, parsed.entityId)
       ensureTenantScope(ctx, entity.tenantId)
       ensureOrganizationScope(ctx, entity.organizationId)
 
@@ -491,7 +491,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const { interaction, nextInteractionId } = await runInTransaction(em, async (trx) => {
       let interaction = await trx.findOne(CustomerInteraction, { id: before.interaction.id })
-      const entity = await requireCustomerEntity(trx, before.interaction.entityId, undefined, 'Customer not found')
+      const entity = await requireTimelineParentEntity(trx, before.interaction.entityId)
 
       if (!interaction) {
         interaction = trx.create(CustomerInteraction, {
@@ -918,7 +918,7 @@ const deleteInteractionCommand: CommandHandler<{ body?: Record<string, unknown>;
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const { interaction, nextInteractionId } = await runInTransaction(em, async (trx) => {
-        const entity = await requireCustomerEntity(trx, before.interaction.entityId, undefined, 'Customer not found')
+        const entity = await requireTimelineParentEntity(trx, before.interaction.entityId)
         let interaction = await trx.findOne(CustomerInteraction, { id: before.interaction.id })
         if (!interaction) {
           interaction = trx.create(CustomerInteraction, {
@@ -1018,7 +1018,7 @@ const recomputeNextCommand: CommandHandler<{ entityId: string }, { entityId: str
     const parsed = recomputeNextSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const projection = await recomputeNextInteraction(em, parsed.entityId)
-    const entity = await requireCustomerEntity(em, parsed.entityId, undefined, 'Customer not found')
+    const entity = await requireTimelineParentEntity(em, parsed.entityId)
     await emitNextInteractionUpdatedEvent(ctx, {
       entityId: parsed.entityId,
       nextInteractionId: projection.nextInteractionId,

--- a/packages/core/src/modules/customers/commands/shared.ts
+++ b/packages/core/src/modules/customers/commands/shared.ts
@@ -39,6 +39,24 @@ export async function requireCustomerEntity(
   return entity
 }
 
+export async function requireTimelineParentEntity(
+  em: EntityManager,
+  id: string,
+): Promise<CustomerEntity> {
+  const entity = await em.findOne(CustomerEntity, { id, deletedAt: null })
+  if (entity) {
+    if (entity.kind !== 'person' && entity.kind !== 'company') {
+      throw new CrudHttpError(422, { error: 'entityId must reference a person or company' })
+    }
+    return entity
+  }
+  const deal = await em.findOne(CustomerDeal, { id, deletedAt: null })
+  if (deal) {
+    throw new CrudHttpError(422, { error: 'entityId must reference a person or company, not a deal' })
+  }
+  throw new CrudHttpError(404, { error: 'Customer not found' })
+}
+
 export async function syncEntityTags(
   em: EntityManager,
   entity: CustomerEntity,


### PR DESCRIPTION
## Summary

Timeline write endpoints were returning a misleading `404 Customer not found` when `entityId` contained a deal UUID. This change adds timeline-specific validation so comments and activities return a clear `422 Unprocessable Entity` when `entityId` points to a deal instead of a person or company.

## Testing

Added unit coverage in `packages/core/src/modules/customers/commands/__tests__/shared.test.ts` for:
- valid person/company entity lookup
- deal UUID returning `422`
- unknown UUID returning `404`
- unsupported entity kind returning `422`

Executed:
```bash
yarn jest packages/core/src/modules/customers/commands/__tests__/shared.test.ts --runInBand
```

Result: `19/19` tests passed.

## Spec / Docs

No spec or documentation update needed for this narrow validation fix.

## Linked issues

Fixes #794