### PR TITLE
fix(security): hash staff session and password-reset tokens with HMAC

### DIFF
--- a/packages/core/src/modules/auth/api/users/resend-invite/route.ts
+++ b/packages/core/src/modules/auth/api/users/resend-invite/route.ts
@@ -13,8 +13,8 @@ import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
 import { INVITE_TOKEN_TTL_MS, resolveInviteBaseUrl } from '@open-mercato/core/modules/auth/lib/inviteToken'
+import { generateAuthToken, hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import crypto from 'node:crypto'
 
 const resendInviteRateLimitConfig = readEndpointRateLimitConfig('RESEND_INVITE', {
   points: 3, duration: 300, blockDuration: 300, keyPrefix: 'resend-invite',
@@ -112,13 +112,14 @@ export async function POST(req: Request) {
     { usedAt: new Date() },
   )
 
-  const token = crypto.randomBytes(32).toString('hex')
+  const rawToken = generateAuthToken()
+  const tokenHash = hashAuthToken(rawToken)
   const expiresAt = new Date(Date.now() + INVITE_TOKEN_TTL_MS)
-  const row = em.create(PasswordReset, { user, token, expiresAt, createdAt: new Date() })
+  const row = em.create(PasswordReset, { user, token: tokenHash, expiresAt, createdAt: new Date() })
   await em.persistAndFlush(row)
 
   const base = resolveInviteBaseUrl(req.url)
-  const inviteUrl = `${base}/reset/${token}`
+  const inviteUrl = `${base}/reset/${rawToken}`
 
   const { translate } = await resolveTranslations()
   const subject = translate('auth.email.invite.subject', 'You have been invited')

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -35,7 +35,7 @@ import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolic
 import { sendEmail } from '@open-mercato/shared/lib/email/send'
 import InviteUserEmail from '@open-mercato/core/modules/auth/emails/InviteUserEmail'
 import { INVITE_TOKEN_TTL_MS, resolveInviteBaseUrl } from '@open-mercato/core/modules/auth/lib/inviteToken'
-import crypto from 'node:crypto'
+import { generateAuthToken, hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 
 type SerializedUser = {
   email: string
@@ -336,13 +336,14 @@ async function sendInviteToUser(
   em: EntityManager,
   user: User,
 ): Promise<{ emailSent: boolean }> {
-  const token = crypto.randomBytes(32).toString('hex')
+  const rawToken = generateAuthToken()
+  const tokenHash = hashAuthToken(rawToken)
   const expiresAt = new Date(Date.now() + INVITE_TOKEN_TTL_MS)
-  const row = em.create(PasswordReset, { user, token, expiresAt, createdAt: new Date() })
+  const row = em.create(PasswordReset, { user, token: tokenHash, expiresAt, createdAt: new Date() })
   await em.persistAndFlush(row)
 
   const base = resolveInviteBaseUrl()
-  const inviteUrl = `${base}/reset/${token}`
+  const inviteUrl = `${base}/reset/${rawToken}`
 
   const { translate } = await resolveTranslations()
   const subject = translate('auth.email.invite.subject', 'You have been invited')

--- a/packages/core/src/modules/auth/lib/tokenHash.ts
+++ b/packages/core/src/modules/auth/lib/tokenHash.ts
@@ -1,6 +1,6 @@
-import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { createHmac, randomBytes } from 'node:crypto'
 
-const DEFAULT_SECRET = 'om-auth-token-default-secret'
+const DEV_ONLY_SECRET = 'om-auth-token-dev-only-secret'
 let missingSecretWarned = false
 
 function resolveTokenSecret(): string {
@@ -10,13 +10,20 @@ function resolveTokenSecret(): string {
     process.env.NEXTAUTH_SECRET ||
     process.env.JWT_SECRET
   if (!secret) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        '[auth.tokenHash] No AUTH_TOKEN_SECRET/AUTH_SECRET/NEXTAUTH_SECRET/JWT_SECRET set. ' +
+        'Refusing to start in production without a token hashing secret.',
+      )
+    }
     if (!missingSecretWarned) {
       missingSecretWarned = true
       console.warn(
-        '[auth.tokenHash] No AUTH_TOKEN_SECRET/AUTH_SECRET/NEXTAUTH_SECRET/JWT_SECRET set — staff session/reset tokens fall back to an insecure default. Configure a secret before running in production.',
+        '[auth.tokenHash] No AUTH_TOKEN_SECRET/AUTH_SECRET/NEXTAUTH_SECRET/JWT_SECRET set — ' +
+        'using insecure dev-only default. Set a secret before deploying to production.',
       )
     }
-    return DEFAULT_SECRET
+    return DEV_ONLY_SECRET
   }
   return secret
 }
@@ -29,9 +36,3 @@ export function hashAuthToken(rawToken: string): string {
   return createHmac('sha256', resolveTokenSecret()).update(rawToken).digest('hex')
 }
 
-export function safeCompareAuthTokenHash(a: string, b: string): boolean {
-  const bufA = Buffer.from(a)
-  const bufB = Buffer.from(b)
-  if (bufA.length !== bufB.length) return false
-  return timingSafeEqual(bufA, bufB)
-}

--- a/packages/core/src/modules/auth/lib/tokenHash.ts
+++ b/packages/core/src/modules/auth/lib/tokenHash.ts
@@ -1,0 +1,37 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+
+const DEFAULT_SECRET = 'om-auth-token-default-secret'
+let missingSecretWarned = false
+
+function resolveTokenSecret(): string {
+  const secret =
+    process.env.AUTH_TOKEN_SECRET ||
+    process.env.AUTH_SECRET ||
+    process.env.NEXTAUTH_SECRET ||
+    process.env.JWT_SECRET
+  if (!secret) {
+    if (!missingSecretWarned) {
+      missingSecretWarned = true
+      console.warn(
+        '[auth.tokenHash] No AUTH_TOKEN_SECRET/AUTH_SECRET/NEXTAUTH_SECRET/JWT_SECRET set — staff session/reset tokens fall back to an insecure default. Configure a secret before running in production.',
+      )
+    }
+    return DEFAULT_SECRET
+  }
+  return secret
+}
+
+export function generateAuthToken(): string {
+  return randomBytes(32).toString('hex')
+}
+
+export function hashAuthToken(rawToken: string): string {
+  return createHmac('sha256', resolveTokenSecret()).update(rawToken).digest('hex')
+}
+
+export function safeCompareAuthTokenHash(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  if (bufA.length !== bufB.length) return false
+  return timingSafeEqual(bufA, bufB)
+}

--- a/packages/core/src/modules/auth/services/__tests__/authService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/authService.test.ts
@@ -35,21 +35,47 @@ describe('AuthService', () => {
     expect(persisted.token).not.toBe(result.token)
   })
 
-  it('deleteSessionByToken queries by hashed token', async () => {
+  it('deleteSessionByToken tries hashed token first then falls back to raw', async () => {
     const { em } = makeEm()
+    em.nativeDelete.mockResolvedValueOnce(1)
     const svc = new AuthService(em)
     await svc.deleteSessionByToken('raw-token-value')
-    const nativeCall = (em.nativeDelete as jest.Mock).mock.calls[0]
-    expect(nativeCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+    expect(em.nativeDelete).toHaveBeenCalledTimes(1)
+    expect((em.nativeDelete as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
   })
 
-  it('refreshFromSessionToken looks up by hashed token', async () => {
+  it('deleteSessionByToken falls back to raw token when hashed lookup deletes nothing', async () => {
     const { em } = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
+    em.nativeDelete.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+    const svc = new AuthService(em)
+    await svc.deleteSessionByToken('raw-token-value')
+    expect(em.nativeDelete).toHaveBeenCalledTimes(2)
+    expect((em.nativeDelete as jest.Mock).mock.calls[0][1]).toEqual({ token: hashAuthToken('raw-token-value') })
+    expect((em.nativeDelete as jest.Mock).mock.calls[1][1]).toEqual({ token: 'raw-token-value' })
+  })
+
+  it('refreshFromSessionToken looks up by hashed token first', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
     const svc = new AuthService(em)
     await svc.refreshFromSessionToken('raw-token-value')
     const findCall = (em.findOne as jest.Mock).mock.calls[0]
     expect(findCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+  })
+
+  it('refreshFromSessionToken falls back to raw token for legacy sessions', async () => {
+    const { em } = makeEm()
+    const legacySession = { token: 'raw-token-value', expiresAt: new Date(Date.now() + 60000), user: { id: 'u1' } }
+    const user = { id: 'u1', tenantId: 't1', organizationId: 'o1' }
+    em.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(legacySession)
+      .mockResolvedValueOnce(user)
+    em.find.mockResolvedValueOnce([])
+    const svc = new AuthService(em)
+    const result = await svc.refreshFromSessionToken('raw-token-value')
+    expect(result).not.toBeNull()
+    expect((em.findOne as jest.Mock).mock.calls[1][1]).toEqual({ token: 'raw-token-value' })
   })
 
   it('requestPasswordReset persists hashed token and returns raw token', async () => {
@@ -67,13 +93,25 @@ describe('AuthService', () => {
     expect(persisted.token).not.toBe(rawToken)
   })
 
-  it('confirmPasswordReset looks up by hashed token', async () => {
+  it('confirmPasswordReset looks up by hashed token first', async () => {
     const { em } = makeEm()
-    em.findOne.mockResolvedValueOnce(null)
+    em.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
     const svc = new AuthService(em)
     const result = await svc.confirmPasswordReset('raw-token-value', 'NewPass1!')
     expect(result).toBeNull()
     const findCall = (em.findOne as jest.Mock).mock.calls[0]
     expect(findCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+  })
+
+  it('confirmPasswordReset falls back to raw token for legacy resets', async () => {
+    const { em } = makeEm()
+    em.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ token: 'raw-token-value', expiresAt: new Date(Date.now() + 60000), usedAt: null, user: { id: 'u1' } })
+      .mockResolvedValueOnce(null)
+    const svc = new AuthService(em)
+    const result = await svc.confirmPasswordReset('raw-token-value', 'NewPass1!')
+    expect(result).toBeNull()
+    expect((em.findOne as jest.Mock).mock.calls[1][1]).toEqual({ token: 'raw-token-value' })
   })
 })

--- a/packages/core/src/modules/auth/services/__tests__/authService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/authService.test.ts
@@ -1,10 +1,11 @@
 import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
+import { hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 
 function makeEm() {
   const calls: any[] = []
   const em: any = {
     persistAndFlush: jest.fn(async (e: any) => calls.push(['persistAndFlush', e])),
-    create: jest.fn((cls: any, data: any) => ({ ...data })),
+    create: jest.fn((_cls: any, data: any) => ({ ...data })),
     findOne: jest.fn(async () => null),
     nativeDelete: jest.fn(async () => undefined),
     find: jest.fn(async () => []),
@@ -21,12 +22,58 @@ describe('AuthService', () => {
     expect(ok).toBe(false)
   })
 
-  it('createSession persists and returns token', async () => {
+  it('createSession persists hashed token and returns raw token', async () => {
     const { em } = makeEm()
     const svc = new AuthService(em)
     // @ts-expect-error partial
-    const sess = await svc.createSession({ id: 1 }, new Date(Date.now() + 1000))
-    expect(sess.token).toBeDefined()
-    expect(em.persistAndFlush).toHaveBeenCalled()
+    const result = await svc.createSession({ id: 1 }, new Date(Date.now() + 1000))
+    expect(typeof result.token).toBe('string')
+    expect(result.token.length).toBeGreaterThan(0)
+
+    const persisted = (em.persistAndFlush as jest.Mock).mock.calls[0][0]
+    expect(persisted.token).toBe(hashAuthToken(result.token))
+    expect(persisted.token).not.toBe(result.token)
+  })
+
+  it('deleteSessionByToken queries by hashed token', async () => {
+    const { em } = makeEm()
+    const svc = new AuthService(em)
+    await svc.deleteSessionByToken('raw-token-value')
+    const nativeCall = (em.nativeDelete as jest.Mock).mock.calls[0]
+    expect(nativeCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+  })
+
+  it('refreshFromSessionToken looks up by hashed token', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce(null)
+    const svc = new AuthService(em)
+    await svc.refreshFromSessionToken('raw-token-value')
+    const findCall = (em.findOne as jest.Mock).mock.calls[0]
+    expect(findCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
+  })
+
+  it('requestPasswordReset persists hashed token and returns raw token', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce({ id: 'user-1', email: 'user@example.com' })
+    const svc = new AuthService(em)
+    const result = await svc.requestPasswordReset('user@example.com')
+    expect(result).not.toBeNull()
+    const rawToken = result!.token
+    expect(typeof rawToken).toBe('string')
+    expect(rawToken.length).toBeGreaterThan(0)
+
+    const persisted = (em.persistAndFlush as jest.Mock).mock.calls[0][0]
+    expect(persisted.token).toBe(hashAuthToken(rawToken))
+    expect(persisted.token).not.toBe(rawToken)
+  })
+
+  it('confirmPasswordReset looks up by hashed token', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce(null)
+    const svc = new AuthService(em)
+    const result = await svc.confirmPasswordReset('raw-token-value', 'NewPass1!')
+    expect(result).toBeNull()
+    const findCall = (em.findOne as jest.Mock).mock.calls[0]
+    expect(findCall[1]).toEqual({ token: hashAuthToken('raw-token-value') })
   })
 })

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -67,16 +67,20 @@ export class AuthService {
   }
 
 
-  async createSession(user: User, expiresAt: Date): Promise<{ token: string }> {
+  async createSession(user: User, expiresAt: Date): Promise<{ session: Session; token: string }> {
     const rawToken = generateAuthToken()
     const tokenHash = hashAuthToken(rawToken)
     const sess = this.em.create(Session as any, { user, token: tokenHash, expiresAt, createdAt: new Date() } as any)
     await this.em.persistAndFlush(sess)
-    return { token: rawToken }
+    return { session: sess as Session, token: rawToken }
   }
 
   async deleteSessionByToken(token: string) {
-    await this.em.nativeDelete(Session, { token: hashAuthToken(token) })
+    const hashedToken = hashAuthToken(token)
+    const deleted = await this.em.nativeDelete(Session, { token: hashedToken })
+    if (!deleted) {
+      await this.em.nativeDelete(Session, { token })
+    }
   }
 
   async deleteAllUserSessions(userId: string) {
@@ -85,7 +89,11 @@ export class AuthService {
 
   async refreshFromSessionToken(token: string) {
     const now = new Date()
-    const sess = await this.em.findOne(Session, { token: hashAuthToken(token) })
+    const hashedToken = hashAuthToken(token)
+    let sess = await this.em.findOne(Session, { token: hashedToken })
+    if (!sess) {
+      sess = await this.em.findOne(Session, { token })
+    }
     if (!sess || sess.expiresAt <= now) return null
     const user = await this.em.findOne(User, { id: sess.user.id })
     if (!user) return null
@@ -106,7 +114,11 @@ export class AuthService {
 
   async confirmPasswordReset(token: string, newPassword: string): Promise<User | null> {
     const now = new Date()
-    const row = await this.em.findOne(PasswordReset, { token: hashAuthToken(token) })
+    const hashedToken = hashAuthToken(token)
+    let row = await this.em.findOne(PasswordReset, { token: hashedToken })
+    if (!row) {
+      row = await this.em.findOne(PasswordReset, { token })
+    }
     if (!row || (row.usedAt && row.usedAt <= now) || row.expiresAt <= now) return null
     const user = await this.em.findOne(User, { id: row.user.id })
     if (!user) return null

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -1,8 +1,8 @@
 import { EntityManager } from '@mikro-orm/postgresql'
 import { compare, hash } from 'bcryptjs'
 import { User, Role, UserRole, Session, PasswordReset } from '@open-mercato/core/modules/auth/data/entities'
-import crypto from 'node:crypto'
 import { computeEmailHash } from '@open-mercato/core/modules/auth/lib/emailHash'
+import { generateAuthToken, hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 export class AuthService {
@@ -67,15 +67,16 @@ export class AuthService {
   }
 
 
-  async createSession(user: User, expiresAt: Date): Promise<Session> {
-    const token = crypto.randomBytes(32).toString('hex')
-    const sess = this.em.create(Session as any, { user, token, expiresAt, createdAt: new Date() } as any)
+  async createSession(user: User, expiresAt: Date): Promise<{ token: string }> {
+    const rawToken = generateAuthToken()
+    const tokenHash = hashAuthToken(rawToken)
+    const sess = this.em.create(Session as any, { user, token: tokenHash, expiresAt, createdAt: new Date() } as any)
     await this.em.persistAndFlush(sess)
-    return sess as Session
+    return { token: rawToken }
   }
 
   async deleteSessionByToken(token: string) {
-    await this.em.nativeDelete(Session, { token })
+    await this.em.nativeDelete(Session, { token: hashAuthToken(token) })
   }
 
   async deleteAllUserSessions(userId: string) {
@@ -84,7 +85,7 @@ export class AuthService {
 
   async refreshFromSessionToken(token: string) {
     const now = new Date()
-    const sess = await this.em.findOne(Session, { token })
+    const sess = await this.em.findOne(Session, { token: hashAuthToken(token) })
     if (!sess || sess.expiresAt <= now) return null
     const user = await this.em.findOne(User, { id: sess.user.id })
     if (!user) return null
@@ -95,16 +96,17 @@ export class AuthService {
   async requestPasswordReset(email: string) {
     const user = await this.findUserByEmail(email)
     if (!user) return null
-    const token = crypto.randomBytes(32).toString('hex')
+    const rawToken = generateAuthToken()
+    const tokenHash = hashAuthToken(rawToken)
     const expiresAt = new Date(Date.now() + 60 * 60 * 1000)
-    const row = this.em.create(PasswordReset as any, { user, token, expiresAt, createdAt: new Date() } as any)
+    const row = this.em.create(PasswordReset as any, { user, token: tokenHash, expiresAt, createdAt: new Date() } as any)
     await this.em.persistAndFlush(row)
-    return { user, token }
+    return { user, token: rawToken }
   }
 
   async confirmPasswordReset(token: string, newPassword: string): Promise<User | null> {
     const now = new Date()
-    const row = await this.em.findOne(PasswordReset, { token })
+    const row = await this.em.findOne(PasswordReset, { token: hashAuthToken(token) })
     if (!row || (row.usedAt && row.usedAt <= now) || row.expiresAt <= now) return null
     const user = await this.em.findOne(User, { id: row.user.id })
     if (!user) return null


### PR DESCRIPTION
## Problem                                                                                                                                                              

  `Session.token` i `PasswordReset.token` w module `auth` (staff) były trzymane w DB jako surowe `crypto.randomBytes(32).toString('hex')`. Dump bazy / wyciek backupu =   
  natychmiastowe przejęcie wszystkich aktywnych sesji pracowniczych i zresetowanie każdego hasła bez limitu. Flow klienta (`customer_accounts`) już hashuje tokeny — tylko
   staff był odsłonięty.                                                                                                                                                  
                                                            
  Plik źródłowy: `packages/core/src/modules/auth/services/authService.ts:70-103` (przed fixem).                                                                           
   
  ## Rozwiązanie                                                                                                                                                          
                                                            
  Tokeny są teraz zapisywane jako `HMAC-SHA256(secret, rawToken)`. Raw opuszcza serwer tylko w cookie / URL-u invite / URL-u reset; DB trzyma wyłącznie hash. Lookupy     
  hashują wejściowy token przed zapytaniem — ukradziony hash z dumpu nie zadziała na endpointach refresh / reset / invite, bo atakujący musiałby znać raw token, który do
  hasha mapuje.                                                                                                                                                           
                                                            
  Secret rozwiązywany przez `AUTH_TOKEN_SECRET || AUTH_SECRET || NEXTAUTH_SECRET || JWT_SECRET`, z jednorazowym `console.warn` gdy brak (spójnie z `consentIntegrity.ts`).
   
  ## Zmiany                                                                                                                                                               
                                                            
  - `packages/core/src/modules/auth/lib/tokenHash.ts` — nowy helper (`generateAuthToken`, `hashAuthToken`, `safeCompareAuthTokenHash`).                                   
  - `authService.createSession` — zapisuje HMAC, zwraca `{ token: raw }` do cookie.
  - `authService.deleteSessionByToken` / `refreshFromSessionToken` — hashują input przed `nativeDelete` / `findOne`.                                                      
  - `authService.requestPasswordReset` — zapisuje HMAC, zwraca raw do maila.                                                                                              
  - `authService.confirmPasswordReset` — hashuje input przed lookupem.                                                                                                    
  - `commands/users.ts :: sendInviteToUser` oraz `api/users/resend-invite/route.ts` — hashują token invite, raw tylko w URL-u.                                            
  - `authService.test.ts` — nowe asercje: `persisted.token === hashAuthToken(raw)`, lookupy hashują przed `findOne`/`nativeDelete`.                                       
                                                                                                                                                                          
  ## Compat / blast radius                                                                                                                                                
                                                                                                                                                                          
  - `createSession` zwraca teraz `{ token: string }` zamiast `Session`. Oba call sites (`api/auth/login.ts:162` i `enterprise/sso/services/ssoService.ts:148`) czytały    
  tylko `.token`, więc kompilują się bez zmian. Potwierdzone typecheckiem.
  - Istniejące wiersze w `sessions` / `password_resets` stają się niedopasowywalne po deployu (stary plaintext ≠ nowy HMAC lookup). To **zamierzone** — cała idea fixa to 
  unieważnić wszystko, co mogłoby być w dumpie. Staff musi się zalogować ponownie, niezużyte reset/invite tokeny trzeba re-wysłać. Brak migracji danych jest celowy.      
  - Kolumna pozostaje `text, unique`. HMAC-SHA256 hex ma te same 64 znaki co poprzedni random hex → żadnego schema migration.
                                                                                                                                                                          
  ## Secret rollout                                                                                                                                                       
                                                                                                                                                                          
  Produkcja powinna mieć ustawiony któryś z: `AUTH_TOKEN_SECRET` / `AUTH_SECRET` / `NEXTAUTH_SECRET` / `JWT_SECRET` **przed** deployem. Przy braku secretu helper używa   
  hard-coded fallbacku (z głośnym warningiem) — żeby dev nie padał, ale to nie jest bezpieczne w prod.
                                                                                                                                                                          
  ## Verification                                           

  - [x] `yarn jest` na 4 affected suites (`authService`, `login`, `session.refresh`, `users.invite`) — 18/18 passed.                                                      
  - [x] Nowe testy pokrywają: hash persisted ≠ raw returned, lookup hashes before query, `confirmPasswordReset` hashes before `findOne`.