### PR TITLE
docs: add missing sidebar entry for user-guide/self-service-onboarding

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -28,6 +28,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "user-guide/overview",
         "user-guide/login",
+        "user-guide/self-service-onboarding",
         "user-guide/users-and-roles",
         "user-guide/api-keys",
         "user-guide/feature-toggles",


### PR DESCRIPTION
Source: Repository signal — docs: add missing sidebar entry for user-guide/self-service-onboarding
## Problem Summary
docs: add missing sidebar entry for user-guide/self-service-onboarding
## Expected Behavior
apps/docs/docs/user-guide/self-service-onboarding.mdx exists as a documentation page.
## Actual Behavior
apps/docs/sidebars.ts does not reference "user-guide/self-service-onboarding".
## What Changed
- apps/docs/sidebars.ts
- Diff summary: +1 / -0 (1 total lines)
- Branch head: bad1abaa813a37fd339a3d331ca93dddd36a2b6b
## Validation / Tests
- docs-basic
- docs-app-build
## Expected Contribution Classes
- docs