### PR TITLE
fix(security): enforce tenant isolation on sudo challenge configs

### DIFF
--- a/packages/enterprise/src/modules/security/api/sudo/_shared.ts
+++ b/packages/enterprise/src/modules/security/api/sudo/_shared.ts
@@ -6,7 +6,11 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { Organization, Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import type { SudoChallengeConfig } from '../../data/entities'
-import type { SudoChallengeService, SudoChallengeServiceError } from '../../services/SudoChallengeService'
+import type {
+  SudoAuthScope,
+  SudoChallengeService,
+  SudoChallengeServiceError,
+} from '../../services/SudoChallengeService'
 import { isSudoRequiredError } from '../../lib/sudo-middleware'
 import { localizeSecurityApiBody, securityApiError } from '../i18n'
 
@@ -18,6 +22,15 @@ export type SudoRequestContext = {
   container: RequestContainer
   commandContext: CommandRuntimeContext
   sudoChallengeService: SudoChallengeService
+  scope: SudoAuthScope
+}
+
+export function buildSudoAuthScope(auth: Auth): SudoAuthScope {
+  return {
+    tenantId: auth.tenantId ?? null,
+    organizationId: auth.orgId ?? null,
+    isSuperAdmin: auth.isSuperAdmin === true,
+  }
 }
 
 export function toSudoConfigResponse(config: SudoChallengeConfig) {
@@ -108,6 +121,7 @@ export async function resolveSudoContext(req: Request): Promise<SudoRequestConte
       request: req,
     },
     sudoChallengeService: container.resolve<SudoChallengeService>('sudoChallengeService'),
+    scope: buildSudoAuthScope(auth),
   }
 }
 

--- a/packages/enterprise/src/modules/security/api/sudo/configs/[id]/route.ts
+++ b/packages/enterprise/src/modules/security/api/sudo/configs/[id]/route.ts
@@ -57,7 +57,10 @@ export async function GET(req: Request, ctx?: RouteContext) {
   }
 
   try {
-    const config = await context.sudoChallengeService.getConfigById(parsedParams.data.id)
+    const config = await context.sudoChallengeService.getConfigById(
+      parsedParams.data.id,
+      context.scope,
+    )
     if (!config) {
       return securityApiError(404, 'Sudo config not found')
     }

--- a/packages/enterprise/src/modules/security/api/sudo/configs/route.ts
+++ b/packages/enterprise/src/modules/security/api/sudo/configs/route.ts
@@ -42,7 +42,7 @@ export async function GET(req: Request) {
   if (context instanceof NextResponse) return context
 
   try {
-    const items = await context.sudoChallengeService.listConfigs()
+    const items = await context.sudoChallengeService.listConfigs(context.scope)
     const enriched = await attachSudoConfigScopeNames(context.container, items)
     return NextResponse.json({ items: enriched })
   } catch (error) {

--- a/packages/enterprise/src/modules/security/commands/createSudoConfig.ts
+++ b/packages/enterprise/src/modules/security/commands/createSudoConfig.ts
@@ -8,6 +8,7 @@ import { SudoChallengeConfig } from '../data/entities'
 import type { SudoChallengeService } from '../services/SudoChallengeService'
 import {
   applySudoConfigSnapshot,
+  buildSudoAuthScopeFromAuth,
   captureSudoConfigSnapshot,
   readSudoConfigUndoPayload,
   type SudoConfigUndoPayload,
@@ -29,7 +30,8 @@ registerCommand({
     }
 
     const service = ctx.container.resolve<SudoChallengeService>('sudoChallengeService')
-    const config = await service.createConfig(parsed.data, ctx.auth.sub)
+    const scope = buildSudoAuthScopeFromAuth(ctx.auth)
+    const config = await service.createConfig(parsed.data, ctx.auth.sub, scope)
     return { id: config.id }
   },
   async buildLog({ result, ctx }) {

--- a/packages/enterprise/src/modules/security/commands/deleteSudoConfig.ts
+++ b/packages/enterprise/src/modules/security/commands/deleteSudoConfig.ts
@@ -7,6 +7,7 @@ import { ChallengeMethod, SudoChallengeConfig } from '../data/entities'
 import type { SudoChallengeService } from '../services/SudoChallengeService'
 import {
   applySudoConfigSnapshot,
+  buildSudoAuthScopeFromAuth,
   captureSudoConfigSnapshot,
   readSudoConfigUndoPayload,
   type SudoConfigUndoPayload,
@@ -31,6 +32,13 @@ registerCommand({
     if (!config) {
       throw new CrudHttpError(404, { error: 'Sudo configuration not found' })
     }
+    const scope = buildSudoAuthScopeFromAuth(ctx.auth)
+    if (!scope.isSuperAdmin) {
+      const tenantMatches = (config.tenantId ?? null) === scope.tenantId && scope.tenantId !== null
+      if (!tenantMatches || config.isDeveloperDefault) {
+        throw new CrudHttpError(404, { error: 'Sudo configuration not found' })
+      }
+    }
     return { before: captureSudoConfigSnapshot(config) }
   },
   async execute(rawInput, ctx) {
@@ -40,7 +48,8 @@ registerCommand({
     }
 
     const service = ctx.container.resolve<SudoChallengeService>('sudoChallengeService')
-    await service.deleteConfig(parsed.data.id)
+    const scope = buildSudoAuthScopeFromAuth(ctx.auth)
+    await service.deleteConfig(parsed.data.id, scope)
     return { ok: true as const }
   },
   async buildLog({ input, snapshots, ctx }) {

--- a/packages/enterprise/src/modules/security/commands/sudoConfig.shared.ts
+++ b/packages/enterprise/src/modules/security/commands/sudoConfig.shared.ts
@@ -1,5 +1,7 @@
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import type { ChallengeMethod, SudoChallengeConfig } from '../data/entities'
+import type { SudoAuthScope } from '../services/SudoChallengeService'
 
 export type SudoConfigUndoSnapshot = {
   id: string
@@ -51,6 +53,17 @@ export function applySudoConfigSnapshot(
   config.configuredBy = snapshot.configuredBy
   config.deletedAt = snapshot.deletedAt ? new Date(snapshot.deletedAt) : null
   config.updatedAt = new Date()
+}
+
+export function buildSudoAuthScopeFromAuth(auth: AuthContext | null | undefined): SudoAuthScope {
+  if (!auth) {
+    return { tenantId: null, organizationId: null, isSuperAdmin: false }
+  }
+  return {
+    tenantId: (auth.tenantId as string | null | undefined) ?? null,
+    organizationId: (auth.orgId as string | null | undefined) ?? null,
+    isSuperAdmin: auth.isSuperAdmin === true,
+  }
 }
 
 export function readSudoConfigUndoPayload(logEntry: unknown): SudoConfigUndoPayload | null {

--- a/packages/enterprise/src/modules/security/commands/updateSudoConfig.ts
+++ b/packages/enterprise/src/modules/security/commands/updateSudoConfig.ts
@@ -8,6 +8,7 @@ import { SudoChallengeConfig } from '../data/entities'
 import type { SudoChallengeService } from '../services/SudoChallengeService'
 import {
   applySudoConfigSnapshot,
+  buildSudoAuthScopeFromAuth,
   captureSudoConfigSnapshot,
   readSudoConfigUndoPayload,
   type SudoConfigUndoPayload,
@@ -33,6 +34,13 @@ registerCommand({
     if (!config) {
       throw new CrudHttpError(404, { error: 'Sudo configuration not found' })
     }
+    const scope = buildSudoAuthScopeFromAuth(ctx.auth)
+    if (!scope.isSuperAdmin) {
+      const tenantMatches = (config.tenantId ?? null) === scope.tenantId && scope.tenantId !== null
+      if (!tenantMatches || config.isDeveloperDefault) {
+        throw new CrudHttpError(404, { error: 'Sudo configuration not found' })
+      }
+    }
     return { before: captureSudoConfigSnapshot(config) }
   },
   async execute(rawInput, ctx) {
@@ -45,7 +53,8 @@ registerCommand({
     }
 
     const service = ctx.container.resolve<SudoChallengeService>('sudoChallengeService')
-    await service.updateConfig(parsed.data.id, parsed.data.data, ctx.auth.sub)
+    const scope = buildSudoAuthScopeFromAuth(ctx.auth)
+    await service.updateConfig(parsed.data.id, parsed.data.data, ctx.auth.sub, scope)
     return { ok: true as const }
   },
   async buildLog({ input, snapshots, ctx }) {

--- a/packages/enterprise/src/modules/security/services/SudoChallengeService.ts
+++ b/packages/enterprise/src/modules/security/services/SudoChallengeService.ts
@@ -53,6 +53,12 @@ type UserScope = {
   organizationId: string | null
 }
 
+export type SudoAuthScope = {
+  tenantId: string | null
+  organizationId?: string | null
+  isSuperAdmin?: boolean
+}
+
 type DeveloperDefaultPayload = {
   targetIdentifier: string
   label?: string | null
@@ -79,11 +85,19 @@ export class SudoChallengeService {
     private readonly securityConfig: SecurityModuleConfig = readSecurityModuleConfig(),
   ) {}
 
-  async listConfigs(): Promise<SudoChallengeConfig[]> {
+  async listConfigs(scope?: SudoAuthScope): Promise<SudoChallengeConfig[]> {
     await this.ensureDeveloperDefaultsRegistered()
+    const filter: FilterQuery<SudoChallengeConfig> = { deletedAt: null }
+    if (scope && !scope.isSuperAdmin) {
+      if (!scope.tenantId) return []
+      ;(filter as Record<string, unknown>).$or = [
+        { tenantId: scope.tenantId },
+        { tenantId: null },
+      ]
+    }
     return this.em.find(
       SudoChallengeConfig,
-      { deletedAt: null },
+      filter,
       {
         orderBy: {
           targetIdentifier: 'asc',
@@ -95,9 +109,12 @@ export class SudoChallengeService {
     )
   }
 
-  async getConfigById(id: string): Promise<SudoChallengeConfig | null> {
+  async getConfigById(id: string, scope?: SudoAuthScope): Promise<SudoChallengeConfig | null> {
     await this.ensureDeveloperDefaultsRegistered()
-    return this.em.findOne(SudoChallengeConfig, { id, deletedAt: null })
+    const config = await this.em.findOne(SudoChallengeConfig, { id, deletedAt: null })
+    if (!config) return null
+    if (scope && !this.isConfigVisibleToScope(config, scope)) return null
+    return config
   }
 
   async isProtected(
@@ -309,14 +326,21 @@ export class SudoChallengeService {
     return Boolean(session && session.expiresAt.getTime() > Date.now())
   }
 
-  async createConfig(input: SudoConfigInput, configuredBy: string): Promise<SudoChallengeConfig> {
+  async createConfig(
+    input: SudoConfigInput,
+    configuredBy: string,
+    scope?: SudoAuthScope,
+  ): Promise<SudoChallengeConfig> {
     await this.ensureDeveloperDefaultsRegistered()
-    this.validateScope(input.tenantId ?? null, input.organizationId ?? null)
-    await this.ensureUniqueConfig(input.targetIdentifier, input.tenantId ?? null, input.organizationId ?? null)
+    const inputTenantId = input.tenantId ?? null
+    const inputOrganizationId = input.organizationId ?? null
+    this.validateScope(inputTenantId, inputOrganizationId)
+    if (scope) this.assertWriteScope(inputTenantId, inputOrganizationId, scope)
+    await this.ensureUniqueConfig(input.targetIdentifier, inputTenantId, inputOrganizationId)
 
     const config = this.em.create(SudoChallengeConfig, {
-      tenantId: input.tenantId ?? null,
-      organizationId: input.organizationId ?? null,
+      tenantId: inputTenantId,
+      organizationId: inputOrganizationId,
       label: input.label ?? null,
       targetIdentifier: input.targetIdentifier,
       isEnabled: input.isEnabled,
@@ -339,17 +363,29 @@ export class SudoChallengeService {
     return config
   }
 
-  async updateConfig(id: string, input: SudoConfigUpdateInput, configuredBy: string): Promise<SudoChallengeConfig> {
+  async updateConfig(
+    id: string,
+    input: SudoConfigUpdateInput,
+    configuredBy: string,
+    scope?: SudoAuthScope,
+  ): Promise<SudoChallengeConfig> {
     await this.ensureDeveloperDefaultsRegistered()
     const config = await this.em.findOne(SudoChallengeConfig, { id, deletedAt: null })
     if (!config) {
       throw new SudoChallengeServiceError('Sudo configuration not found', 404)
+    }
+    if (scope) {
+      this.assertWriteScope(config.tenantId ?? null, config.organizationId ?? null, scope)
+      if (config.isDeveloperDefault && !scope.isSuperAdmin) {
+        throw new SudoChallengeServiceError('Sudo configuration not found', 404)
+      }
     }
 
     const nextTenantId = input.tenantId !== undefined ? input.tenantId ?? null : config.tenantId ?? null
     const nextOrganizationId = input.organizationId !== undefined ? input.organizationId ?? null : config.organizationId ?? null
     const nextTargetIdentifier = input.targetIdentifier ?? config.targetIdentifier
     this.validateScope(nextTenantId, nextOrganizationId)
+    if (scope) this.assertWriteScope(nextTenantId, nextOrganizationId, scope)
     await this.ensureUniqueConfig(nextTargetIdentifier, nextTenantId, nextOrganizationId, config.id)
 
     if (input.tenantId !== undefined) config.tenantId = input.tenantId ?? null
@@ -372,10 +408,16 @@ export class SudoChallengeService {
     return config
   }
 
-  async deleteConfig(id: string): Promise<void> {
+  async deleteConfig(id: string, scope?: SudoAuthScope): Promise<void> {
     const config = await this.em.findOne(SudoChallengeConfig, { id, deletedAt: null })
     if (!config) {
       throw new SudoChallengeServiceError('Sudo configuration not found', 404)
+    }
+    if (scope) {
+      this.assertWriteScope(config.tenantId ?? null, config.organizationId ?? null, scope)
+      if (config.isDeveloperDefault && !scope.isSuperAdmin) {
+        throw new SudoChallengeServiceError('Sudo configuration not found', 404)
+      }
     }
     config.deletedAt = new Date()
     config.updatedAt = new Date()
@@ -472,6 +514,36 @@ export class SudoChallengeService {
   private validateScope(tenantId: string | null, organizationId: string | null): void {
     if (organizationId && !tenantId) {
       throw new SudoChallengeServiceError('Organization-scoped sudo config requires a tenant', 400)
+    }
+  }
+
+  private isConfigVisibleToScope(config: SudoChallengeConfig, scope: SudoAuthScope): boolean {
+    if (scope.isSuperAdmin) return true
+    if (!scope.tenantId) return false
+    const configTenantId = config.tenantId ?? null
+    if (configTenantId === null) return true
+    return configTenantId === scope.tenantId
+  }
+
+  private assertWriteScope(
+    targetTenantId: string | null,
+    targetOrganizationId: string | null,
+    scope: SudoAuthScope,
+  ): void {
+    if (scope.isSuperAdmin) return
+    if (!scope.tenantId) {
+      throw new SudoChallengeServiceError('Sudo configuration not found', 404)
+    }
+    if ((targetTenantId ?? null) !== scope.tenantId) {
+      throw new SudoChallengeServiceError('Sudo configuration not found', 404)
+    }
+    if (
+      scope.organizationId !== undefined
+      && scope.organizationId !== null
+      && targetOrganizationId !== null
+      && targetOrganizationId !== scope.organizationId
+    ) {
+      throw new SudoChallengeServiceError('Sudo configuration not found', 404)
     }
   }
 

--- a/packages/enterprise/src/modules/security/services/__tests__/SudoChallengeService.test.ts
+++ b/packages/enterprise/src/modules/security/services/__tests__/SudoChallengeService.test.ts
@@ -1,6 +1,6 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { ChallengeMethod } from '../../data/entities'
+import { ChallengeMethod, SudoChallengeConfig } from '../../data/entities'
 import { registerSecuritySudoTargetEntries } from '../../lib/module-security-registry'
 import {
   defaultSecurityModuleConfig,
@@ -82,24 +82,36 @@ function createServiceContext(
       else sessions.push(record)
     }),
     flush: jest.fn().mockResolvedValue(undefined),
-    find: jest.fn(async (_entity: unknown, query: Record<string, unknown>) => {
-      if ('targetIdentifier' in query) {
-        return configs.filter((config) =>
-          config.targetIdentifier === query.targetIdentifier
-          && config.deletedAt === query.deletedAt,
-        )
+    find: jest.fn(async (entity: unknown, query: Record<string, unknown>) => {
+      if (entity === SudoChallengeConfig) {
+        return configs.filter((config) => {
+          if ('targetIdentifier' in query && config.targetIdentifier !== query.targetIdentifier) return false
+          if (query.deletedAt !== undefined && config.deletedAt !== query.deletedAt) return false
+          if (query.tenantId !== undefined && config.tenantId !== query.tenantId) return false
+          const orPredicates = (query as Record<string, unknown>).$or as Array<Record<string, unknown>> | undefined
+          if (Array.isArray(orPredicates) && orPredicates.length > 0) {
+            const matches = orPredicates.some((predicate) => {
+              if ('tenantId' in predicate && config.tenantId !== (predicate.tenantId as string | null)) return false
+              return true
+            })
+            if (!matches) return false
+          }
+          return true
+        })
       }
       return []
     }),
-    findOne: jest.fn(async (_entity: unknown, query: Record<string, unknown>) => {
-      if ('targetIdentifier' in query) {
-        return configs.find((config) =>
-          config.targetIdentifier === query.targetIdentifier
-          && config.tenantId === (query.tenantId as string | null | undefined)
-          && config.organizationId === (query.organizationId as string | null | undefined)
-          && (query.isDeveloperDefault === undefined || config.isDeveloperDefault === query.isDeveloperDefault)
-          && (query.deletedAt === undefined || config.deletedAt === query.deletedAt)
-        ) ?? null
+    findOne: jest.fn(async (entity: unknown, query: Record<string, unknown>) => {
+      if (entity === SudoChallengeConfig) {
+        return configs.find((config) => {
+          if (query.id !== undefined && config.id !== query.id) return false
+          if ('targetIdentifier' in query && config.targetIdentifier !== query.targetIdentifier) return false
+          if (query.tenantId !== undefined && config.tenantId !== query.tenantId) return false
+          if (query.organizationId !== undefined && config.organizationId !== query.organizationId) return false
+          if (query.isDeveloperDefault !== undefined && config.isDeveloperDefault !== query.isDeveloperDefault) return false
+          if (query.deletedAt !== undefined && config.deletedAt !== query.deletedAt) return false
+          return true
+        }) ?? null
       }
       if ('sessionToken' in query || 'id' in query) {
         return sessions.find((session) => {
@@ -302,5 +314,129 @@ describe('SudoChallengeService', () => {
 
     expect(result.method).toBe('password')
     expect(mfaVerificationService.createChallenge).not.toHaveBeenCalled()
+  })
+
+  describe('tenant isolation for sudo configs', () => {
+    function seedConfig(
+      configs: ConfigRecord[],
+      overrides?: Partial<ConfigRecord>,
+    ): ConfigRecord {
+      const record: ConfigRecord = {
+        id: 'config-a',
+        tenantId: 'tenant-a',
+        organizationId: null,
+        label: null,
+        targetIdentifier: 'security.custom.target',
+        isEnabled: true,
+        isDeveloperDefault: false,
+        ttlSeconds: 300,
+        challengeMethod: ChallengeMethod.PASSWORD,
+        configuredBy: 'user-a',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+        ...overrides,
+      }
+      configs.push(record)
+      return record
+    }
+
+    test('updateConfig rejects cross-tenant writes from a tenant admin', async () => {
+      const { service, configs } = createServiceContext()
+      seedConfig(configs)
+
+      await expect(
+        service.updateConfig(
+          'config-a',
+          { isEnabled: false },
+          'user-b',
+          { tenantId: 'tenant-b', organizationId: null, isSuperAdmin: false },
+        ),
+      ).rejects.toMatchObject({
+        name: 'SudoChallengeServiceError',
+        statusCode: 404,
+      })
+
+      expect(configs[0].isEnabled).toBe(true)
+      expect(configs[0].configuredBy).toBe('user-a')
+    })
+
+    test('deleteConfig rejects cross-tenant deletes from a tenant admin', async () => {
+      const { service, configs } = createServiceContext()
+      seedConfig(configs)
+
+      await expect(
+        service.deleteConfig('config-a', {
+          tenantId: 'tenant-b',
+          organizationId: null,
+          isSuperAdmin: false,
+        }),
+      ).rejects.toMatchObject({
+        name: 'SudoChallengeServiceError',
+        statusCode: 404,
+      })
+
+      expect(configs[0].deletedAt).toBeNull()
+    })
+
+    test('getConfigById and listConfigs hide cross-tenant records from a tenant admin', async () => {
+      const { service, configs } = createServiceContext()
+      seedConfig(configs)
+      seedConfig(configs, {
+        id: 'config-b',
+        tenantId: 'tenant-b',
+        targetIdentifier: 'security.custom.target.b',
+        configuredBy: 'user-b',
+      })
+
+      const foreignScope = { tenantId: 'tenant-b', organizationId: null, isSuperAdmin: false }
+      const fetched = await service.getConfigById('config-a', foreignScope)
+      expect(fetched).toBeNull()
+
+      const visible = await service.listConfigs(foreignScope)
+      expect(visible.map((item) => item.id)).not.toContain('config-a')
+      expect(visible.map((item) => item.id)).toContain('config-b')
+    })
+
+    test('createConfig rejects attempts to target a foreign tenant', async () => {
+      const { service, configs } = createServiceContext()
+
+      await expect(
+        service.createConfig(
+          {
+            tenantId: 'tenant-b',
+            organizationId: null,
+            targetIdentifier: 'security.custom.new',
+            isEnabled: true,
+            ttlSeconds: 300,
+            challengeMethod: ChallengeMethod.PASSWORD,
+          },
+          'user-a',
+          { tenantId: 'tenant-a', organizationId: null, isSuperAdmin: false },
+        ),
+      ).rejects.toMatchObject({
+        name: 'SudoChallengeServiceError',
+        statusCode: 404,
+      })
+
+      expect(configs.find((item) => item.targetIdentifier === 'security.custom.new')).toBeUndefined()
+    })
+
+    test('superadmin bypasses tenant scope and can manage any config', async () => {
+      const { service, configs } = createServiceContext()
+      seedConfig(configs)
+
+      const superAdminScope = { tenantId: null, organizationId: null, isSuperAdmin: true }
+      await service.updateConfig(
+        'config-a',
+        { isEnabled: false },
+        'super-admin',
+        superAdminScope,
+      )
+      expect(configs[0].isEnabled).toBe(false)
+
+      await service.deleteConfig('config-a', superAdminScope)
+      expect(configs[0].deletedAt).toBeInstanceOf(Date)
+    })
   })
 })


### PR DESCRIPTION
            
  ## Summary
                                                                                                                                                                          
  - **Vulnerability:** A tenant admin holding `security.sudo.manage` could `PUT /api/security/sudo/configs/[id]` or `DELETE` sudo configurations owned by another tenant —
  with no `tenantId` filter.                                                                                                                                              
  - **Fix:** `SudoChallengeService` now takes an explicit `SudoAuthScope` (`tenantId`, `organizationId`, `isSuperAdmin`) on all read/write paths. Non-superadmin callers  
  can only see/mutate configs scoped to their own `tenantId`, cannot touch developer defaults, and cannot create configs targeting a foreign tenant or the global       
  (null-tenant) scope. `listConfigs` is scoped the same way. Cross-tenant attempts return 404 to avoid leaking existence.                                                 
  - **Defense in depth:** the `updateSudoConfig` / `deleteSudoConfig` command handlers also fail closed in `prepare`, so a cross-tenant attempt never captures an undo
  snapshot either.                                                                                                                                                        
                                                                                                                                                                          
  ## Files touched
                                                                                                                                                                          
  - `packages/enterprise/src/modules/security/services/SudoChallengeService.ts` — added `SudoAuthScope`, `isConfigVisibleToScope`, `assertWriteScope`; threaded scope
  through `listConfigs` / `getConfigById` / `createConfig` / `updateConfig` / `deleteConfig`.                                                                             
  - `packages/enterprise/src/modules/security/api/sudo/_shared.ts` — `resolveSudoContext` now attaches a `SudoAuthScope` built from the authenticated request
  (`buildSudoAuthScope`).                                                                                                                                                 
  - `packages/enterprise/src/modules/security/api/sudo/configs/route.ts`, `.../[id]/route.ts` — pass `context.scope` to the service.                                      
  - `packages/enterprise/src/modules/security/commands/{create,update,delete}SudoConfig.ts` — derive scope via `buildSudoAuthScopeFromAuth(ctx.auth)` and pass it to the
  service; `update`/`delete` additionally enforce scope in `prepare`.                                                                                                     
  - `packages/enterprise/src/modules/security/commands/sudoConfig.shared.ts` — new `buildSudoAuthScopeFromAuth` helper.                                                   
                                                                                                                                                                          
  ## Test plan                                                                                                                                                            
                                                                                                                                                                          
  - [x] `yarn jest src/modules/security/services/__tests__/SudoChallengeService.test.ts` → 11/11 passing, including 5 new cases in `tenant isolation for sudo configs`:   
    - [x] `updateConfig` rejects cross-tenant writes from a tenant admin                                                                                                  
    - [x] `deleteConfig` rejects cross-tenant deletes from a tenant admin
    - [x] `getConfigById` / `listConfigs` hide cross-tenant records from a tenant admin                                                                                   
    - [x] `createConfig` rejects attempts to target a foreign tenant                                                                                                      
    - [x] superadmin bypasses tenant scope and can manage any config                                                                                                      
  - [x] `yarn jest src/modules/security/commands/__tests__/sudoConfigCommands.test.ts` → 3/3 passing (undo flows unaffected)                                              
  - [x] `yarn jest src/modules/security/api/sudo src/modules/security/api/__tests__/interceptors.test.ts` → 8/8 passing                                                   
  - [x] `yarn typecheck` (enterprise) → clean