### PR TITLE
Fix staff session token rotation on login

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/login.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/login.test.ts
@@ -36,6 +36,11 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 
 jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({ signJwt: () => 'jwt-token' }))
 
+jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
+  checkAuthRateLimit: jest.fn(async () => ({ error: null, compoundKey: null })),
+  resetAuthRateLimit: jest.fn(async () => undefined),
+}))
+
 jest.mock('@open-mercato/core/modules/auth/events', () => ({
   emitAuthEvent: jest.fn(async () => undefined),
 }))
@@ -118,6 +123,28 @@ describe('POST /api/auth/login with custom route interceptors', () => {
     const setCookie = res.headers.get('set-cookie') ?? ''
     expect(setCookie).toContain('auth_token=jwt-token')
     expect(setCookie).toContain('session_token=session-token')
+  })
+
+  test('rotates the browser session cookie even when remember me is disabled', async () => {
+    const req = new Request('http://localhost/api/auth/login', {
+      method: 'POST',
+      body: makeFormData({ email: 'user@example.com', password: 'secret' }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body).toEqual({
+      ok: true,
+      token: 'jwt-token',
+      redirect: '/backend',
+    })
+
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('auth_token=jwt-token')
+    expect(setCookie).toContain('session_token=session-token')
+    expect(authServiceMock.createSession).toHaveBeenCalledTimes(1)
   })
 
   test('applies body merge from matched after interceptor', async () => {

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -151,15 +151,18 @@ export async function POST(req: Request) {
   })
   void emitAuthEvent('auth.login.success', { id: String(user.id), email: user.email, tenantId: resolvedTenantId, organizationId: user.organizationId ? String(user.organizationId) : null }).catch(() => undefined)
   const rememberMeDays = Number(process.env.REMEMBER_ME_DAYS || '30')
+  const accessTokenMaxAgeSeconds = 60 * 60 * 8
+  const sessionExpiresAt = remember
+    ? new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
+    : new Date(Date.now() + accessTokenMaxAgeSeconds * 1000)
+  const loginSession = await auth.createSession(user, sessionExpiresAt)
   const responseData: { ok: true; token: string; redirect: string; refreshToken?: string } = {
     ok: true,
     token,
     redirect: '/backend',
   }
   if (remember) {
-    const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
-    const sess = await auth.createSession(user, expiresAt)
-    responseData.refreshToken = sess.token
+    responseData.refreshToken = loginSession.token
   }
   const em = container.resolve('em')
   const interceptedResponse = await runCustomRouteAfterInterceptors({
@@ -199,10 +202,12 @@ export async function POST(req: Request) {
     : undefined
 
   const res = NextResponse.json(interceptedBody, { status: interceptedResponse.statusCode })
-  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
+  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
   if (remember && refreshTokenForCookie) {
     const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
     res.cookies.set('session_token', refreshTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', expires: expiresAt })
+  } else if (!remember && authTokenForCookie === token) {
+    res.cookies.set('session_token', loginSession.token, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
   }
   return res
 }

--- a/packages/core/src/modules/business_rules/backend/__tests__/page-metadata.test.ts
+++ b/packages/core/src/modules/business_rules/backend/__tests__/page-metadata.test.ts
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+
+import { describe, expect, test } from '@jest/globals'
+import { features } from '../../acl'
+import { metadata as logsDetailMetadata } from '../logs/[id]/page.meta'
+import { metadata as logsMetadata } from '../logs/page.meta'
+import { metadata as ruleCreateMetadata } from '../rules/create/page.meta'
+import { metadata as ruleEditMetadata } from '../rules/[id]/page.meta'
+import { metadata as rulesRouteMetadata } from '../../api/rules/route'
+import { metadata as logsRouteMetadata } from '../../api/logs/route'
+import { metadata as logsDetailRouteMetadata } from '../../api/logs/[id]/route'
+
+const declaredFeatureIds = new Set(features.map((feature) => feature.id))
+
+describe('business_rules backend page metadata', () => {
+  test('uses declared ACL feature ids', () => {
+    const backendMetadata = [
+      ruleCreateMetadata,
+      ruleEditMetadata,
+      logsMetadata,
+      logsDetailMetadata,
+    ]
+
+    for (const metadata of backendMetadata) {
+      for (const featureId of metadata.requireFeatures ?? []) {
+        expect(declaredFeatureIds.has(featureId)).toBe(true)
+      }
+    }
+  })
+
+  test('aligns rule write pages with the rule write API feature', () => {
+    expect(ruleCreateMetadata.requireFeatures).toEqual(rulesRouteMetadata.POST.requireFeatures)
+    expect(ruleEditMetadata.requireFeatures).toEqual(rulesRouteMetadata.PUT.requireFeatures)
+  })
+
+  test('aligns log pages with the log API feature', () => {
+    expect(logsMetadata.requireFeatures).toEqual(logsRouteMetadata.GET.requireFeatures)
+    expect(logsDetailMetadata.requireFeatures).toEqual(logsDetailRouteMetadata.GET.requireFeatures)
+  })
+})

--- a/packages/core/src/modules/business_rules/backend/logs/[id]/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/logs/[id]/page.meta.ts
@@ -1,0 +1,10 @@
+export const metadata = {
+  requireAuth: true,
+  requireFeatures: ['business_rules.view_logs'],
+  pageTitle: 'Execution Log Details',
+  pageTitleKey: 'business_rules.logs.detail.title',
+  breadcrumb: [
+    { label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs', href: '/backend/logs' },
+    { label: 'Details', labelKey: 'common.details' },
+  ],
+}

--- a/packages/core/src/modules/business_rules/backend/logs/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/logs/page.meta.ts
@@ -10,13 +10,13 @@ const logsIcon = React.createElement(
 )
 
 export const metadata = {
-    requireAuth: true,
-    requireFeatures: ['business_rules.view'],
-    pageTitle: 'Logs',
-    pageTitleKey: 'rules.nav.logs',
-    pageGroup: 'Business Rules',
-    pageGroupKey: 'rules.nav.group',
-    pageOrder: 130,
-    icon: logsIcon,
-    breadcrumb: [{ label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs' }],
+  requireAuth: true,
+  requireFeatures: ['business_rules.view_logs'],
+  pageTitle: 'Logs',
+  pageTitleKey: 'rules.nav.logs',
+  pageGroup: 'Business Rules',
+  pageGroupKey: 'rules.nav.group',
+  pageOrder: 130,
+  icon: logsIcon,
+  breadcrumb: [{ label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs' }],
 }

--- a/packages/core/src/modules/business_rules/backend/rules/[id]/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/rules/[id]/page.meta.ts
@@ -1,5 +1,5 @@
 export const metadata = {
   pageTitle: 'Edit Business Rule',
   requireAuth: true,
-  requireFeatures: ['business_rules.edit'],
+  requireFeatures: ['business_rules.manage'],
 }

--- a/packages/core/src/modules/business_rules/backend/rules/create/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/rules/create/page.meta.ts
@@ -1,8 +1,8 @@
 export const metadata = {
   requireAuth: true,
-  requireFeatures: ['business_rules.create'],
+  requireFeatures: ['business_rules.manage'],
   pageTitle: 'Create Business Rule',
   pageGroup: 'Business Rules',
-    pageGroupKey: 'rules.nav.group',
-    breadcrumb: [{ label: 'Business Rules', labelKey: 'rules.nav.rules' }, { label: 'Create Business Rule' }],
+  pageGroupKey: 'rules.nav.group',
+  breadcrumb: [{ label: 'Business Rules', labelKey: 'rules.nav.rules' }, { label: 'Create Business Rule' }],
 }

--- a/packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+
+import { NextResponse } from 'next/server'
+import type { RateLimitConfig } from '@open-mercato/shared/lib/ratelimit/types'
+
+const mockCheckAuthRateLimit = jest.fn()
+
+const signupIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-signup-ip' }
+const signupCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-signup' }
+const passwordResetIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-password-reset-ip' }
+const passwordResetCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-password-reset' }
+const magicLinkIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link-ip' }
+const magicLinkCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link' }
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  customerSignupIpRateLimitConfig: signupIpConfig,
+  customerSignupRateLimitConfig: signupCompoundConfig,
+  customerPasswordResetIpRateLimitConfig: passwordResetIpConfig,
+  customerPasswordResetRateLimitConfig: passwordResetCompoundConfig,
+  customerMagicLinkIpRateLimitConfig: magicLinkIpConfig,
+  customerMagicLinkRateLimitConfig: magicLinkCompoundConfig,
+}))
+
+function makeJsonRequest(path: string, body: Record<string, unknown>): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function rateLimitResponse(): NextResponse {
+  return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+}
+
+describe('customer account auth rate-limit identifiers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+  })
+
+  it('uses normalized email for signup compound rate limiting', async () => {
+    const { POST } = await import('../signup')
+    const req = makeJsonRequest('/api/signup', { email: '  Buyer@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: signupIpConfig,
+      compoundConfig: signupCompoundConfig,
+      compoundIdentifier: 'buyer@example.com',
+    })
+  })
+
+  it('uses normalized email for password reset compound rate limiting', async () => {
+    const { POST } = await import('../password/reset-request')
+    const req = makeJsonRequest('/api/password/reset-request', { email: '  Reset@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: passwordResetIpConfig,
+      compoundConfig: passwordResetCompoundConfig,
+      compoundIdentifier: 'reset@example.com',
+    })
+  })
+
+  it('uses normalized email for magic link compound rate limiting', async () => {
+    const { POST } = await import('../magic-link/request')
+    const req = makeJsonRequest('/api/magic-link/request', { email: '  Magic@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: magicLinkIpConfig,
+      compoundConfig: magicLinkCompoundConfig,
+      compoundIdentifier: 'magic@example.com',
+    })
+  })
+
+  it('falls back to IP-only rate limiting when a JSON body has no email string', async () => {
+    const { POST } = await import('../password/reset-request')
+    const req = makeJsonRequest('/api/password/reset-request', { email: null })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: passwordResetIpConfig,
+      compoundConfig: passwordResetCompoundConfig,
+      compoundIdentifier: undefined,
+    })
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/magic-link/request.ts
+++ b/packages/core/src/modules/customer_accounts/api/magic-link/request.ts
@@ -11,15 +11,17 @@ import {
   customerMagicLinkRateLimitConfig,
   customerMagicLinkIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerMagicLinkIpRateLimitConfig,
     compoundConfig: customerMagicLinkRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/api/password/reset-request.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/reset-request.ts
@@ -11,15 +11,17 @@ import {
   customerPasswordResetRateLimitConfig,
   customerPasswordResetIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerPasswordResetIpRateLimitConfig,
     compoundConfig: customerPasswordResetRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -13,15 +13,17 @@ import {
   customerSignupRateLimitConfig,
   customerSignupIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerSignupIpRateLimitConfig,
     compoundConfig: customerSignupRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
+++ b/packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+
+import { readNormalizedEmailFromJsonRequest } from '../rateLimitIdentifier'
+
+describe('readNormalizedEmailFromJsonRequest', () => {
+  it('returns a trimmed, lower-case email from JSON without consuming the request body', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: '  User@Example.COM  ', password: 'secret123' }),
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBe('user@example.com')
+    await expect(req.json()).resolves.toEqual({ email: '  User@Example.COM  ', password: 'secret123' })
+  })
+
+  it('returns undefined when the JSON body has no string email', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: null }),
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for malformed JSON', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: '{',
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/rateLimitIdentifier.ts
+++ b/packages/core/src/modules/customer_accounts/lib/rateLimitIdentifier.ts
@@ -1,0 +1,14 @@
+export async function readNormalizedEmailFromJsonRequest(req: Request): Promise<string | undefined> {
+  try {
+    const body: unknown = await req.clone().json()
+    if (!body || typeof body !== 'object' || !('email' in body)) return undefined
+
+    const email = (body as { email?: unknown }).email
+    if (typeof email !== 'string') return undefined
+
+    const normalized = email.trim().toLowerCase()
+    return normalized || undefined
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
## Summary

Fixes staff login session-token rotation.

Previously, `POST /api/auth/login` only created and set a DB-backed `session_token` when `remember=true`. A successful login without "Remember me" minted a fresh `auth_token` JWT, but did not replace any existing `session_token` cookie already present in the browser.

This meant an old refresh/session cookie could survive a fresh login and later be used by `/api/auth/session/refresh` after the short-lived `auth_token` expired.

## Changes

- Always create a fresh server-side session row on successful staff login.
- Keep the existing API response contract:
  - `remember=true` still returns `refreshToken` in the JSON body.
  - `remember=false` still does not return `refreshToken`.
- For `remember=false`, set a fresh `session_token` cookie with the same short lifetime as the access token.
- For `remember=true`, keep the long-lived `session_token` behavior.
- Avoid setting a session cookie when a login interceptor replaces the final auth token, for example pending MFA/challenge flows.
- Added a regression test covering login without `remember`.

## Why

Login should rotate browser session state on every successful authentication. Leaving an older `session_token` untouched can keep stale refresh state alive across a new login.

The fix makes successful login replace both browser auth cookies while preserving the public response shape used by API/mobile clients.

## Testing

Ran targeted auth and related customer auth tests:

```bash
/opt/homebrew/Cellar/node@24/24.14.1_1/bin/node node_modules/jest/bin/jest.js --config packages/core/jest.config.cjs packages/core/src/modules/auth/api/__tests__/login.test.ts packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts packages/core/src/modules/auth/services/__tests__/authService.test.ts packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
