### PR TITLE
fix(workflows): accept date strings in definition form schema

### DIFF
--- a/packages/core/src/modules/workflows/components/formConfig.tsx
+++ b/packages/core/src/modules/workflows/components/formConfig.tsx
@@ -14,8 +14,8 @@ export type WorkflowDefinitionFormValues = {
   description?: string | null
   version: number
   enabled: boolean
-  effectiveFrom?: Date | null
-  effectiveTo?: Date | null
+  effectiveFrom?: string | null
+  effectiveTo?: string | null
   metadata?: {
     tags?: string[]
     category?: string
@@ -43,8 +43,8 @@ export const workflowDefinitionFormSchema = z.object({
     .nullable(),
   version: z.number().int().min(1),
   enabled: z.boolean(),
-  effectiveFrom: z.date().optional().nullable(),
-  effectiveTo: z.date().optional().nullable(),
+  effectiveFrom: z.string().optional().nullable(),
+  effectiveTo: z.string().optional().nullable(),
   metadata: z.object({
     tags: z.array(z.string()).optional(),
     category: z.string().max(50).optional(),
@@ -224,6 +224,23 @@ export function createFormGroups(
   ]
 }
 
+function toDateInputValue(value?: string | Date | null): string | null {
+  if (!value) return null
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null
+    return value.toISOString().slice(0, 10)
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10)
+    const parsed = new Date(trimmed)
+    if (Number.isNaN(parsed.getTime())) return null
+    return parsed.toISOString().slice(0, 10)
+  }
+  return null
+}
+
 /**
  * Parse workflow definition to form values
  */
@@ -234,8 +251,8 @@ export function parseWorkflowToFormValues(workflow: any): WorkflowDefinitionForm
     description: workflow.description || null,
     version: workflow.version || 1,
     enabled: workflow.enabled ?? true,
-    effectiveFrom: workflow.effectiveFrom ? new Date(workflow.effectiveFrom) : null,
-    effectiveTo: workflow.effectiveTo ? new Date(workflow.effectiveTo) : null,
+    effectiveFrom: toDateInputValue(workflow.effectiveFrom),
+    effectiveTo: toDateInputValue(workflow.effectiveTo),
     metadata: workflow.metadata || { tags: [], category: '', icon: '' },
     steps: workflow.definition?.steps || [],
     transitions: workflow.definition?.transitions || [],
@@ -252,8 +269,8 @@ export function buildWorkflowPayload(values: WorkflowDefinitionFormValues) {
     description: values.description || null,
     version: values.version,
     enabled: values.enabled,
-    effectiveFrom: values.effectiveFrom ? values.effectiveFrom.toISOString() : null,
-    effectiveTo: values.effectiveTo ? values.effectiveTo.toISOString() : null,
+    effectiveFrom: values.effectiveFrom || null,
+    effectiveTo: values.effectiveTo || null,
     metadata: values.metadata || null,
     definition: {
       steps: values.steps,


### PR DESCRIPTION
## Summary

Fixes `Invalid input: expected date, received string` shown under **Effective From** / **Effective To** when creating or editing a workflow definition.

**Root cause:** The client form declared `effectiveFrom` / `effectiveTo` as `Date | null` with `z.date()` schemas, and wrapped loaded values in `new Date(...)`. But CrudForm's `<input type=\"date\">` emits `YYYY-MM-DD` strings, so the Zod validation rejected the submission. Loaded values were also unreadable by the date input, which only renders when the value is a string.

**Fix:** Align the workflows definition form with the existing `staff/LeaveRequestForm` pattern:
- Type `effectiveFrom` / `effectiveTo` as `string | null`
- Validate as `z.string()`
- Normalize incoming API values via a local `toDateInputValue` helper that short-circuits when the string already begins with `YYYY-MM-DD` (as `toISOString()` output always does)
- Pass the string payload straight through to the API, whose `dateOrNull` preprocessor already accepts plain date strings

## Test plan

- [ ] Create a new workflow definition, set Effective From and Effective To, submit — no validation error, record persists.
- [ ] Edit an existing workflow with dates set — values render correctly in the date inputs and save without error.
- [ ] Clear the dates and save — payload sends \`null\` for both fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)