### PR TITLE
Fix API dispatcher bypass for top-level RBAC metadata

### DIFF
--- a/apps/mercato/src/__tests__/api-authorization.test.ts
+++ b/apps/mercato/src/__tests__/api-authorization.test.ts
@@ -212,6 +212,32 @@ describe('API Route Authorization', () => {
       expect(response.status).toBe(403)
       await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
     })
+
+    it('should enforce top-level metadata for route files when method metadata is absent', async () => {
+      const originalMetadata = mockedRouteModule.metadata
+      mockedRouteModule.metadata = {
+        requireAuth: true,
+        requireFeatures: ['example.todos.view'],
+      } as RouteMetadata & typeof mockedRouteModule.metadata
+
+      try {
+        mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['admin'], 'admin@test.com'))
+        mockRbac.userHasAllFeatures.mockResolvedValueOnce(false)
+
+        const request = new NextRequest('http://localhost:3001/api/example/test')
+        const response = await GET(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
+
+        expect(response.status).toBe(403)
+        await expect(response.json()).resolves.toMatchObject({ error: 'Forbidden' })
+        expect(mockRbac.userHasAllFeatures).toHaveBeenCalledWith(
+          'user1',
+          ['example.todos.view'],
+          expect.objectContaining({ tenantId: 'tenant1' }),
+        )
+      } finally {
+        mockedRouteModule.metadata = originalMetadata
+      }
+    })
   })
 
   describe('POST /example/test', () => {

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -86,9 +86,11 @@ async function emitLifecycleEvent(eventId: ApplicationLifecycleEventId, payload:
 
 function extractMethodMetadata(metadata: unknown, method: HttpMethod): MethodMetadata | null {
   if (!metadata || typeof metadata !== 'object') return null
-  const entry = (metadata as Partial<Record<HttpMethod, unknown>>)[method]
-  if (!entry || typeof entry !== 'object') return null
-  const source = entry as Record<string, unknown>
+  const metadataRecord = metadata as Partial<Record<HttpMethod, unknown>>
+  const entry = metadataRecord[method]
+  const source = entry && typeof entry === 'object'
+    ? entry as Record<string, unknown>
+    : metadata as Record<string, unknown>
   const normalized: MethodMetadata = {}
   if (typeof source.requireAuth === 'boolean') normalized.requireAuth = source.requireAuth
   if (Array.isArray(source.requireRoles)) {
@@ -108,7 +110,7 @@ function extractMethodMetadata(metadata: unknown, method: HttpMethod): MethodMet
       }
     }
   }
-  return normalized
+  return Object.keys(normalized).length > 0 ? normalized : null
 }
 
 function normalizeLoadedMetadata(

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -86,9 +86,11 @@ async function emitLifecycleEvent(eventId: ApplicationLifecycleEventId, payload:
 
 function extractMethodMetadata(metadata: unknown, method: HttpMethod): MethodMetadata | null {
   if (!metadata || typeof metadata !== 'object') return null
-  const entry = (metadata as Partial<Record<HttpMethod, unknown>>)[method]
-  if (!entry || typeof entry !== 'object') return null
-  const source = entry as Record<string, unknown>
+  const metadataRecord = metadata as Partial<Record<HttpMethod, unknown>>
+  const entry = metadataRecord[method]
+  const source = entry && typeof entry === 'object'
+    ? entry as Record<string, unknown>
+    : metadata as Record<string, unknown>
   const normalized: MethodMetadata = {}
   if (typeof source.requireAuth === 'boolean') normalized.requireAuth = source.requireAuth
   if (Array.isArray(source.requireRoles)) {
@@ -108,7 +110,7 @@ function extractMethodMetadata(metadata: unknown, method: HttpMethod): MethodMet
       }
     }
   }
-  return normalized
+  return Object.keys(normalized).length > 0 ? normalized : null
 }
 
 function normalizeLoadedMetadata(


### PR DESCRIPTION
## Summary

The issue was in the central API dispatcher authorization logic.

Some API routes declared access rules as top-level metadata:

```ts
export const metadata = {
  requireAuth: true,
  requireFeatures: ['some.feature'],
}
```

But the dispatcher only read method-specific metadata, like:

```ts
export const metadata = {
  POST: { requireAuth: true, requireFeatures: ['some.feature'] },
}
```

Because of that, top-level `requireFeatures` could be ignored. If the route handler only checked whether the user was logged in, a user without the required role/feature could still execute the action.

The fix updates the dispatcher to prefer method-specific metadata when present, but fall back to top-level metadata when there is no method entry. The same fix was applied to the create-app template so new generated apps inherit the corrected behavior.

A regression test was added to verify that top-level `requireFeatures` now correctly denies access with `403` when RBAC says the user lacks the required feature.