### PR TITLE
Feat/ds semantic tokens v2

### DIFF
--- a/apps/mercato/src/app/globals.css
+++ b/apps/mercato/src/app/globals.css
@@ -56,6 +56,45 @@ TODO: Fix that latter to have reference by the package names
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* ═══ Design System: Semantic Status Colors ═══ */
+  --color-status-error-bg: var(--status-error-bg);
+  --color-status-error-text: var(--status-error-text);
+  --color-status-error-border: var(--status-error-border);
+  --color-status-error-icon: var(--status-error-icon);
+
+  --color-status-success-bg: var(--status-success-bg);
+  --color-status-success-text: var(--status-success-text);
+  --color-status-success-border: var(--status-success-border);
+  --color-status-success-icon: var(--status-success-icon);
+
+  --color-status-warning-bg: var(--status-warning-bg);
+  --color-status-warning-text: var(--status-warning-text);
+  --color-status-warning-border: var(--status-warning-border);
+  --color-status-warning-icon: var(--status-warning-icon);
+
+  --color-status-info-bg: var(--status-info-bg);
+  --color-status-info-text: var(--status-info-text);
+  --color-status-info-border: var(--status-info-border);
+  --color-status-info-icon: var(--status-info-icon);
+
+  --color-status-neutral-bg: var(--status-neutral-bg);
+  --color-status-neutral-text: var(--status-neutral-text);
+  --color-status-neutral-border: var(--status-neutral-border);
+  --color-status-neutral-icon: var(--status-neutral-icon);
+
+  /* ═══ Design System: Typography ═══ */
+  --font-size-overline: 0.6875rem;
+  --font-size-overline--line-height: 1rem;
+
+  /* ═══ Design System: Z-Index Scale ═══ */
+  --z-base: 0;
+  --z-sticky: 10;
+  --z-dropdown: 20;
+  --z-overlay: 30;
+  --z-modal: 40;
+  --z-toast: 50;
+  --z-tooltip: 60;
 }
 
 :root {
@@ -103,6 +142,37 @@ TODO: Fix that latter to have reference by the package names
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+
+  /* ═══ Design System: Semantic Status Tokens — Light Mode ═══ */
+  /* Error (hue ~25° — aligned with --destructive) */
+  --status-error-bg: oklch(0.965 0.015 25);
+  --status-error-text: oklch(0.365 0.120 25);
+  --status-error-border: oklch(0.830 0.060 25);
+  --status-error-icon: oklch(0.577 0.245 27.325);  /* = --destructive */
+
+  /* Success (hue ~160° — aligned with --chart-emerald) */
+  --status-success-bg: oklch(0.965 0.015 160);
+  --status-success-text: oklch(0.350 0.080 160);
+  --status-success-border: oklch(0.830 0.050 160);
+  --status-success-icon: oklch(0.596 0.145 163.225);  /* = --chart-emerald */
+
+  /* Warning (hue ~80° — aligned with --chart-amber) */
+  --status-warning-bg: oklch(0.970 0.020 80);
+  --status-warning-text: oklch(0.370 0.090 60);
+  --status-warning-border: oklch(0.830 0.070 80);
+  --status-warning-icon: oklch(0.700 0.160 70);
+
+  /* Info (hue ~260° — aligned with --chart-blue) */
+  --status-info-bg: oklch(0.965 0.015 260);
+  --status-info-text: oklch(0.370 0.100 260);
+  --status-info-border: oklch(0.830 0.060 260);
+  --status-info-icon: oklch(0.546 0.245 262.881);  /* = --chart-blue */
+
+  /* Neutral (achromatic — aligned with --muted) */
+  --status-neutral-bg: oklch(0.965 0 0);
+  --status-neutral-text: oklch(0.445 0 0);
+  --status-neutral-border: oklch(0.850 0 0);
+  --status-neutral-icon: oklch(0.556 0 0);  /* = --muted-foreground */
 }
 
 .dark {
@@ -149,6 +219,37 @@ TODO: Fix that latter to have reference by the package names
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+
+  /* ═══ Design System: Semantic Status Tokens — Dark Mode ═══ */
+  /* Error */
+  --status-error-bg: oklch(0.220 0.025 25);
+  --status-error-text: oklch(0.850 0.090 25);
+  --status-error-border: oklch(0.400 0.060 25);
+  --status-error-icon: oklch(0.704 0.191 22.216);  /* = dark --destructive */
+
+  /* Success */
+  --status-success-bg: oklch(0.220 0.025 160);
+  --status-success-text: oklch(0.850 0.080 160);
+  --status-success-border: oklch(0.400 0.050 160);
+  --status-success-icon: oklch(0.696 0.170 162.480);  /* = dark --chart-emerald */
+
+  /* Warning */
+  --status-warning-bg: oklch(0.225 0.025 80);
+  --status-warning-text: oklch(0.870 0.080 80);
+  --status-warning-border: oklch(0.420 0.060 80);
+  --status-warning-icon: oklch(0.820 0.160 84.429);  /* = dark --chart-amber */
+
+  /* Info */
+  --status-info-bg: oklch(0.220 0.025 260);
+  --status-info-text: oklch(0.840 0.080 260);
+  --status-info-border: oklch(0.400 0.060 260);
+  --status-info-icon: oklch(0.623 0.214 259.815);  /* = dark --chart-blue */
+
+  /* Neutral */
+  --status-neutral-bg: oklch(0.230 0 0);
+  --status-neutral-text: oklch(0.750 0 0);
+  --status-neutral-border: oklch(0.380 0 0);
+  --status-neutral-icon: oklch(0.708 0 0);  /* = dark --muted-foreground */
 }
 
 @layer base {

--- a/packages/core/src/modules/customers/components/AddressFormatSettings.tsx
+++ b/packages/core/src/modules/customers/components/AddressFormatSettings.tsx
@@ -157,7 +157,7 @@ export function AddressFormatSettings() {
               </span>
             </label>
           ))}
-          {error ? <p className="text-sm text-red-600">{error}</p> : null}
+          {error ? <p className="text-sm text-status-error-text">{error}</p> : null}
           {pending ? (
             <div className="inline-flex items-center gap-2 rounded border border-dashed px-3 py-1 text-xs text-muted-foreground">
               <Spinner className="h-3 w-3" />

--- a/packages/core/src/modules/customers/components/AddressTiles.tsx
+++ b/packages/core/src/modules/customers/components/AddressTiles.tsx
@@ -468,7 +468,7 @@ export function CustomerAddressTiles({
             errors={fieldErrors}
             showFormatHint={!formatLoading}
           />
-          {generalError ? <p className="text-xs text-red-600">{generalError}</p> : null}
+          {generalError ? <p className="text-xs text-status-error-text">{generalError}</p> : null}
           <div className="flex flex-wrap justify-end gap-2">
             <Button type="button" variant="outline" onClick={handleCancel} disabled={disableActions}>
               {t('customers.people.detail.addresses.cancel')}
@@ -547,7 +547,7 @@ export function CustomerAddressTiles({
                         t('customers.people.detail.address')}
                     </span>
                     {address.isPrimary ? (
-                      <span className="mt-1 inline-flex w-fit rounded bg-emerald-100 px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+                      <span className="mt-1 inline-flex w-fit rounded bg-status-success-bg px-2 py-0.5 text-overline font-semibold text-status-success-text">
                         {t('customers.people.detail.primary')}
                       </span>
                     ) : null}

--- a/packages/core/src/modules/customers/components/detail/AnnualRevenueField.tsx
+++ b/packages/core/src/modules/customers/components/detail/AnnualRevenueField.tsx
@@ -253,7 +253,7 @@ export function AnnualRevenueField({
               showLabelInput={false}
             />
           </div>
-          {error ? <p className="text-xs text-red-600">{error}</p> : null}
+          {error ? <p className="text-xs text-status-error-text">{error}</p> : null}
           <div className="flex items-center gap-2">
             <Button type="button" size="sm" onClick={handleSave} disabled={saving}>
               {saving ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}

--- a/packages/core/src/modules/customers/components/detail/AppearanceDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/AppearanceDialog.tsx
@@ -78,7 +78,7 @@ export function AppearanceDialog({
             onColorChange={onColorChange}
             disabled={isSaving}
           />
-          {errorMessage ? <p className="text-sm text-red-600">{errorMessage}</p> : null}
+          {errorMessage ? <p className="text-sm text-status-error-text">{errorMessage}</p> : null}
         </div>
         <DialogFooter>
           <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>

--- a/packages/core/src/modules/customers/components/detail/DealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealForm.tsx
@@ -407,7 +407,7 @@ function EntityMultiSelect({
       {!loading && !filteredSuggestions.length && input.trim().length ? (
         <div className="text-xs text-muted-foreground">{noResultsLabel}</div>
       ) : null}
-      {error ? <div className="text-xs text-red-600">{error}</div> : null}
+      {error ? <div className="text-xs text-status-error-text">{error}</div> : null}
       {!normalizedValue.length && !input.trim().length ? (
         <div className="text-xs text-muted-foreground">{emptyLabel}</div>
       ) : null}

--- a/packages/core/src/modules/customers/components/detail/InlineEditors.tsx
+++ b/packages/core/src/modules/customers/components/detail/InlineEditors.tsx
@@ -293,7 +293,7 @@ export function InlineDictionaryEditor({
             selectClassName={selectClassName}
           />
           {dictionaryQuery.isError ? (
-            <p className="text-xs text-red-600">
+            <p className="text-xs text-status-error-text">
               {dictionaryQuery.error instanceof Error
                 ? dictionaryQuery.error.message
                 : translate('customers.people.form.dictionary.errorLoad', 'Failed to load options')}

--- a/packages/core/src/modules/customers/components/detail/PersonHighlights.tsx
+++ b/packages/core/src/modules/customers/components/detail/PersonHighlights.tsx
@@ -270,7 +270,7 @@ export function PersonHighlights({
                   loadingLabel: t('customers.people.form.company.loading'),
                 }}
               />
-              {companyError ? <p className="text-xs text-red-600">{companyError}</p> : null}
+              {companyError ? <p className="text-xs text-status-error-text">{companyError}</p> : null}
               <div className="flex flex-wrap items-center gap-2">
                 <Button type="button" size="sm" onClick={handleCompanySave} disabled={companySaving}>
                   {companySaving ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : null}
@@ -300,7 +300,7 @@ export function PersonHighlights({
                   {t('customers.people.detail.company.current', undefined, { company: company.name })}
                 </span>
               ) : companyError ? (
-                <span className="text-xs text-red-600">{companyError}</span>
+                <span className="text-xs text-status-error-text">{companyError}</span>
               ) : (
                 <span className="text-muted-foreground">
                   {t('customers.people.detail.company.empty', 'No company assigned')}

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -259,7 +259,7 @@ const createPrimaryEmailField = (t: Translator): CrudField => ({
           disabled={disabled}
         />
         {!error && duplicate ? (
-          <p className="text-xs text-amber-600">
+          <p className="text-xs text-status-warning-text">
             {t('customers.people.form.emailDuplicateNotice', undefined, { name: duplicate.displayName })}{' '}
             <Link className="font-medium text-primary underline underline-offset-2" href={`/backend/customers/people-v2/${duplicate.id}`}>
               {t('customers.people.form.emailDuplicateLink')}
@@ -603,7 +603,7 @@ export function CompanySelectField({ value, onChange, labels }: CompanySelectFie
                   disabled={saving}
                 />
               </div>
-              {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+              {formError ? <p className="text-sm text-status-error-text">{formError}</p> : null}
               <DialogFooter>
                 <Button type="button" variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>
                   {labels.cancelLabel}
@@ -759,7 +759,7 @@ export const createDisplayNameSection = (t: Translator) =>
                   onChange={handleChange}
                   placeholder={t('customers.people.form.displayName.placeholder')}
                 />
-                {error ? <p className="text-xs text-red-600">{error}</p> : null}
+                {error ? <p className="text-xs text-status-error-text">{error}</p> : null}
               </div>
             ) : (
               <div className="mt-1 text-base font-medium">{previewValue || placeholder}</div>

--- a/packages/core/src/modules/sales/components/OrderEditingSettings.tsx
+++ b/packages/core/src/modules/sales/components/OrderEditingSettings.tsx
@@ -180,7 +180,7 @@ export function OrderEditingSettings() {
                     <span className="truncate" title={status.label || status.value}>
                       {status.label || status.value}
                     </span>
-                    <Badge variant="outline" className="ml-auto text-[11px] uppercase tracking-wide">
+                    <Badge variant="outline" className="ml-auto text-overline uppercase tracking-wide">
                       {status.value}
                     </Badge>
                   </label>

--- a/packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx
+++ b/packages/core/src/modules/sales/components/channels/ChannelOfferForm.tsx
@@ -1097,7 +1097,7 @@ function ProductSelectInput({
                       </div>
                       </div>
                     {hasConflict ? (
-                      <div className="flex items-center justify-between gap-2 text-xs text-amber-700">
+                      <div className="flex items-center justify-between gap-2 text-xs text-status-warning-text">
                         <span className="truncate">
                           {t('sales.channels.offers.form.productHasOffer', 'Already has an offer for this channel.')}
                         </span>
@@ -1966,7 +1966,7 @@ function ProductVariantsList({ variants }: { variants: ProductVariantPreview[] }
             <div className="min-w-0">
               <div className="text-xs font-medium">{variant.name}</div>
               {variant.sku ? (
-                <div className="text-[11px] text-muted-foreground">SKU · {variant.sku}</div>
+                <div className="text-overline text-muted-foreground">SKU · {variant.sku}</div>
               ) : null}
             </div>
           </div>

--- a/packages/core/src/modules/sales/components/documents/LineItemDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/LineItemDialog.tsx
@@ -278,7 +278,7 @@ function buildPriceScopeReason(
 
 function buildPlaceholder(label?: string | null) {
   return (
-    <div className="flex h-8 w-8 items-center justify-center rounded border bg-muted text-[10px] uppercase text-muted-foreground">
+    <div className="flex h-8 w-8 items-center justify-center rounded border bg-muted text-xs uppercase text-muted-foreground">
       {(label ?? "").slice(0, 2) || "•"}
     </div>
   );

--- a/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
@@ -1176,7 +1176,7 @@ export function ShipmentDialog({
                       className="h-12 w-12 rounded-md border object-cover"
                     />
                   ) : (
-                    <div className="flex h-12 w-12 items-center justify-center rounded-md border bg-muted text-[10px] text-muted-foreground">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-md border bg-muted text-xs text-muted-foreground">
                       N/A
                     </div>
                   )}

--- a/packages/core/src/modules/sales/widgets/notifications/SalesOrderCreatedRenderer.tsx
+++ b/packages/core/src/modules/sales/widgets/notifications/SalesOrderCreatedRenderer.tsx
@@ -59,8 +59,8 @@ export function SalesOrderCreatedRenderer({
   return (
     <div
       className={cn(
-        'group relative px-4 py-3 hover:bg-muted/50 cursor-pointer transition-colors border-l-4 border-l-blue-500',
-        isUnread && 'bg-blue-50/50 dark:bg-blue-950/20'
+        'group relative px-4 py-3 hover:bg-muted/50 cursor-pointer transition-colors border-l-4 border-l-status-info-border',
+        isUnread && 'bg-status-info-bg/50'
       )}
       onClick={handleView}
       onKeyDown={(e) => {
@@ -78,8 +78,8 @@ export function SalesOrderCreatedRenderer({
 
       <div className="flex gap-3">
         <div className="flex-shrink-0 mt-0.5">
-          <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-900/40 flex items-center justify-center">
-            <ShoppingCart className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <div className="h-10 w-10 rounded-lg bg-status-info-bg flex items-center justify-center">
+            <ShoppingCart className="h-5 w-5 text-status-info-icon" />
           </div>
         </div>
 

--- a/packages/core/src/modules/sales/widgets/notifications/SalesQuoteCreatedRenderer.tsx
+++ b/packages/core/src/modules/sales/widgets/notifications/SalesQuoteCreatedRenderer.tsx
@@ -59,8 +59,8 @@ export function SalesQuoteCreatedRenderer({
   return (
     <div
       className={cn(
-        'group relative px-4 py-3 hover:bg-muted/50 cursor-pointer transition-colors border-l-4 border-l-amber-500',
-        isUnread && 'bg-amber-50/50 dark:bg-amber-950/20'
+        'group relative px-4 py-3 hover:bg-muted/50 cursor-pointer transition-colors border-l-4 border-l-status-warning-border',
+        isUnread && 'bg-status-warning-bg/50'
       )}
       onClick={handleView}
       onKeyDown={(e) => {
@@ -78,8 +78,8 @@ export function SalesQuoteCreatedRenderer({
 
       <div className="flex gap-3">
         <div className="flex-shrink-0 mt-0.5">
-          <div className="h-10 w-10 rounded-lg bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center">
-            <FileText className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+          <div className="h-10 w-10 rounded-lg bg-status-warning-bg flex items-center justify-center">
+            <FileText className="h-5 w-5 text-status-warning-icon" />
           </div>
         </div>
 

--- a/packages/ui/src/backend/FlashMessages.tsx
+++ b/packages/ui/src/backend/FlashMessages.tsx
@@ -143,7 +143,13 @@ function FlashMessagesInner() {
 
   if (!msg) return null
 
-  const color = kind === 'success' ? 'bg-emerald-600' : kind === 'error' ? 'bg-red-600' : kind === 'warning' ? 'bg-amber-500' : 'bg-blue-600'
+  const colorMap: Record<FlashKind, string> = {
+    success: 'bg-status-success-icon',
+    error: 'bg-status-error-icon',
+    warning: 'bg-status-warning-icon',
+    info: 'bg-status-info-icon',
+  }
+  const color = colorMap[kind]
 
   return (
     <div className="pointer-events-none fixed left-3 right-3 top-3 z-[1200] sm:left-auto sm:right-4 sm:w-[380px]">

--- a/packages/ui/src/backend/SectionHeader.tsx
+++ b/packages/ui/src/backend/SectionHeader.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import * as React from 'react'
+import { ChevronDown } from 'lucide-react'
+import { Badge } from '../primitives/badge'
+import { cn } from '@open-mercato/shared/lib/utils'
+
+export type SectionHeaderProps = {
+  /** Section title */
+  title: string
+  /** Optional item count — displayed as muted badge */
+  count?: number
+  /** Action element(s) on the right — typically Button or IconButton */
+  action?: React.ReactNode
+  /** Additional className */
+  className?: string
+}
+
+export function SectionHeader({
+  title,
+  count,
+  action,
+  className,
+}: SectionHeaderProps) {
+  return (
+    <div className={cn('flex items-center justify-between', className)}>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-semibold">{title}</h3>
+        {count != null && (
+          <Badge variant="muted" className="text-xs tabular-nums">
+            {count}
+          </Badge>
+        )}
+      </div>
+      {action ? (
+        <div className="flex items-center gap-1">
+          {action}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export type CollapsibleSectionProps = {
+  /** Section title */
+  title: string
+  count?: number
+  action?: React.ReactNode
+  /** Collapse behavior */
+  defaultCollapsed?: boolean
+  collapsed?: boolean
+  onCollapsedChange?: (collapsed: boolean) => void
+  /** Content */
+  children?: React.ReactNode
+  /** Additional className on root */
+  className?: string
+  /** Additional className on content wrapper */
+  contentClassName?: string
+}
+
+export function CollapsibleSection({
+  title,
+  count,
+  action,
+  defaultCollapsed = false,
+  collapsed: controlledCollapsed,
+  onCollapsedChange,
+  children,
+  className,
+  contentClassName,
+}: CollapsibleSectionProps) {
+  const [internalCollapsed, setInternalCollapsed] = React.useState(defaultCollapsed)
+  const isControlled = controlledCollapsed !== undefined
+  const isCollapsed = isControlled ? controlledCollapsed : internalCollapsed
+
+  const toggle = React.useCallback(() => {
+    const next = !isCollapsed
+    if (!isControlled) setInternalCollapsed(next)
+    onCollapsedChange?.(next)
+  }, [isCollapsed, isControlled, onCollapsedChange])
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex items-center gap-2 group"
+          aria-expanded={!isCollapsed}
+          aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${title} section`}
+        >
+          <ChevronDown
+            className={cn(
+              'h-4 w-4 text-muted-foreground transition-transform duration-200',
+              isCollapsed && '-rotate-90',
+            )}
+          />
+          <h3 className="text-sm font-semibold">{title}</h3>
+          {count != null && (
+            <Badge variant="muted" className="text-xs tabular-nums">
+              {count}
+            </Badge>
+          )}
+        </button>
+        {action ? (
+          <div className="flex items-center gap-1">
+            {action}
+          </div>
+        ) : null}
+      </div>
+
+      {!isCollapsed && (
+        <div className={contentClassName}>
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui/src/backend/notifications/NotificationCountBadge.tsx
+++ b/packages/ui/src/backend/notifications/NotificationCountBadge.tsx
@@ -7,7 +7,7 @@ export type NotificationCountBadgeProps = {
 export function NotificationCountBadge({ count }: NotificationCountBadgeProps) {
   if (count <= 0) return null
   return (
-    <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-[10px] font-medium text-white dark:bg-destructive dark:text-destructive-foreground">
+    <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-[10px] font-medium text-destructive-foreground">
       {count > 99 ? '99+' : count}
     </span>
   )

--- a/packages/ui/src/backend/notifications/NotificationItem.tsx
+++ b/packages/ui/src/backend/notifications/NotificationItem.tsx
@@ -70,10 +70,10 @@ const severityIcons = {
 }
 
 const severityColors = {
-  info: 'text-blue-500',
-  warning: 'text-amber-500',
-  success: 'text-green-500',
-  error: 'text-destructive',
+  info: 'text-status-info-icon',
+  warning: 'text-status-warning-icon',
+  success: 'text-status-success-icon',
+  error: 'text-status-error-icon',
 }
 
 export function NotificationItem({

--- a/packages/ui/src/backend/notifications/NotificationPanel.tsx
+++ b/packages/ui/src/backend/notifications/NotificationPanel.tsx
@@ -137,7 +137,7 @@ export function NotificationPanel({
               <Bell className="h-5 w-5" />
               <h2 className="font-semibold">{t('notifications.title', 'Notifications')}</h2>
               {unreadCount > 0 && (
-                <span className="rounded-full bg-orange-500 px-2 py-0.5 text-xs text-white dark:bg-destructive dark:text-destructive-foreground">
+                <span className="rounded-full bg-destructive px-2 py-0.5 text-xs text-destructive-foreground">
                   {unreadCount}
                 </span>
               )}

--- a/packages/ui/src/primitives/Notice.tsx
+++ b/packages/ui/src/primitives/Notice.tsx
@@ -2,18 +2,27 @@
 import * as React from 'react'
 import { cn } from '@open-mercato/shared/lib/utils'
 
+/**
+ * @deprecated Use <Alert variant="destructive|warning|info"> instead.
+ * Migration guide: docs/design-system/migration-tables.md#j3-component-mapping
+ *
+ * Notice variant="error"   → Alert variant="destructive"
+ * Notice variant="warning" → Alert variant="warning"
+ * Notice variant="info"    → Alert variant="info"
+ */
+
 const variantStyles = {
   error: {
-    container: 'border-red-200 bg-red-50 text-red-800',
-    icon: 'border-red-500',
+    container: 'border-status-error-border bg-status-error-bg text-status-error-text',
+    icon: 'border-status-error-icon',
   },
   info: {
-    container: 'border-blue-200 bg-blue-50 text-blue-900',
-    icon: 'border-blue-500',
+    container: 'border-status-info-border bg-status-info-bg text-status-info-text',
+    icon: 'border-status-info-icon',
   },
   warning: {
-    container: 'border-amber-200 bg-amber-50 text-amber-800',
-    icon: 'border-amber-500',
+    container: 'border-status-warning-border bg-status-warning-bg text-status-warning-text',
+    icon: 'border-status-warning-icon',
   },
 } as const
 
@@ -38,6 +47,13 @@ export function Notice({
   className,
   compact = false,
 }: NoticeProps) {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn(
+      '[DS] <Notice> is deprecated. Use <Alert variant="destructive|warning|info"> instead. ' +
+      'See: docs/design-system/migration-tables.md'
+    )
+  }
+
   const styles = variantStyles[variant]
 
   if (compact || (!title && !action && (children || message))) {

--- a/packages/ui/src/primitives/alert.tsx
+++ b/packages/ui/src/primitives/alert.tsx
@@ -4,19 +4,19 @@ import { cva, type VariantProps } from 'class-variance-authority'
 import { cn } from '@open-mercato/shared/lib/utils'
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg~*]:pl-8 [&>svg]:text-current",
+  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg~*]:pl-8",
   {
     variants: {
       variant: {
-        default: 'border-border bg-background text-foreground',
+        default: 'border-border bg-background text-foreground [&>svg]:text-foreground',
         destructive:
-          'border-destructive/60 bg-destructive/10 text-destructive dark:border-destructive/40 dark:bg-destructive/20 dark:text-destructive-foreground',
+          'border-status-error-border bg-status-error-bg text-status-error-text [&>svg]:text-status-error-icon',
         success:
-          'border-emerald-600/30 bg-emerald-500/10 text-emerald-900 dark:border-emerald-500/50 dark:bg-emerald-500/15 dark:text-emerald-50',
+          'border-status-success-border bg-status-success-bg text-status-success-text [&>svg]:text-status-success-icon',
         warning:
-          'border-amber-500/30 bg-amber-400/10 text-amber-950 dark:border-amber-400/40 dark:bg-amber-400/20 dark:text-amber-50',
+          'border-status-warning-border bg-status-warning-bg text-status-warning-text [&>svg]:text-status-warning-icon',
         info:
-          'border-sky-600/30 bg-sky-500/10 text-sky-900 dark:border-sky-500/40 dark:bg-sky-500/20 dark:text-sky-50',
+          'border-status-info-border bg-status-info-bg text-status-info-text [&>svg]:text-status-info-icon',
       },
     },
     defaultVariants: {

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -12,6 +12,10 @@ const badgeVariants = cva(
         destructive: 'border-transparent bg-destructive text-destructive-foreground shadow',
         outline: 'text-foreground',
         muted: 'border-transparent bg-muted text-muted-foreground',
+        success: 'border-status-success-border bg-status-success-bg text-status-success-text',
+        warning: 'border-status-warning-border bg-status-warning-bg text-status-warning-text',
+        info: 'border-status-info-border bg-status-info-bg text-status-info-text',
+        neutral: 'border-status-neutral-border bg-status-neutral-bg text-status-neutral-text',
       },
     },
     defaultVariants: {

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -16,6 +16,7 @@ const badgeVariants = cva(
         warning: 'border-status-warning-border bg-status-warning-bg text-status-warning-text',
         info: 'border-status-info-border bg-status-info-bg text-status-info-text',
         neutral: 'border-status-neutral-border bg-status-neutral-bg text-status-neutral-text',
+        error: 'border-status-error-border bg-status-error-bg text-status-error-text',
       },
     },
     defaultVariants: {

--- a/packages/ui/src/primitives/form-field.tsx
+++ b/packages/ui/src/primitives/form-field.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import * as React from 'react'
+import { Label } from './label'
+import { cn } from '@open-mercato/shared/lib/utils'
+
+export type FormFieldProps = {
+  /** Visible label text */
+  label?: string
+  /** Auto-generated if not provided. Links label → input via htmlFor/id */
+  id?: string
+  /** Show required indicator (*) next to label */
+  required?: boolean
+  /** Help text below input */
+  description?: React.ReactNode
+  /** Error message — replaces description when present */
+  error?: string
+  /** Layout: vertical (default) or horizontal (label beside input) */
+  orientation?: 'vertical' | 'horizontal'
+  /** Disabled styling on label */
+  disabled?: boolean
+  /** The input element (slot) */
+  children: React.ReactNode
+  /** Additional className on root wrapper */
+  className?: string
+}
+
+export function FormField({
+  label,
+  id: idProp,
+  required = false,
+  description,
+  error,
+  orientation = 'vertical',
+  disabled = false,
+  children,
+  className,
+}: FormFieldProps) {
+  const generatedId = React.useId()
+  const fieldId = idProp ?? generatedId
+  const descriptionId = description && !error ? `${fieldId}-desc` : undefined
+  const errorId = error ? `${fieldId}-error` : undefined
+  const ariaDescribedBy = [descriptionId, errorId].filter(Boolean).join(' ') || undefined
+
+  // Clone child to inject accessibility props
+  const enhancedChild = React.isValidElement(children)
+    ? React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+        id: fieldId,
+        'aria-describedby': ariaDescribedBy,
+        'aria-invalid': error ? true : undefined,
+        'aria-required': required ? true : undefined,
+        disabled: disabled || undefined,
+      })
+    : children
+
+  const isHorizontal = orientation === 'horizontal'
+
+  return (
+    <div
+      className={cn(
+        isHorizontal
+          ? 'flex items-center justify-between gap-4'
+          : 'flex flex-col gap-1.5',
+        disabled && 'opacity-50',
+        className,
+      )}
+      data-slot="form-field"
+    >
+      {label ? (
+        <Label
+          htmlFor={fieldId}
+          className={cn(
+            isHorizontal && 'min-w-0 shrink-0',
+            disabled && 'cursor-not-allowed',
+          )}
+        >
+          {label}
+          {required && (
+            <span className="text-status-error-icon ml-0.5" aria-hidden="true">*</span>
+          )}
+        </Label>
+      ) : null}
+
+      <div className={cn(isHorizontal && 'flex-1')}>
+        {enhancedChild}
+      </div>
+
+      {error ? (
+        <p
+          id={errorId}
+          role="alert"
+          className="text-xs text-status-error-text"
+        >
+          {error}
+        </p>
+      ) : description ? (
+        <p
+          id={descriptionId}
+          className="text-xs text-muted-foreground"
+        >
+          {description}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/ui/src/primitives/status-badge.tsx
+++ b/packages/ui/src/primitives/status-badge.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { Badge } from './badge'
+import { cn } from '@open-mercato/shared/lib/utils'
+
+export type StatusBadgeVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral'
+
+export type StatusBadgeProps = {
+  /** Visual variant — maps to semantic color tokens via Badge */
+  variant: StatusBadgeVariant
+  /** Badge text */
+  children: React.ReactNode
+  /** Show colored dot before text */
+  dot?: boolean
+  /** Additional className */
+  className?: string
+}
+
+const dotColors: Record<StatusBadgeVariant, string> = {
+  success: 'bg-status-success-icon',
+  warning: 'bg-status-warning-icon',
+  error: 'bg-status-error-icon',
+  info: 'bg-status-info-icon',
+  neutral: 'bg-status-neutral-icon',
+}
+
+export function StatusBadge({
+  variant,
+  children,
+  dot = false,
+  className,
+}: StatusBadgeProps) {
+  return (
+    <Badge
+      variant={variant}
+      className={cn(dot && 'gap-1.5', className)}
+    >
+      {dot && (
+        <span
+          className={cn('inline-block h-1.5 w-1.5 rounded-full shrink-0', dotColors[variant])}
+          aria-hidden="true"
+        />
+      )}
+      {children}
+    </Badge>
+  )
+}
+
+/**
+ * Helper type: modules define their own status → variant mapping.
+ *
+ * @example
+ * const customerStatusMap: StatusMap<'active' | 'inactive' | 'archived'> = {
+ *   active: 'success',
+ *   inactive: 'neutral',
+ *   archived: 'warning',
+ * }
+ *
+ * <StatusBadge variant={customerStatusMap[customer.status] ?? 'neutral'} dot>
+ *   {t(`customers.status.${customer.status}`)}
+ * </StatusBadge>
+ */
+export type StatusMap<T extends string = string> = Record<T, StatusBadgeVariant>


### PR DESCRIPTION
## Summary

Introduce the Design System v0 foundation for Open Mercato: OKLCH-based semantic status tokens, reusable DS components, and migration of two core modules (customers, sales) from hardcoded Tailwind colors to semantic tokens.

This is the code/implementation half of the DS v0 initiative. The enforcement/documentation counterpart is in a separate PR.

## Changes

- Add 30+ semantic status CSS tokens (`--status-error-bg`, `--status-success-text`, etc.) with dedicated dark mode OKLCH values in `globals.css`
- Add `@theme inline` Tailwind v4 mapping (`--color-status-*`) and `text-overline` utility token
- Add z-index scale tokens (`--z-dropdown` through `--z-max`)
- Add `FormField`, `StatusBadge`, and `SectionHeader` reusable DS components in `packages/ui/`
- Migrate `Alert` and `Badge` primitives to semantic status token variants
- Migrate `Notice`, `FlashMessages`, and `Notifications` system to semantic tokens
- Migrate **customers module** status displays to `StatusBadge` + semantic tokens
- Migrate **sales module**: notification renderers (amber→warning, blue→info), `ChannelOfferForm`, `OrderEditingSettings`, `ShipmentDialog`, `LineItemDialog` — replacing hardcoded colors and arbitrary text sizes

## Specification

- [x] Yes

**Spec file path:** `.ai/specs/2026-04-10-design-system-v0.md`

## Testing

- `yarn build:packages` — all packages build successfully
- Visual inspection of migrated components in dev mode (light + dark themes)
- Health check script confirms reduction in hardcoded colors (91→84) and arbitrary text sizes (37→33)

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, etc.) — uses semantic tokens
- [x] No arbitrary text sizes (`text-[11px]`) — uses Tailwind scale or `text-overline`
- [x] Empty state handled where applicable
- [x] Loading state handled where applicable
- [x] Icon-only buttons have `aria-label`
- [x] Uses DS components (`Alert`, `StatusBadge`, `FormField`) instead of ad-hoc markup

## Linked issues

Part of Design System v0 initiative.