### PR TITLE
Fix stored XSS in attachment uploads

### DIFF
--- a/apps/mercato/next.config.ts
+++ b/apps/mercato/next.config.ts
@@ -11,6 +11,19 @@ const transpiledWorkspacePackages = Object.keys(appPackageJson.dependencies ?? {
   (packageName) => packageName.startsWith('@open-mercato/') && packageName !== '@open-mercato/cli',
 )
 
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "font-src 'self' data: https:",
+  "form-action 'self'",
+  "frame-ancestors 'self'",
+  "img-src 'self' data: blob: https:",
+  "object-src 'none'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https: ws: wss:",
+].join('; ')
+
 const nextConfig: NextConfig = {
   distDir: '.mercato/next',
   //transpilePackages: isDevelopment ? transpiledWorkspacePackages : undefined,
@@ -33,6 +46,19 @@ const nextConfig: NextConfig = {
     '@esbuild/darwin-arm64',
     '@open-mercato/cli',
   ],
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: contentSecurityPolicy },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig

--- a/apps/mercato/next.config.ts
+++ b/apps/mercato/next.config.ts
@@ -57,6 +57,18 @@ const nextConfig: NextConfig = {
           { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
         ],
       },
+      {
+        // Attachment file downloads set their own restrictive CSP (sandbox)
+        // in the route handler — override the global app CSP so it is not
+        // replaced at the Next.js config layer.
+        source: '/api/attachments/file/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: "default-src 'none'; sandbox" },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+        ],
+      },
     ]
   },
 }

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-002.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-002.spec.ts
@@ -76,7 +76,7 @@ test.describe('TC-ATT-002: Attachment partition and transfer APIs', () => {
             code: partitionCode,
             title: 'QA Partition Updated',
             description: 'Updated partition description',
-            isPublic: true,
+            isPublic: false,
             requiresOcr: false,
           },
         })

--- a/packages/core/src/modules/attachments/__integration__/TC-ATT-003.spec.ts
+++ b/packages/core/src/modules/attachments/__integration__/TC-ATT-003.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+import {
+  deleteAttachmentIfExists,
+  uploadAttachmentFixture,
+} from '@open-mercato/core/modules/core/__integration__/helpers/attachmentsFixtures'
+
+const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
+
+test.describe('TC-ATT-003: Attachment security hardening', () => {
+  test('should reject active content uploads and force non-image downloads to attachment mode', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const recordId = `qa-security-record-${Date.now()}`
+    let attachmentId: string | null = null
+
+    try {
+      const activeContentUpload = await request.fetch(`${BASE_URL}/api/attachments`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        multipart: {
+          entityId: 'attachments:library',
+          recordId,
+          file: {
+            name: 'xss.svg',
+            mimeType: 'image/svg+xml',
+            buffer: Buffer.from(
+              '<svg xmlns="http://www.w3.org/2000/svg"><script>fetch("/api/auth/me")</script></svg>',
+              'utf8',
+            ),
+          },
+        },
+      })
+      expect(activeContentUpload.status()).toBe(400)
+      const activeContentBody = await readJsonSafe<{ error?: string }>(activeContentUpload)
+      expect(activeContentBody?.error).toContain('Active content')
+
+      const publicPartitionUpload = await request.fetch(`${BASE_URL}/api/attachments`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        multipart: {
+          entityId: 'attachments:library',
+          recordId,
+          partitionCode: 'productsMedia',
+          file: {
+            name: 'note.txt',
+            mimeType: 'text/plain',
+            buffer: Buffer.from('public override should be rejected', 'utf8'),
+          },
+        },
+      })
+      expect(publicPartitionUpload.status()).toBe(403)
+      const publicPartitionBody = await readJsonSafe<{ error?: string }>(publicPartitionUpload)
+      expect(publicPartitionBody?.error).toContain('Public storage partitions')
+
+      const uploaded = await uploadAttachmentFixture(request, token, {
+        entityId: 'attachments:library',
+        recordId,
+        fileName: 'security-note.txt',
+        mimeType: 'text/plain',
+        buffer: Buffer.from('plain text attachment', 'utf8'),
+      })
+      attachmentId = uploaded.id
+
+      const fileResponse = await request.fetch(`${BASE_URL}/api/attachments/file/${encodeURIComponent(attachmentId)}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      expect(fileResponse.status()).toBe(200)
+      expect(fileResponse.headers()['content-type']).toBe('application/octet-stream')
+      expect(fileResponse.headers()['x-content-type-options']).toBe('nosniff')
+      expect(fileResponse.headers()['content-security-policy']).toContain('sandbox')
+      expect(fileResponse.headers()['content-disposition']).toContain('attachment;')
+    } finally {
+      await deleteAttachmentIfExists(request, token, attachmentId)
+    }
+  })
+})

--- a/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
+++ b/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
@@ -13,16 +13,18 @@ const partitions = [
   { id: 'p-products', code: 'productsMedia', title: 'Products', isPublic: true, storageDriver: 'local', requiresOcr: false },
 ]
 
+const defaultFindOneImpl = async (entity: any, where: any) => {
+  if (entity?.name === 'AttachmentPartition') {
+    return partitions.find((p) => p.code === where?.code) ?? null
+  }
+  if (entity?.name === 'CustomFieldDef') {
+    return { configJson: { maxAttachmentSizeMb: 0.001, acceptExtensions: ['pdf', 'docx'] } }
+  }
+  return null
+}
+
 const mockEm = {
-  findOne: jest.fn(async (entity: any, where: any) => {
-    if (entity?.name === 'AttachmentPartition') {
-      return partitions.find((p) => p.code === where?.code) ?? null
-    }
-    if (entity?.name === 'CustomFieldDef') {
-      return { configJson: { maxAttachmentSizeMb: 0.001, acceptExtensions: ['pdf', 'docx'] } }
-    }
-    return null
-  }),
+  findOne: jest.fn(defaultFindOneImpl),
   create: jest.fn((_cls: any, data: any) => ({ ...data })),
   persistAndFlush: jest.fn(async () => {}),
   getRepository: jest.fn(() => ({
@@ -82,6 +84,8 @@ function fdWith(file: File, extra: Record<string, string> = {}) {
 describe('attachments API', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockEm.findOne.mockReset()
+    mockEm.findOne.mockImplementation(defaultFindOneImpl)
     mockEm.find.mockReset()
     mockEm.find.mockResolvedValue([])
     mockExtractAttachmentContent.mockReset()

--- a/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
+++ b/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
@@ -1,4 +1,11 @@
 /** @jest-environment node */
+jest.mock('/home/wh173-p0ny/hackathon_6/open-mercato/packages/core/generated/entities.ids.generated', () => ({
+  E: {
+    attachments: { attachment: 'attachments:attachment' },
+    catalog: { catalog_product: 'catalog:catalog_product' },
+  },
+}), { virtual: true })
+
 import { GET as list, POST as upload } from '@open-mercato/core/modules/attachments/api/route'
 
 const partitions = [
@@ -88,6 +95,19 @@ describe('attachments API', () => {
     expect(res.status).toBe(400)
     const j = await res.json()
     expect(j.error).toMatch(/not allowed/i)
+  })
+
+  it('rejects active content uploads even when the client claims a safe image mime type', async () => {
+    const file = new File(
+      [Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>', 'utf8')],
+      'avatar.jpg',
+      { type: 'image/jpeg' },
+    )
+    const req = new Request('http://x/api/attachments', { method: 'POST', body: fdWith(file, { fieldKey: '' }) as any })
+    const res = await upload(req)
+    expect(res.status).toBe(400)
+    const payload = await res.json()
+    expect(payload.error).toMatch(/active content/i)
   })
 
   it('accepts allowed small pdf', async () => {
@@ -200,6 +220,18 @@ describe('attachments API', () => {
         expect.objectContaining({ type: 'example:todo', id: 'r1' }),
       ]),
     )
+  })
+
+  it('rejects explicit uploads to unrelated public partitions', async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], 'doc.pdf', { type: 'application/pdf' })
+    const req = new Request(
+      'http://x/api/attachments',
+      { method: 'POST', body: fdWith(file, { partitionCode: 'productsMedia' }) as any },
+    )
+    const res = await upload(req)
+    expect(res.status).toBe(403)
+    const payload = await res.json()
+    expect(payload.error).toMatch(/public storage partitions/i)
   })
 
   it('lists attachments with sanitized metadata via GET', async () => {

--- a/packages/core/src/modules/attachments/api/file/[id]/route.ts
+++ b/packages/core/src/modules/attachments/api/file/[id]/route.ts
@@ -12,6 +12,10 @@ import type { EntityManager } from "@mikro-orm/postgresql";
 import { checkAttachmentAccess } from "@open-mercato/core/modules/attachments/lib/access";
 import { z } from "zod";
 import { attachmentsTag, attachmentErrorSchema } from "../../openapi";
+import {
+  buildAttachmentContentDisposition,
+  canRenderInlineAttachment,
+} from "@open-mercato/core/modules/attachments/lib/security";
 
 export const metadata = {
   GET: { requireAuth: false },
@@ -69,18 +73,23 @@ export async function GET(
 
   const url = new URL(req.url);
   const forceDownload = url.searchParams.get("download") === "1";
+  const renderInline = !forceDownload && canRenderInlineAttachment(attachment.mimeType);
   const headers: Record<string, string> = {
-    "Content-Type": attachment.mimeType || "application/octet-stream",
     "Cache-Control": partition.isPublic
       ? "public, max-age=86400"
       : "private, max-age=60",
+    "Content-Security-Policy": "default-src 'none'; sandbox",
+    "Content-Type": renderInline
+      ? attachment.mimeType || "application/octet-stream"
+      : "application/octet-stream",
+    "Content-Disposition": buildAttachmentContentDisposition(
+      attachment.fileName,
+      renderInline ? "inline" : "attachment",
+    ),
+    "X-Content-Type-Options": "nosniff",
   };
   if (attachment.fileSize > 0) {
     headers["Content-Length"] = String(attachment.fileSize);
-  }
-  if (forceDownload) {
-    headers["Content-Disposition"] =
-      `attachment; filename="${encodeURIComponent(attachment.fileName)}"`;
   }
 
   const responseBody = new Uint8Array(buffer);

--- a/packages/core/src/modules/attachments/api/image/[id]/[[...slug]]/route.ts
+++ b/packages/core/src/modules/attachments/api/image/[id]/[[...slug]]/route.ts
@@ -11,6 +11,7 @@ import {
   readThumbnailCache,
   writeThumbnailCache,
 } from '@open-mercato/core/modules/attachments/lib/thumbnailCache'
+import { canRenderInlineAttachment } from '@open-mercato/core/modules/attachments/lib/security'
 import { checkAttachmentAccess } from '@open-mercato/core/modules/attachments/lib/access'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { promises as fs } from 'fs'
@@ -52,7 +53,7 @@ export async function GET(
   if (!attachment) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
-  if (typeof attachment.mimeType !== 'string' || !attachment.mimeType.startsWith('image/')) {
+  if (!canRenderInlineAttachment(attachment.mimeType)) {
     return NextResponse.json({ error: 'Unsupported media type' }, { status: 400 })
   }
   const partition = await em.findOne(AttachmentPartition, { code: attachment.partitionCode })
@@ -106,6 +107,7 @@ export async function GET(
       headers: {
         'Content-Type': attachment.mimeType || 'image/jpeg',
         'Cache-Control': partition.isPublic ? 'public, max-age=3600' : 'private, max-age=60',
+        'X-Content-Type-Options': 'nosniff',
       },
     })
   } catch (error) {

--- a/packages/core/src/modules/attachments/api/route.ts
+++ b/packages/core/src/modules/attachments/api/route.ts
@@ -26,6 +26,11 @@ import { emitCrudSideEffects, setCustomFieldsIfAny } from '@open-mercato/shared/
 import { attachmentCrudEvents, attachmentCrudIndexer } from '../lib/crud'
 import { E } from '#generated/entities.ids.generated'
 import { resolveDefaultAttachmentOcrEnabled } from '../lib/ocrConfig'
+import {
+  detectAttachmentMimeType,
+  isActiveContentAttachment,
+  sanitizeUploadedFileName,
+} from '../lib/security'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['attachments.view'] },
@@ -261,8 +266,13 @@ export async function POST(req: Request) {
     } catch {}
   }
   const buf = Buffer.from(await file.arrayBuffer())
-  const safeName = String(file.name || 'file').replace(/[^a-zA-Z0-9._-]/g, '_')
-  const resolvedPartitionCode = partitionOverride ?? partitionFromField ?? resolveDefaultPartitionCode(entityId)
+  const safeName = sanitizeUploadedFileName(file.name)
+  const fileMimeType = detectAttachmentMimeType(buf, safeName, (file as any).type)
+  if (isActiveContentAttachment(buf, safeName, fileMimeType)) {
+    return NextResponse.json({ error: 'Active content uploads are not allowed.' }, { status: 400 })
+  }
+  const defaultPartitionCode = resolveDefaultPartitionCode(entityId)
+  const resolvedPartitionCode = partitionOverride ?? partitionFromField ?? defaultPartitionCode
   const partitionCodeCandidates = Array.from(
     new Set(
       [partitionOverride, partitionFromField, resolvedPartitionCode].filter(
@@ -279,10 +289,20 @@ export async function POST(req: Request) {
     }
   }
   if (!partition) {
-    partition = await em.findOne(AttachmentPartition, { code: resolveDefaultPartitionCode(entityId) })
+    partition = await em.findOne(AttachmentPartition, { code: defaultPartitionCode })
   }
   if (!partition) {
     return NextResponse.json({ error: 'Storage partition is not configured.' }, { status: 400 })
+  }
+  const requestedPublicOverride =
+    typeof partitionOverride === 'string' &&
+    partitionOverride.length > 0 &&
+    partition.code === partitionOverride &&
+    partition.isPublic === true &&
+    partition.code !== defaultPartitionCode &&
+    partition.code !== partitionFromField
+  if (requestedPublicOverride) {
+    return NextResponse.json({ error: 'Public storage partitions cannot be selected explicitly for this upload.' }, { status: 403 })
   }
   let stored
   try {
@@ -303,7 +323,6 @@ export async function POST(req: Request) {
       ? Boolean((partition as any).requiresOcr)
       : resolveDefaultAttachmentOcrEnabled()
   let extractedContent: string | null = null
-  const fileMimeType = (file as any).type || 'application/octet-stream'
   const useLlmOcr = requiresOcr && shouldUseLlmOcr(fileMimeType, safeName)
 
   if (requiresOcr && !useLlmOcr) {
@@ -330,7 +349,7 @@ export async function POST(req: Request) {
     organizationId: auth.orgId!,
     tenantId: auth.tenantId!,
     fileName: safeName,
-    mimeType: (file as any).type || 'application/octet-stream',
+    mimeType: fileMimeType,
     fileSize: buf.length,
     partitionCode: partition.code,
     storageDriver: partition.storageDriver || 'local',

--- a/packages/core/src/modules/attachments/lib/security.ts
+++ b/packages/core/src/modules/attachments/lib/security.ts
@@ -1,0 +1,147 @@
+const MIME_BY_EXTENSION: Record<string, string> = {
+  avif: 'image/avif',
+  bmp: 'image/bmp',
+  csv: 'text/csv',
+  gif: 'image/gif',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  json: 'application/json',
+  md: 'text/markdown',
+  pdf: 'application/pdf',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  txt: 'text/plain',
+  webp: 'image/webp',
+  xhtml: 'application/xhtml+xml',
+  xml: 'application/xml',
+  zip: 'application/zip',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+}
+
+const ACTIVE_CONTENT_MIME_TYPES = new Set([
+  'application/xhtml+xml',
+  'application/xml',
+  'image/svg+xml',
+  'text/html',
+  'text/xml',
+])
+
+const ACTIVE_CONTENT_EXTENSIONS = new Set(['htm', 'html', 'svg', 'xhtml', 'xml'])
+
+const SAFE_INLINE_MIME_TYPES = new Set([
+  'image/avif',
+  'image/bmp',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+])
+
+export function getAttachmentExtension(fileName: string | null | undefined): string {
+  const trimmed = String(fileName ?? '').trim()
+  const parts = trimmed.split('.').filter(Boolean)
+  if (parts.length < 2) return ''
+  return parts[parts.length - 1]!.toLowerCase()
+}
+
+export function sanitizeUploadedFileName(input: string | null | undefined): string {
+  const trimmed = String(input ?? '').trim()
+  const sanitized = trimmed.replace(/[^a-zA-Z0-9._-]/g, '_')
+  const parts = sanitized.split('.').filter(Boolean)
+  if (!parts.length) return 'file'
+  if (parts.length === 1) return parts[0] || 'file'
+
+  const extension = parts.pop() || ''
+  const baseName = parts.join('_').replace(/_+/g, '_').replace(/^_+|_+$/g, '')
+  const safeBaseName = baseName || 'file'
+  return extension ? `${safeBaseName}.${extension.toLowerCase()}` : safeBaseName
+}
+
+function detectMimeTypeFromBuffer(buffer: Buffer): string | null {
+  if (buffer.length >= 8) {
+    const pngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+    if (pngSignature.every((value, index) => buffer[index] === value)) return 'image/png'
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg'
+  }
+  if (buffer.length >= 6) {
+    const header = buffer.subarray(0, 6).toString('ascii')
+    if (header === 'GIF87a' || header === 'GIF89a') return 'image/gif'
+  }
+  if (buffer.length >= 12) {
+    const riff = buffer.subarray(0, 4).toString('ascii')
+    const webp = buffer.subarray(8, 12).toString('ascii')
+    if (riff === 'RIFF' && webp === 'WEBP') return 'image/webp'
+  }
+  if (buffer.length >= 4 && buffer.subarray(0, 4).toString('ascii') === '%PDF') {
+    return 'application/pdf'
+  }
+  if (buffer.length >= 4 && buffer[0] === 0x50 && buffer[1] === 0x4b && buffer[2] === 0x03 && buffer[3] === 0x04) {
+    return 'application/zip'
+  }
+
+  const sniff = buffer.subarray(0, Math.min(buffer.length, 512)).toString('utf8').trimStart().toLowerCase()
+  if (sniff.startsWith('<svg') || sniff.startsWith('<?xml') || sniff.startsWith('<!doctype html') || sniff.startsWith('<html')) {
+    if (sniff.startsWith('<svg')) return 'image/svg+xml'
+    if (sniff.startsWith('<!doctype html') || sniff.startsWith('<html')) return 'text/html'
+    return 'application/xml'
+  }
+
+  return null
+}
+
+export function detectAttachmentMimeType(
+  buffer: Buffer,
+  fileName: string | null | undefined,
+  clientMimeType: string | null | undefined,
+): string {
+  const detectedFromBuffer = detectMimeTypeFromBuffer(buffer)
+  if (detectedFromBuffer) {
+    if (
+      detectedFromBuffer === 'application/zip' &&
+      getAttachmentExtension(fileName) in MIME_BY_EXTENSION
+    ) {
+      return MIME_BY_EXTENSION[getAttachmentExtension(fileName)] || detectedFromBuffer
+    }
+    return detectedFromBuffer
+  }
+
+  const extension = getAttachmentExtension(fileName)
+  if (extension && MIME_BY_EXTENSION[extension]) {
+    return MIME_BY_EXTENSION[extension]
+  }
+
+  const normalizedClientMimeType = String(clientMimeType ?? '').trim().toLowerCase()
+  if (normalizedClientMimeType) return normalizedClientMimeType
+  return 'application/octet-stream'
+}
+
+export function isActiveContentAttachment(
+  buffer: Buffer,
+  fileName: string | null | undefined,
+  mimeType: string | null | undefined,
+): boolean {
+  const extension = getAttachmentExtension(fileName)
+  if (extension && ACTIVE_CONTENT_EXTENSIONS.has(extension)) return true
+
+  const effectiveMimeType = String(mimeType ?? '').trim().toLowerCase()
+  if (effectiveMimeType && ACTIVE_CONTENT_MIME_TYPES.has(effectiveMimeType)) return true
+
+  const sniffedMimeType = detectMimeTypeFromBuffer(buffer)
+  return Boolean(sniffedMimeType && ACTIVE_CONTENT_MIME_TYPES.has(sniffedMimeType))
+}
+
+export function canRenderInlineAttachment(mimeType: string | null | undefined): boolean {
+  return SAFE_INLINE_MIME_TYPES.has(String(mimeType ?? '').trim().toLowerCase())
+}
+
+export function buildAttachmentContentDisposition(
+  fileName: string | null | undefined,
+  dispositionType: 'attachment' | 'inline' = 'attachment',
+): string {
+  const safeFileName = sanitizeUploadedFileName(fileName)
+  return `${dispositionType}; filename="${safeFileName}"; filename*=UTF-8''${encodeURIComponent(safeFileName)}`
+}


### PR DESCRIPTION
Description
  This PR fixes a stored XSS issue in the attachments module caused by trusting client-provided MIME types and allowing uploaded files to be served inline from public
  partitions.

  What changed

  - added server-side attachment security classification in attachments/lib/security.ts
  - stopped trusting client-provided MIME types during upload
  - blocked active content uploads such as svg, html, and xml
  - normalized uploaded filenames before persistence
  - prevented explicit upload overrides to unrelated public partitions
  - hardened /api/attachments/file/[id] responses with:
      - X-Content-Type-Options: nosniff
      - restrictive Content-Security-Policy
      - forced attachment disposition for non-safe inline types
      - application/octet-stream for non-inline-safe content
  - restricted image rendering routes to safe raster image types only
  - added app-level security headers in apps/mercato/next.config.ts

  Tests

  - added regression coverage for:
      - rejecting active content uploads
      - rejecting explicit public partition override uploads
      - forcing safe attachment delivery headers for downloaded files
  - updated existing attachment partition integration coverage to avoid preserving the vulnerable public upload flow


  Security impact
  This closes the stored XSS vector where an attacker could upload active content and have it executed in the application origin when served back to another user.