### PR TITLE
UI Contract Violations

### DIFF
--- a/packages/core/src/modules/auth/components/AclEditor.tsx
+++ b/packages/core/src/modules/auth/components/AclEditor.tsx
@@ -191,7 +191,7 @@ export function AclEditor({
       }
       if (kind === 'user' && userRoles && userRoles.length > 0) {
         try {
-          const roleQuery = new URLSearchParams({ pageSize: '1000' })
+          const roleQuery = new URLSearchParams({ pageSize: '100' })
           if (tenantId) roleQuery.set('tenantId', tenantId)
           const roleQueryString = roleQuery.toString()
           const rolesJson = await readJsonOr<RoleListResponse>(

--- a/packages/core/src/modules/workflows/backend/events/page.tsx
+++ b/packages/core/src/modules/workflows/backend/events/page.tsx
@@ -10,6 +10,7 @@ import { useQuery } from '@tanstack/react-query'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { ErrorMessage } from '@open-mercato/ui/backend/detail'
 
 type WorkflowEvent = {
   id: string
@@ -253,6 +254,24 @@ export default function WorkflowEventsPage() {
     },
   ]
 
+  if (error) {
+    return (
+      <Page>
+        <PageBody>
+          <ErrorMessage
+            label={t('workflows.events.messages.loadFailed')}
+            description={error.message}
+            action={(
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                {t('common.retry', 'Retry')}
+              </Button>
+            )}
+          />
+        </PageBody>
+      </Page>
+    )
+  }
+
   return (
     <Page>
       <PageBody>
@@ -265,7 +284,6 @@ export default function WorkflowEventsPage() {
           onFiltersApply={handleFiltersApply}
           onFiltersClear={handleFiltersClear}
           isLoading={isLoading}
-          error={error ? t('workflows.events.messages.loadFailed') : undefined}
           pagination={{ page, pageSize, total, totalPages, onPageChange: setPage }}
           actions={
             <Button

--- a/packages/search/src/modules/search/__tests__/ai-tools.aggregate.test.ts
+++ b/packages/search/src/modules/search/__tests__/ai-tools.aggregate.test.ts
@@ -1,0 +1,113 @@
+import { aiTools } from '../ai-tools'
+
+const aggregateTool = aiTools.find((t) => t.name === 'search_aggregate')
+if (!aggregateTool) throw new Error('search_aggregate tool not found in aiTools — was it renamed?')
+
+function makeCtx(queryResult: { items: unknown[]; total: number }) {
+  const mockQuery = jest.fn().mockResolvedValue(queryResult)
+  const ctx = {
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    userId: null,
+    userFeatures: ['search.view'],
+    isSuperAdmin: false,
+    container: {
+      resolve: (_name: string) => ({ query: mockQuery }),
+    },
+  }
+  return { ctx, mockQuery }
+}
+
+describe('search_aggregate tool', () => {
+  it('sends pageSize: 100 to the query engine', async () => {
+    const { ctx, mockQuery } = makeCtx({ items: [], total: 0 })
+
+    await aggregateTool.handler({ entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 }, ctx)
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      'customers:customer_deal',
+      expect.objectContaining({
+        page: { page: 1, pageSize: 100 },
+      }),
+    )
+  })
+
+  it('groups returned items by the specified field', async () => {
+    const items = [
+      { status: 'open' },
+      { status: 'open' },
+      { status: 'closed' },
+      { status: null },
+    ]
+    const { ctx } = makeCtx({ items, total: 4 })
+
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { buckets: Array<{ value: string | null; count: number; percentage: number }>; total: number }
+
+    expect(result.total).toBe(4)
+    const open = result.buckets.find((b) => b.value === 'open')
+    const closed = result.buckets.find((b) => b.value === 'closed')
+    const nullBucket = result.buckets.find((b) => b.value === null)
+    expect(open?.count).toBe(2)
+    expect(closed?.count).toBe(1)
+    expect(nullBucket?.count).toBe(1)
+  })
+
+  it('respects the limit on returned buckets', async () => {
+    const items = Array.from({ length: 10 }, (_, i) => ({ category: `cat-${i}` }))
+    const { ctx } = makeCtx({ items, total: 10 })
+
+    const result = await aggregateTool.handler(
+      { entityType: 'catalog:product', groupBy: 'category', limit: 3 },
+      ctx,
+    ) as { buckets: unknown[] }
+
+    expect(result.buckets.length).toBe(3)
+  })
+
+  it('computes percentage against the sampled item count', async () => {
+    const items = [{ status: 'open' }, { status: 'open' }, { status: 'closed' }]
+    const { ctx } = makeCtx({ items, total: 1000 }) // DB total irrelevant; sample is 3
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { buckets: Array<{ value: string; percentage: number }> }
+    const open = result.buckets.find((b) => b.value === 'open')
+    expect(open?.percentage).toBeCloseTo(66.67, 1)
+  })
+
+  it('returns buckets sorted by count descending', async () => {
+    const items = [
+      { status: 'closed' },
+      { status: 'open' }, { status: 'open' }, { status: 'open' },
+      { status: 'pending' }, { status: 'pending' },
+    ]
+    const { ctx } = makeCtx({ items, total: 6 })
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { buckets: Array<{ value: string; count: number }> }
+    expect(result.buckets.map((b) => b.value)).toEqual(['open', 'pending', 'closed'])
+  })
+
+  it('returns empty buckets for empty result set', async () => {
+    const { ctx } = makeCtx({ items: [], total: 0 })
+    const result = await aggregateTool.handler(
+      { entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 },
+      ctx,
+    ) as { total: number; buckets: unknown[] }
+    expect(result.total).toBe(0)
+    expect(result.buckets).toEqual([])
+  })
+
+  it('throws when tenantId is missing', async () => {
+    const { ctx } = makeCtx({ items: [], total: 0 })
+    const noTenantCtx = { ...ctx, tenantId: null }
+
+    await expect(
+      aggregateTool.handler({ entityType: 'customers:customer_deal', groupBy: 'status', limit: 20 }, noTenantCtx),
+    ).rejects.toThrow('Tenant context is required')
+  })
+})

--- a/packages/search/src/modules/search/ai-tools.ts
+++ b/packages/search/src/modules/search/ai-tools.ts
@@ -299,7 +299,7 @@ const searchSchemaTool: AiToolDefinition = {
 const searchAggregateTool: AiToolDefinition = {
   name: 'search_aggregate',
   description:
-    'Get record counts grouped by a field value. Useful for analytics like "how many deals by stage?" or "customers by status".',
+    'Get record counts grouped by a field value. Useful for analytics like "how many deals by stage?" or "customers by status". Samples up to 100 records — percentages may not reflect the full dataset for large entity sets.',
   inputSchema: z.object({
     entityType: z
       .string()
@@ -331,7 +331,7 @@ const searchAggregateTool: AiToolDefinition = {
     const result = await queryEngine.query(input.entityType, {
       tenantId: ctx.tenantId,
       organizationId: ctx.organizationId,
-      page: { page: 1, pageSize: 1000 }, // Fetch up to 1000 for aggregation
+      page: { page: 1, pageSize: 100 },
     })
 
     const counts = new Map<string | null, number>()


### PR DESCRIPTION
Fix: UI/API contract violations — pageSize limit and missing error state                                               
                                                                                                                         
  Background                                                                                                             
   
  Three components violated the platform's API contract (pageSize must not exceed 100) or silently swallowed query       
  errors, leaving users with a blank screen and no feedback.      
                                                                                                                         
  ---                                                             
  Changes
         
  1. AclEditor.tsx — pageSize 1000 → 100
                                                                                                                         
  The role-banner fetch inside the user ACL editor requested 1000 roles per page, breaking the API contract. Capped to   
  100, which covers all realistic tenant configurations.                                                                 
                                                                                                                         
  2. search/ai-tools.ts — search_aggregate pageSize 1000 → 100    

  The search_aggregate MCP tool fetched up to 1000 records for in-memory GROUP BY aggregation, violating the contract.   
  Changed to 100.
                                                                                                                         
  Updated the tool description to explicitly warn AI callers that results are based on a sample of up to 100 records and 
  that percentages may not reflect the full dataset for large entity sets — preventing misuse as a precise analytics
  tool.                                                                                                                  
                                                                  
  3. workflows/backend/events/page.tsx — missing error state                                                             
   
  The workflow events page destructured error from useQuery but never rendered it. On a failed API call, users saw an    
  empty table with no explanation.                                
                                                                                                                         
  Added a proper early-return error guard following the established pattern from definitions/page.tsx:                   
   
  if (error) {                                                                                                           
    return (                                                      
      <Page>
        <PageBody>
          <ErrorMessage
            label={t('workflows.events.messages.loadFailed')}                                                            
            description={error.message}
            action={<Button onClick={() => refetch()}>{t('common.retry', 'Retry')}</Button>}                             
          />                                                                                                             
        </PageBody>                                                                                                      
      </Page>                                                                                                            
    )                                                             
  }

  Also removed the now-unreachable error prop that had been passed to <DataTable>.

  ---
  Tests
       
  Added packages/search/src/modules/search/__tests__/ai-tools.aggregate.test.ts with 7 unit tests for the
  search_aggregate handler:                                                                                              
   
  ┌─────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────┐   
  │                      Test                       │                        What it verifies                        │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ sends pageSize: 100 to the query engine         │ API contract enforced at the call site                         │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ groups returned items by the specified field    │ correct Map-based GROUP BY including null keys                 │   
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤   
  │ respects the limit on returned buckets          │ output slice honours the caller's bucket cap                   │   
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤   
  │ computes percentage against the sampled item    │ percentage is fraction of the 100-record sample, not the DB    │
  │ count                                           │ total                                                          │   
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤
  │ returns buckets sorted by count descending      │ highest-count buckets appear first                             │   
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤   
  │ returns empty buckets for empty result set      │ no division-by-zero, total: 0, buckets: []                     │
  ├─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────┤   
  │ throws when tenantId is missing                 │ tenant-scope guard fires before any query                      │
  └─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────┘   
                                                                  
  ---                                                                                                                    
  What was not changed
                                                                                                                         
  - No pagination logic was added for the AclEditor roles fetch or the aggregate tool. Both are documented limitations
  (// TODO: paginate if tenant has >100 roles) and the proper fix (server-side GROUP BY for aggregation, a /all endpoint 
  for roles) is tracked separately.
  - No other logic was touched in any of the modified files. 