### PR TITLE
Prevent Host Header Poisoning in Auth Security Email Links

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -28,6 +28,10 @@ NEXTAUTH_SECRET=
 
 # Public URL used in emails and onboarding flows
 APP_URL=http://localhost:3000
+# Additional trusted origins for app requests that must pass host validation.
+# APP_URL is required in production for security-sensitive email links.
+# Example: APP_ALLOWED_ORIGINS=https://admin.example.com,https://ops.example.com
+# APP_ALLOWED_ORIGINS=
 
 # Enable self-service onboarding (default: false)
 SELF_SERVICE_ONBOARDING_ENABLED=false

--- a/packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
@@ -77,10 +77,11 @@ const tenantB = 'b0b0b0b0-b0b0-4b0b-8b0b-b0b0b0b0b0b0'
 const userId = 'c0c0c0c0-c0c0-4c0c-8c0c-c0c0c0c0c0c0'
 const actorId = 'd0d0d0d0-d0d0-4d0d-8d0d-d0d0d0d0d0d0'
 const orgId = 'e0e0e0e0-e0e0-4e0e-8e0e-e0e0e0e0e0e0'
+const originalEnv = process.env
 
-function makeRequest(body: Record<string, unknown>) {
+function makeRequest(body: Record<string, unknown>, url = 'http://localhost/api/auth/users/resend-invite') {
   __readJsonBody.current = body
-  return new Request('http://localhost/api/auth/users/resend-invite', {
+  return new Request(url, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
@@ -101,6 +102,12 @@ function makeUser(overrides: Record<string, unknown> = {}) {
 describe('POST /api/auth/users/resend-invite', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      APP_URL: undefined,
+      NEXT_PUBLIC_APP_URL: undefined,
+      APP_ALLOWED_ORIGINS: undefined,
+    }
     mockGetAuthFromRequest.mockResolvedValue({
       sub: actorId,
       tenantId: tenantA,
@@ -114,6 +121,10 @@ describe('POST /api/auth/users/resend-invite', () => {
     mockPersistAndFlush.mockResolvedValue(undefined)
     mockNativeUpdate.mockResolvedValue(undefined)
     mockSendEmail.mockResolvedValue(undefined)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
   })
 
   test('returns 401 when unauthenticated', async () => {
@@ -208,5 +219,21 @@ describe('POST /api/auth/users/resend-invite', () => {
     const body = await res.json()
     expect(body.error).toBe('Record locked')
     expect(mockPersistAndFlush).not.toHaveBeenCalled()
+  })
+
+  test('rejects a poisoned host before rotating invite tokens', async () => {
+    process.env = {
+      ...process.env,
+      APP_URL: 'https://app.example.com',
+    }
+
+    const res = await POST(makeRequest({ id: userId }, 'https://evil.example/api/auth/users/resend-invite'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toBe('Invalid request origin')
+    expect(mockNativeUpdate).not.toHaveBeenCalled()
+    expect(mockPersistAndFlush).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/auth/api/__tests__/reset.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/reset.test.ts
@@ -137,4 +137,15 @@ describe('POST /api/auth/reset', () => {
     expect(mockRequestPasswordReset).not.toHaveBeenCalled()
     expect(mockSendEmail).not.toHaveBeenCalled()
   })
+
+  test('returns success even when email delivery fails', async () => {
+    mockSendEmail.mockRejectedValueOnce(new Error('RESEND_API_KEY is not set'))
+
+    const res = await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(mockRequestPasswordReset).toHaveBeenCalledWith('staff@example.com')
+  })
 })

--- a/packages/core/src/modules/auth/api/__tests__/reset.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/reset.test.ts
@@ -1,0 +1,140 @@
+import { POST } from '@open-mercato/core/modules/auth/api/reset'
+
+const mockRequestPasswordReset = jest.fn()
+const mockSendEmail = jest.fn()
+const mockCheckAuthRateLimit = jest.fn()
+const mockResetPasswordEmail = jest.fn((props: { resetUrl: string }) => props)
+
+const mockContainer = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'authService') {
+      return {
+        requestPasswordReset: mockRequestPasswordReset,
+      }
+    }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/email/send', () => ({
+  sendEmail: jest.fn((args: unknown) => mockSendEmail(args)),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/emails/ResetPasswordEmail', () => ({
+  __esModule: true,
+  default: jest.fn((props: { resetUrl: string }) => mockResetPasswordEmail(props)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/notifications/lib/notificationBuilder', () => ({
+  buildNotificationFromType: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/core/modules/notifications/lib/notificationService', () => ({
+  resolveNotificationService: jest.fn(() => ({
+    create: jest.fn(async () => undefined),
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/notifications', () => ({
+  __esModule: true,
+  default: [],
+}))
+
+jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
+  checkAuthRateLimit: jest.fn((args: unknown) => mockCheckAuthRateLimit(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/ratelimit/config', () => ({
+  readEndpointRateLimitConfig: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/shared/lib/ratelimit/helpers', () => ({
+  rateLimitErrorSchema: {},
+}))
+
+const originalEnv = process.env
+
+function makeResetRequest(url: string) {
+  const body = new URLSearchParams()
+  body.set('email', 'staff@example.com')
+  return new Request(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+}
+
+describe('POST /api/auth/reset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = {
+      ...originalEnv,
+      APP_URL: 'https://app.example.com',
+      NEXT_PUBLIC_APP_URL: undefined,
+      APP_ALLOWED_ORIGINS: undefined,
+    }
+    mockCheckAuthRateLimit.mockResolvedValue({ error: null })
+    mockRequestPasswordReset.mockResolvedValue({
+      user: {
+        id: 'user-1',
+        email: 'staff@example.com',
+        tenantId: null,
+        organizationId: null,
+      },
+      token: 'reset-token-1',
+    })
+    mockSendEmail.mockResolvedValue(undefined)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  test('builds the reset link from APP_URL', async () => {
+    const res = await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+
+    expect(res.status).toBe(200)
+    expect(mockRequestPasswordReset).toHaveBeenCalledWith('staff@example.com')
+    expect(mockResetPasswordEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resetUrl: 'https://app.example.com/reset/reset-token-1',
+      }),
+    )
+  })
+
+  test('rejects a poisoned host before issuing a reset token', async () => {
+    const res = await POST(makeResetRequest('https://evil.example/api/auth/reset'))
+    const body = await res.json()
+
+    expect(res.status).toBe(400)
+    expect(body.error).toBe('Invalid request origin')
+    expect(mockRequestPasswordReset).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+
+  test('fails closed in production when APP_URL is missing', async () => {
+    process.env = {
+      ...process.env,
+      APP_URL: undefined,
+      NODE_ENV: 'production',
+    }
+
+    const res = await POST(makeResetRequest('https://app.example.com/api/auth/reset'))
+    const body = await res.json()
+
+    expect(res.status).toBe(500)
+    expect(body.error).toBe('Password reset is not configured')
+    expect(mockRequestPasswordReset).not.toHaveBeenCalled()
+    expect(mockSendEmail).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/auth/api/reset.ts
+++ b/packages/core/src/modules/auth/api/reset.ts
@@ -65,7 +65,11 @@ export async function POST(req: Request) {
     hint: translate('auth.email.resetPassword.hint', "If you didn't request this, you can safely ignore this email."),
   }
 
-  await sendEmail({ to: user.email, subject, react: ResetPasswordEmail({ resetUrl, copy }) })
+  try {
+    await sendEmail({ to: user.email, subject, react: ResetPasswordEmail({ resetUrl, copy }) })
+  } catch (err) {
+    console.error('[auth.reset] Failed to send reset email:', err)
+  }
   try {
     const tenantId = user.tenantId ? String(user.tenantId) : null
     if (tenantId) {

--- a/packages/core/src/modules/auth/api/reset.ts
+++ b/packages/core/src/modules/auth/api/reset.ts
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
+import { AppOriginConfigurationError, AppOriginRejectedError, toSecurityEmailUrl } from '@open-mercato/shared/lib/url'
 
 const resetRateLimitConfig = readEndpointRateLimitConfig('RESET', {
   points: 3, duration: 60, blockDuration: 60, keyPrefix: 'reset',
@@ -36,14 +37,25 @@ export async function POST(req: Request) {
     const fieldErrors = parsed.error.flatten().fieldErrors
     return NextResponse.json({ error: 'Validation failed', fieldErrors }, { status: 422 })
   }
+  let resetUrlTemplate: string
+  try {
+    resetUrlTemplate = toSecurityEmailUrl(req, '/reset/__token__')
+  } catch (error) {
+    if (error instanceof AppOriginRejectedError) {
+      return NextResponse.json({ error: 'Invalid request origin' }, { status: 400 })
+    }
+    if (error instanceof AppOriginConfigurationError) {
+      console.error('[auth.reset] APP_URL is required for password reset emails in production')
+      return NextResponse.json({ error: 'Password reset is not configured' }, { status: 500 })
+    }
+    throw error
+  }
   const c = await createRequestContainer()
   const auth = c.resolve<AuthService>('authService')
   const resReq = await auth.requestPasswordReset(parsed.data.email)
   if (!resReq) return NextResponse.json({ ok: true })
   const { user, token } = resReq
-  const url = new URL(req.url)
-  const base = process.env.APP_URL || `${url.protocol}//${url.host}`
-  const resetUrl = `${base}/reset/${token}`
+  const resetUrl = resetUrlTemplate.replace('__token__', token)
 
   const { translate } = await resolveTranslations()
   const subject = translate('auth.email.resetPassword.subject', 'Reset your password')
@@ -89,6 +101,10 @@ const passwordResetResponseSchema = z.object({
   ok: z.literal(true),
 })
 
+const passwordResetErrorSchema = z.object({
+  error: z.string(),
+})
+
 export const openApi: OpenApiRouteDoc = {
   tag: 'Authentication & Accounts',
   summary: 'Request password reset',
@@ -104,7 +120,9 @@ export const openApi: OpenApiRouteDoc = {
         { status: 200, description: 'Reset email dispatched (or ignored for unknown accounts)', schema: passwordResetResponseSchema },
       ],
       errors: [
+        { status: 400, description: 'Invalid request origin', schema: passwordResetErrorSchema },
         { status: 429, description: 'Too many password reset requests', schema: rateLimitErrorSchema },
+        { status: 500, description: 'Password reset email origin is not configured', schema: passwordResetErrorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/auth/api/reset.ts
+++ b/packages/core/src/modules/auth/api/reset.ts
@@ -13,7 +13,7 @@ import { z } from 'zod'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
-import { AppOriginConfigurationError, AppOriginRejectedError, toSecurityEmailUrl } from '@open-mercato/shared/lib/url'
+import { mapSecurityEmailUrlError, toSecurityEmailUrl } from '@open-mercato/shared/lib/url'
 
 const resetRateLimitConfig = readEndpointRateLimitConfig('RESET', {
   points: 3, duration: 60, blockDuration: 60, keyPrefix: 'reset',
@@ -41,13 +41,11 @@ export async function POST(req: Request) {
   try {
     resetUrlTemplate = toSecurityEmailUrl(req, '/reset/__token__')
   } catch (error) {
-    if (error instanceof AppOriginRejectedError) {
-      return NextResponse.json({ error: 'Invalid request origin' }, { status: 400 })
-    }
-    if (error instanceof AppOriginConfigurationError) {
-      console.error('[auth.reset] APP_URL is required for password reset emails in production')
-      return NextResponse.json({ error: 'Password reset is not configured' }, { status: 500 })
-    }
+    const mapped = mapSecurityEmailUrlError(error, {
+      scope: 'auth.reset',
+      configMessage: 'Password reset is not configured',
+    })
+    if (mapped) return NextResponse.json(mapped.body, { status: mapped.status })
     throw error
   }
   const c = await createRequestContainer()

--- a/packages/core/src/modules/auth/api/users/resend-invite/route.ts
+++ b/packages/core/src/modules/auth/api/users/resend-invite/route.ts
@@ -13,6 +13,7 @@ import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
 import { INVITE_TOKEN_TTL_MS, resolveInviteBaseUrl } from '@open-mercato/core/modules/auth/lib/inviteToken'
+import { AppOriginConfigurationError, AppOriginRejectedError } from '@open-mercato/shared/lib/url'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import crypto from 'node:crypto'
 
@@ -106,6 +107,20 @@ export async function POST(req: Request) {
     return NextResponse.json(guardResult.body, { status: guardResult.status })
   }
 
+  let base: string
+  try {
+    base = resolveInviteBaseUrl(req.url)
+  } catch (error) {
+    if (error instanceof AppOriginRejectedError) {
+      return NextResponse.json({ error: 'Invalid request origin' }, { status: 400 })
+    }
+    if (error instanceof AppOriginConfigurationError) {
+      console.error('[auth.users.resend-invite] APP_URL is required for invitation emails in production')
+      return NextResponse.json({ error: 'Invitation email is not configured' }, { status: 500 })
+    }
+    throw error
+  }
+
   await em.nativeUpdate(
     PasswordReset,
     { user: user.id, usedAt: null } as any,
@@ -117,7 +132,6 @@ export async function POST(req: Request) {
   const row = em.create(PasswordReset, { user, token, expiresAt, createdAt: new Date() })
   await em.persistAndFlush(row)
 
-  const base = resolveInviteBaseUrl(req.url)
   const inviteUrl = `${base}/reset/${token}`
 
   const { translate } = await resolveTranslations()
@@ -174,10 +188,12 @@ export const openApi: OpenApiRouteDoc = {
         { status: 200, description: 'Invite email sent', schema: responseSchema },
       ],
       errors: [
+        { status: 400, description: 'Invalid request origin', schema: errorSchema },
         { status: 404, description: 'User not found', schema: errorSchema },
         { status: 409, description: 'User already has a password', schema: errorSchema },
         { status: 422, description: 'Validation error', schema: validationErrorSchema },
         { status: 429, description: 'Rate limit exceeded', schema: rateLimitErrorSchema },
+        { status: 500, description: 'Invitation email origin is not configured', schema: errorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/auth/api/users/resend-invite/route.ts
+++ b/packages/core/src/modules/auth/api/users/resend-invite/route.ts
@@ -12,8 +12,8 @@ import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
-import { INVITE_TOKEN_TTL_MS, resolveInviteBaseUrl } from '@open-mercato/core/modules/auth/lib/inviteToken'
-import { AppOriginConfigurationError, AppOriginRejectedError } from '@open-mercato/shared/lib/url'
+import { INVITE_TOKEN_TTL_MS } from '@open-mercato/core/modules/auth/lib/inviteToken'
+import { getSecurityEmailBaseUrl, mapSecurityEmailUrlError } from '@open-mercato/shared/lib/url'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import crypto from 'node:crypto'
 
@@ -109,15 +109,13 @@ export async function POST(req: Request) {
 
   let base: string
   try {
-    base = resolveInviteBaseUrl(req.url)
+    base = getSecurityEmailBaseUrl(req.url)
   } catch (error) {
-    if (error instanceof AppOriginRejectedError) {
-      return NextResponse.json({ error: 'Invalid request origin' }, { status: 400 })
-    }
-    if (error instanceof AppOriginConfigurationError) {
-      console.error('[auth.users.resend-invite] APP_URL is required for invitation emails in production')
-      return NextResponse.json({ error: 'Invitation email is not configured' }, { status: 500 })
-    }
+    const mapped = mapSecurityEmailUrlError(error, {
+      scope: 'auth.users.resend-invite',
+      configMessage: 'Invitation email is not configured',
+    })
+    if (mapped) return NextResponse.json(mapped.body, { status: mapped.status })
     throw error
   }
 

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -34,7 +34,8 @@ import notificationTypes from '@open-mercato/core/modules/auth/notifications'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { sendEmail } from '@open-mercato/shared/lib/email/send'
 import InviteUserEmail from '@open-mercato/core/modules/auth/emails/InviteUserEmail'
-import { INVITE_TOKEN_TTL_MS, resolveInviteBaseUrl } from '@open-mercato/core/modules/auth/lib/inviteToken'
+import { INVITE_TOKEN_TTL_MS } from '@open-mercato/core/modules/auth/lib/inviteToken'
+import { getSecurityEmailBaseUrl } from '@open-mercato/shared/lib/url'
 import crypto from 'node:crypto'
 
 type SerializedUser = {
@@ -341,7 +342,7 @@ async function sendInviteToUser(
   const row = em.create(PasswordReset, { user, token, expiresAt, createdAt: new Date() })
   await em.persistAndFlush(row)
 
-  const base = resolveInviteBaseUrl()
+  const base = getSecurityEmailBaseUrl()
   const inviteUrl = `${base}/reset/${token}`
 
   const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/auth/lib/inviteToken.ts
+++ b/packages/core/src/modules/auth/lib/inviteToken.ts
@@ -1,7 +1,1 @@
-import { getSecurityEmailBaseUrl } from '@open-mercato/shared/lib/url'
-
 export const INVITE_TOKEN_TTL_MS = 48 * 60 * 60 * 1000
-
-export function resolveInviteBaseUrl(requestUrl?: string): string {
-  return getSecurityEmailBaseUrl(requestUrl)
-}

--- a/packages/core/src/modules/auth/lib/inviteToken.ts
+++ b/packages/core/src/modules/auth/lib/inviteToken.ts
@@ -1,17 +1,7 @@
+import { getSecurityEmailBaseUrl } from '@open-mercato/shared/lib/url'
+
 export const INVITE_TOKEN_TTL_MS = 48 * 60 * 60 * 1000
 
 export function resolveInviteBaseUrl(requestUrl?: string): string {
-  const appUrl = process.env.APP_URL
-  if (appUrl) return appUrl.replace(/\/$/, '')
-
-  if (requestUrl) {
-    const url = new URL(requestUrl)
-    return `${url.protocol}//${url.host}`
-  }
-
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('APP_URL environment variable must be set in production')
-  }
-
-  return 'http://localhost:3000'
+  return getSecurityEmailBaseUrl(requestUrl)
 }

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -28,6 +28,10 @@ NEXTAUTH_SECRET=
 
 # Public URL used in emails and onboarding flows
 APP_URL=http://localhost:3000
+# Additional trusted origins for app requests that must pass host validation.
+# APP_URL is required in production for security-sensitive email links.
+# Example: APP_ALLOWED_ORIGINS=https://admin.example.com,https://ops.example.com
+# APP_ALLOWED_ORIGINS=
 
 # Enable self-service onboarding (default: false)
 SELF_SERVICE_ONBOARDING_ENABLED=false

--- a/packages/shared/src/lib/__tests__/url.test.ts
+++ b/packages/shared/src/lib/__tests__/url.test.ts
@@ -1,0 +1,69 @@
+import {
+  AppOriginConfigurationError,
+  AppOriginRejectedError,
+  assertAllowedAppOrigin,
+  getSecurityEmailBaseUrl,
+  toSecurityEmailUrl,
+} from '../url'
+
+describe('security email URL helpers', () => {
+  test('uses APP_URL for security email links and preserves its base path', () => {
+    const env = {
+      APP_URL: 'https://app.example.com/admin/',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://app.example.com/api/auth/reset')
+
+    expect(toSecurityEmailUrl(request, '/reset/token-1', env)).toBe('https://app.example.com/admin/reset/token-1')
+  })
+
+  test('rejects request origins outside the configured allowlist', () => {
+    const env = {
+      APP_URL: 'https://app.example.com',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://evil.example/api/auth/reset')
+
+    expect(() => assertAllowedAppOrigin(request, env)).toThrow(AppOriginRejectedError)
+  })
+
+  test('rejects a mismatched Host header even when the request URL origin is allowed', () => {
+    const env = {
+      APP_URL: 'https://app.example.com',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://app.example.com/api/auth/reset', {
+      headers: { host: 'evil.example' },
+    })
+
+    expect(() => assertAllowedAppOrigin(request, env)).toThrow(AppOriginRejectedError)
+  })
+
+  test('allows extra configured origins', () => {
+    const env = {
+      APP_URL: 'https://app.example.com',
+      APP_ALLOWED_ORIGINS: 'https://admin.example.com, https://ops.example.com',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://admin.example.com/api/auth/reset')
+
+    expect(() => assertAllowedAppOrigin(request, env)).not.toThrow()
+  })
+
+  test('requires APP_URL for security email links in production', () => {
+    const env = {
+      NODE_ENV: 'production',
+    }
+
+    expect(() => getSecurityEmailBaseUrl(undefined, env)).toThrow(AppOriginConfigurationError)
+  })
+
+  test('does not fall back to the request host when APP_URL is missing outside production', () => {
+    const env = {
+      NODE_ENV: 'test',
+    }
+    const request = new Request('https://evil.example/api/auth/reset')
+
+    expect(toSecurityEmailUrl(request, '/reset/token-1', env)).toBe('http://localhost:3000/reset/token-1')
+  })
+})

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -1,6 +1,6 @@
 const DEFAULT_DEV_APP_URL = 'http://localhost:3000'
 
-type EnvLike = {
+type EnvLike = Record<string, string | undefined> & {
   APP_URL?: string
   NEXT_PUBLIC_APP_URL?: string
   APP_ALLOWED_ORIGINS?: string

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -8,6 +8,11 @@ type EnvLike = {
 }
 type RequestInput = Request | string | undefined
 
+export type SecurityEmailUrlErrorMapping = {
+  scope: string
+  configMessage: string
+}
+
 export class AppOriginConfigurationError extends Error {
   constructor(message: string) {
     super(message)
@@ -22,23 +27,27 @@ export class AppOriginRejectedError extends Error {
   }
 }
 
-function normalizeBaseUrl(raw: string | undefined): string | null {
+function parseBaseUrl(raw: string | undefined): URL | null {
   const value = raw?.trim()
   if (!value) return null
   try {
     const url = new URL(value)
     url.hash = ''
     url.search = ''
-    return url.toString().replace(/\/$/, '')
+    return url
   } catch {
     return null
   }
 }
 
+function normalizeBaseUrl(raw: string | undefined): string | null {
+  const url = parseBaseUrl(raw)
+  return url ? url.toString().replace(/\/$/, '') : null
+}
+
 function normalizeOrigin(raw: string | undefined): string | null {
-  const baseUrl = normalizeBaseUrl(raw)
-  if (!baseUrl) return null
-  return new URL(baseUrl).origin
+  const url = parseBaseUrl(raw)
+  return url ? url.origin : null
 }
 
 function readCsv(value: string | undefined): string[] {
@@ -142,4 +151,18 @@ export function getSecurityEmailBaseUrl(input?: RequestInput, env: EnvLike = pro
 export function toSecurityEmailUrl(input: RequestInput, path: string, env: EnvLike = process.env): string {
   const base = getSecurityEmailBaseUrl(input, env)
   return `${base}/${path.replace(/^\/+/, '')}`
+}
+
+export function mapSecurityEmailUrlError(
+  error: unknown,
+  mapping: SecurityEmailUrlErrorMapping,
+): { status: number; body: { error: string } } | null {
+  if (error instanceof AppOriginRejectedError) {
+    return { status: 400, body: { error: 'Invalid request origin' } }
+  }
+  if (error instanceof AppOriginConfigurationError) {
+    console.error(`[${mapping.scope}] APP_URL is required in production`)
+    return { status: 500, body: { error: mapping.configMessage } }
+  }
+  return null
 }

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -1,3 +1,118 @@
+const DEFAULT_DEV_APP_URL = 'http://localhost:3000'
+
+type EnvLike = {
+  APP_URL?: string
+  NEXT_PUBLIC_APP_URL?: string
+  APP_ALLOWED_ORIGINS?: string
+  NODE_ENV?: string
+}
+type RequestInput = Request | string | undefined
+
+export class AppOriginConfigurationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AppOriginConfigurationError'
+  }
+}
+
+export class AppOriginRejectedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AppOriginRejectedError'
+  }
+}
+
+function normalizeBaseUrl(raw: string | undefined): string | null {
+  const value = raw?.trim()
+  if (!value) return null
+  try {
+    const url = new URL(value)
+    url.hash = ''
+    url.search = ''
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return null
+  }
+}
+
+function normalizeOrigin(raw: string | undefined): string | null {
+  const baseUrl = normalizeBaseUrl(raw)
+  if (!baseUrl) return null
+  return new URL(baseUrl).origin
+}
+
+function readCsv(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+function readAllowedOrigins(env: EnvLike): Set<string> {
+  const origins = new Set<string>()
+  for (const raw of [env.APP_URL, env.NEXT_PUBLIC_APP_URL, ...readCsv(env.APP_ALLOWED_ORIGINS)]) {
+    const origin = normalizeOrigin(raw)
+    if (origin) origins.add(origin)
+  }
+  return origins
+}
+
+function readFirstHeaderValue(value: string | null): string | null {
+  const first = value?.split(',')[0]?.trim()
+  return first && first.length > 0 ? first : null
+}
+
+function originFromHost(protocol: string, rawHost: string | null): string | null {
+  const host = readFirstHeaderValue(rawHost)
+  if (!host) return null
+  return normalizeOrigin(`${protocol}//${host}`)
+}
+
+function requestOrigins(input: RequestInput): Set<string> {
+  const origins = new Set<string>()
+  if (!input) return origins
+
+  const requestUrl = typeof input === 'string' ? input : input.url
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(requestUrl)
+  } catch {
+    return origins
+  }
+
+  const urlOrigin = normalizeOrigin(parsedUrl.origin)
+  if (urlOrigin) origins.add(urlOrigin)
+
+  if (typeof input === 'string') return origins
+
+  const forwardedProto = readFirstHeaderValue(input.headers.get('x-forwarded-proto')) ?? parsedUrl.protocol.replace(/:$/, '')
+  const protocol = forwardedProto.endsWith(':') ? forwardedProto : `${forwardedProto}:`
+  const hostOrigin = originFromHost(protocol, input.headers.get('host'))
+  const forwardedHostOrigin = originFromHost(protocol, input.headers.get('x-forwarded-host'))
+  if (hostOrigin) origins.add(hostOrigin)
+  if (forwardedHostOrigin) origins.add(forwardedHostOrigin)
+  return origins
+}
+
+export function assertAllowedAppOrigin(input: RequestInput, env: EnvLike = process.env): void {
+  const allowedOrigins = readAllowedOrigins(env)
+  if (allowedOrigins.size === 0) {
+    if (env.NODE_ENV === 'production') {
+      throw new AppOriginConfigurationError('APP_URL must be configured in production')
+    }
+    return
+  }
+
+  const origins = requestOrigins(input)
+  if (origins.size === 0) return
+
+  for (const origin of origins) {
+    if (!allowedOrigins.has(origin)) {
+      throw new AppOriginRejectedError('Request origin is not allowed')
+    }
+  }
+}
+
 export function getAppBaseUrl(req: Request): string {
   const url = new URL(req.url)
   return (
@@ -9,4 +124,22 @@ export function getAppBaseUrl(req: Request): string {
 
 export function toAbsoluteUrl(req: Request, path: string): string {
   return new URL(path, getAppBaseUrl(req)).toString()
+}
+
+export function getSecurityEmailBaseUrl(input?: RequestInput, env: EnvLike = process.env): string {
+  const configuredAppUrl = normalizeBaseUrl(env.APP_URL)
+  if (!configuredAppUrl) {
+    if (env.NODE_ENV === 'production') {
+      throw new AppOriginConfigurationError('APP_URL must be configured in production')
+    }
+    return DEFAULT_DEV_APP_URL
+  }
+
+  assertAllowedAppOrigin(input, env)
+  return configuredAppUrl
+}
+
+export function toSecurityEmailUrl(input: RequestInput, path: string, env: EnvLike = process.env): string {
+  const base = getSecurityEmailBaseUrl(input, env)
+  return `${base}/${path.replace(/^\/+/, '')}`
 }


### PR DESCRIPTION
## Summary

Fixes a high-risk Host Header Poisoning issue in auth security emails.

Password reset links were built from `APP_URL`, but if `APP_URL` was missing they fell back to the request URL/host. In production this allowed an attacker to submit a reset request with a poisoned `Host` header and cause the victim to receive a reset link pointing to an attacker-controlled domain, leaking the reset token in the URL.

## Changes

- Added central app origin validation helpers in `@open-mercato/shared/lib/url`
- Added allowlist support via:
  - `APP_URL`
  - `NEXT_PUBLIC_APP_URL`
  - `APP_ALLOWED_ORIGINS`
- Added production fail-closed behavior for security email links when `APP_URL` is missing
- Removed request-host fallback for password reset and invite email links
- Rejects requests with unknown `Host` / `X-Forwarded-Host` before issuing reset/invite tokens
- Updated auth reset and resend-invite OpenAPI error documentation
- Added regression tests for:
  - poisoned request origin
  - poisoned `Host` header
  - missing `APP_URL` in production
  - no request-host fallback outside production
- Documented `APP_ALLOWED_ORIGINS` in env examples

## Security Impact

This prevents reset/invite tokens from being sent in URLs on attacker-controlled origins when production is misconfigured or when hostile host headers are supplied.

In production, `APP_URL` is now required for security-sensitive email links.

## Verification

I attempted to run targeted Jest tests, but the local environment cannot start Node:

- `yarn` is not available in PATH
- direct `jest` execution fails because Homebrew Node cannot load `libsimdjson.29.dylib`

Commands attempted:

```bash
yarn workspace @open-mercato/shared test --runTestsByPath src/lib/__tests__/url.test.ts
yarn workspace @open-mercato/core test --runTestsByPath src/modules/auth/api/__tests__/reset.test.ts src/modules/auth/api/__tests__/resend-invite.route.test.ts
./node_modules/.bin/jest --config packages/shared/jest.config.cjs --runTestsByPath packages/shared/src/lib/__tests__/url.test.ts
./node_modules/.bin/jest --config packages/core/jest.config.cjs --runTestsByPath packages/core/src/modules/auth/api/__tests__/reset.test.ts packages/core/src/modules/auth/api/__tests__/resend-invite.route.test.ts
