### PR TITLE
fix(sales): add email and phone validation to shipment form (#1018)

### DIFF
--- a/packages/core/src/modules/shipping_carriers/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/shipping_carriers/data/__tests__/validators.test.ts
@@ -1,0 +1,224 @@
+import { createShipmentSchema, calculateRatesSchema } from '../validators'
+
+const UUID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+const validAddress = {
+  countryCode: 'PL',
+  postalCode: '00-001',
+  city: 'Warsaw',
+  line1: 'ul. Testowa 1',
+}
+
+const validPackage = { weightKg: 1, lengthCm: 20, widthCm: 15, heightCm: 10 }
+
+const createBase = {
+  providerKey: 'inpost',
+  orderId: UUID,
+  origin: validAddress,
+  destination: validAddress,
+  packages: [validPackage],
+  serviceCode: 'standard',
+}
+
+const ratesBase = {
+  providerKey: 'inpost',
+  origin: validAddress,
+  destination: validAddress,
+  packages: [validPackage],
+}
+
+// ---------------------------------------------------------------------------
+// createShipmentSchema — email validation
+// ---------------------------------------------------------------------------
+
+describe('createShipmentSchema — email validation', () => {
+  it('accepts a valid senderEmail', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderEmail: 'sender@example.com',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid receiverEmail', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      receiverEmail: 'receiver@example.com',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts when email fields are omitted', () => {
+    const result = createShipmentSchema.safeParse(createBase)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an invalid senderEmail', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderEmail: 'abc',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('senderEmail')
+    }
+  })
+
+  it('rejects an invalid receiverEmail', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      receiverEmail: 'not-an-email',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('receiverEmail')
+    }
+  })
+
+  it('rejects email without domain', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderEmail: 'user@',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('trims whitespace from email before validation', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderEmail: '  valid@example.com  ',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.senderEmail).toBe('valid@example.com')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createShipmentSchema — phone validation
+// ---------------------------------------------------------------------------
+
+describe('createShipmentSchema — phone validation', () => {
+  it('accepts a valid senderPhone with country code', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderPhone: '+48 500 000 000',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid receiverPhone with digits only', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      receiverPhone: '500000000',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts phone with dashes and parentheses', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderPhone: '+1 (555) 123-4567',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts when phone fields are omitted', () => {
+    const result = createShipmentSchema.safeParse(createBase)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects alphabetic-only phone value', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderPhone: 'xyz',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('senderPhone')
+    }
+  })
+
+  it('rejects phone that is too short', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      receiverPhone: '123',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('receiverPhone')
+    }
+  })
+
+  it('rejects phone starting with a letter', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderPhone: 'a1234567',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('trims whitespace from phone before validation', () => {
+    const result = createShipmentSchema.safeParse({
+      ...createBase,
+      senderPhone: '  +48 500 000 000  ',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.senderPhone).toBe('+48 500 000 000')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// calculateRatesSchema — email & phone validation
+// ---------------------------------------------------------------------------
+
+describe('calculateRatesSchema — email validation', () => {
+  it('accepts a valid receiverEmail', () => {
+    const result = calculateRatesSchema.safeParse({
+      ...ratesBase,
+      receiverEmail: 'test@example.com',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an invalid receiverEmail', () => {
+    const result = calculateRatesSchema.safeParse({
+      ...ratesBase,
+      receiverEmail: 'bad-email',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('receiverEmail')
+    }
+  })
+})
+
+describe('calculateRatesSchema — phone validation', () => {
+  it('accepts a valid receiverPhone', () => {
+    const result = calculateRatesSchema.safeParse({
+      ...ratesBase,
+      receiverPhone: '+48 500 000 000',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects an invalid receiverPhone', () => {
+    const result = calculateRatesSchema.safeParse({
+      ...ratesBase,
+      receiverPhone: 'xyz',
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'))
+      expect(paths).toContain('receiverPhone')
+    }
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/data/validators.ts
+++ b/packages/core/src/modules/shipping_carriers/data/validators.ts
@@ -15,13 +15,19 @@ const packageSchema = z.object({
   heightCm: z.number().positive(),
 })
 
+/** Permissive phone regex: allows +, digits, spaces, dashes, dots, and parentheses. Min 7 chars. */
+export const PHONE_REGEX = /^[+\d][\d\s\-().]{6,}$/
+
+const emailField = z.string().trim().email('Invalid email address.').max(320).optional()
+const phoneField = z.string().trim().regex(PHONE_REGEX, 'Invalid phone number.').max(50).optional()
+
 export const calculateRatesSchema = z.object({
   providerKey: z.string().min(1),
   origin: addressSchema,
   destination: addressSchema,
   packages: z.array(packageSchema).min(1),
-  receiverPhone: z.string().optional(),
-  receiverEmail: z.string().optional(),
+  receiverPhone: phoneField,
+  receiverEmail: emailField,
 })
 
 export const createShipmentSchema = z.object({
@@ -32,10 +38,10 @@ export const createShipmentSchema = z.object({
   packages: z.array(packageSchema).min(1),
   serviceCode: z.string().min(1),
   labelFormat: z.enum(['pdf', 'zpl', 'png']).optional(),
-  senderPhone: z.string().optional(),
-  senderEmail: z.string().optional(),
-  receiverPhone: z.string().optional(),
-  receiverEmail: z.string().optional(),
+  senderPhone: phoneField,
+  senderEmail: emailField,
+  receiverPhone: phoneField,
+  receiverEmail: emailField,
   targetPoint: z.string().optional(),
   c2cSendingMethod: z.enum(['parcel_locker', 'dispatch_order', 'pop', 'any_point']).optional(),
 })


### PR DESCRIPTION
Source: GitHub issue #1018 — Shipment form allows invalid email and phone values

## Summary
Adds proper zod validation for email and phone fields in shipment create and rate calculation schemas. Previously any string was accepted. Includes 19 new test cases.

## Changes
- `packages/core/src/modules/shipping_carriers/data/validators.ts` — email `.email()` + phone regex on 6 fields
- `packages/core/src/modules/shipping_carriers/data/__tests__/validators.test.ts` — 19 new tests

## Review Summary
- Rounds: 1
- Concerns raised: None
- Reviewer verdict: Approved
- Confidence: High

## Validation
- PASS: 19 new tests + 58 existing tests (no regressions)

## Expected Contribution Classes
- bugfix
- tests