### PR TITLE
feat(workflows): link workflow instance ID in list table

### DIFF
--- a/packages/core/src/modules/workflows/backend/instances/page.tsx
+++ b/packages/core/src/modules/workflows/backend/instances/page.tsx
@@ -213,14 +213,14 @@ export default function WorkflowInstancesListPage() {
       header: t('workflows.instances.fields.workflowId'),
       accessorKey: 'workflowId',
       cell: ({ row }) => (
-        <div>
+        <Link href={`/backend/instances/${row.original.id}`} className="block hover:underline">
           <div className="font-mono text-sm font-medium">{row.original.workflowId}</div>
           {row.original.correlationKey && (
             <div className="text-xs text-muted-foreground">
               {t('workflows.instances.fields.correlationKey')}: {row.original.correlationKey}
             </div>
           )}
-        </div>
+        </Link>
       ),
     },
     {


### PR DESCRIPTION
## Summary

The workflow instance list page required users to open the row actions dropdown to navigate to an instance's detail page. This wraps the workflow ID column cell in a `<Link>` so users can click directly to navigate.

## Changes

- Wrapped the `workflowId` column cell in a Next.js `<Link>` pointing to `/backend/instances/{id}`
- Added `hover:underline` styling for visual affordance

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

## Testing

- Verified type-check passes (no new errors introduced)
- Manual verification: click workflow ID in list navigates to detail page

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues