### PR TITLE
fix(search): hide navbar search when search module is disabled

### DIFF
--- a/apps/mercato/src/components/BackendHeaderChrome.tsx
+++ b/apps/mercato/src/components/BackendHeaderChrome.tsx
@@ -71,6 +71,10 @@ export function BackendHeaderChrome({
     () => hasFeature(grantedFeatures, 'messages.view'),
     [grantedFeatures],
   )
+  const showSearch = React.useMemo(
+    () => hasFeature(grantedFeatures, 'search.global'),
+    [grantedFeatures],
+  )
 
   return (
     <>
@@ -79,7 +83,7 @@ export function BackendHeaderChrome({
           <LazyAiChatHeaderButton />
         </AiAssistantShellIntegration>
       ) : null}
-      {isReady ? (
+      {isReady && showSearch ? (
         <LazyGlobalSearchDialog
           embeddingConfigured={embeddingConfigured}
           missingConfigMessage={missingConfigMessage}


### PR DESCRIPTION
## Summary

The global search dialog (Cmd+K) was rendered unconditionally in the navbar, even when the search module is disabled. This gates it behind the `search.global` ACL feature, matching the existing pattern used for AI assistant and messages.

## Changes

- Gate `GlobalSearchDialog` rendering behind `hasFeature(grantedFeatures, 'search.global')` in `BackendHeaderChrome`

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

## Testing

- Verified the change follows the same `hasFeature` pattern used for `ai_assistant.view` and `messages.view`
- Type-checked the file (no new errors introduced)

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues