### PR TITLE
fix(auth): prevent open redirect in locale switch endpoint

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/locale.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/locale.route.test.ts
@@ -1,0 +1,120 @@
+/** @jest-environment node */
+import { GET, POST } from '@open-mercato/core/modules/auth/api/locale/route'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback?: string) => fallback ?? '',
+    translate: (_key: string, fallback?: string) => fallback ?? '',
+  }),
+}))
+
+const BASE = 'https://app.example.com'
+
+function makeGetRequest(params: Record<string, string>) {
+  const url = new URL('/api/auth/locale', BASE)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value)
+  }
+  return new Request(url.toString())
+}
+
+describe('GET /api/auth/locale — open redirect fix (CWE-601)', () => {
+  describe('redirect safety', () => {
+    it('redirects to the given path when redirect is a same-origin relative path', async () => {
+      const res = await GET(makeGetRequest({ locale: 'en', redirect: '/dashboard' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toBe(`${BASE}/dashboard`)
+    })
+
+    it('redirects to / when redirect points to an external domain', async () => {
+      const res = await GET(makeGetRequest({ locale: 'en', redirect: 'https://evil.com/fake-login' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toBe(`${BASE}/`)
+    })
+
+    it('redirects to / when redirect uses a protocol-relative URL targeting another host', async () => {
+      const res = await GET(makeGetRequest({ locale: 'en', redirect: '//evil.com/steal' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toBe(`${BASE}/`)
+    })
+
+    it('redirects to / when redirect is omitted', async () => {
+      const res = await GET(makeGetRequest({ locale: 'en' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toBe(`${BASE}/`)
+    })
+
+    it('redirects to / when redirect uses javascript: scheme', async () => {
+      const res = await GET(makeGetRequest({ locale: 'en', redirect: 'javascript:alert(1)' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toBe(`${BASE}/`)
+    })
+
+    it('preserves query string on same-origin redirect', async () => {
+      const res = await GET(makeGetRequest({ locale: 'en', redirect: '/orders?page=2&filter=open' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toBe(`${BASE}/orders?page=2&filter=open`)
+    })
+  })
+
+  describe('locale validation', () => {
+    it('sets locale cookie on valid locale', async () => {
+      const res = await GET(makeGetRequest({ locale: 'pl', redirect: '/' }))
+
+      expect(res.status).toBe(307)
+      expect(res.headers.get('set-cookie')).toContain('locale=pl')
+    })
+
+    it('returns 400 for an unsupported locale', async () => {
+      const res = await GET(makeGetRequest({ locale: 'xx', redirect: '/' }))
+
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when locale is missing', async () => {
+      const res = await GET(makeGetRequest({ redirect: '/' }))
+
+      expect(res.status).toBe(400)
+    })
+  })
+})
+
+describe('POST /api/auth/locale', () => {
+  it('sets locale cookie and returns ok for a valid locale', async () => {
+    const res = await POST(new Request(`${BASE}/api/auth/locale`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ locale: 'de' }),
+    }))
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true })
+    expect(res.headers.get('set-cookie')).toContain('locale=de')
+  })
+
+  it('returns 400 for an unsupported locale', async () => {
+    const res = await POST(new Request(`${BASE}/api/auth/locale`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ locale: 'xx' }),
+    }))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 for malformed JSON body', async () => {
+    const res = await POST(new Request(`${BASE}/api/auth/locale`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not-json',
+    }))
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/core/src/modules/auth/api/locale/route.ts
+++ b/packages/core/src/modules/auth/api/locale/route.ts
@@ -24,6 +24,17 @@ export async function POST(req: Request) {
   }
 }
 
+function resolveSafeRedirectPath(rawRedirect: string | null, origin: string): string {
+  const raw = rawRedirect ?? '/'
+  try {
+    const resolved = new URL(raw, origin)
+    if (resolved.origin !== origin) return '/'
+    return resolved.pathname + resolved.search
+  } catch {
+    return '/'
+  }
+}
+
 export async function GET(req: Request) {
   const { t } = await resolveTranslations()
   const url = new URL(req.url)
@@ -31,7 +42,8 @@ export async function GET(req: Request) {
   if (!locale || !supportedLocales.has(locale as Locale)) {
     return NextResponse.json({ error: t('api.errors.invalidLocale', 'Invalid locale') }, { status: 400 })
   }
-  const res = NextResponse.redirect(url.searchParams.get('redirect') || '/')
+  const safePath = resolveSafeRedirectPath(url.searchParams.get('redirect'), url.origin)
+  const res = NextResponse.redirect(new URL(safePath, url.origin))
   res.cookies.set('locale', locale as Locale, { path: '/', maxAge: 60 * 60 * 24 * 365 })
   return res
 }


### PR DESCRIPTION
  ## Summary                                                

  `GET /api/auth/locale` is an unauthenticated endpoint that sets a locale                                                                           
  cookie and redirects the user. The `redirect` query parameter was passed
  verbatim to `NextResponse.redirect()` with no origin check — allowing an                                                                           
  attacker to craft a trusted-domain link that silently redirected victims                                                                           
  to any external site (classic open redirect / phishing vector).                                                                                    
                                                                                                                                                     
  The fix adds `resolveSafeRedirectPath()`: it resolves the supplied value                                                                           
  against the server's own origin and rejects anything that resolves to a                                                                            
  different origin, falling back to `/`.                                                                                                             
                                                                                                                                                     
  ## Changes
                                                                                                                                                     
  - `packages/core/src/modules/auth/api/locale/route.ts` — extracted `resolveSafeRedirectPath()` helper that validates the redirect target is        
  same-origin before using it; replaced the raw `url.searchParams.get('redirect')` redirect with the safe path
  - `packages/core/src/modules/auth/api/__tests__/locale.route.test.ts` — new test file with 12 unit tests covering redirect safety (external domain,
   protocol-relative URL, `javascript:` scheme, missing param, same-origin with query string) and locale validation for both GET and POST handlers   
  
  ## Specification                                                                                                                                   
                                                            
  **Does a spec exist for this feature/module?**
  - [x] N/A (minor change, no spec needed)
                                                                                                                                                     
  ## Testing
                                                                                                                                                     
  ```bash                                                   
  # Unit tests — all 12 pass
  npx jest src/modules/auth/api/__tests__/locale.route.test.ts                                                                                       
  
  # Full CI gates                                                                                                                                    
  yarn build:packages   # PASS — 18/18                      
  yarn generate         # PASS                                                                                                                       
  yarn typecheck        # PASS — 18/18                      
  yarn i18n:check-sync  # PASS — all 4 locales in sync                                                                                               
  yarn test             # PASS — 259 suites, 2410 tests                                                                                              
                                                                                                                                                     
  Checklist                                                                                                                                          
                                                            
  - This pull request targets develop.                                                                                                               
  - I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
  - I updated documentation, locales, or generators if the change requires it.                                                                       
  - I added or adjusted tests that cover the change.                                                                                                 
  - I added or updated integration tests in .ai/qa/tests/ (or documented why integration coverage is not required): resolveSafeRedirectPath is a pure
   function with no HTTP or DB surface; redirect safety is fully covered by unit tests across all relevant attack vectors.                           
  - I created or updated the spec in .ai/specs/ with a changelog entry (if applicable): N/A.