### PR TITLE
fix(business_rules): accept date strings in rule form schema

### DIFF
--- a/packages/core/src/modules/business_rules/backend/rules/[id]/page.tsx
+++ b/packages/core/src/modules/business_rules/backend/rules/[id]/page.tsx
@@ -51,10 +51,7 @@ export default function EditBusinessRulePage() {
 
   const initialValues = React.useMemo(() => {
     if (rule) {
-      const parsed = parseRuleToFormValues(rule)
-      console.log('Rule data:', rule)
-      console.log('Parsed initial values:', parsed)
-      return parsed
+      return parseRuleToFormValues(rule)
     }
     return null
   }, [rule])

--- a/packages/core/src/modules/business_rules/components/formConfig.tsx
+++ b/packages/core/src/modules/business_rules/components/formConfig.tsx
@@ -32,8 +32,8 @@ export type BusinessRuleFormValues = {
   enabled: boolean
   priority: number
   version: number
-  effectiveFrom?: Date | null
-  effectiveTo?: Date | null
+  effectiveFrom?: string | null
+  effectiveTo?: string | null
 }
 
 /**
@@ -54,8 +54,8 @@ export const businessRuleFormSchema = z.object({
   enabled: z.boolean(),
   priority: z.number().int().min(0).max(9999),
   version: z.number().int().min(1),
-  effectiveFrom: z.date().optional().nullable(),
-  effectiveTo: z.date().optional().nullable(),
+  effectiveFrom: z.string().optional().nullable(),
+  effectiveTo: z.string().optional().nullable(),
 })
 
 /**

--- a/packages/core/src/modules/business_rules/components/utils/formHelpers.ts
+++ b/packages/core/src/modules/business_rules/components/utils/formHelpers.ts
@@ -1,6 +1,23 @@
 import type { BusinessRuleFormValues } from '../formConfig'
 import type { CreateBusinessRuleInput } from '../../data/validators'
 
+function toDateInputValue(value?: string | Date | null): string | null {
+  if (!value) return null
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null
+    return value.toISOString().slice(0, 10)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10)
+    const parsed = new Date(trimmed)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed.toISOString().slice(0, 10)
+  }
+  return null
+}
+
 /**
  * Convert form values to API payload
  */
@@ -60,8 +77,8 @@ export function parseRuleToFormValues(rule: any): BusinessRuleFormValues {
     enabled: rule.enabled,
     priority: rule.priority,
     version: rule.version,
-    effectiveFrom: rule.effectiveFrom ? new Date(rule.effectiveFrom) : null,
-    effectiveTo: rule.effectiveTo ? new Date(rule.effectiveTo) : null,
+    effectiveFrom: toDateInputValue(rule.effectiveFrom),
+    effectiveTo: toDateInputValue(rule.effectiveTo),
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes `Invalid input: expected date, received string` shown under **Effective From** / **Effective To** when creating or editing a business rule.

**Root cause:** The client form declared `effectiveFrom` / `effectiveTo` as `Date | null` with `z.date()` schemas, and wrapped loaded values in `new Date(...)`. But CrudForm's `<input type="date">` emits `YYYY-MM-DD` strings, so the Zod validation rejected the submission. Loaded values were also unreadable by the date input, which only renders when the value is a string.

**Fix:** Align the business rule form with the existing `staff/LeaveRequestForm` pattern:
- Type `effectiveFrom` / `effectiveTo` as `string | null`
- Validate as `z.string()`
- Normalize incoming API values via a local `toDateInputValue` helper that short-circuits when the string already begins with `YYYY-MM-DD` (as `toISOString()` output always does)
- Pass the string payload straight through to the API

Also drops two stray `console.log` debug statements from the edit page.

## Test plan

- [ ] Create a new business rule, set Effective From and Effective To, submit — no validation error, record persists.
- [ ] Edit an existing rule with dates set — values render correctly in the date inputs and save without error.
- [ ] Clear the dates and save — payload sends `null` for both fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)