### PR TITLE
refactor(shared): extract toDateInputValue to shared/lib/time

### DIFF
--- a/packages/core/src/modules/customers/components/detail/DealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealForm.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { z } from 'zod'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { toDateInputValue } from '@open-mercato/shared/lib/time'
 import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
@@ -157,16 +158,6 @@ const schema = z.object({
   personIds: z.array(z.string().trim().min(1)).optional(),
   companyIds: z.array(z.string().trim().min(1)).optional(),
 }).passthrough()
-
-function toDateInputValue(value: string | null | undefined): string {
-  if (!value) return ''
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) return ''
-  const year = parsed.getUTCFullYear()
-  const month = String(parsed.getUTCMonth() + 1).padStart(2, '0')
-  const day = String(parsed.getUTCDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
 
 function normalizeCurrency(value: string | null | undefined): string {
   if (!value) return ''
@@ -842,7 +833,7 @@ export function DealForm({
       valueAmount: normalizeNumber(initialValues?.valueAmount ?? null),
       valueCurrency: normalizeCurrency(initialValues?.valueCurrency ?? null),
       probability: normalizeNumber(initialValues?.probability ?? null),
-      expectedCloseAt: toDateInputValue(initialValues?.expectedCloseAt ?? null),
+      expectedCloseAt: toDateInputValue(initialValues?.expectedCloseAt ?? null) ?? '',
       description: initialValues?.description ?? '',
       personIds: sanitizeIdList(initialValues?.personIds ?? resolveIdsFromSource(initialValues?.people)),
       companyIds: sanitizeIdList(initialValues?.companyIds ?? resolveIdsFromSource(initialValues?.companies)),

--- a/packages/core/src/modules/staff/components/LeaveRequestForm.tsx
+++ b/packages/core/src/modules/staff/components/LeaveRequestForm.tsx
@@ -10,6 +10,7 @@ import {
   type UnavailabilityReasonEntry,
 } from '@open-mercato/core/modules/planner/components/unavailabilityReasons'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { toDateInputValue } from '@open-mercato/shared/lib/time'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 
@@ -50,23 +51,6 @@ export type LeaveRequestFormProps = {
 }
 
 const DEFAULT_TIMEZONE = 'UTC'
-
-function toDateInputValue(value?: string | Date | null): string | null {
-  if (!value) return null
-  if (value instanceof Date) {
-    if (Number.isNaN(value.getTime())) return null
-    return value.toISOString().slice(0, 10)
-  }
-  if (typeof value === 'string') {
-    const trimmed = value.trim()
-    if (!trimmed) return null
-    if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10)
-    const parsed = new Date(trimmed)
-    if (Number.isNaN(parsed.getTime())) return null
-    return parsed.toISOString().slice(0, 10)
-  }
-  return null
-}
 
 export function buildLeaveRequestPayload(
   values: LeaveRequestFormValues,

--- a/packages/core/src/modules/staff/components/detail/JobHistorySection.tsx
+++ b/packages/core/src/modules/staff/components/detail/JobHistorySection.tsx
@@ -10,6 +10,7 @@ import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { createCrud, updateCrud, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { toDateInputValue } from '@open-mercato/shared/lib/time'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 
 type JobHistoryRecord = {
@@ -165,8 +166,8 @@ export function JobHistorySection({ memberId }: { memberId: string | null }) {
         name: activeRecord.name,
         companyName: activeRecord.companyName ?? '',
         description: activeRecord.description ?? '',
-        startDate: toDateInputValue(activeRecord.startDate),
-        endDate: toDateInputValue(activeRecord.endDate),
+        startDate: toDateInputValue(activeRecord.startDate) ?? '',
+        endDate: toDateInputValue(activeRecord.endDate) ?? '',
       }
     : {
         name: '',
@@ -304,13 +305,6 @@ function buildJobHistoryPayload(values: JobHistoryFormValues) {
   if (values.startDate) payload.startDate = values.startDate
   if (values.endDate) payload.endDate = values.endDate
   return payload
-}
-
-function toDateInputValue(value?: string | null): string {
-  if (!value) return ''
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-  return date.toISOString().slice(0, 10)
 }
 
 function formatDateRange(

--- a/packages/shared/src/lib/__tests__/time.test.ts
+++ b/packages/shared/src/lib/__tests__/time.test.ts
@@ -1,4 +1,4 @@
-import { formatRelativeTime, formatDateTime } from '../time'
+import { formatRelativeTime, formatDateTime, toDateInputValue } from '../time'
 
 describe('formatRelativeTime', () => {
   const now = new Date('2026-02-18T12:00:00Z')
@@ -108,5 +108,30 @@ describe('formatDateTime', () => {
   it('returns a locale string for valid date', () => {
     const d = new Date('2026-02-18T12:00:00Z')
     expect(formatDateTime(d.toISOString())).toEqual(d.toLocaleString())
+  })
+})
+
+describe('toDateInputValue', () => {
+  it('returns null for missing or invalid values', () => {
+    expect(toDateInputValue(undefined)).toBeNull()
+    expect(toDateInputValue(null)).toBeNull()
+    expect(toDateInputValue('')).toBeNull()
+    expect(toDateInputValue('   ')).toBeNull()
+    expect(toDateInputValue('not-a-date')).toBeNull()
+    expect(toDateInputValue(new Date('not-a-date'))).toBeNull()
+  })
+
+  it('passes through a plain YYYY-MM-DD string unchanged', () => {
+    expect(toDateInputValue('2026-04-10')).toBe('2026-04-10')
+  })
+
+  it('slices the date portion of an ISO 8601 string', () => {
+    expect(toDateInputValue('2026-04-10T23:00:00.000Z')).toBe('2026-04-10')
+    expect(toDateInputValue('2026-04-10T00:00:00+02:00')).toBe('2026-04-10')
+  })
+
+  it('formats a Date instance as the UTC calendar day', () => {
+    const date = new Date('2026-04-10T00:00:00.000Z')
+    expect(toDateInputValue(date)).toBe('2026-04-10')
   })
 })

--- a/packages/shared/src/lib/time.ts
+++ b/packages/shared/src/lib/time.ts
@@ -5,6 +5,30 @@ export function formatDateTime(value?: string | null): string | null {
   if (Number.isNaN(date.getTime())) return null
   return date.toLocaleString()
 }
+
+/**
+ * Normalize a date value to the `YYYY-MM-DD` shape expected by
+ * `<input type="date">`. Accepts ISO strings, plain date strings, and
+ * `Date` instances. When the input already begins with `YYYY-MM-DD`
+ * (as `toISOString()` output always does) those characters are taken
+ * directly, avoiding any timezone reinterpretation.
+ */
+export function toDateInputValue(value?: string | Date | null): string | null {
+  if (!value) return null
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null
+    return value.toISOString().slice(0, 10)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10)
+    const parsed = new Date(trimmed)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed.toISOString().slice(0, 10)
+  }
+  return null
+}
 export type RelativeTimeTranslator = (
   key: string,
   fallback?: string,


### PR DESCRIPTION
## Summary

Four modules had independently re-implemented the same helper for normalizing ISO date strings, plain date strings, and `Date` instances into the `YYYY-MM-DD` shape that `<input type="date">` requires:

- `customers/DealForm`
- `staff/LeaveRequestForm`
- `staff/JobHistorySection`
- `sales/dashboard/shared` — **intentionally different** (uses local timezone for dashboard range filtering), NOT touched by this PR

This PR moves the canonical variant to `packages/shared/lib/time.ts` alongside the existing `formatDateTime` / `formatRelativeTime` helpers, adds focused tests, and replaces the three local copies with shared imports. Call sites that expected an empty string instead of `null` get a `?? ''` nullish coalescing at the call site.

## Helper contract

```ts
toDateInputValue(value?: string | Date | null): string | null
```

- Passes through a plain `YYYY-MM-DD` string unchanged
- Slices the date portion of an ISO 8601 string (the short-circuit path for `toISOString()` output)
- Formats a `Date` instance as the UTC calendar day
- Returns `null` for `null`, `undefined`, empty/whitespace strings, and invalid input

## Test plan

- [x] `yarn jest packages/shared/src/lib/__tests__/time.test.ts` — 16/16 pass including 4 new cases covering plain `YYYY-MM-DD`, ISO 8601 with time/offset, `Date` instance, and null/invalid
- [ ] `yarn test` across the repo — confirm no existing tests break from the helper moves
- [ ] Smoke test: open a customers deal, staff leave request, and staff job history entry with dates set — inputs render the correct day

## Draft status

Marked as draft because two other modules (`workflows/formConfig.tsx` and `business_rules/formHelpers.ts`) are currently introducing local copies of the same helper as part of urgent bug fixes on parallel branches. Once those land, this PR will rebase and extend the replacement set to cover them too. Keeping this separate to keep each PR's diff tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)