### PR TITLE
tests: add low-level coverage for appResolver.ts

### DIFF
--- a/packages/shared/src/lib/bootstrap/__tests__/appResolver.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/appResolver.test.ts
@@ -21,6 +21,17 @@ function createApp(rootDir: string, relativeAppDir: string, configName: NextConf
   return { appDir, mercatoDir, generatedDir }
 }
 
+function createInvalidConfigDirectory(rootDir: string, relativeAppDir: string, configName: NextConfigName): AppRoot {
+  const appDir = path.join(rootDir, relativeAppDir)
+  const mercatoDir = path.join(appDir, '.mercato')
+  const generatedDir = path.join(mercatoDir, 'generated')
+
+  fs.mkdirSync(path.join(appDir, configName), { recursive: true })
+  fs.mkdirSync(generatedDir, { recursive: true })
+
+  return { appDir, mercatoDir, generatedDir }
+}
+
 describe('appResolver', () => {
   let tempDir: string
 
@@ -61,6 +72,16 @@ describe('appResolver', () => {
       expect(findAppRoot(nestedDir)).toEqual(innerApp)
     })
 
+    it('ignores directories masquerading as Next.js config files', () => {
+      const outerApp = createApp(tempDir, 'apps/outer', 'next.config.ts')
+      const invalidInnerApp = createInvalidConfigDirectory(outerApp.appDir, 'examples/inner', 'next.config.js')
+      const nestedDir = path.join(invalidInnerApp.appDir, 'src')
+
+      fs.mkdirSync(nestedDir, { recursive: true })
+
+      expect(findAppRoot(nestedDir)).toEqual(outerApp)
+    })
+
     it('returns null when no Next.js app can be found', () => {
       const nestedDir = path.join(tempDir, 'packages', 'shared', 'src')
 
@@ -80,6 +101,9 @@ describe('appResolver', () => {
       createApp(tempDir, 'apps/docs', 'next.config.js')
       createApp(tempDir, 'apps/admin', 'next.config.mjs')
       createApp(tempDir, 'apps/incomplete', 'next.config.ts', false)
+      createInvalidConfigDirectory(tempDir, 'apps/not-really-an-app', 'next.config.ts')
+
+      fs.mkdirSync(path.join(tempDir, 'apps', 'folder-without-next-config'), { recursive: true })
 
       fs.writeFileSync(path.join(tempDir, 'apps', 'README.md'), 'not an app')
 

--- a/packages/shared/src/lib/bootstrap/appResolver.ts
+++ b/packages/shared/src/lib/bootstrap/appResolver.ts
@@ -7,6 +7,28 @@ export interface AppRoot {
   generatedDir: string
 }
 
+const nextConfigNames = [
+  'next.config.ts',
+  'next.config.js',
+  'next.config.mjs',
+] as const
+
+function hasNextConfigFile(appDir: string): boolean {
+  return nextConfigNames.some((configName) => {
+    const configPath = path.join(appDir, configName)
+
+    if (!fs.existsSync(configPath)) {
+      return false
+    }
+
+    try {
+      return fs.statSync(configPath).isFile()
+    } catch {
+      return false
+    }
+  })
+}
+
 /**
  * Find the Next.js app root by searching for next.config.ts/js/mjs.
  *
@@ -20,12 +42,8 @@ export interface AppRoot {
 export function findAppRoot(startDir: string = process.cwd()): AppRoot | null {
   let current = startDir
 
-  while (current !== path.dirname(current)) {
-    const configTs = path.join(current, 'next.config.ts')
-    const configJs = path.join(current, 'next.config.js')
-    const configMjs = path.join(current, 'next.config.mjs')
-
-    if (fs.existsSync(configTs) || fs.existsSync(configJs) || fs.existsSync(configMjs)) {
+  while (true) {
+    if (hasNextConfigFile(current)) {
       const mercatoDir = path.join(current, '.mercato')
       const generatedDir = path.join(mercatoDir, 'generated')
 
@@ -39,7 +57,12 @@ export function findAppRoot(startDir: string = process.cwd()): AppRoot | null {
       return { appDir: current, mercatoDir, generatedDir }
     }
 
-    current = path.dirname(current)
+    const parent = path.dirname(current)
+    if (parent === current) {
+      break
+    }
+
+    current = parent
   }
 
   return null
@@ -65,13 +88,7 @@ export function findAllApps(rootDir: string): AppRoot[] {
 
     const appDir = path.join(appsDir, entry.name)
 
-    // Check for Next.js config
-    const hasNextConfig =
-      fs.existsSync(path.join(appDir, 'next.config.ts')) ||
-      fs.existsSync(path.join(appDir, 'next.config.js')) ||
-      fs.existsSync(path.join(appDir, 'next.config.mjs'))
-
-    if (!hasNextConfig) continue
+    if (!hasNextConfigFile(appDir)) continue
 
     const mercatoDir = path.join(appDir, '.mercato')
     const generatedDir = path.join(mercatoDir, 'generated')


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for appResolver.ts
## Problem Summary
tests: add low-level coverage for appResolver.ts
## Expected Behavior
packages/shared/src/lib/bootstrap/appResolver.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/shared/src/lib/bootstrap/appResolver.ts.
Checked: packages/shared/src/lib/bootstrap/appResolver.test.ts
packages/shared/src/lib/bootstrap/__tests__/appResolver.test.ts
packages/shared/src/lib/bootstrap/appResolver.spec.ts
packages/shared/src/lib/bootstrap/__tests__/appResolver.spec.ts ...
## What Changed
- packages/shared/src/lib/bootstrap/__tests__/appResolver.test.ts
- packages/shared/src/lib/bootstrap/appResolver.ts
- Diff summary: +55 / -14 (69 total lines)
- Branch head: 99f07263d3e4d83c5810598614cb094baf1c7af8
## Validation / Tests
- shared-package-checks
## Expected Contribution Classes
- tests
- bugfix