### PR TITLE
fix: gitignore test-results and playwright-report globally

### DIFF
--- a/.ai/qa/.gitignore
+++ b/.ai/qa/.gitignore
@@ -1,3 +1,0 @@
-test-results/
-playwright-report/
-ephemeral-env.json

--- a/.ai/qa/AGENTS.md
+++ b/.ai/qa/AGENTS.md
@@ -44,7 +44,6 @@ Discovery troubleshooting:
 │   └── ...
 ├── tests/                       # Playwright config/helpers + legacy test location
 │   ├── playwright.config.ts
-│   ├── .gitignore               # Ignores test-results/
 │   ├── helpers/
 │   │   ├── auth.ts              # Login helper
 │   │   └── api.ts               # API call helper

--- a/.ai/qa/tests/.gitignore
+++ b/.ai/qa/tests/.gitignore
@@ -1,2 +1,0 @@
-test-results/
-playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 .turbo
 
 # testing
-/coverage
+coverage/
 test-results/
 playwright-report/
 published-app/

--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,6 @@ docker/opencode/opencode.jsonc
 .ai/qa/ephemeral-env.lock/owner.json
 .ai/qa/ephemeral-env.lock/*
 .ai/qa/ephemeral*
+.ai/qa/test-results
 .ai/dev-ephemeral-envs.json
 .agents/

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@
 
 # testing
 /coverage
-/test-results
-/playwright-report
+test-results/
+playwright-report/
 published-app/
 
 # next.js
@@ -120,7 +120,5 @@ docker/opencode/opencode.jsonc
 .ai/qa/ephemeral-env.lock/owner.json
 .ai/qa/ephemeral-env.lock/*
 .ai/qa/ephemeral*
-.ai/qa/test-results
-.ai/qa/playwright-report
 .ai/dev-ephemeral-envs.json
 .agents/

--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,6 @@ docker/opencode/opencode.jsonc
 .ai/qa/ephemeral-env.lock/*
 .ai/qa/ephemeral*
 .ai/qa/test-results
+.ai/qa/playwright-report
 .ai/dev-ephemeral-envs.json
 .agents/

--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -17,6 +17,7 @@ node_modules/
 /test-results
 /playwright-report
 .ai/qa/test-results
+.ai/qa/playwright-report
 
 # next.js
 .next/

--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -14,10 +14,8 @@ node_modules/
 
 # testing
 /coverage
-/test-results
-/playwright-report
-.ai/qa/test-results
-.ai/qa/playwright-report
+test-results/
+playwright-report/
 
 # next.js
 .next/

--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -16,6 +16,7 @@ node_modules/
 /coverage
 /test-results
 /playwright-report
+.ai/qa/test-results
 
 # next.js
 .next/

--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -13,7 +13,7 @@ node_modules/
 .turbo
 
 # testing
-/coverage
+coverage/
 test-results/
 playwright-report/
 


### PR DESCRIPTION
## Summary

Scaffolded apps (via `npx mercato`) were missing gitignore coverage for `.ai/qa/test-results/` and `.ai/qa/playwright-report/`, risking accidental commits of test artifacts.

- Use global `test-results/` and `playwright-report/` patterns (no path prefix) so they match anywhere in the tree
- Remove redundant nested `.gitignore` files (`.ai/qa/.gitignore`, `.ai/qa/tests/.gitignore`)

## Test plan

- [x] `git check-ignore .ai/qa/test-results/ .ai/qa/playwright-report/ test-results/` confirms all paths are ignored
- [x] Template gitignore includes the same global patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)