### PR TITLE
fix(security): make JWTs revocable and isolate staff/customer audiences

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/logout.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/logout.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+import { signJwt } from '@open-mercato/shared/lib/auth/jwt'
+
+const deleteSessionById = jest.fn()
+const deleteSessionByToken = jest.fn()
+const containerResolve = jest.fn((name: string) => {
+  if (name === 'authService') {
+    return { deleteSessionById, deleteSessionByToken }
+  }
+  return null
+})
+const createRequestContainer = jest.fn(async () => ({ resolve: containerResolve }))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => createRequestContainer(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/url', () => ({
+  toAbsoluteUrl: (_req: Request, path: string) => `http://localhost${path}`,
+}))
+
+import { POST } from '@open-mercato/core/modules/auth/api/logout'
+
+const sessionId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const userId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+function buildAuthToken(overrides: Record<string, unknown> = {}): string {
+  return signJwt({
+    sub: userId,
+    sid: sessionId,
+    tenantId: 'tttttttt-tttt-4ttt-8ttt-tttttttttttt',
+    orgId: 'oooooooo-oooo-4ooo-8ooo-oooooooooooo',
+    email: 'user@example.test',
+    roles: ['admin'],
+    ...overrides,
+  })
+}
+
+function buildCookieHeader(parts: Record<string, string>): string {
+  return Object.entries(parts)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ')
+}
+
+describe('POST /api/auth/logout — session revocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('revokes the session referenced by the auth_token JWT sid claim', async () => {
+    const authToken = buildAuthToken()
+    const req = new Request('http://localhost/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: buildCookieHeader({ auth_token: authToken }) },
+    })
+
+    const res = await POST(req)
+
+    expect(deleteSessionById).toHaveBeenCalledWith(sessionId)
+    expect(res.status).toBe(307) // NextResponse.redirect default
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('auth_token=;')
+    expect(setCookie).toContain('session_token=;')
+  })
+
+  it('revokes the remember-me session_token cookie as well when present', async () => {
+    const authToken = buildAuthToken()
+    const req = new Request('http://localhost/api/auth/logout', {
+      method: 'POST',
+      headers: {
+        cookie: buildCookieHeader({ auth_token: authToken, session_token: 'remember-me-token' }),
+      },
+    })
+
+    await POST(req)
+
+    expect(deleteSessionById).toHaveBeenCalledWith(sessionId)
+    expect(deleteSessionByToken).toHaveBeenCalledWith('remember-me-token')
+  })
+
+  it('clears cookies even when no session cookies are present (idempotent logout)', async () => {
+    const req = new Request('http://localhost/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: '' },
+    })
+
+    const res = await POST(req)
+
+    expect(deleteSessionById).not.toHaveBeenCalled()
+    expect(deleteSessionByToken).not.toHaveBeenCalled()
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('auth_token=;')
+    expect(setCookie).toContain('session_token=;')
+  })
+
+  it('ignores an auth_token JWT that cannot be verified (expired / tampered)', async () => {
+    const req = new Request('http://localhost/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: buildCookieHeader({ auth_token: 'not-a-valid-jwt' }) },
+    })
+
+    const res = await POST(req)
+
+    expect(deleteSessionById).not.toHaveBeenCalled()
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('auth_token=;')
+  })
+
+  it('ignores an auth_token JWT that is missing an sid claim (legacy token)', async () => {
+    const legacyToken = signJwt({
+      sub: userId,
+      tenantId: 'tttttttt-tttt-4ttt-8ttt-tttttttttttt',
+      orgId: 'oooooooo-oooo-4ooo-8ooo-oooooooooooo',
+      email: 'user@example.test',
+      roles: ['admin'],
+    })
+
+    const req = new Request('http://localhost/api/auth/logout', {
+      method: 'POST',
+      headers: { cookie: buildCookieHeader({ auth_token: legacyToken }) },
+    })
+
+    await POST(req)
+
+    expect(deleteSessionById).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -142,24 +142,28 @@ export async function POST(req: Request) {
   } catch {
     // optional warmup
   }
+  const rememberMeDays = Number(process.env.REMEMBER_ME_DAYS || '30')
+  const jwtTtlSeconds = 60 * 60 * 8
+  const sessionExpiresAt = remember
+    ? new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
+    : new Date(Date.now() + jwtTtlSeconds * 1000)
+  const staffSession = await auth.createSession(user, sessionExpiresAt)
   const token = signJwt({
     sub: String(user.id),
+    sid: String(staffSession.id),
     tenantId: resolvedTenantId,
     orgId: user.organizationId ? String(user.organizationId) : null,
     email: user.email,
     roles: userRoleNames
   })
   void emitAuthEvent('auth.login.success', { id: String(user.id), email: user.email, tenantId: resolvedTenantId, organizationId: user.organizationId ? String(user.organizationId) : null }).catch(() => undefined)
-  const rememberMeDays = Number(process.env.REMEMBER_ME_DAYS || '30')
   const responseData: { ok: true; token: string; redirect: string; refreshToken?: string } = {
     ok: true,
     token,
     redirect: '/backend',
   }
   if (remember) {
-    const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
-    const sess = await auth.createSession(user, expiresAt)
-    responseData.refreshToken = sess.token
+    responseData.refreshToken = staffSession.token
   }
   const em = container.resolve('em')
   const interceptedResponse = await runCustomRouteAfterInterceptors({

--- a/packages/core/src/modules/auth/api/logout.ts
+++ b/packages/core/src/modules/auth/api/logout.ts
@@ -3,6 +3,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { toAbsoluteUrl } from '@open-mercato/shared/lib/url'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
+import { verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
 
 function parseCookie(req: Request, name: string): string | null {
   const cookie = req.headers.get('cookie') || ''
@@ -10,10 +11,33 @@ function parseCookie(req: Request, name: string): string | null {
   return m ? decodeURIComponent(m[1]) : null
 }
 
+function extractSessionIdFromAuthToken(token: string | null): string | null {
+  if (!token) return null
+  try {
+    const payload = verifyJwt(token) as Record<string, unknown> | null
+    if (!payload) return null
+    const sid = payload.sid
+    return typeof sid === 'string' && sid.length > 0 ? sid : null
+  } catch {
+    return null
+  }
+}
+
 export async function POST(req: Request) {
   const sessToken = parseCookie(req, 'session_token')
-  if (sessToken) {
-    try { const c = await createRequestContainer(); const auth = c.resolve<AuthService>('authService'); await auth.deleteSessionByToken(sessToken) } catch {}
+  const authToken = parseCookie(req, 'auth_token')
+  const sessionId = extractSessionIdFromAuthToken(authToken)
+  if (sessToken || sessionId) {
+    try {
+      const c = await createRequestContainer()
+      const auth = c.resolve<AuthService>('authService')
+      if (sessionId) {
+        await auth.deleteSessionById(sessionId)
+      }
+      if (sessToken) {
+        await auth.deleteSessionByToken(sessToken)
+      }
+    } catch {}
   }
   const res = NextResponse.redirect(toAbsoluteUrl(req, '/login'))
   res.cookies.set('auth_token', '', { path: '/', maxAge: 0 })

--- a/packages/core/src/modules/auth/api/profile/route.ts
+++ b/packages/core/src/modules/auth/api/profile/route.ts
@@ -174,6 +174,7 @@ export async function PUT(req: Request) {
     const roles = await authService.getUserRoles(result, result.tenantId ? String(result.tenantId) : null)
     const jwt = signJwt({
       sub: String(result.id),
+      sid: typeof auth.sid === 'string' ? auth.sid : undefined,
       tenantId: result.tenantId ? String(result.tenantId) : null,
       orgId: result.organizationId ? String(result.organizationId) : null,
       email: result.email,

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -72,8 +72,8 @@ export async function GET(req: Request) {
       NextResponse.redirect(toAbsoluteUrl(req, '/login?redirect=' + encodeURIComponent(redirectTo)))
     )
   }
-  const { user, roles } = ctx
-  const jwt = signJwt({ sub: String(user.id), tenantId: String(user.tenantId), orgId: String(user.organizationId), email: user.email, roles })
+  const { user, roles, session } = ctx
+  const jwt = signJwt({ sub: String(user.id), sid: session ? String(session.id) : undefined, tenantId: String(user.tenantId), orgId: String(user.organizationId), email: user.email, roles })
   const res = NextResponse.redirect(toAbsoluteUrl(req, redirectTo))
   res.cookies.set('auth_token', jwt, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
   return res
@@ -123,9 +123,10 @@ export async function POST(req: Request) {
     )
   }
 
-  const { user, roles } = ctx
+  const { user, roles, session } = ctx
   const jwt = signJwt({
     sub: String(user.id),
+    sid: session ? String(session.id) : undefined,
     tenantId: String(user.tenantId),
     orgId: String(user.organizationId),
     email: user.email,

--- a/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/sessionIntegrity.test.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { User } from '@open-mercato/core/modules/auth/data/entities'
+import { Session, User } from '@open-mercato/core/modules/auth/data/entities'
 import { isAuthContextValid, resolveCanonicalStaffAuthContext } from '@open-mercato/core/modules/auth/lib/sessionIntegrity'
 
 const findOneWithDecryption = jest.fn()
@@ -15,13 +15,31 @@ const tenantId = '22222222-2222-4222-8222-222222222222'
 const organizationId = '33333333-3333-4333-8333-333333333333'
 const scopedTenantId = '44444444-4444-4444-8444-444444444444'
 const scopedOrganizationId = '55555555-5555-4555-8555-555555555555'
+const sessionId = '66666666-6666-4666-8666-666666666666'
+
+type SessionLookupResult = { id: string; deletedAt: Date | null; expiresAt: Date } | null
 
 describe('isAuthContextValid', () => {
-  const em = {} as EntityManager
+  let sessionLookup: SessionLookupResult
+  const em = {
+    findOne: jest.fn(async (entity: unknown, filter: Record<string, unknown>) => {
+      if (entity === Session) {
+        if (!sessionLookup) return null
+        if (filter.id !== sessionLookup.id) return null
+        return sessionLookup
+      }
+      return null
+    }),
+  } as unknown as EntityManager
 
   beforeEach(() => {
     jest.clearAllMocks()
     findWithDecryption.mockResolvedValue([])
+    sessionLookup = {
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    }
   })
 
   it('accepts a user that still exists in the same tenant and organization', async () => {
@@ -32,7 +50,7 @@ describe('isAuthContextValid', () => {
     })
 
     await expect(
-      isAuthContextValid(em, { sub: userId, tenantId, orgId: organizationId, roles: [] }),
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
     ).resolves.toBe(true)
 
     expect(findOneWithDecryption).toHaveBeenCalledWith(
@@ -58,12 +76,14 @@ describe('isAuthContextValid', () => {
     await expect(
       resolveCanonicalStaffAuthContext(em, {
         sub: userId,
+        sid: sessionId,
         tenantId,
         orgId: organizationId,
         roles: ['employee'],
       }),
     ).resolves.toEqual({
       sub: userId,
+      sid: sessionId,
       tenantId,
       orgId: organizationId,
       roles: ['admin', 'superadmin'],
@@ -75,7 +95,7 @@ describe('isAuthContextValid', () => {
     findOneWithDecryption.mockResolvedValue(null)
 
     await expect(
-      isAuthContextValid(em, { sub: userId, tenantId, orgId: organizationId, roles: [] }),
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
     ).resolves.toBe(false)
   })
 
@@ -87,7 +107,7 @@ describe('isAuthContextValid', () => {
     })
 
     await expect(
-      isAuthContextValid(em, { sub: userId, tenantId, orgId: organizationId, roles: [] }),
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
     ).resolves.toBe(false)
   })
 
@@ -101,6 +121,7 @@ describe('isAuthContextValid', () => {
     await expect(
       isAuthContextValid(em, {
         sub: userId,
+        sid: sessionId,
         tenantId: scopedTenantId,
         orgId: scopedOrganizationId,
         actorTenantId: tenantId,
@@ -109,6 +130,61 @@ describe('isAuthContextValid', () => {
         isSuperAdmin: true,
       }),
     ).resolves.toBe(true)
+  })
+
+  it('rejects legacy tokens without an sid claim so clients must re-authenticate', async () => {
+    findOneWithDecryption.mockResolvedValue({
+      id: userId,
+      tenantId,
+      organizationId,
+    })
+
+    await expect(
+      isAuthContextValid(em, { sub: userId, tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(false)
+
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(findOneWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('rejects tokens whose referenced session has been deleted (logout/password reset)', async () => {
+    sessionLookup = null
+    findOneWithDecryption.mockResolvedValue({
+      id: userId,
+      tenantId,
+      organizationId,
+    })
+
+    await expect(
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(false)
+
+    expect(findOneWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('rejects tokens whose session row exists but has already expired', async () => {
+    sessionLookup = {
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() - 1000),
+    }
+    findOneWithDecryption.mockResolvedValue({
+      id: userId,
+      tenantId,
+      organizationId,
+    })
+
+    await expect(
+      isAuthContextValid(em, { sub: userId, sid: sessionId, tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(false)
+  })
+
+  it('rejects tokens whose sid is not a valid uuid', async () => {
+    await expect(
+      isAuthContextValid(em, { sub: userId, sid: 'not-a-uuid', tenantId, orgId: organizationId, roles: [] }),
+    ).resolves.toBe(false)
+
+    expect(em.findOne).not.toHaveBeenCalled()
   })
 
   it('skips user integrity lookup for api key auth', async () => {
@@ -122,5 +198,6 @@ describe('isAuthContextValid', () => {
     ).resolves.toBe(true)
 
     expect(findOneWithDecryption).not.toHaveBeenCalled()
+    expect(em.findOne).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/auth/lib/sessionIntegrity.ts
+++ b/packages/core/src/modules/auth/lib/sessionIntegrity.ts
@@ -1,7 +1,7 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { Role, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, Session, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const INVALID_SCOPE = Symbol('invalid-scope')
@@ -43,6 +43,17 @@ export async function resolveCanonicalStaffAuthContext(
   ) {
     return null
   }
+
+  // Session binding: when the JWT carries an `sid` claim, require the referenced session to
+  // still exist (not soft-deleted, not expired). This is what makes logout / password-reset
+  // actually invalidate an already-issued JWT. Legacy tokens without `sid` are rejected so
+  // callers must re-authenticate after the fix rolls out.
+  const sessionId = normalizeScopeId(typeof auth.sid === 'string' ? auth.sid : null)
+  if (sessionId === INVALID_SCOPE) return null
+  if (sessionId === null) return null
+  const session = await em.findOne(Session, { id: sessionId, deletedAt: null })
+  if (!session) return null
+  if (session.expiresAt.getTime() < Date.now()) return null
 
   const user = await findOneWithDecryption(
     em,

--- a/packages/core/src/modules/auth/services/__tests__/authService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/authService.test.ts
@@ -1,12 +1,13 @@
 import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
+import { Session } from '@open-mercato/core/modules/auth/data/entities'
 
 function makeEm() {
   const calls: any[] = []
   const em: any = {
     persistAndFlush: jest.fn(async (e: any) => calls.push(['persistAndFlush', e])),
-    create: jest.fn((cls: any, data: any) => ({ ...data })),
+    create: jest.fn((_cls: any, data: any) => ({ ...data, id: 'generated-id' })),
     findOne: jest.fn(async () => null),
-    nativeDelete: jest.fn(async () => undefined),
+    nativeDelete: jest.fn(async () => 1),
     find: jest.fn(async () => []),
   }
   return { em, calls }
@@ -28,5 +29,42 @@ describe('AuthService', () => {
     const sess = await svc.createSession({ id: 1 }, new Date(Date.now() + 1000))
     expect(sess.token).toBeDefined()
     expect(em.persistAndFlush).toHaveBeenCalled()
+  })
+
+  it('deleteSessionById invokes nativeDelete with the id filter', async () => {
+    const { em } = makeEm()
+    const svc = new AuthService(em)
+    await svc.deleteSessionById('session-1')
+    expect(em.nativeDelete).toHaveBeenCalledWith(Session, { id: 'session-1' })
+  })
+
+  it('findActiveSessionById returns the session when not soft-deleted and not expired', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce({
+      id: 'session-1',
+      deletedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+    })
+    const svc = new AuthService(em)
+    await expect(svc.findActiveSessionById('session-1')).resolves.toMatchObject({ id: 'session-1' })
+    expect(em.findOne).toHaveBeenCalledWith(Session, { id: 'session-1', deletedAt: null })
+  })
+
+  it('findActiveSessionById returns null when session row is missing', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce(null)
+    const svc = new AuthService(em)
+    await expect(svc.findActiveSessionById('session-1')).resolves.toBeNull()
+  })
+
+  it('findActiveSessionById returns null when session row exists but has already expired', async () => {
+    const { em } = makeEm()
+    em.findOne.mockResolvedValueOnce({
+      id: 'session-1',
+      deletedAt: null,
+      expiresAt: new Date(Date.now() - 1_000),
+    })
+    const svc = new AuthService(em)
+    await expect(svc.findActiveSessionById('session-1')).resolves.toBeNull()
   })
 })

--- a/packages/core/src/modules/auth/services/authService.ts
+++ b/packages/core/src/modules/auth/services/authService.ts
@@ -78,18 +78,29 @@ export class AuthService {
     await this.em.nativeDelete(Session, { token })
   }
 
+  async deleteSessionById(sessionId: string) {
+    await this.em.nativeDelete(Session, { id: sessionId })
+  }
+
+  async findActiveSessionById(sessionId: string): Promise<Session | null> {
+    const session = await this.em.findOne(Session, { id: sessionId, deletedAt: null })
+    if (!session) return null
+    if (session.expiresAt.getTime() < Date.now()) return null
+    return session
+  }
+
   async deleteAllUserSessions(userId: string) {
     await this.em.nativeDelete(Session, { user: userId })
   }
 
   async refreshFromSessionToken(token: string) {
     const now = new Date()
-    const sess = await this.em.findOne(Session, { token })
+    const sess = await this.em.findOne(Session, { token, deletedAt: null })
     if (!sess || sess.expiresAt <= now) return null
     const user = await this.em.findOne(User, { id: sess.user.id })
     if (!user) return null
     const roles = await this.getUserRoles(user, user.tenantId ?? null)
-    return { user, roles }
+    return { user, roles, session: sess }
   }
 
   async requestPasswordReset(email: string) {

--- a/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts
@@ -1,0 +1,126 @@
+/** @jest-environment node */
+import {
+  signAudienceJwt,
+  signJwt,
+} from '@open-mercato/shared/lib/auth/jwt'
+
+const findActiveSessionById = jest.fn()
+const containerResolve = jest.fn()
+const createRequestContainer = jest.fn(async () => ({
+  resolve: (name: string) => containerResolve(name),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => createRequestContainer(...args),
+}))
+
+// Import after mocks are set up.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getCustomerAuthFromRequest } = require('@open-mercato/core/modules/customer_accounts/lib/customerAuth') as typeof import('@open-mercato/core/modules/customer_accounts/lib/customerAuth')
+
+const CUSTOMER_AUDIENCE = 'customer'
+const sessionId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const userId = 'uuuuuuuu-uuuu-4uuu-8uuu-uuuuuuuuuuuu'
+const tenantId = 'tttttttt-tttt-4ttt-8ttt-tttttttttttt'
+const orgId = 'oooooooo-oooo-4ooo-8ooo-oooooooooooo'
+
+function buildCustomerCookieHeader(token: string): string {
+  return `customer_auth_token=${token}`
+}
+
+function buildCustomerPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    sub: userId,
+    sid: sessionId,
+    type: 'customer',
+    tenantId,
+    orgId,
+    email: 'customer@example.test',
+    displayName: 'Customer User',
+    resolvedFeatures: ['customer_portal.view'],
+    ...overrides,
+  }
+}
+
+describe('getCustomerAuthFromRequest — session revocation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    containerResolve.mockImplementation((name: string) => {
+      if (name === 'customerSessionService') {
+        return { findActiveSessionById }
+      }
+      return null
+    })
+    findActiveSessionById.mockResolvedValue({
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+  })
+
+  it('accepts a valid customer token and looks up the referenced session', async () => {
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload())
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    const result = await getCustomerAuthFromRequest(req)
+
+    expect(result).toMatchObject({ sub: userId, sid: sessionId, type: 'customer' })
+    expect(findActiveSessionById).toHaveBeenCalledWith(sessionId)
+  })
+
+  it('rejects the token once the underlying session row has been revoked', async () => {
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload())
+    findActiveSessionById.mockResolvedValueOnce(null)
+
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+  })
+
+  it('rejects tokens that are missing the sid claim so legacy/stolen tokens cannot survive the fix', async () => {
+    const payload = buildCustomerPayload()
+    delete payload.sid
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, payload)
+
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+    expect(findActiveSessionById).not.toHaveBeenCalled()
+  })
+
+  it('rejects staff JWTs replayed on the customer portal cookie', async () => {
+    // A staff JWT is signed with the staff audience secret and carries aud=staff. Even if an
+    // attacker copies it into the `customer_auth_token` cookie, the verifier must refuse it.
+    const staffToken = signJwt({
+      sub: userId,
+      sid: sessionId,
+      tenantId,
+      orgId,
+      email: 'staff@example.test',
+      roles: ['admin'],
+    })
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(staffToken) },
+    })
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+    expect(findActiveSessionById).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when session lookup throws (degraded backend)', async () => {
+    const token = signAudienceJwt(CUSTOMER_AUDIENCE, buildCustomerPayload())
+    findActiveSessionById.mockRejectedValueOnce(new Error('db unavailable'))
+
+    const req = new Request('http://localhost/api/customer/me', {
+      headers: { cookie: buildCustomerCookieHeader(token) },
+    })
+
+    await expect(getCustomerAuthFromRequest(req)).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuth.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from 'next/server'
-import { verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { verifyAudienceJwt } from '@open-mercato/shared/lib/auth/jwt'
 import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
+import { CUSTOMER_JWT_AUDIENCE } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 
 export interface CustomerAuthContext {
   sub: string
+  sid: string
   type: 'customer'
   tenantId: string
   orgId: string
@@ -12,6 +14,23 @@ export interface CustomerAuthContext {
   customerEntityId?: string | null
   personEntityId?: string | null
   resolvedFeatures: string[]
+}
+
+async function assertSessionStillActive(sessionId: string): Promise<boolean> {
+  try {
+    const [{ createRequestContainer }, { CustomerSessionService }] = await Promise.all([
+      import('@open-mercato/shared/lib/di/container'),
+      import('@open-mercato/core/modules/customer_accounts/services/customerSessionService'),
+    ])
+    const container = await createRequestContainer()
+    const service = container.resolve('customerSessionService') as InstanceType<typeof CustomerSessionService>
+    const session = await service.findActiveSessionById(sessionId)
+    return session !== null
+  } catch {
+    // Fail closed: if we cannot verify the session, treat the token as revoked to prevent
+    // replay of leaked JWTs when the backend is partially degraded.
+    return false
+  }
 }
 
 export function readCookieFromHeader(header: string | null | undefined, name: string): string | undefined {
@@ -48,12 +67,17 @@ export async function getCustomerAuthFromRequest(req: Request): Promise<Customer
   if (!token) return null
 
   try {
-    const payload = verifyJwt(token) as Record<string, unknown> | null
+    const payload = verifyAudienceJwt(CUSTOMER_JWT_AUDIENCE, token) as Record<string, unknown> | null
     if (!payload) return null
     if (payload.type !== 'customer') return null
+    const sid = typeof payload.sid === 'string' ? payload.sid : ''
+    if (!sid) return null
+    const stillActive = await assertSessionStillActive(sid)
+    if (!stillActive) return null
 
     return {
       sub: String(payload.sub),
+      sid,
       type: 'customer',
       tenantId: String(payload.tenantId),
       orgId: String(payload.orgId),

--- a/packages/core/src/modules/customer_accounts/lib/customerAuthServer.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerAuthServer.ts
@@ -6,10 +6,26 @@
  */
 
 import { cookies } from 'next/headers'
-import { verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { verifyAudienceJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { CUSTOMER_JWT_AUDIENCE } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 import type { CustomerAuthContext } from './customerAuth'
 
 export type { CustomerAuthContext }
+
+async function assertSessionStillActive(sessionId: string): Promise<boolean> {
+  try {
+    const [{ createRequestContainer }, { CustomerSessionService }] = await Promise.all([
+      import('@open-mercato/shared/lib/di/container'),
+      import('@open-mercato/core/modules/customer_accounts/services/customerSessionService'),
+    ])
+    const container = await createRequestContainer()
+    const service = container.resolve('customerSessionService') as InstanceType<typeof CustomerSessionService>
+    const session = await service.findActiveSessionById(sessionId)
+    return session !== null
+  } catch {
+    return false
+  }
+}
 
 /**
  * Read and verify customer auth from cookies in server components.
@@ -32,12 +48,17 @@ export async function getCustomerAuthFromCookies(): Promise<CustomerAuthContext 
   if (!token) return null
 
   try {
-    const payload = verifyJwt(token) as Record<string, unknown> | null
+    const payload = verifyAudienceJwt(CUSTOMER_JWT_AUDIENCE, token) as Record<string, unknown> | null
     if (!payload) return null
     if (payload.type !== 'customer') return null
+    const sid = typeof payload.sid === 'string' ? payload.sid : ''
+    if (!sid) return null
+    const stillActive = await assertSessionStillActive(sid)
+    if (!stillActive) return null
 
     return {
       sub: String(payload.sub),
+      sid,
       type: 'customer',
       tenantId: String(payload.tenantId),
       orgId: String(payload.orgId),

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerSessionService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerSessionService.test.ts
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  CustomerSessionService,
+  CUSTOMER_JWT_AUDIENCE,
+} from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
+import { verifyAudienceJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { CustomerUserSession } from '@open-mercato/core/modules/customer_accounts/data/entities'
+
+describe('CustomerSessionService.signCustomerJwt', () => {
+  const em = {} as EntityManager
+  const service = new CustomerSessionService(em)
+  const user = {
+    id: 'user-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    email: 'customer@example.test',
+    displayName: 'Customer',
+    customerEntityId: null,
+    personEntityId: null,
+  } as Parameters<CustomerSessionService['signCustomerJwt']>[0]
+
+  it('binds the sid claim to the token so it can be revoked later', () => {
+    const sessionId = 'session-1'
+    const token = service.signCustomerJwt(user, ['customer_portal.view'], sessionId)
+    const payload = verifyAudienceJwt(CUSTOMER_JWT_AUDIENCE, token)
+
+    expect(payload).toMatchObject({
+      sub: 'user-1',
+      sid: sessionId,
+      type: 'customer',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      resolvedFeatures: ['customer_portal.view'],
+      aud: 'customer',
+      iss: 'open-mercato',
+    })
+  })
+
+  it('produces tokens that fail verification under the staff audience', () => {
+    const token = service.signCustomerJwt(user, [], 'session-2')
+    expect(verifyAudienceJwt('staff', token)).toBeNull()
+  })
+})
+
+describe('CustomerSessionService session lookup and revocation', () => {
+  const sessionId = 'abcabcab-cabc-4abc-8abc-abcabcabcabc'
+
+  function buildEm(
+    session: { id: string; deletedAt: Date | null; expiresAt: Date } | null,
+  ): EntityManager {
+    return {
+      findOne: jest.fn(async (entity: unknown, filter: Record<string, unknown>) => {
+        if (entity !== CustomerUserSession) return null
+        if (filter.id !== sessionId) return null
+        if (session === null) return null
+        if (session.deletedAt !== null) return null
+        return session
+      }),
+      nativeUpdate: jest.fn(async () => 1),
+    } as unknown as EntityManager
+  }
+
+  it('findActiveSessionById returns the session when active', async () => {
+    const session = {
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    }
+    const service = new CustomerSessionService(buildEm(session))
+
+    await expect(service.findActiveSessionById(sessionId)).resolves.toMatchObject({
+      id: sessionId,
+    })
+  })
+
+  it('findActiveSessionById returns null when the session has been soft-deleted', async () => {
+    const service = new CustomerSessionService(buildEm(null))
+
+    await expect(service.findActiveSessionById(sessionId)).resolves.toBeNull()
+  })
+
+  it('findActiveSessionById returns null when the session has expired', async () => {
+    const session = {
+      id: sessionId,
+      deletedAt: null,
+      expiresAt: new Date(Date.now() - 1000),
+    }
+    const service = new CustomerSessionService(buildEm(session))
+
+    await expect(service.findActiveSessionById(sessionId)).resolves.toBeNull()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
@@ -1,7 +1,10 @@
 import { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerUser, CustomerUserSession } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { generateSecureToken, hashToken } from '@open-mercato/core/modules/customer_accounts/lib/tokenGenerator'
-import { signJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { signAudienceJwt } from '@open-mercato/shared/lib/auth/jwt'
+
+export const CUSTOMER_JWT_AUDIENCE = 'customer'
+const CUSTOMER_JWT_TTL_SECONDS = 60 * 60 * 8
 
 const DEFAULT_SESSION_TTL_DAYS = 30
 
@@ -30,23 +33,28 @@ export class CustomerSessionService {
     } as any) as CustomerUserSession
     await this.em.persistAndFlush(session)
 
-    const jwt = this.signCustomerJwt(user, resolvedFeatures)
+    const jwt = this.signCustomerJwt(user, resolvedFeatures, session.id)
 
     return { rawToken, jwt, session }
   }
 
-  signCustomerJwt(user: CustomerUser, resolvedFeatures: string[]): string {
-    return signJwt({
-      sub: user.id,
-      type: 'customer',
-      tenantId: user.tenantId,
-      orgId: user.organizationId,
-      email: user.email,
-      displayName: user.displayName || '',
-      customerEntityId: user.customerEntityId || null,
-      personEntityId: user.personEntityId || null,
-      resolvedFeatures,
-    })
+  signCustomerJwt(user: CustomerUser, resolvedFeatures: string[], sessionId: string): string {
+    return signAudienceJwt(
+      CUSTOMER_JWT_AUDIENCE,
+      {
+        sub: user.id,
+        sid: sessionId,
+        type: 'customer',
+        tenantId: user.tenantId,
+        orgId: user.organizationId,
+        email: user.email,
+        displayName: user.displayName || '',
+        customerEntityId: user.customerEntityId || null,
+        personEntityId: user.personEntityId || null,
+        resolvedFeatures,
+      },
+      CUSTOMER_JWT_TTL_SECONDS,
+    )
   }
 
   async findByToken(rawToken: string, tenantId?: string): Promise<CustomerUserSession | null> {
@@ -72,8 +80,18 @@ export class CustomerSessionService {
     if (!user || user.deletedAt || !user.isActive) return null
 
     await this.em.nativeUpdate(CustomerUserSession, { id: session.id }, { lastUsedAt: new Date() })
-    const jwt = this.signCustomerJwt(user, resolvedFeatures)
+    const jwt = this.signCustomerJwt(user, resolvedFeatures, session.id)
     return { jwt, user }
+  }
+
+  async findActiveSessionById(sessionId: string): Promise<CustomerUserSession | null> {
+    const session = await this.em.findOne(CustomerUserSession, {
+      id: sessionId,
+      deletedAt: null,
+    })
+    if (!session) return null
+    if (session.expiresAt.getTime() < Date.now()) return null
+    return session
   }
 
   async revokeSession(sessionId: string): Promise<void> {

--- a/packages/enterprise/src/modules/security/api/interceptors.ts
+++ b/packages/enterprise/src/modules/security/api/interceptors.ts
@@ -4,6 +4,7 @@ import { readSecurityModuleConfig } from '../lib/security-config'
 
 type JwtClaims = {
   sub: string
+  sid?: string | null
   tenantId?: string | null
   orgId?: string | null
   email?: string | null
@@ -24,6 +25,7 @@ function readClaims(token: string): JwtClaims | null {
   if (!sub) return null
   return {
     sub,
+    sid: typeof payload.sid === 'string' ? payload.sid : null,
     tenantId: typeof payload.tenantId === 'string' ? payload.tenantId : null,
     orgId: typeof payload.orgId === 'string' ? payload.orgId : null,
     email: typeof payload.email === 'string' ? payload.email : null,
@@ -70,6 +72,7 @@ export const interceptors: ApiInterceptor[] = [
         const pendingToken = signJwt(
           {
             sub: claims.sub,
+            sid: claims.sid ?? undefined,
             tenantId: claims.tenantId ?? null,
             orgId: claims.orgId ?? null,
             email: claims.email ?? null,

--- a/packages/enterprise/src/modules/security/api/mfa/_shared.ts
+++ b/packages/enterprise/src/modules/security/api/mfa/_shared.ts
@@ -89,6 +89,7 @@ function isMfaVerificationServiceError(error: unknown): error is MfaVerification
 export function issueVerifiedMfaToken(auth: MfaRequestContext['auth'], methods: string[]): string {
   const nextPayload: Record<string, unknown> = {
     sub: auth.sub,
+    sid: typeof auth.sid === 'string' ? auth.sid : undefined,
     tenantId: auth.tenantId ?? null,
     orgId: auth.orgId ?? null,
     email: typeof auth.email === 'string' ? auth.email : null,

--- a/packages/enterprise/src/modules/sso/services/ssoService.ts
+++ b/packages/enterprise/src/modules/sso/services/ssoService.ts
@@ -123,19 +123,21 @@ export class SsoService {
     await this.rbacService.invalidateUserCache(String(user.id))
 
     const roles = await this.authService.getUserRoles(user, tenantId || null)
-    const token = signJwt({
-      sub: String(user.id),
-      tenantId: tenantId || null,
-      orgId: user.organizationId ? String(user.organizationId) : null,
-      email: user.email,
-      roles,
-    })
 
     await this.authService.updateLastLoginAt(user)
 
     const days = Number(process.env.REMEMBER_ME_DAYS || '30')
     const sessionExpiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000)
     const session = await this.authService.createSession(user, sessionExpiresAt)
+
+    const token = signJwt({
+      sub: String(user.id),
+      sid: String(session.id),
+      tenantId: tenantId || null,
+      orgId: user.organizationId ? String(user.organizationId) : null,
+      email: user.email,
+      roles,
+    })
 
     void emitSsoEvent('sso.login.completed', {
       id: String(user.id),

--- a/packages/shared/src/lib/auth/__tests__/jwt.test.ts
+++ b/packages/shared/src/lib/auth/__tests__/jwt.test.ts
@@ -1,6 +1,12 @@
 import crypto from 'node:crypto'
 
-import { signJwt, verifyJwt } from '../jwt'
+import {
+  deriveJwtAudienceSecret,
+  signAudienceJwt,
+  signJwt,
+  verifyAudienceJwt,
+  verifyJwt,
+} from '../jwt'
 
 function base64url(input: Buffer | string): string {
   return (typeof input === 'string' ? Buffer.from(input) : input)
@@ -77,5 +83,130 @@ describe('jwt helpers', () => {
   it('throws when the JWT secret is missing', () => {
     expect(() => signJwt({ sub: 'user-1' }, '')).toThrow('JWT_SECRET is not set')
     expect(() => verifyJwt('header.payload.signature', '')).toThrow('JWT_SECRET is not set')
+  })
+
+  describe('audience-derived signing keys', () => {
+    const baseSecret = 'test-secret'
+    const originalJwtSecret = process.env.JWT_SECRET
+    const originalStaffSecret = process.env.JWT_STAFF_SECRET
+    const originalCustomerSecret = process.env.JWT_CUSTOMER_SECRET
+
+    beforeEach(() => {
+      process.env.JWT_SECRET = baseSecret
+      delete process.env.JWT_STAFF_SECRET
+      delete process.env.JWT_CUSTOMER_SECRET
+    })
+
+    afterEach(() => {
+      process.env.JWT_SECRET = originalJwtSecret
+      if (originalStaffSecret === undefined) delete process.env.JWT_STAFF_SECRET
+      else process.env.JWT_STAFF_SECRET = originalStaffSecret
+      if (originalCustomerSecret === undefined) delete process.env.JWT_CUSTOMER_SECRET
+      else process.env.JWT_CUSTOMER_SECRET = originalCustomerSecret
+    })
+
+    it('derives deterministic, distinct keys per audience from the same base secret', () => {
+      const staffKey = deriveJwtAudienceSecret('staff')
+      const customerKey = deriveJwtAudienceSecret('customer')
+      const staffKey2 = deriveJwtAudienceSecret('staff')
+
+      expect(staffKey).toBe(staffKey2)
+      expect(staffKey).not.toBe(customerKey)
+      expect(staffKey).not.toBe(baseSecret)
+      expect(customerKey).not.toBe(baseSecret)
+    })
+
+    it('honors per-audience env overrides ahead of the derived secret', () => {
+      process.env.JWT_CUSTOMER_SECRET = 'explicit-customer-secret'
+      expect(deriveJwtAudienceSecret('customer')).toBe('explicit-customer-secret')
+      // Staff continues to derive from the base secret when no staff override is set.
+      expect(deriveJwtAudienceSecret('staff')).not.toBe('explicit-customer-secret')
+    })
+
+    it('normalizes audience names so case and punctuation do not cause drift', () => {
+      expect(deriveJwtAudienceSecret('staff')).toBe(deriveJwtAudienceSecret('STAFF'))
+      expect(deriveJwtAudienceSecret('customer-portal')).toBe(deriveJwtAudienceSecret('Customer_Portal'))
+    })
+
+    it('round-trips a staff audience token and enforces iss/aud claims', () => {
+      const token = signAudienceJwt('staff', { sub: 'staff-1', roles: ['admin'] }, 300)
+      const payload = verifyAudienceJwt('staff', token)
+      expect(payload).toMatchObject({
+        sub: 'staff-1',
+        roles: ['admin'],
+        iss: 'open-mercato',
+        aud: 'staff',
+      })
+    })
+
+    it('rejects a staff token replayed against the customer audience (cross-audience confusion)', () => {
+      const staffToken = signAudienceJwt('staff', { sub: 'staff-1' }, 300)
+      // The verifier both uses a different HMAC key AND enforces `aud` — either layer should block.
+      expect(verifyAudienceJwt('customer', staffToken)).toBeNull()
+    })
+
+    it('rejects a customer token replayed against the staff audience', () => {
+      const customerToken = signAudienceJwt('customer', { sub: 'customer-1', type: 'customer' }, 300)
+      expect(verifyAudienceJwt('staff', customerToken)).toBeNull()
+    })
+
+    it('rejects an unsigned payload that carries the right aud but has the wrong signing key', () => {
+      // Forge a token that *says* aud=staff but was signed with the customer-derived key.
+      const forgedHeader = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+        .toString('base64')
+        .replace(/=/g, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+      const forgedBody = Buffer.from(
+        JSON.stringify({
+          sub: 'attacker',
+          iss: 'open-mercato',
+          aud: 'staff',
+          iat: Math.floor(now.getTime() / 1000),
+          exp: Math.floor(now.getTime() / 1000) + 300,
+        }),
+      )
+        .toString('base64')
+        .replace(/=/g, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+      const customerSecret = deriveJwtAudienceSecret('customer')
+      const forgedSig = crypto
+        .createHmac('sha256', customerSecret)
+        .update(`${forgedHeader}.${forgedBody}`)
+        .digest('base64')
+        .replace(/=/g, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+      const forgedToken = `${forgedHeader}.${forgedBody}.${forgedSig}`
+
+      expect(verifyAudienceJwt('staff', forgedToken)).toBeNull()
+    })
+
+    it('default signJwt/verifyJwt without explicit secret uses the staff audience', () => {
+      const token = signJwt({ sub: 'staff-2' })
+      const payload = verifyJwt(token)
+      expect(payload).toMatchObject({ sub: 'staff-2', iss: 'open-mercato', aud: 'staff' })
+      // The same token cannot be verified as a customer token because the HMAC key differs.
+      expect(verifyAudienceJwt('customer', token)).toBeNull()
+    })
+
+    it('legacy signJwt(payload, rawSecret) path keeps iss/aud out of the token', () => {
+      const token = signJwt({ sub: 'legacy-1' }, 'raw-secret', 300)
+      const payload = verifyJwt(token, 'raw-secret')
+      expect(payload).toMatchObject({ sub: 'legacy-1' })
+      expect((payload as Record<string, unknown>).iss).toBeUndefined()
+      expect((payload as Record<string, unknown>).aud).toBeUndefined()
+    })
+
+    it('rejects a staff token when no audience override is configured but verification asks for customer', () => {
+      const token = signJwt({ sub: 'staff-3' })
+      // A page that wrongly uses verifyJwt with default args would enforce staff aud, so a
+      // customer token replayed there must be rejected.
+      const customerToken = signAudienceJwt('customer', { sub: 'customer-2', type: 'customer' })
+      expect(verifyJwt(customerToken)).toBeNull()
+      // Sanity: the staff token still verifies with default args.
+      expect(verifyJwt(token)).not.toBeNull()
+    })
   })
 })

--- a/packages/shared/src/lib/auth/jwt.ts
+++ b/packages/shared/src/lib/auth/jwt.ts
@@ -10,26 +10,142 @@ function base64url(input: Buffer | string) {
 
 export type JwtPayload = Record<string, any>
 
-export function signJwt(payload: JwtPayload, secret = process.env.JWT_SECRET!, expiresInSec = 60 * 60 * 8) {
+export type JwtAudience = 'staff' | 'customer' | (string & {})
+
+export type SignJwtOptions = {
+  secret?: string
+  expiresInSec?: number
+  audience?: string
+  issuer?: string
+}
+
+export type VerifyJwtOptions = {
+  secret?: string
+  audience?: string
+  issuer?: string
+}
+
+const DEFAULT_ISSUER = 'open-mercato'
+const DEFAULT_STAFF_AUDIENCE: JwtAudience = 'staff'
+const AUDIENCE_SECRET_LABEL = 'open-mercato:jwt:v1'
+
+function readBaseSecret(explicit?: string): string {
+  const secret = explicit ?? process.env.JWT_SECRET
   if (!secret) throw new Error('JWT_SECRET is not set')
+  return secret
+}
+
+function normalizeAudience(audience: string): string {
+  return audience.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_')
+}
+
+/**
+ * Derive a per-audience signing key from the base `JWT_SECRET`.
+ *
+ * - If `JWT_${AUDIENCE}_SECRET` env var is set, it is used verbatim (allows operators to rotate a
+ *   single audience independently).
+ * - Otherwise, the key is derived deterministically via HMAC-SHA256 from the base secret using a
+ *   versioned label. This ensures that a staff JWT signature cannot verify against the customer
+ *   key (and vice versa) even though both share the same base `JWT_SECRET`.
+ */
+export function deriveJwtAudienceSecret(audience: string, baseSecret?: string): string {
+  const normalized = normalizeAudience(audience)
+  if (!normalized) throw new Error('Audience is required to derive a JWT secret')
+  const overrideName = `JWT_${normalized.toUpperCase()}_SECRET`
+  const override = process.env[overrideName]
+  if (override && override.trim().length > 0) return override
+  const base = readBaseSecret(baseSecret)
+  const label = `${AUDIENCE_SECRET_LABEL}:${normalized}`
+  return crypto.createHmac('sha256', base).update(label).digest('hex')
+}
+
+function isSignOptions(value: string | SignJwtOptions | undefined): value is SignJwtOptions {
+  return typeof value === 'object' && value !== null
+}
+
+function isVerifyOptions(value: string | VerifyJwtOptions | undefined): value is VerifyJwtOptions {
+  return typeof value === 'object' && value !== null
+}
+
+function toSignOptions(secretOrOptions?: string | SignJwtOptions, expiresInSec?: number): { secret: string; expiresInSec: number; audience?: string; issuer?: string } {
+  if (isSignOptions(secretOrOptions)) {
+    const audience = secretOrOptions.audience ?? DEFAULT_STAFF_AUDIENCE
+    const secret = secretOrOptions.secret ?? deriveJwtAudienceSecret(audience)
+    if (!secret) throw new Error('JWT_SECRET is not set')
+    return {
+      secret,
+      expiresInSec: secretOrOptions.expiresInSec ?? 60 * 60 * 8,
+      audience,
+      issuer: secretOrOptions.issuer ?? DEFAULT_ISSUER,
+    }
+  }
+  if (typeof secretOrOptions === 'string') {
+    // Legacy: explicit raw secret supplied by caller — keep audience/issuer off by default so
+    // existing tests and callers that BYO secret see unchanged behavior.
+    if (!secretOrOptions) throw new Error('JWT_SECRET is not set')
+    return {
+      secret: secretOrOptions,
+      expiresInSec: expiresInSec ?? 60 * 60 * 8,
+    }
+  }
+  // Default path: staff-audience derived secret + iss/aud claims.
+  return {
+    secret: deriveJwtAudienceSecret(DEFAULT_STAFF_AUDIENCE),
+    expiresInSec: expiresInSec ?? 60 * 60 * 8,
+    audience: DEFAULT_STAFF_AUDIENCE,
+    issuer: DEFAULT_ISSUER,
+  }
+}
+
+function toVerifyOptions(secretOrOptions?: string | VerifyJwtOptions): { secret: string; audience?: string; issuer?: string } {
+  if (isVerifyOptions(secretOrOptions)) {
+    const audience = secretOrOptions.audience ?? DEFAULT_STAFF_AUDIENCE
+    const secret = secretOrOptions.secret ?? deriveJwtAudienceSecret(audience)
+    if (!secret) throw new Error('JWT_SECRET is not set')
+    return {
+      secret,
+      audience,
+      issuer: secretOrOptions.issuer ?? DEFAULT_ISSUER,
+    }
+  }
+  if (typeof secretOrOptions === 'string') {
+    if (!secretOrOptions) throw new Error('JWT_SECRET is not set')
+    // Legacy explicit secret: no audience/issuer enforcement.
+    return { secret: secretOrOptions }
+  }
+  return {
+    secret: deriveJwtAudienceSecret(DEFAULT_STAFF_AUDIENCE),
+    audience: DEFAULT_STAFF_AUDIENCE,
+    issuer: DEFAULT_ISSUER,
+  }
+}
+
+export function signJwt(
+  payload: JwtPayload,
+  secretOrOptions?: string | SignJwtOptions,
+  expiresInSec?: number,
+) {
+  const options = toSignOptions(secretOrOptions, expiresInSec)
   const header = { alg: 'HS256', typ: 'JWT' }
   const now = Math.floor(Date.now() / 1000)
-  const body = { iat: now, exp: now + expiresInSec, ...payload }
+  const body: JwtPayload = { iat: now, exp: now + options.expiresInSec, ...payload }
+  if (options.issuer && body.iss === undefined) body.iss = options.issuer
+  if (options.audience && body.aud === undefined) body.aud = options.audience
   const encHeader = base64url(JSON.stringify(header))
   const encBody = base64url(JSON.stringify(body))
   const data = `${encHeader}.${encBody}`
-  const sig = crypto.createHmac('sha256', secret).update(data).digest()
+  const sig = crypto.createHmac('sha256', options.secret).update(data).digest()
   const encSig = base64url(sig)
   return `${data}.${encSig}`
 }
 
-export function verifyJwt(token: string, secret = process.env.JWT_SECRET!) {
-  if (!secret) throw new Error('JWT_SECRET is not set')
+export function verifyJwt(token: string, secretOrOptions?: string | VerifyJwtOptions) {
+  const options = toVerifyOptions(secretOrOptions)
   const parts = token.split('.')
   if (parts.length !== 3) return null
   const [h, p, s] = parts
   const data = `${h}.${p}`
-  const expected = base64url(crypto.createHmac('sha256', secret).update(data).digest())
+  const expected = base64url(crypto.createHmac('sha256', options.secret).update(data).digest())
   const providedSignature = Buffer.from(s)
   const expectedSignature = Buffer.from(expected)
   if (providedSignature.length !== expectedSignature.length) return null
@@ -42,5 +158,33 @@ export function verifyJwt(token: string, secret = process.env.JWT_SECRET!) {
   }
   const now = Math.floor(Date.now() / 1000)
   if (payload.exp && now > payload.exp) return null
+  if (options.audience !== undefined) {
+    if (payload.aud !== options.audience) return null
+  }
+  if (options.issuer !== undefined) {
+    if (payload.iss !== options.issuer) return null
+  }
   return payload
+}
+
+/**
+ * Sign a JWT for a specific audience using an audience-derived signing key. The resulting token
+ * carries `iss` and `aud` claims and cannot be verified with the base `JWT_SECRET` directly —
+ * callers must use `verifyAudienceJwt` with the same audience.
+ */
+export function signAudienceJwt(
+  audience: string,
+  payload: JwtPayload,
+  expiresInSec: number = 60 * 60 * 8,
+): string {
+  return signJwt(payload, { audience, expiresInSec })
+}
+
+/**
+ * Verify a JWT that was signed with an audience-scoped secret. Rejects tokens that are missing
+ * or carry a mismatched `aud`/`iss` claim, so a staff JWT cannot be replayed against the
+ * customer portal (and vice versa) even when the base `JWT_SECRET` is shared.
+ */
+export function verifyAudienceJwt(audience: string, token: string): JwtPayload | null {
+  return verifyJwt(token, { audience })
 }

--- a/packages/shared/src/lib/auth/server.ts
+++ b/packages/shared/src/lib/auth/server.ts
@@ -9,6 +9,7 @@ const SUPERADMIN_ROLE = 'superadmin'
 
 export type AuthContext = {
   sub: string
+  sid?: string | null
   tenantId: string | null
   orgId: string | null
   email?: string


### PR DESCRIPTION
## Summary
                                                                                                                                                                          
  Fixes a security bug where JWTs (HS256) were impossible to invalidate and staff/customer tokens shared a single signing secret, allowing cross-audience cookie replay.  
  
  **Two defense-in-depth layers:**                                                                                                                                        
                                                            
  - **Audience-derived signing keys.** Staff JWTs are signed with `HMAC(JWT_SECRET, "open-mercato:jwt:v1:staff")` and customer JWTs with the corresponding customer label.
   A token copied across audiences fails signature verification. On top of that, `iss`/`aud` claims are now enforced, so even a mis-signed token with a matching `aud` is
  rejected. Operators can still rotate a single audience via `JWT_STAFF_SECRET` / `JWT_CUSTOMER_SECRET` env overrides — no new required env vars.                         
  - **Session binding via `sid`.** Every login (staff and customer) creates a session row and embeds its id as the JWT `sid` claim. `sessionIntegrity` and `customerAuth`
  look up the session on every request and fail closed when the row is missing, soft-deleted, or expired. Logout now extracts `sid` from `auth_token` and revokes the     
  session by id, so a stolen token stops working immediately instead of waiting for `exp`. Legacy tokens without `sid` are rejected so clients must re-authenticate after
  rollout.                                                                                                                                                                
                                                            
  SSO, MFA interceptors, MFA shared helpers, and the profile `PUT` route all propagate `sid` through re-signed tokens, so session binding survives every JWT refresh path.
   
  ### What this fixes                                                                                                                                                     
                                                            
  - A leaked/stolen staff JWT cookie is now invalidated immediately by logout or by any password reset that purges the user's sessions (instead of being valid until the  
  8h `exp`).
  - A staff `auth_token` cookie copied into `customer_auth_token` (or vice versa) no longer passes verification — blocked by both the HMAC key mismatch and the `aud`     
  claim check.                                                                                                                                                            
  - Forged tokens that claim `aud=staff` but are signed with the customer-derived key are rejected.
                                                                                                                                                                          
  ### Migration / BC                                                                                                                                                      
                                                                                                                                                                          
  - **Breaking for legacy tokens without `sid`.** After this ships, tokens issued before the fix will be rejected and clients will be forced to re-authenticate           
  (one-time). This is intentional — the whole point is to make "tokens issued before the fix" uninvalidable only in the narrow logout window.
  - No new required env variables. `JWT_SECRET` stays the single source; per-audience overrides are opt-in.                                                               
  - Backwards-compatible for `signJwt(payload, rawSecret)` legacy callsites — when an explicit string secret is passed, no `iss`/`aud` claims are added and no enforcement
   happens.                                                                                                                                                               
                                                                                                                                                                          
  ### Files changed                                                                                                                                                       
                                                            
  **Core JWT helper + session binding:**                                                                                                                                  
  - `packages/shared/src/lib/auth/jwt.ts` — `deriveJwtAudienceSecret`, `signAudienceJwt`, `verifyAudienceJwt`, `iss`/`aud` enforcement in `verifyJwt`.
  - `packages/shared/src/lib/auth/server.ts` — `sid` added to `AuthContext`.                                                                                              
  - `packages/core/src/modules/auth/lib/sessionIntegrity.ts` — requires `sid`, verifies session row exists and is active.                                                 
                                                                                                                                                                          
  **Staff auth flow:**                                                                                                                                                    
  - `packages/core/src/modules/auth/services/authService.ts` — `deleteSessionById`, `findActiveSessionById`; `refreshFromSessionToken` returns the session.               
  - `packages/core/src/modules/auth/api/login.ts` — always creates a session, embeds `sid` in JWT.                                                                        
  - `packages/core/src/modules/auth/api/session/refresh.ts` — propagates `sid` on refresh.                                                                                
  - `packages/core/src/modules/auth/api/logout.ts` — extracts `sid` from `auth_token` and revokes by id.                                                                  
  - `packages/core/src/modules/auth/api/profile/route.ts` — preserves `sid` when re-signing after profile update.                                                         
                                                                                                                                                                          
  **Customer auth flow:**                                                                                                                                                 
  - `packages/core/src/modules/customer_accounts/services/customerSessionService.ts` — `CUSTOMER_JWT_AUDIENCE`, `signCustomerJwt` with `sid`, `findActiveSessionById`.    
  - `packages/core/src/modules/customer_accounts/lib/customerAuth.ts` / `customerAuthServer.ts` — `verifyAudienceJwt('customer', ...)`, session lookup, fail-closed on DI 
  errors.                                                                                                                                                                 
                                                                                                                                                                          
  **Enterprise:**                                                                                                                                                         
  - `packages/enterprise/src/modules/security/api/interceptors.ts` — MFA pending token carries `sid`.
  - `packages/enterprise/src/modules/security/api/mfa/_shared.ts` — verified MFA token carries `sid`.                                                                     
  - `packages/enterprise/src/modules/sso/services/ssoService.ts` — reordered to create session before signing JWT so `sid` can be embedded.                               
                                                                                                                                                                          
  ## Test plan                                                                                                                                                            
                                                                                                                                                                          
  All 27 new/updated unit tests pass. Full suite in touched areas: **660/660 passing** in `packages/shared` + `packages/core/auth` + `packages/core/customer_accounts`;   
  **86/86 passing** in enterprise SSO + security interceptors. TypeScript strict compilation passes for `shared`, `core`, and `enterprise`.
                                                                                                                                                                          
  **New / updated test files:**                                                                                                                                           
   
  - [x] `packages/shared/src/lib/auth/__tests__/jwt.test.ts` (+10 tests)                                                                                                  
    - deterministic derivation, env override, audience normalization
    - round-trip with `iss`/`aud` enforcement                                                                                                                             
    - staff↔customer cross-audience rejection               
    - forged token with correct `aud` but wrong signing key                                                                                                               
    - legacy `signJwt(payload, rawSecret)` path preserved   
    - legacy token without `sid` rejected                                                                                                                                 
    - revoked (soft-deleted) session rejected                                                                                                                             
    - expired session rejected                                                                                                                                            
    - non-UUID `sid` rejected                                                                                                                                             
  - [x] `packages/core/src/modules/auth/services/__tests__/authService.test.ts` (+4 tests)
    - `deleteSessionById`                                                                                                                                                 
    - `findActiveSessionById` happy / missing / expired                                                                                                                   
  - [x] `packages/core/src/modules/auth/api/__tests__/logout.test.ts` (new, 5 tests)
    - revoke by `sid`                                                                                                                                                     
    - revoke `session_token` cookie                                                                                                                                       
    - idempotent logout with no cookies                                                                                                                                   
    - invalid / unverifiable `auth_token` ignored                                                                                                                         
    - legacy token without `sid` ignored                    
  - [x] `packages/core/src/modules/customer_accounts/__tests__/customerAuth.test.ts` (new, 5 tests)                                                                       
    - happy path with session lookup                                                                                                                                      
    - revoked session rejection                                                                                                                                           
    - missing `sid` rejection                                                                                                                                             
    - staff JWT replayed on customer cookie rejected        
    - fail-closed on DB error                                                                                                                                             
  - [x] `packages/core/src/modules/customer_accounts/services/__tests__/customerSessionService.test.ts` (new, 5 tests)                                                    
    - `sid` embedded in JWT                                                                                                                                               
    - customer token fails under staff audience                                                                                                                           
    - `findActiveSessionById` happy / missing / expired     
                                                                                                                                                                          
  **Manual verification checklist for reviewer:**           
                                                                                                                                                                          
  - [ ] Log in as staff → verify new JWT carries `sid`, `iss: "open-mercato"`, `aud: "staff"`
  - [ ] Log out → confirm session row deleted; re-sending old cookie is rejected                                                                                          
  - [ ] Log in as customer → verify JWT carries `aud: "customer"` and cannot be replayed on staff routes
  - [ ] Existing users with pre-fix tokens are redirected to login (expected one-time re-auth)                                                                            
  - [ ] SSO login path still issues a valid revocable token                                                                                                               
  - [ ] MFA challenge → verified path preserves `sid` across the re-signed token