### PR TITLE
replace raw fetch with apiCall/apiFetch, add readJsonSafe, expose openApi, fix Escape handler

### DIFF
--- a/packages/ai-assistant/src/frontend/components/DockableChat/DockableChat.tsx
+++ b/packages/ai-assistant/src/frontend/components/DockableChat/DockableChat.tsx
@@ -204,6 +204,11 @@ export function DockableChat() {
   const handleChatKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') {
       e.stopPropagation()
+      if (phase !== 'idle') {
+        reset()
+      } else {
+        close()
+      }
     }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()

--- a/packages/ai-assistant/src/frontend/hooks/useCommandPalette.ts
+++ b/packages/ai-assistant/src/frontend/hooks/useCommandPalette.ts
@@ -19,6 +19,8 @@ import type {
   DebugEventType,
   OpenCodeQuestion,
 } from '../types'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiFetch } from '@open-mercato/ui/backend/utils/api'
 import { COMMAND_PALETTE_SHORTCUT, AI_CHAT_SHORTCUT } from '../constants'
 import { filterTools } from '../utils/toolMatcher'
 import { useMcpTools } from './useMcpTools'
@@ -497,7 +499,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
   // Route query using fast model
   const routeQuery = useCallback(
     async (query: string): Promise<RouteResult> => {
-      const response = await fetch('/api/ai_assistant/route', {
+      const { ok, result, status } = await apiCall<RouteResult>('/api/ai_assistant/route', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -509,11 +511,15 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
         }),
       })
 
-      if (!response.ok) {
-        throw new Error(`Routing failed: ${response.status}`)
+      if (!ok) {
+        throw new Error(`Routing failed: ${status}`)
       }
 
-      return response.json()
+      if (!result) {
+        throw new Error('Routing returned empty response')
+      }
+
+      return result
     },
     [tools]
   )
@@ -547,7 +553,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
         const controller = new AbortController()
         currentStreamController.current = controller
 
-        const response = await fetch('/api/ai_assistant/chat', {
+        const response = await apiFetch('/api/ai_assistant/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -765,7 +771,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
         }
         setMessages([userMessage])
 
-        const response = await fetch('/api/ai_assistant/chat', {
+        const response = await apiFetch('/api/ai_assistant/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -978,7 +984,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
         currentStreamController.current = controller
 
         // Send to chat API with OpenCode session for context persistence
-        const response = await fetch('/api/ai_assistant/chat', {
+        const response = await apiFetch('/api/ai_assistant/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -1271,7 +1277,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
       try {
         // Send answer as simple POST - the original SSE stream will receive the follow-up
         const sessionId = pendingQuestion.sessionID
-        const response = await fetch('/api/ai_assistant/chat', {
+        const { ok, result, status } = await apiCall<{ error?: string }>('/api/ai_assistant/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -1283,9 +1289,8 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
           }),
         })
 
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}))
-          throw new Error(errorData.error || `Answer request failed: ${response.status}`)
+        if (!ok) {
+          throw new Error(result?.error || `Answer request failed: ${status}`)
         }
 
         // Answer sent successfully - the original stream will handle the response
@@ -1325,7 +1330,7 @@ export function useCommandPalette(options: UseCommandPaletteOptions) {
 
       try {
         // Send to chat API
-        const response = await fetch('/api/ai_assistant/chat', {
+        const response = await apiFetch('/api/ai_assistant/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({

--- a/packages/ai-assistant/src/frontend/hooks/useMcpTools.ts
+++ b/packages/ai-assistant/src/frontend/hooks/useMcpTools.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect } from 'react'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import type { ToolInfo, ToolExecutionResult } from '../types'
 
 export function useMcpTools() {
@@ -12,16 +13,14 @@ export function useMcpTools() {
     setIsLoading(true)
     setError(null)
     try {
-      const response = await fetch('/api/ai_assistant/tools', {
-        headers: {
-          'x-om-forbidden-redirect': '0',
-        },
-      })
-      if (!response.ok) {
-        throw new Error(`Failed to fetch tools: ${response.status}`)
+      const { ok, result, status } = await apiCall<{ tools: ToolInfo[] }>(
+        '/api/ai_assistant/tools',
+        { headers: { 'x-om-forbidden-redirect': '0' } }
+      )
+      if (!ok) {
+        throw new Error(`Failed to fetch tools: ${status}`)
       }
-      const data = await response.json()
-      setTools(data.tools || [])
+      setTools(result?.tools || [])
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load tools')
       setTools([])
@@ -33,27 +32,28 @@ export function useMcpTools() {
   const executeTool = useCallback(
     async (toolName: string, args: Record<string, unknown> = {}): Promise<ToolExecutionResult> => {
       try {
-        const response = await fetch('/api/ai_assistant/tools/execute', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-om-forbidden-redirect': '0',
-          },
-          body: JSON.stringify({ toolName, args }),
-        })
+        const { ok, result, status } = await apiCall<{ result: unknown; error?: string }>(
+          '/api/ai_assistant/tools/execute',
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-om-forbidden-redirect': '0',
+            },
+            body: JSON.stringify({ toolName, args }),
+          }
+        )
 
-        const data = await response.json()
-
-        if (!response.ok) {
+        if (!ok) {
           return {
             success: false,
-            error: data.error || `Tool execution failed: ${response.status}`,
+            error: result?.error || `Tool execution failed: ${status}`,
           }
         }
 
         return {
           success: true,
-          result: data.result,
+          result: result?.result,
         }
       } catch (err) {
         return {

--- a/packages/ai-assistant/src/modules/ai_assistant/api/chat/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/chat/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import {
   handleOpenCodeMessageStreaming,
@@ -118,6 +119,14 @@ RESPONSE RULES:
 - Present results in clean business language with **bold names** and bullet points.
 - Only ask for confirmation before create/update/delete operations.
 `.trim()
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'AI Assistant',
+  summary: 'AI chat',
+  methods: {
+    POST: { summary: 'Send message to AI agent via SSE stream' },
+  },
+}
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['ai_assistant.view'] },

--- a/packages/ai-assistant/src/modules/ai_assistant/api/health/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/health/route.ts
@@ -1,6 +1,15 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { handleOpenCodeHealth } from '../../lib/opencode-handlers'
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'AI Assistant',
+  summary: 'AI assistant health check',
+  methods: {
+    GET: { summary: 'Check OpenCode and MCP connection status' },
+  },
+}
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['ai_assistant.view'] },

--- a/packages/ai-assistant/src/modules/ai_assistant/api/route/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/route/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { generateObject } from '../../lib/ai-sdk'
 import {
   createOpenAI,
@@ -18,6 +19,14 @@ import {
   isProviderConfigured,
   type ChatProviderId,
 } from '../../lib/chat-config'
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'AI Assistant',
+  summary: 'AI query routing',
+  methods: {
+    POST: { summary: 'Route user query to appropriate AI handler' },
+  },
+}
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['ai_assistant.view'] },

--- a/packages/ai-assistant/src/modules/ai_assistant/api/settings/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/settings/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import {
   OPEN_CODE_PROVIDER_IDS,
@@ -8,6 +9,14 @@ import {
   resolveOpenCodeModel,
   resolveOpenCodeProviderId,
 } from '@open-mercato/shared/lib/ai/opencode-provider'
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'AI Assistant',
+  summary: 'AI assistant settings',
+  methods: {
+    GET: { summary: 'Get AI provider configuration' },
+  },
+}
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['ai_assistant.view'] },

--- a/packages/ai-assistant/src/modules/ai_assistant/api/tools/execute/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/tools/execute/route.ts
@@ -1,10 +1,19 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { executeTool } from '../../../lib/tool-executor'
 import { loadAllModuleTools } from '../../../lib/tool-loader'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { McpToolContext } from '../../../lib/types'
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'AI Assistant',
+  summary: 'Execute AI tool',
+  methods: {
+    POST: { summary: 'Execute a specific MCP tool by name' },
+  },
+}
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['ai_assistant.view'] },

--- a/packages/ai-assistant/src/modules/ai_assistant/api/tools/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/tools/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
@@ -6,6 +7,14 @@ import { getToolRegistry } from '../../lib/tool-registry'
 import { loadAllModuleTools } from '../../lib/tool-loader'
 import { hasRequiredFeatures } from '../../lib/auth'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'AI Assistant',
+  summary: 'List AI tools',
+  methods: {
+    GET: { summary: 'List available MCP tools filtered by user permissions' },
+  },
+}
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['ai_assistant.view'] },

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/opencode-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/opencode-client.ts
@@ -4,6 +4,7 @@
  * Client for communicating with OpenCode server running in headless mode.
  * OpenCode is used as an AI agent that can execute MCP tools.
  */
+import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 
 export type OpenCodeClientConfig = {
   baseUrl: string
@@ -195,7 +196,9 @@ export class OpenCodeClient {
       throw new Error(`Health check failed: ${res.status}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<OpenCodeHealth>(res, null)
+    if (!data) throw new Error('Health check returned invalid JSON response')
+    return data
   }
 
   /**
@@ -210,7 +213,9 @@ export class OpenCodeClient {
       throw new Error(`MCP status check failed: ${res.status}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<OpenCodeMcpStatus>(res, null)
+    if (!data) throw new Error('MCP status check returned invalid JSON response')
+    return data
   }
 
   /**
@@ -228,7 +233,9 @@ export class OpenCodeClient {
       throw new Error(`Failed to create session: ${error}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<OpenCodeSession>(res, null)
+    if (!data) throw new Error('Create session returned invalid JSON response')
+    return data
   }
 
   /**
@@ -243,7 +250,9 @@ export class OpenCodeClient {
       throw new Error(`Failed to get session: ${res.status}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<OpenCodeSession>(res, null)
+    if (!data) throw new Error('Get session returned invalid JSON response')
+    return data
   }
 
   /**
@@ -275,7 +284,9 @@ export class OpenCodeClient {
       throw new Error(`Failed to send message: ${error}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<OpenCodeMessage>(res, null)
+    if (!data) throw new Error('Send message returned invalid JSON response')
+    return data
   }
 
   /**
@@ -305,7 +316,9 @@ export class OpenCodeClient {
       throw new Error(`Failed to get config: ${res.status}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<Record<string, unknown>>(res, null)
+    if (!data) throw new Error('Get config returned invalid JSON response')
+    return data
   }
 
   /**
@@ -320,7 +333,9 @@ export class OpenCodeClient {
       throw new Error(`Failed to get questions: ${res.status}`)
     }
 
-    return res.json()
+    const data = await readJsonSafe<OpenCodeQuestion[]>(res, null)
+    if (!data) throw new Error('Get questions returned invalid JSON response')
+    return data
   }
 
   /**
@@ -395,7 +410,8 @@ export class OpenCodeClient {
       if (res.ok) {
         const contentType = res.headers.get('content-type')
         if (contentType && contentType.includes('application/json')) {
-          return res.json()
+          const data = await readJsonSafe<{ status: string; questionId?: string }>(res, null)
+          if (data) return data
         }
       }
     } catch {


### PR DESCRIPTION
Title: fix(ai-assistant): replace raw fetch with apiCall/apiFetch, add readJsonSafe, expose openApi, fix Escape handler
                                                                                                                         
  ---                                                             
  Summary                                                                                                                
                                                                  
  Fixes several related hygiene issues in the ai-assistant package that violated platform conventions:
                                                                                                                         
  - Raw fetch() usage in frontend hooks instead of the platform wrappers (apiCall/apiFetch)                              
  - Unsafe .json() parsing without error handling in frontend hooks and the OpenCode client                              
  - Missing export const openApi on all six AI assistant API route files                                                 
  - Broken Escape key handler in DockableChat — propagation was stopped but the dialog was never closed                  
                                                                                                                         
  ---                                                                                                                    
  Changes                                                                                                                
                                                                  
  1. Replace fetch() with apiCall / apiFetch in frontend hooks
                                                                                                                         
  useMcpTools.ts                                                                                                         
  - fetchTools and executeTool now use apiCall<T>() from @open-mercato/ui/backend/utils/apiCall                          
  - JSON parsing is handled automatically by apiCall; manual .json() calls removed                                       
                                                                                  
  useCommandPalette.ts                                                                                                   
  - routeQuery and answerQuestion (non-streaming JSON responses) now use apiCall<T>()                                    
  - startAgenticChat, startGeneralChat, sendAgenticMessage, and sendMessage (SSE streams) now use apiFetch() from        
  @open-mercato/ui/backend/utils/api — preserves streaming body access while adding proper 401/403 redirect handling     
                                                                                                                         
  2. Replace .json() with readJsonSafe in the OpenCode client     
                                                                                                                         
  opencode-client.ts                                              
  - All eight methods that called res.json() (health, mcpStatus, createSession, getSession, sendMessage, getConfig,
  getPendingQuestions, getSessionStatus) now use readJsonSafe<T>(res, null) from                                         
  @open-mercato/shared/lib/http/readJsonSafe                                    
  - Each call is followed by an explicit null-check with a descriptive error message, preventing silent failures on      
  malformed JSON responses from the OpenCode Docker container     
                                                                                                                         
  3. Add export const openApi to all AI assistant API routes
                                                                                                                         
  All six route files now export a properly typed OpenApiRouteDoc object, enabling automatic OpenAPI documentation       
  generation:
                                                                                                                         
  ┌────────────────────────────┬────────┬───────────────────────────────────────────────────────┐
  │           Route            │ Method │                        Summary                        │
  ├────────────────────────────┼────────┼───────────────────────────────────────────────────────┤
  │ api/settings/route.ts      │ GET    │ Get AI provider configuration                         │
  ├────────────────────────────┼────────┼───────────────────────────────────────────────────────┤
  │ api/chat/route.ts          │ POST   │ Send message to AI agent via SSE stream               │                        
  ├────────────────────────────┼────────┼───────────────────────────────────────────────────────┤                        
  │ api/health/route.ts        │ GET    │ Check OpenCode and MCP connection status              │                        
  ├────────────────────────────┼────────┼───────────────────────────────────────────────────────┤                        
  │ api/route/route.ts         │ POST   │ Route user query to appropriate AI handler            │
  ├────────────────────────────┼────────┼───────────────────────────────────────────────────────┤                        
  │ api/tools/route.ts         │ GET    │ List available MCP tools filtered by user permissions │
  ├────────────────────────────┼────────┼───────────────────────────────────────────────────────┤                        
  │ api/tools/execute/route.ts │ POST   │ Execute a specific MCP tool by name                   │
  └────────────────────────────┴────────┴───────────────────────────────────────────────────────┘                        
   
  4. Fix Escape key handler in DockableChat                                                                              
                                                                  
  DockableChat.tsx
  - handleChatKeyDown previously called e.stopPropagation() on Escape, blocking the global keyboard listener without
  taking any action                                                                                                      
  - Now calls reset() when a chat phase is active (phase !== 'idle') or close() when already idle — consistent with the
  keyboard handler behaviour in useCommandPalette.ts                                                                     
                                                                                                                         
  ---
  Test Plan                                                                                                              
                                                                                                                         
  - Open AI chat (Cmd+J) — pressing Escape returns to idle state; pressing Escape again closes the panel
  - Tool list loads correctly on palette open (network tab shows /api/ai_assistant/tools with proper auth headers)       
  - Tool execution works (/api/ai_assistant/tools/execute returns success)                                               
  - Chat routing (/api/ai_assistant/route) succeeds and returns a RouteResult                                            
  - Answering an OpenCode confirmation question sends the answer and resumes streaming                                   
  - OpenAPI spec is regenerated (yarn generate) and includes all six AI assistant routes under the AI Assistant tag      
  - Package builds cleanly: yarn build:packages — ai-assistant built successfully  