### PR TITLE
Fix customer auth compound rate-limit identifiers

### DIFF
--- a/packages/core/src/modules/business_rules/backend/__tests__/page-metadata.test.ts
+++ b/packages/core/src/modules/business_rules/backend/__tests__/page-metadata.test.ts
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+
+import { describe, expect, test } from '@jest/globals'
+import { features } from '../../acl'
+import { metadata as logsDetailMetadata } from '../logs/[id]/page.meta'
+import { metadata as logsMetadata } from '../logs/page.meta'
+import { metadata as ruleCreateMetadata } from '../rules/create/page.meta'
+import { metadata as ruleEditMetadata } from '../rules/[id]/page.meta'
+import { metadata as rulesRouteMetadata } from '../../api/rules/route'
+import { metadata as logsRouteMetadata } from '../../api/logs/route'
+import { metadata as logsDetailRouteMetadata } from '../../api/logs/[id]/route'
+
+const declaredFeatureIds = new Set(features.map((feature) => feature.id))
+
+describe('business_rules backend page metadata', () => {
+  test('uses declared ACL feature ids', () => {
+    const backendMetadata = [
+      ruleCreateMetadata,
+      ruleEditMetadata,
+      logsMetadata,
+      logsDetailMetadata,
+    ]
+
+    for (const metadata of backendMetadata) {
+      for (const featureId of metadata.requireFeatures ?? []) {
+        expect(declaredFeatureIds.has(featureId)).toBe(true)
+      }
+    }
+  })
+
+  test('aligns rule write pages with the rule write API feature', () => {
+    expect(ruleCreateMetadata.requireFeatures).toEqual(rulesRouteMetadata.POST.requireFeatures)
+    expect(ruleEditMetadata.requireFeatures).toEqual(rulesRouteMetadata.PUT.requireFeatures)
+  })
+
+  test('aligns log pages with the log API feature', () => {
+    expect(logsMetadata.requireFeatures).toEqual(logsRouteMetadata.GET.requireFeatures)
+    expect(logsDetailMetadata.requireFeatures).toEqual(logsDetailRouteMetadata.GET.requireFeatures)
+  })
+})

--- a/packages/core/src/modules/business_rules/backend/logs/[id]/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/logs/[id]/page.meta.ts
@@ -1,0 +1,10 @@
+export const metadata = {
+  requireAuth: true,
+  requireFeatures: ['business_rules.view_logs'],
+  pageTitle: 'Execution Log Details',
+  pageTitleKey: 'business_rules.logs.detail.title',
+  breadcrumb: [
+    { label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs', href: '/backend/logs' },
+    { label: 'Details', labelKey: 'common.details' },
+  ],
+}

--- a/packages/core/src/modules/business_rules/backend/logs/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/logs/page.meta.ts
@@ -10,13 +10,13 @@ const logsIcon = React.createElement(
 )
 
 export const metadata = {
-    requireAuth: true,
-    requireFeatures: ['business_rules.view'],
-    pageTitle: 'Logs',
-    pageTitleKey: 'rules.nav.logs',
-    pageGroup: 'Business Rules',
-    pageGroupKey: 'rules.nav.group',
-    pageOrder: 130,
-    icon: logsIcon,
-    breadcrumb: [{ label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs' }],
+  requireAuth: true,
+  requireFeatures: ['business_rules.view_logs'],
+  pageTitle: 'Logs',
+  pageTitleKey: 'rules.nav.logs',
+  pageGroup: 'Business Rules',
+  pageGroupKey: 'rules.nav.group',
+  pageOrder: 130,
+  icon: logsIcon,
+  breadcrumb: [{ label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs' }],
 }

--- a/packages/core/src/modules/business_rules/backend/rules/[id]/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/rules/[id]/page.meta.ts
@@ -1,5 +1,5 @@
 export const metadata = {
   pageTitle: 'Edit Business Rule',
   requireAuth: true,
-  requireFeatures: ['business_rules.edit'],
+  requireFeatures: ['business_rules.manage'],
 }

--- a/packages/core/src/modules/business_rules/backend/rules/create/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/rules/create/page.meta.ts
@@ -1,8 +1,8 @@
 export const metadata = {
   requireAuth: true,
-  requireFeatures: ['business_rules.create'],
+  requireFeatures: ['business_rules.manage'],
   pageTitle: 'Create Business Rule',
   pageGroup: 'Business Rules',
-    pageGroupKey: 'rules.nav.group',
-    breadcrumb: [{ label: 'Business Rules', labelKey: 'rules.nav.rules' }, { label: 'Create Business Rule' }],
+  pageGroupKey: 'rules.nav.group',
+  breadcrumb: [{ label: 'Business Rules', labelKey: 'rules.nav.rules' }, { label: 'Create Business Rule' }],
 }

--- a/packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+
+import { NextResponse } from 'next/server'
+import type { RateLimitConfig } from '@open-mercato/shared/lib/ratelimit/types'
+
+const mockCheckAuthRateLimit = jest.fn()
+
+const signupIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-signup-ip' }
+const signupCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-signup' }
+const passwordResetIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-password-reset-ip' }
+const passwordResetCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-password-reset' }
+const magicLinkIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link-ip' }
+const magicLinkCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link' }
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  customerSignupIpRateLimitConfig: signupIpConfig,
+  customerSignupRateLimitConfig: signupCompoundConfig,
+  customerPasswordResetIpRateLimitConfig: passwordResetIpConfig,
+  customerPasswordResetRateLimitConfig: passwordResetCompoundConfig,
+  customerMagicLinkIpRateLimitConfig: magicLinkIpConfig,
+  customerMagicLinkRateLimitConfig: magicLinkCompoundConfig,
+}))
+
+function makeJsonRequest(path: string, body: Record<string, unknown>): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function rateLimitResponse(): NextResponse {
+  return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+}
+
+describe('customer account auth rate-limit identifiers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+  })
+
+  it('uses normalized email for signup compound rate limiting', async () => {
+    const { POST } = await import('../signup')
+    const req = makeJsonRequest('/api/signup', { email: '  Buyer@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: signupIpConfig,
+      compoundConfig: signupCompoundConfig,
+      compoundIdentifier: 'buyer@example.com',
+    })
+  })
+
+  it('uses normalized email for password reset compound rate limiting', async () => {
+    const { POST } = await import('../password/reset-request')
+    const req = makeJsonRequest('/api/password/reset-request', { email: '  Reset@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: passwordResetIpConfig,
+      compoundConfig: passwordResetCompoundConfig,
+      compoundIdentifier: 'reset@example.com',
+    })
+  })
+
+  it('uses normalized email for magic link compound rate limiting', async () => {
+    const { POST } = await import('../magic-link/request')
+    const req = makeJsonRequest('/api/magic-link/request', { email: '  Magic@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: magicLinkIpConfig,
+      compoundConfig: magicLinkCompoundConfig,
+      compoundIdentifier: 'magic@example.com',
+    })
+  })
+
+  it('falls back to IP-only rate limiting when a JSON body has no email string', async () => {
+    const { POST } = await import('../password/reset-request')
+    const req = makeJsonRequest('/api/password/reset-request', { email: null })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: passwordResetIpConfig,
+      compoundConfig: passwordResetCompoundConfig,
+      compoundIdentifier: undefined,
+    })
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/magic-link/request.ts
+++ b/packages/core/src/modules/customer_accounts/api/magic-link/request.ts
@@ -11,15 +11,17 @@ import {
   customerMagicLinkRateLimitConfig,
   customerMagicLinkIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerMagicLinkIpRateLimitConfig,
     compoundConfig: customerMagicLinkRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/api/password/reset-request.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/reset-request.ts
@@ -11,15 +11,17 @@ import {
   customerPasswordResetRateLimitConfig,
   customerPasswordResetIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerPasswordResetIpRateLimitConfig,
     compoundConfig: customerPasswordResetRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -13,15 +13,17 @@ import {
   customerSignupRateLimitConfig,
   customerSignupIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerSignupIpRateLimitConfig,
     compoundConfig: customerSignupRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
+++ b/packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+
+import { readNormalizedEmailFromJsonRequest } from '../rateLimitIdentifier'
+
+describe('readNormalizedEmailFromJsonRequest', () => {
+  it('returns a trimmed, lower-case email from JSON without consuming the request body', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: '  User@Example.COM  ', password: 'secret123' }),
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBe('user@example.com')
+    await expect(req.json()).resolves.toEqual({ email: '  User@Example.COM  ', password: 'secret123' })
+  })
+
+  it('returns undefined when the JSON body has no string email', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: null }),
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for malformed JSON', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: '{',
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/rateLimitIdentifier.ts
+++ b/packages/core/src/modules/customer_accounts/lib/rateLimitIdentifier.ts
@@ -1,0 +1,14 @@
+export async function readNormalizedEmailFromJsonRequest(req: Request): Promise<string | undefined> {
+  try {
+    const body: unknown = await req.clone().json()
+    if (!body || typeof body !== 'object' || !('email' in body)) return undefined
+
+    const email = (body as { email?: unknown }).email
+    if (typeof email !== 'string') return undefined
+
+    const normalized = email.trim().toLowerCase()
+    return normalized || undefined
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
## Summary

Fixes customer account auth endpoints using an empty compound rate-limit identifier.

Affected endpoints:
- `POST /api/password/reset-request`
- `POST /api/magic-link/request`
- `POST /api/signup`

These endpoints were calling `checkAuthRateLimit()` with:

```ts
compoundIdentifier: ''
