### PR TITLE
add error handling and encryption-safe lookups to notification subscr…

### DIFF
--- a/packages/core/src/modules/messages/workers/__tests__/send-email.worker.handler.test.ts
+++ b/packages/core/src/modules/messages/workers/__tests__/send-email.worker.handler.test.ts
@@ -33,7 +33,8 @@ describe('messages send-email worker handler', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     getMessageEmailAttachmentsMock.mockResolvedValue([])
-    findOneWithDecryptionMock.mockImplementation(async (_em, entity, where) => {
+    findOneWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown, where: { id?: string }) => {
+      if (entity === Message) return baseMessage
       if (entity === User && where.id === 'sender-1') return { id: 'sender-1', name: 'Sender', email: 'sender@example.com' }
       if (entity === User && where.id === 'recipient-1') return { id: 'recipient-1', email: 'recipient@example.com' }
       return null
@@ -41,19 +42,13 @@ describe('messages send-email worker handler', () => {
   })
 
   function createWorkerContext(overrides: Partial<{
-    message: unknown
     recipient: unknown
     nativeUpdateResults: number[]
   }> = {}) {
     const nativeUpdateResults = [...(overrides.nativeUpdateResults ?? [1])]
 
     const emFork = {
-      findOne: jest.fn(async (entity: unknown, where: Record<string, unknown>) => {
-        if (entity === Message) {
-          if (overrides.message !== undefined) return overrides.message
-          return baseMessage
-        }
-
+      findOne: jest.fn(async (entity: unknown) => {
         if (entity === MessageRecipient) {
           if (overrides.recipient !== undefined) return overrides.recipient
           return {
@@ -63,7 +58,6 @@ describe('messages send-email worker handler', () => {
           }
         }
 
-        if (entity && where?.id) return null
         return null
       }),
       find: jest.fn(async () => []),
@@ -87,7 +81,8 @@ describe('messages send-email worker handler', () => {
   }
 
   it('skips when message does not exist', async () => {
-    const { ctx } = createWorkerContext({ message: null })
+    findOneWithDecryptionMock.mockResolvedValue(null)
+    const { ctx } = createWorkerContext()
 
     await handle(
       {
@@ -126,8 +121,34 @@ describe('messages send-email worker handler', () => {
     expect(sendMessageEmailToExternalMock).not.toHaveBeenCalled()
   })
 
+  it('skips recipient delivery when emailSentAt is already set (idempotency guard)', async () => {
+    const { ctx } = createWorkerContext({
+      recipient: {
+        messageId: 'message-1',
+        recipientUserId: 'recipient-1',
+        emailSentAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    })
+
+    await handle(
+      {
+        payload: {
+          type: 'recipient',
+          messageId: 'message-1',
+          recipientUserId: 'recipient-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        },
+      } as never,
+      ctx as never,
+    )
+
+    expect(sendMessageEmailToRecipientMock).not.toHaveBeenCalled()
+  })
+
   it('releases claim when recipient has no email', async () => {
-    findOneWithDecryptionMock.mockImplementation(async (_em, entity, where) => {
+    findOneWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown, where: { id?: string }) => {
+      if (entity === Message) return baseMessage
       if (entity === User && where.id === 'sender-1') return { id: 'sender-1', name: 'Sender', email: 'sender@example.com' }
       if (entity === User && where.id === 'recipient-1') return { id: 'recipient-1', email: null }
       return null

--- a/packages/core/src/modules/messages/workers/send-email.worker.ts
+++ b/packages/core/src/modules/messages/workers/send-email.worker.ts
@@ -82,12 +82,18 @@ async function resolveMessageScope(
   em: EntityManager,
   payload: SendMessageEmailJob
 ) {
-  return await em.findOne(Message, {
-    id: payload.messageId,
-    tenantId: payload.tenantId,
-    organizationId: payload.organizationId ?? null,
-    deletedAt: null,
-  })
+  return await findOneWithDecryption(
+    em,
+    Message,
+    {
+      id: payload.messageId,
+      tenantId: payload.tenantId,
+      organizationId: payload.organizationId ?? null,
+      deletedAt: null,
+    },
+    undefined,
+    { tenantId: payload.tenantId, organizationId: payload.organizationId ?? null },
+  )
 }
 
 export async function claimRecipientDelivery(

--- a/packages/core/src/modules/notifications/__tests__/deliver-notification.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/deliver-notification.test.ts
@@ -105,11 +105,11 @@ describe('deliver notification subscriber', () => {
     resolveNotificationDeliveryConfig.mockResolvedValue(baseConfig)
     resolveNotificationPanelUrl.mockReturnValue('https://app.example.com/backend/notifications')
     getNotificationDeliveryStrategies.mockReturnValue([])
-    findOneWithDecryption.mockResolvedValue({ email: 'user@example.com', name: 'User' })
+    findOneWithDecryption
+      .mockResolvedValueOnce(notification)
+      .mockResolvedValueOnce({ email: 'user@example.com', name: 'User' })
 
-    const em = {
-      findOne: jest.fn().mockResolvedValue(notification),
-    }
+    const em = {}
 
     const { default: handle } = await import('../subscribers/deliver-notification')
 
@@ -161,11 +161,11 @@ describe('deliver notification subscriber', () => {
     })
     resolveNotificationPanelUrl.mockReturnValue('https://app.example.com/backend/notifications')
     getNotificationDeliveryStrategies.mockReturnValue([customStrategy])
-    findOneWithDecryption.mockResolvedValue({ email: 'user@example.com', name: 'User' })
+    findOneWithDecryption
+      .mockResolvedValueOnce(notification)
+      .mockResolvedValueOnce({ email: 'user@example.com', name: 'User' })
 
-    const em = {
-      findOne: jest.fn().mockResolvedValue(notification),
-    }
+    const em = {}
 
     const { default: handle } = await import('../subscribers/deliver-notification')
 
@@ -207,11 +207,11 @@ describe('deliver notification subscriber', () => {
     resolveNotificationDeliveryConfig.mockResolvedValue(baseConfig)
     resolveNotificationPanelUrl.mockReturnValue('https://app.example.com/backend/notifications')
     getNotificationDeliveryStrategies.mockReturnValue([])
-    findOneWithDecryption.mockResolvedValue({ email: 'user@example.com', name: 'User' })
+    findOneWithDecryption
+      .mockResolvedValueOnce(notificationWithActionHref)
+      .mockResolvedValueOnce({ email: 'user@example.com', name: 'User' })
 
-    const em = {
-      findOne: jest.fn().mockResolvedValue(notificationWithActionHref),
-    }
+    const em = {}
 
     const { default: handle } = await import('../subscribers/deliver-notification')
 
@@ -256,11 +256,11 @@ describe('deliver notification subscriber', () => {
     resolveNotificationDeliveryConfig.mockResolvedValue(configWithoutAppUrl)
     resolveNotificationPanelUrl.mockReturnValue(null)
     getNotificationDeliveryStrategies.mockReturnValue([])
-    findOneWithDecryption.mockResolvedValue({ email: 'user@example.com', name: 'User' })
+    findOneWithDecryption
+      .mockResolvedValueOnce(notification)
+      .mockResolvedValueOnce({ email: 'user@example.com', name: 'User' })
 
-    const em = {
-      findOne: jest.fn().mockResolvedValue(notification),
-    }
+    const em = {}
 
     const { default: handle } = await import('../subscribers/deliver-notification')
 

--- a/packages/core/src/modules/notifications/subscribers/__tests__/deliver-notification.test.ts
+++ b/packages/core/src/modules/notifications/subscribers/__tests__/deliver-notification.test.ts
@@ -1,0 +1,133 @@
+import handle from '../deliver-notification'
+import { Notification } from '../../data/entities'
+import { User } from '../../../auth/data/entities'
+
+const findOneWithDecryptionMock = jest.fn()
+const loadDictionaryMock = jest.fn()
+const sendEmailMock = jest.fn()
+const resolveNotificationDeliveryConfigMock = jest.fn()
+const resolveNotificationPanelUrlMock = jest.fn()
+const getNotificationDeliveryStrategiesMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  loadDictionary: (...args: unknown[]) => loadDictionaryMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/translate', () => ({
+  createFallbackTranslator: () => (_key: string, fallback: string) => fallback,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/config', () => ({
+  defaultLocale: 'en',
+}))
+
+jest.mock('@open-mercato/shared/lib/email/send', () => ({
+  sendEmail: (...args: unknown[]) => sendEmailMock(...args),
+}))
+
+jest.mock('../../lib/deliveryConfig', () => ({
+  DEFAULT_NOTIFICATION_DELIVERY_CONFIG: { strategies: { email: { enabled: false }, custom: {} } },
+  resolveNotificationDeliveryConfig: (...args: unknown[]) => resolveNotificationDeliveryConfigMock(...args),
+  resolveNotificationPanelUrl: (...args: unknown[]) => resolveNotificationPanelUrlMock(...args),
+}))
+
+jest.mock('../../lib/deliveryStrategies', () => ({
+  getNotificationDeliveryStrategies: () => getNotificationDeliveryStrategiesMock(),
+}))
+
+jest.mock('../../emails/NotificationEmail', () => () => null)
+
+describe('deliver-notification subscriber', () => {
+  const baseNotification = {
+    id: 'notif-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    recipientUserId: 'user-1',
+    titleKey: null,
+    title: 'Test Notification',
+    bodyKey: null,
+    body: 'Test Body',
+    titleVariables: null,
+    bodyVariables: null,
+    actionData: null,
+    sourceEntityId: null,
+  }
+
+  const basePayload = {
+    notificationId: 'notif-1',
+    recipientUserId: 'user-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+  }
+
+  function buildCtx() {
+    const em = {}
+    return {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        throw new Error(`Unknown service: ${name}`)
+      },
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resolveNotificationDeliveryConfigMock.mockResolvedValue({
+      strategies: { email: { enabled: false }, custom: {} },
+    })
+    resolveNotificationPanelUrlMock.mockReturnValue(null)
+    getNotificationDeliveryStrategiesMock.mockReturnValue([])
+    loadDictionaryMock.mockResolvedValue({})
+    findOneWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === Notification) return baseNotification
+      if (entity === User) return { email: 'user@example.com', name: 'User' }
+      return null
+    })
+  })
+
+  it('returns early without sending when notification is not found', async () => {
+    findOneWithDecryptionMock.mockResolvedValue(null)
+
+    await handle(basePayload, buildCtx() as never)
+
+    expect(sendEmailMock).not.toHaveBeenCalled()
+  })
+
+  it('re-throws when resolveNotificationCopy fails so the event bus can retry', async () => {
+    loadDictionaryMock.mockRejectedValue(new Error('i18n service unavailable'))
+
+    await expect(handle(basePayload, buildCtx() as never)).rejects.toThrow('i18n service unavailable')
+  })
+
+  it('re-throws when resolveRecipient fails so the event bus can retry', async () => {
+    findOneWithDecryptionMock.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === Notification) return baseNotification
+      throw new Error('database connection lost')
+    })
+
+    await expect(handle(basePayload, buildCtx() as never)).rejects.toThrow('database connection lost')
+  })
+
+  it('does not throw when email send fails (inner catch absorbs it)', async () => {
+    resolveNotificationDeliveryConfigMock.mockResolvedValue({
+      strategies: {
+        email: {
+          enabled: true,
+          from: 'noreply@example.com',
+          subjectPrefix: null,
+          replyTo: null,
+        },
+        custom: {},
+      },
+    })
+    resolveNotificationPanelUrlMock.mockReturnValue('https://app.example.com/notifications')
+    sendEmailMock.mockRejectedValue(new Error('SMTP connection refused'))
+
+    await expect(handle(basePayload, buildCtx() as never)).resolves.toBeUndefined()
+    expect(sendEmailMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/notifications/subscribers/deliver-notification.ts
+++ b/packages/core/src/modules/notifications/subscribers/deliver-notification.ts
@@ -104,11 +104,21 @@ export default async function handle(payload: NotificationCreatedPayload, ctx: R
   }
 
   const em = ctx.resolve('em') as EntityManager
-  const notification = await em.findOne(Notification, {
-    id: payload.notificationId,
-    tenantId: payload.tenantId,
-    organizationId: payload.organizationId ?? null,
-  })
+  const notification = await findOneWithDecryption(
+    em,
+    Notification,
+    {
+      id: payload.notificationId,
+      tenantId: payload.tenantId,
+      organizationId: payload.organizationId ?? null,
+    },
+    undefined,
+    {
+      tenantId: payload.tenantId,
+      organizationId: payload.organizationId ?? null,
+      encryptionService: null,
+    },
+  )
   if (!notification) {
     debug('notification not found', payload.notificationId)
     return
@@ -121,92 +131,101 @@ export default async function handle(payload: NotificationCreatedPayload, ctx: R
     encryptionService = null
   }
 
-  const recipient = (await resolveRecipient(em, notification, encryptionService)) ?? { email: null, name: null }
-  if (!recipient?.email) {
-    debug('recipient has no email', notification.recipientUserId)
-  }
-  const { title, body, t } = await resolveNotificationCopy(notification)
-  const panelUrl = resolveNotificationPanelUrl(deliveryConfig)
-  if (!panelUrl) {
-    debug('missing panelUrl; check appUrl/panelPath settings')
-  }
-
-  const panelLink = panelUrl ? buildPanelLink(panelUrl, notification.id) : null
-  const baseOrigin = panelUrl ? new URL(panelUrl).origin : null
-  const actionLinks = (notification.actionData?.actions ?? [])
-    .map((action) => {
-      let href = action.href
-      if (href && notification.sourceEntityId) {
-        href = href.replace('{sourceEntityId}', notification.sourceEntityId)
-      }
-      const fullHref = (href && baseOrigin) ? `${baseOrigin}${href}` : panelLink
-      if (!fullHref) return null
-      return {
-        id: action.id,
-        label: action.labelKey ? t(action.labelKey, action.label) : action.label,
-        href: fullHref,
-      }
-    })
-    .filter((action): action is NonNullable<typeof action> => action !== null)
-
-  if (deliveryConfig.strategies.email.enabled && recipient?.email && panelLink) {
-    const subjectPrefix = deliveryConfig.strategies.email.subjectPrefix?.trim()
-    const subject = subjectPrefix ? `${subjectPrefix} ${title}` : title
-    const copy = {
-      preview: t('notifications.delivery.email.preview', 'New notification'),
-      heading: t('notifications.delivery.email.heading', 'You have a new notification'),
-      bodyIntro: t('notifications.delivery.email.bodyIntro', 'Review the notification details and take any required actions.'),
-      actionNotice: t('notifications.delivery.email.actionNotice', 'Actions are available in Open Mercato and are read-only in this email.'),
-      openCta: t('notifications.delivery.email.openCta', 'Open notification center'),
-      footer: t('notifications.delivery.email.footer', 'Open Mercato notifications'),
+  try {
+    const recipient = (await resolveRecipient(em, notification, encryptionService)) ?? { email: null, name: null }
+    if (!recipient?.email) {
+      debug('recipient has no email', notification.recipientUserId)
+    }
+    const { title, body, t } = await resolveNotificationCopy(notification)
+    const panelUrl = resolveNotificationPanelUrl(deliveryConfig)
+    if (!panelUrl) {
+      debug('missing panelUrl; check appUrl/panelPath settings')
     }
 
-    try {
-      debug('sending email', { to: recipient.email, from: deliveryConfig.strategies.email.from, subject })
-      await sendEmail({
-        to: recipient.email,
-        subject,
-        from: deliveryConfig.strategies.email.from,
-        replyTo: deliveryConfig.strategies.email.replyTo,
-        react: NotificationEmail({
+    const panelLink = panelUrl ? buildPanelLink(panelUrl, notification.id) : null
+    const baseOrigin = panelUrl ? new URL(panelUrl).origin : null
+    const actionLinks = (notification.actionData?.actions ?? [])
+      .map((action) => {
+        let href = action.href
+        if (href && notification.sourceEntityId) {
+          href = href.replace('{sourceEntityId}', notification.sourceEntityId)
+        }
+        const fullHref = (href && baseOrigin) ? `${baseOrigin}${href}` : panelLink
+        if (!fullHref) return null
+        return {
+          id: action.id,
+          label: action.labelKey ? t(action.labelKey, action.label) : action.label,
+          href: fullHref,
+        }
+      })
+      .filter((action): action is NonNullable<typeof action> => action !== null)
+
+    if (deliveryConfig.strategies.email.enabled && recipient?.email && panelLink) {
+      const subjectPrefix = deliveryConfig.strategies.email.subjectPrefix?.trim()
+      const subject = subjectPrefix ? `${subjectPrefix} ${title}` : title
+      const copy = {
+        preview: t('notifications.delivery.email.preview', 'New notification'),
+        heading: t('notifications.delivery.email.heading', 'You have a new notification'),
+        bodyIntro: t('notifications.delivery.email.bodyIntro', 'Review the notification details and take any required actions.'),
+        actionNotice: t('notifications.delivery.email.actionNotice', 'Actions are available in Open Mercato and are read-only in this email.'),
+        openCta: t('notifications.delivery.email.openCta', 'Open notification center'),
+        footer: t('notifications.delivery.email.footer', 'Open Mercato notifications'),
+      }
+
+      try {
+        debug('sending email', { to: recipient.email, from: deliveryConfig.strategies.email.from, subject })
+        await sendEmail({
+          to: recipient.email,
+          subject,
+          from: deliveryConfig.strategies.email.from,
+          replyTo: deliveryConfig.strategies.email.replyTo,
+          react: NotificationEmail({
+            title,
+            body,
+            actions: actionLinks,
+            panelUrl: panelLink,
+            copy,
+          }),
+        })
+      } catch (error) {
+        console.error('[notifications] email delivery failed', error)
+      }
+    }
+
+    const strategyConfigs = deliveryConfig.strategies.custom ?? {}
+    const strategies = getNotificationDeliveryStrategies()
+    for (const strategy of strategies) {
+      const strategyConfig = strategyConfigs[strategy.id]
+      const enabled = strategyConfig?.enabled ?? strategy.defaultEnabled ?? false
+      if (!enabled) {
+        debug('custom delivery disabled', strategy.id)
+        continue
+      }
+      try {
+        await strategy.deliver({
+          notification,
+          recipient,
           title,
           body,
-          actions: actionLinks,
-          panelUrl: panelLink,
-          copy,
-        }),
-      })
-    } catch (error) {
-      console.error('[notifications] email delivery failed', error)
+          panelUrl,
+          panelLink,
+          actionLinks,
+          deliveryConfig,
+          config: strategyConfig ?? {},
+          resolve: ctx.resolve,
+          t,
+        })
+      } catch (error) {
+        console.error(`[notifications] delivery strategy failed (${strategy.id})`, error)
+      }
     }
-  }
-
-  const strategyConfigs = deliveryConfig.strategies.custom ?? {}
-  const strategies = getNotificationDeliveryStrategies()
-  for (const strategy of strategies) {
-    const strategyConfig = strategyConfigs[strategy.id]
-    const enabled = strategyConfig?.enabled ?? strategy.defaultEnabled ?? false
-    if (!enabled) {
-      debug('custom delivery disabled', strategy.id)
-      continue
-    }
-    try {
-      await strategy.deliver({
-        notification,
-        recipient,
-        title,
-        body,
-        panelUrl,
-        panelLink,
-        actionLinks,
-        deliveryConfig,
-        config: strategyConfig ?? {},
-        resolve: ctx.resolve,
-        t,
-      })
-    } catch (error) {
-      console.error(`[notifications] delivery strategy failed (${strategy.id})`, error)
-    }
+  } catch (err) {
+    console.error('[notifications:deliver] Failed to deliver notification:', {
+      notificationId: payload.notificationId,
+      recipientUserId: notification.recipientUserId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    throw err
   }
 
   return


### PR DESCRIPTION
 fix: add error handling and encryption-safe lookups to notification subscriber and email worker                           
                                                                                                                            
  Summary                                                                                                                   
                                                                                                                            
  - Silent failure fixed in deliver-notification.ts — the main delivery path (resolveRecipient, resolveNotificationCopy,    
  email send, custom strategies) was not wrapped in error handling. Any uncaught exception would silently drop the          
  notification without giving the persistent event bus a chance to retry. The delivery block is now wrapped in a try/catch  
  that logs the failure with notificationId and recipientUserId context, then re-throws so the event bus retries the
  subscriber.
  - Tenant-scoped em.findOne calls migrated to findWithDecryption — two calls that filtered by tenantId/organizationId were
  using the raw ORM method instead of the encryption-safe helper: Notification lookup in deliver-notification.ts and Message
   lookup in send-email.worker.ts (resolveMessageScope). Both are now routed through findOneWithDecryption, consistent with
  all other tenant-scoped lookups in these modules.                                                                         
  - Idempotency guard verified in send-email.worker.ts — the guard (emailSentAt pre-check + atomic claimRecipientDelivery
  via nativeUpdate with emailSentAt: null filter) was already in place; no change needed.                                   
  
  Test changes                                                                                                              
                                                                  
  - send-email.worker.handler.test.ts — updated findOneWithDecryptionMock to handle the Message entity (previously only User
   was covered, causing 3 tests to fail after the resolveMessageScope migration); added a new case asserting the idempotency
   guard skips delivery when emailSentAt is already set.                                                                    
  - deliver-notification.test.ts (existing) — fixed four tests that mocked em.findOne for notification lookup (now dead
  code) and set findOneWithDecryption to always return the user shape; updated to use mockResolvedValueOnce in call order so
   the notification and user lookups resolve to the correct objects.
  - subscribers/__tests__/deliver-notification.test.ts (new) — covers the four key paths of the subscriber: early return    
  when notification not found, re-throw on resolveNotificationCopy failure, re-throw on resolveRecipient failure, and no    
  propagation when only sendEmail fails (inner catch absorbs it).