### PR TITLE
Fix/superadmin privilege escalation

### DIFF
--- a/packages/core/src/modules/auth/commands/roles.ts
+++ b/packages/core/src/modules/auth/commands/roles.ts
@@ -50,7 +50,7 @@ type RoleSnapshots = {
   undo: RoleUndoSnapshot
 }
 
-const RESERVED_ROLE_NAMES = new Set(['superadmin'])
+const RESERVED_ROLE_NAMES = new Set(['superadmin', 'admin'])
 
 function assertRoleNameAllowed(name: string | undefined | null) {
   if (typeof name !== 'string') return

--- a/packages/core/src/modules/auth/commands/roles.ts
+++ b/packages/core/src/modules/auth/commands/roles.ts
@@ -50,6 +50,17 @@ type RoleSnapshots = {
   undo: RoleUndoSnapshot
 }
 
+const RESERVED_ROLE_NAMES = new Set(['superadmin'])
+
+function assertRoleNameAllowed(name: string | undefined | null) {
+  if (typeof name !== 'string') return
+  const normalized = name.trim().toLowerCase()
+  if (!normalized) return
+  if (RESERVED_ROLE_NAMES.has(normalized)) {
+    throw new CrudHttpError(400, { error: 'Role name is reserved' })
+  }
+}
+
 const createSchema = z.object({
   name: z.string().min(2).max(100),
   tenantId: z.string().uuid().nullable().optional(),
@@ -89,6 +100,7 @@ const createRoleCommand: CommandHandler<Record<string, unknown>, Role> = {
   id: 'auth.roles.create',
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(createSchema, rawInput)
+    assertRoleNameAllowed(parsed.name)
     const resolvedTenantId = parsed.tenantId === undefined ? ctx.auth?.tenantId ?? null : parsed.tenantId ?? null
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
     const role = await de.createOrmEntity({
@@ -201,8 +213,10 @@ const updateRoleCommand: CommandHandler<Record<string, unknown>, Role> = {
     const { parsed, custom } = parseWithCustomFields(updateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
     if (parsed.name !== undefined) {
+      assertRoleNameAllowed(parsed.name)
       const current = await em.findOne(Role, { id: parsed.id, deletedAt: null })
       if (!current) throw new CrudHttpError(404, { error: 'Role not found' })
+      assertRoleNameAllowed(current.name)
       const nextName = parsed.name
       if (nextName !== current.name) {
         const assignments = await em.count(UserRole, { role: current, deletedAt: null })
@@ -210,6 +224,10 @@ const updateRoleCommand: CommandHandler<Record<string, unknown>, Role> = {
           throw new CrudHttpError(400, { error: 'Role name cannot be changed while users are assigned' })
         }
       }
+    } else {
+      const current = await em.findOne(Role, { id: parsed.id, deletedAt: null })
+      if (!current) throw new CrudHttpError(404, { error: 'Role not found' })
+      assertRoleNameAllowed(current.name)
     }
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
     const role = await de.updateOrmEntity({

--- a/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { User } from '@open-mercato/core/modules/auth/data/entities'
+import { RoleAcl, User, UserAcl } from '@open-mercato/core/modules/auth/data/entities'
 import { isAuthContextValid, resolveCanonicalStaffAuthContext } from '@open-mercato/core/modules/auth/lib/sessionIntegrity'
 
 const findOneWithDecryption = jest.fn()
@@ -15,6 +15,24 @@ const tenantId = '22222222-2222-4222-8222-222222222222'
 const organizationId = '33333333-3333-4333-8333-333333333333'
 const scopedTenantId = '44444444-4444-4444-8444-444444444444'
 const scopedOrganizationId = '55555555-5555-4555-8555-555555555555'
+const adminRoleId = '66666666-6666-4666-8666-666666666666'
+const impostorRoleId = '77777777-7777-4777-8777-777777777777'
+
+type MockStore = {
+  user?: unknown
+  userAcl?: unknown
+  roleAcl?: unknown
+}
+
+function mockFindOneByEntity(store: MockStore) {
+  findOneWithDecryption.mockImplementation(async (...args: unknown[]) => {
+    const entity = args[1]
+    if (entity === User) return store.user ?? null
+    if (entity === UserAcl) return store.userAcl ?? null
+    if (entity === RoleAcl) return store.roleAcl ?? null
+    return null
+  })
+}
 
 describe('isAuthContextValid', () => {
   const em = {} as EntityManager
@@ -25,11 +43,7 @@ describe('isAuthContextValid', () => {
   })
 
   it('accepts a user that still exists in the same tenant and organization', async () => {
-    findOneWithDecryption.mockResolvedValue({
-      id: userId,
-      tenantId,
-      organizationId,
-    })
+    mockFindOneByEntity({ user: { id: userId, tenantId, organizationId } })
 
     await expect(
       isAuthContextValid(em, { sub: userId, tenantId, orgId: organizationId, roles: [] }),
@@ -45,14 +59,13 @@ describe('isAuthContextValid', () => {
   })
 
   it('returns canonical auth with roles refreshed from the database', async () => {
-    findOneWithDecryption.mockResolvedValue({
-      id: userId,
-      tenantId,
-      organizationId,
+    mockFindOneByEntity({
+      user: { id: userId, tenantId, organizationId },
+      roleAcl: { isSuperAdmin: true },
     })
     findWithDecryption.mockResolvedValue([
-      { role: { name: 'admin' } },
-      { role: { name: 'superadmin' } },
+      { role: { id: adminRoleId, name: 'admin' } },
+      { role: { id: impostorRoleId, name: 'superadmin' } },
     ])
 
     await expect(
@@ -71,8 +84,57 @@ describe('isAuthContextValid', () => {
     })
   })
 
+  it('does not elevate a user whose role is merely named "superadmin" without a RoleAcl flag', async () => {
+    mockFindOneByEntity({
+      user: { id: userId, tenantId, organizationId },
+    })
+    findWithDecryption.mockResolvedValue([
+      { role: { id: impostorRoleId, name: 'Superadmin' } },
+    ])
+
+    await expect(
+      resolveCanonicalStaffAuthContext(em, {
+        sub: userId,
+        tenantId,
+        orgId: organizationId,
+        roles: ['Superadmin'],
+      }),
+    ).resolves.toEqual({
+      sub: userId,
+      tenantId,
+      orgId: organizationId,
+      roles: ['Superadmin'],
+      isSuperAdmin: false,
+    })
+  })
+
+  it('elevates a user whose role has UserAcl.isSuperAdmin flag set', async () => {
+    mockFindOneByEntity({
+      user: { id: userId, tenantId, organizationId },
+      userAcl: { isSuperAdmin: true },
+    })
+    findWithDecryption.mockResolvedValue([
+      { role: { id: adminRoleId, name: 'admin' } },
+    ])
+
+    await expect(
+      resolveCanonicalStaffAuthContext(em, {
+        sub: userId,
+        tenantId,
+        orgId: organizationId,
+        roles: ['admin'],
+      }),
+    ).resolves.toEqual({
+      sub: userId,
+      tenantId,
+      orgId: organizationId,
+      roles: ['admin'],
+      isSuperAdmin: true,
+    })
+  })
+
   it('rejects an auth context when the user no longer exists', async () => {
-    findOneWithDecryption.mockResolvedValue(null)
+    mockFindOneByEntity({ user: null })
 
     await expect(
       isAuthContextValid(em, { sub: userId, tenantId, orgId: organizationId, roles: [] }),
@@ -80,10 +142,8 @@ describe('isAuthContextValid', () => {
   })
 
   it('rejects an auth context when the persisted tenant or organization changed', async () => {
-    findOneWithDecryption.mockResolvedValue({
-      id: userId,
-      tenantId,
-      organizationId: scopedOrganizationId,
+    mockFindOneByEntity({
+      user: { id: userId, tenantId, organizationId: scopedOrganizationId },
     })
 
     await expect(
@@ -92,11 +152,13 @@ describe('isAuthContextValid', () => {
   })
 
   it('validates superadmin scoped sessions against actor scope, not selected scope', async () => {
-    findOneWithDecryption.mockResolvedValue({
-      id: userId,
-      tenantId,
-      organizationId,
+    mockFindOneByEntity({
+      user: { id: userId, tenantId, organizationId },
+      roleAcl: { isSuperAdmin: true },
     })
+    findWithDecryption.mockResolvedValue([
+      { role: { id: adminRoleId, name: 'admin' } },
+    ])
 
     await expect(
       isAuthContextValid(em, {
@@ -105,7 +167,7 @@ describe('isAuthContextValid', () => {
         orgId: scopedOrganizationId,
         actorTenantId: tenantId,
         actorOrgId: organizationId,
-        roles: ['superadmin'],
+        roles: ['admin'],
         isSuperAdmin: true,
       }),
     ).resolves.toBe(true)

--- a/packages/core/src/modules/auth/lib/sessionIntegrity.ts
+++ b/packages/core/src/modules/auth/lib/sessionIntegrity.ts
@@ -1,7 +1,7 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { Role, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl, User, UserAcl, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const INVALID_SCOPE = Symbol('invalid-scope')
@@ -78,9 +78,17 @@ export async function resolveCanonicalStaffAuthContext(
       )
     : []
 
-  const roles = links
-    .map((link) => link.role?.name)
-    .filter((role): role is string => typeof role === 'string' && role.trim().length > 0)
+  const linkedRoles = links
+    .map((link) => link.role)
+    .filter((role): role is Role => !!role)
+
+  const roles = linkedRoles
+    .map((role) => role.name)
+    .filter((name): name is string => typeof name === 'string' && name.trim().length > 0)
+
+  const isSuperAdmin = currentTenantId
+    ? await hasSuperAdminFlag(em, user.id, linkedRoles, currentTenantId, currentOrganizationId)
+    : false
 
   return {
     ...auth,
@@ -88,8 +96,55 @@ export async function resolveCanonicalStaffAuthContext(
     tenantId: currentTenantId,
     orgId: currentOrganizationId,
     roles,
-    isSuperAdmin: roles.some((role) => role.trim().toLowerCase() === 'superadmin'),
+    isSuperAdmin,
   }
+}
+
+async function hasSuperAdminFlag(
+  em: EntityManager,
+  userId: string,
+  linkedRoles: Role[],
+  tenantId: string,
+  organizationId: string | null,
+): Promise<boolean> {
+  const userAcl = await findOneWithDecryption(
+    em,
+    UserAcl,
+    {
+      user: userId,
+      tenantId,
+      isSuperAdmin: true,
+      deletedAt: null,
+    } as never,
+    undefined,
+    { tenantId, organizationId },
+  )
+  if (userAcl && (userAcl as { isSuperAdmin?: boolean }).isSuperAdmin === true) {
+    return true
+  }
+
+  const roleIds = Array.from(
+    new Set(
+      linkedRoles
+        .map((role) => (role?.id ? String(role.id) : null))
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  )
+  if (!roleIds.length) return false
+
+  const roleAcl = await findOneWithDecryption(
+    em,
+    RoleAcl,
+    {
+      tenantId,
+      isSuperAdmin: true,
+      deletedAt: null,
+      role: { $in: roleIds },
+    } as never,
+    undefined,
+    { tenantId, organizationId },
+  )
+  return !!(roleAcl && (roleAcl as { isSuperAdmin?: boolean }).isSuperAdmin === true)
 }
 
 export async function isAuthContextValid(

--- a/packages/shared/src/lib/auth/server.ts
+++ b/packages/shared/src/lib/auth/server.ts
@@ -73,9 +73,7 @@ function resolveOrganizationOverride(raw: string | undefined): CookieOverride {
 
 function isSuperAdminAuth(auth: AuthContext | null | undefined): boolean {
   if (!auth) return false
-  if ((auth as Record<string, unknown>).isSuperAdmin === true) return true
-  const roles = Array.isArray(auth?.roles) ? auth.roles : []
-  return roles.some((role) => typeof role === 'string' && role.trim().toLowerCase() === SUPERADMIN_ROLE)
+  return (auth as Record<string, unknown>).isSuperAdmin === true
 }
 
 function applySuperAdminScope(
@@ -118,7 +116,7 @@ async function resolveApiKeyAuth(secret: string): Promise<AuthContext> {
     const container = await createRequestContainer()
     const em = (container.resolve('em') as EntityManager)
     const { findApiKeyBySecret } = await import('@open-mercato/core/modules/api_keys/services/apiKeyService')
-    const { Role, User } = await import('@open-mercato/core/modules/auth/data/entities')
+    const { Role, RoleAcl, User } = await import('@open-mercato/core/modules/auth/data/entities')
     const { Organization, Tenant } = await import('@open-mercato/core/modules/directory/data/entities')
 
     const record = await findApiKeyBySecret(em, secret)
@@ -131,6 +129,15 @@ async function resolveApiKeyAuth(secret: string): Promise<AuthContext> {
       ? await em.find(Role, { id: { $in: roleIds }, deletedAt: null })
       : []
     const roleNames = roles.map((role) => role.name).filter((name): name is string => typeof name === 'string' && name.length > 0)
+
+    let keyIsSuperAdmin = false
+    if (roleIds.length) {
+      const superAcl = await em.findOne(
+        RoleAcl,
+        { role: { $in: roleIds } as any, isSuperAdmin: true, deletedAt: null } as any,
+      )
+      keyIsSuperAdmin = !!(superAcl && (superAcl as { isSuperAdmin?: boolean }).isSuperAdmin)
+    }
 
     try {
       record.lastUsedAt = new Date()
@@ -165,6 +172,7 @@ async function resolveApiKeyAuth(secret: string): Promise<AuthContext> {
       orgId: record.organizationId ?? null,
       roles: roleNames,
       isApiKey: true,
+      isSuperAdmin: keyIsSuperAdmin,
       keyId: record.id,
       keyName: record.name,
       ...(actualUserId ? { userId: actualUserId } : {}),


### PR DESCRIPTION
## Summary                                                                                                                                                              
                                                            
  Closes a privilege escalation chain that let a tenant-scoped admin impersonate
  a global super admin and then pivot into any other tenant through the scope
  cookies.                                                                                                                                                                
                                                                                                                                                                          
  The chain had three cooperating bugs:                                                                                                                                   
                                                                                                                                                                          
  1. `sessionIntegrity.ts` derived `isSuperAdmin` from the role **name**                                                                                                  
     (`role.trim().toLowerCase() === 'superadmin'`) instead of a DB flag.
  2. `commands/roles.ts` did not prevent tenants from creating or renaming a                                                                                              
     role to `Superadmin` (or `admin`), so producing the magic name was trivial.                                                                                          
  3. `applySuperAdminScope` honoured `om_selected_tenant` / `om_selected_org`                                                                                             
     cookies as long as the auth context *claimed* superadmin, which turned                                                                                               
     the name-based flag into full cross-tenant takeover.                                                                                                                 
                                                                                                                                                                          
  ## Fix                                                                                                                                                                  
                                                                                                                                                                          
  - **`packages/core/src/modules/auth/lib/sessionIntegrity.ts`**                                                                                                          
    `isSuperAdmin` is now derived from `RoleAcl.isSuperAdmin` / `UserAcl.isSuperAdmin`
    boolean columns only. Role names are ignored. The new `hasSuperAdminFlag()`                                                                                           
    helper queries both tables with tenant-scoped decryption helpers and is only                                                                                          
    called after canonical tenant/organization validation.                                                                                                                
                                                                                                                                                                          
  - **`packages/core/src/modules/auth/commands/roles.ts`**                                                                                                                
    New `RESERVED_ROLE_NAMES = new Set(['superadmin', 'admin'])` + `assertRoleNameAllowed()`.                                                                             
    `createRoleCommand.execute` blocks reserved names on the input.                                                                                                       
    `updateRoleCommand.execute` blocks them on both the requested new name **and**                                                                                        
    the current name of the target role (defence in depth — cannot rename *away*                                                                                          
    from a reserved name either, cannot edit an existing reserved role through                                                                                            
    the command path). The seed path (`setup-app.ts`) uses `em.create(Role)`                                                                                              
    directly and is unaffected.                                                                                                                                           
                                                                                                                                                                          
  - **`packages/shared/src/lib/auth/server.ts`**                                                                                                                          
    `isSuperAdminAuth()` no longer falls back to checking the `roles` array for                                                                                           
    the string `superadmin` — it only trusts `auth.isSuperAdmin === true`.                                                                                                
    `resolveApiKeyAuth()` now computes `keyIsSuperAdmin` from `RoleAcl.isSuperAdmin`                                                                                      
    on the key's linked roles, so API-key callers follow the same contract.                                                                                               
                                                                                                                                                                          
  Net effect: the only way to become a super admin is to have a `RoleAcl` or                                                                                              
  `UserAcl` row with `is_super_admin = true`, which is only set by seed/migration                                                                                         
  or by an existing super admin through the already-guarded                                                                                                               
  `PUT /api/auth/roles/acl` route.                                                                                                                                        
                                                                                                                                                                          
  ## Test plan                                                                                                                                                            
                                                                                                                                                                          
  - [x] `packages/core`: `npx jest src/modules/auth/` — 18 suites, 109 tests, all green                                                                                   
  - [x] New unit coverage in `sessionIntegrity.test.ts`:
    - rejects a user whose role is merely *named* `superadmin` without a `RoleAcl` flag                                                                                   
    - elevates a user with `UserAcl.isSuperAdmin = true`                                                                                                                  
    - existing scope-override and api-key tests still pass                                                                                                                
  - [x] `yarn typecheck` — 18/18 packages, exit 0                                                                                                                         
  - [x] `yarn build` — packages + Next.js app, exit 0                                                                                                                     
                                                                                                                                                                          
  ## Backward compatibility                                                                                                                                               
                                                            
  - **Data model**: unchanged. Relies on existing `role_acls.is_super_admin` /                                                                                            
    `user_acls.is_super_admin` columns.                     
  - **Seeding**: `setup-app.ts` bypasses the command layer, so the default                                                                                                
    `superadmin` / `admin` / `employee` roles are still provisioned.                                                                                                      
  - **API**: `POST`/`PUT /api/auth/roles` now return `400 { error: 'Role name is reserved' }`                                                                             
    for `superadmin` and `admin` (case-insensitive). Any tenant currently trying                                                                                          
    to create such a role was already exploiting the vulnerability.                                                                                                       
  - **ACL writes**: super-admin flipping still goes through `PUT /api/auth/roles/acl`,                                                                                    
    which was already gated on the actor being a (DB-validated) super admin. 