### PR TITLE
Fix open redirect in locale switch endpoint

### DIFF
--- a/apps/mercato/src/__tests__/api-authorization.test.ts
+++ b/apps/mercato/src/__tests__/api-authorization.test.ts
@@ -88,11 +88,11 @@ function getMockedApiRoutes(): ApiRouteManifestEntry[] {
 // Mock manifest-based API routing
 jest.mock('@/.mercato/generated/api-routes.generated', () => ({
   apiRoutes: getMockedApiRoutes(),
-}))
+}), { virtual: true })
 
 jest.mock('@/.mercato/generated/backend-routes.generated', () => ({
   backendRoutes: [],
-}))
+}), { virtual: true })
 
 jest.mock('@open-mercato/shared/modules/registry', () => {
   const actual = jest.requireActual('@open-mercato/shared/modules/registry')
@@ -215,6 +215,35 @@ describe('API Route Authorization', () => {
   })
 
   describe('POST /example/test', () => {
+    it('should reject cross-site unsafe requests before authentication', async () => {
+      const request = new NextRequest('http://localhost:3001/api/example/test', {
+        method: 'POST',
+        headers: {
+          origin: 'https://evil.example',
+        },
+      })
+      const response = await POST(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
+
+      expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toEqual({ error: 'Invalid request origin' })
+      expect(mockResolveAuthFromRequestDetailed).not.toHaveBeenCalled()
+    })
+
+    it('should allow same-origin unsafe requests', async () => {
+      mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['admin'], 'admin@test.com'))
+
+      const request = new NextRequest('http://localhost:3001/api/example/test', {
+        method: 'POST',
+        headers: {
+          origin: 'http://localhost:3001',
+        },
+      })
+      const response = await POST(request, { params: Promise.resolve({ slug: ['example', 'test'] }) })
+
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe('POST success')
+    })
+
     it('should allow access with admin role', async () => {
       mockResolveAuthFromRequestDetailed.mockResolvedValue(authenticatedAuth(['admin'], 'admin@test.com'))
 

--- a/apps/mercato/src/app/api/[...slug]/route.ts
+++ b/apps/mercato/src/app/api/[...slug]/route.ts
@@ -21,6 +21,7 @@ import { getCachedRateLimiterService } from '@open-mercato/core/bootstrap'
 import { checkRateLimit, getClientIp, RATE_LIMIT_ERROR_KEY, RATE_LIMIT_ERROR_FALLBACK } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { getGlobalEventBus } from '@open-mercato/shared/modules/events'
 import { applicationLifecycleEvents, type ApplicationLifecycleEventId } from '@open-mercato/shared/lib/runtime/events'
+import { validateSameOriginMutationRequest } from '@open-mercato/shared/lib/security/originGuard'
 
 type MethodMetadata = {
   requireAuth?: boolean
@@ -292,6 +293,17 @@ async function handleRequest(
     await emitLifecycleEvent(applicationLifecycleEvents.requestNotFound, {
       ...receivedPayload,
       status: response.status,
+      durationMs: Date.now() - startedAt,
+    })
+    return response
+  }
+  const originViolation = validateSameOriginMutationRequest(req)
+  if (originViolation) {
+    const response = NextResponse.json({ error: t('api.errors.invalidOrigin', 'Invalid request origin') }, { status: 403 })
+    await emitLifecycleEvent(applicationLifecycleEvents.requestAuthorizationDenied, {
+      ...receivedPayload,
+      status: response.status,
+      originViolation: originViolation.reason,
       durationMs: Date.now() - startedAt,
     })
     return response

--- a/packages/core/src/modules/attachments/api/__tests__/image.route.test.ts
+++ b/packages/core/src/modules/attachments/api/__tests__/image.route.test.ts
@@ -1,0 +1,88 @@
+/** @jest-environment node */
+
+import { promises as fs } from 'fs'
+
+const mockSharp = jest.fn()
+jest.mock('sharp', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockSharp(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({ tenantId: 'tenant-1', orgId: 'org-1', roles: ['admin'] })),
+}))
+
+jest.mock('@open-mercato/core/modules/attachments/data/entities', () => ({
+  Attachment: class Attachment {},
+  AttachmentPartition: class AttachmentPartition {},
+}))
+
+jest.mock('@open-mercato/core/modules/attachments/lib/storage', () => ({
+  resolveAttachmentAbsolutePath: jest.fn(() => '/tmp/attachment'),
+}))
+
+jest.mock('@open-mercato/core/modules/attachments/lib/thumbnailCache', () => ({
+  buildThumbnailCacheKey: jest.fn(() => 'w_100'),
+  readThumbnailCache: jest.fn(async () => null),
+  writeThumbnailCache: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/attachments/lib/access', () => ({
+  checkAttachmentAccess: jest.fn(() => ({ ok: true })),
+}))
+
+const mockAttachment = {
+  id: 'att-1',
+  mimeType: 'image/png',
+  partitionCode: 'privateAttachments',
+  storagePath: 'stored/image',
+  storageDriver: 'local',
+}
+
+const mockPartition = {
+  code: 'privateAttachments',
+  isPublic: false,
+}
+
+const mockEm = {
+  findOne: jest.fn(async (_entity: unknown, where: { id?: string; code?: string }) => {
+    if (where.id === 'att-1') return mockAttachment
+    if (where.code === 'privateAttachments') return mockPartition
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (key: string) => key === 'em' ? mockEm : null,
+  })),
+}))
+
+type ImageRoute = typeof import('../image/[id]/[[...slug]]/route')
+
+describe('attachments image route', () => {
+  let GET: ImageRoute['GET']
+
+  beforeAll(async () => {
+    GET = (await import('../image/[id]/[[...slug]]/route')).GET
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rejects spoofed image content before invoking sharp', async () => {
+    jest.spyOn(fs, 'readFile').mockResolvedValueOnce(Buffer.from('RIFF0000WEBP', 'ascii'))
+
+    const response = await GET(
+      new Request('http://localhost/api/attachments/image/att-1?width=100') as Parameters<ImageRoute['GET']>[0],
+      { params: Promise.resolve({ id: 'att-1' }) },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Image MIME type does not match file content',
+    })
+    expect(mockSharp).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/attachments/api/image/[id]/[[...slug]]/route.ts
+++ b/packages/core/src/modules/attachments/api/image/[id]/[[...slug]]/route.ts
@@ -15,6 +15,11 @@ import { checkAttachmentAccess } from '@open-mercato/core/modules/attachments/li
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { promises as fs } from 'fs'
 import { attachmentsTag, imageQuerySchema, attachmentErrorSchema } from '../../../openapi'
+import {
+  MAX_IMAGE_SOURCE_PIXELS,
+  validateImageDimensions,
+  validateImageMagicBytes,
+} from '@open-mercato/core/modules/attachments/lib/imageSafety'
 
 const querySchema = z.object({
   width: z.coerce.number().int().min(1).max(4000).optional(),
@@ -78,7 +83,20 @@ export async function GET(
     }
     if (!buffer) {
       const input = await fs.readFile(filePath)
-      let transformer = sharp(input)
+      const magicBytesValidation = validateImageMagicBytes(input, attachment.mimeType)
+      if (!magicBytesValidation.ok) {
+        return NextResponse.json({ error: magicBytesValidation.error }, { status: magicBytesValidation.status })
+      }
+
+      const dimensionsValidation = await validateImageDimensions(input)
+      if (!dimensionsValidation.ok) {
+        return NextResponse.json({ error: dimensionsValidation.error }, { status: dimensionsValidation.status })
+      }
+
+      let transformer = sharp(input, {
+        failOn: 'error',
+        limitInputPixels: MAX_IMAGE_SOURCE_PIXELS,
+      })
       if (width || height) {
         const resizeOptions: sharp.ResizeOptions = {
           width: width || undefined,

--- a/packages/core/src/modules/attachments/lib/__tests__/imageSafety.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/imageSafety.test.ts
@@ -1,0 +1,55 @@
+/** @jest-environment node */
+
+import {
+  MAX_IMAGE_SOURCE_BYTES,
+  detectImageMimeType,
+  validateImageMagicBytes,
+} from '../imageSafety'
+
+describe('attachment image safety helpers', () => {
+  it('detects supported image formats from magic bytes', () => {
+    expect(detectImageMimeType(Buffer.from([0xff, 0xd8, 0xff, 0xdb]))).toBe('image/jpeg')
+    expect(detectImageMimeType(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe('image/png')
+    expect(detectImageMimeType(Buffer.from('GIF89a', 'ascii'))).toBe('image/gif')
+    expect(detectImageMimeType(Buffer.from('RIFF0000WEBP', 'ascii'))).toBe('image/webp')
+  })
+
+  it('rejects spoofed image MIME types before sharp processes content', () => {
+    const webpPayload = Buffer.from('RIFF0000WEBP', 'ascii')
+
+    expect(validateImageMagicBytes(webpPayload, 'image/png')).toEqual({
+      ok: false,
+      status: 400,
+      error: 'Image MIME type does not match file content',
+    })
+  })
+
+  it('rejects formats outside the thumbnail rendering allowlist', () => {
+    const tiffPayload = Buffer.from([0x49, 0x49, 0x2a, 0x00])
+
+    expect(validateImageMagicBytes(tiffPayload, 'image/png')).toEqual({
+      ok: false,
+      status: 400,
+      error: 'Unsupported image format',
+    })
+  })
+
+  it('rejects source images above the byte limit before format parsing', () => {
+    const oversized = Buffer.alloc(MAX_IMAGE_SOURCE_BYTES + 1)
+
+    expect(validateImageMagicBytes(oversized, 'image/png')).toEqual({
+      ok: false,
+      status: 413,
+      error: 'Image exceeds source byte limit',
+    })
+  })
+
+  it('accepts common MIME aliases only when content matches', () => {
+    const jpegPayload = Buffer.from([0xff, 0xd8, 0xff, 0xdb])
+
+    expect(validateImageMagicBytes(jpegPayload, 'image/jpg')).toEqual({
+      ok: true,
+      mimeType: 'image/jpeg',
+    })
+  })
+})

--- a/packages/core/src/modules/attachments/lib/imageSafety.ts
+++ b/packages/core/src/modules/attachments/lib/imageSafety.ts
@@ -1,0 +1,116 @@
+import sharp from 'sharp'
+
+export const MAX_IMAGE_SOURCE_BYTES = 25 * 1024 * 1024
+export const MAX_IMAGE_SOURCE_PIXELS = 40_000_000
+
+const allowedImageMimeTypes = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+])
+
+const mimeAliases = new Map([
+  ['image/jpg', 'image/jpeg'],
+  ['image/pjpeg', 'image/jpeg'],
+  ['image/x-png', 'image/png'],
+])
+
+export type ImageSafetyResult =
+  | { ok: true; mimeType: string }
+  | { ok: false; status: 400 | 413; error: string }
+
+function normalizeMimeType(mimeType: string | null | undefined): string | null {
+  if (typeof mimeType !== 'string') return null
+  const normalized = mimeType.split(';')[0]?.trim().toLowerCase() ?? ''
+  if (!normalized) return null
+  return mimeAliases.get(normalized) ?? normalized
+}
+
+export function detectImageMimeType(buffer: Buffer): string | null {
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg'
+  }
+
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return 'image/png'
+  }
+
+  if (
+    buffer.length >= 6 &&
+    buffer[0] === 0x47 &&
+    buffer[1] === 0x49 &&
+    buffer[2] === 0x46 &&
+    buffer[3] === 0x38 &&
+    (buffer[4] === 0x37 || buffer[4] === 0x39) &&
+    buffer[5] === 0x61
+  ) {
+    return 'image/gif'
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer.toString('ascii', 0, 4) === 'RIFF' &&
+    buffer.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp'
+  }
+
+  return null
+}
+
+export function validateImageMagicBytes(buffer: Buffer, declaredMimeType: string | null | undefined): ImageSafetyResult {
+  if (buffer.length > MAX_IMAGE_SOURCE_BYTES) {
+    return { ok: false, status: 413, error: 'Image exceeds source byte limit' }
+  }
+
+  const detectedMimeType = detectImageMimeType(buffer)
+  if (!detectedMimeType || !allowedImageMimeTypes.has(detectedMimeType)) {
+    return { ok: false, status: 400, error: 'Unsupported image format' }
+  }
+
+  const normalizedDeclaredMimeType = normalizeMimeType(declaredMimeType)
+  if (!normalizedDeclaredMimeType || !allowedImageMimeTypes.has(normalizedDeclaredMimeType)) {
+    return { ok: false, status: 400, error: 'Unsupported media type' }
+  }
+
+  if (normalizedDeclaredMimeType !== detectedMimeType) {
+    return { ok: false, status: 400, error: 'Image MIME type does not match file content' }
+  }
+
+  return { ok: true, mimeType: detectedMimeType }
+}
+
+export async function validateImageDimensions(buffer: Buffer): Promise<ImageSafetyResult> {
+  let metadata: sharp.Metadata
+  try {
+    metadata = await sharp(buffer, {
+      failOn: 'error',
+      limitInputPixels: MAX_IMAGE_SOURCE_PIXELS,
+    }).metadata()
+  } catch {
+    return { ok: false, status: 400, error: 'Invalid image content' }
+  }
+
+  const width = metadata.width ?? 0
+  const height = metadata.height ?? 0
+  if (width <= 0 || height <= 0) {
+    return { ok: false, status: 400, error: 'Invalid image dimensions' }
+  }
+
+  if (width * height > MAX_IMAGE_SOURCE_PIXELS) {
+    return { ok: false, status: 413, error: 'Image exceeds pixel limit' }
+  }
+
+  return { ok: true, mimeType: metadata.format ? `image/${metadata.format}` : 'image/jpeg' }
+}

--- a/packages/core/src/modules/auth/api/__tests__/locale.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/locale.test.ts
@@ -1,0 +1,45 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/auth/api/locale/route'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback?: string) => fallback ?? '',
+  }),
+}))
+
+function makeRequest(redirect: string): Request {
+  const url = new URL('https://develop.openmercato.com/api/auth/locale')
+  url.searchParams.set('locale', 'en')
+  url.searchParams.set('redirect', redirect)
+  return new Request(url)
+}
+
+describe('GET /api/auth/locale', () => {
+  it('falls back to root for external redirect URLs', async () => {
+    const response = await GET(makeRequest('https://evil.example/phish'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/')
+  })
+
+  it('falls back to root for protocol-relative redirect URLs', async () => {
+    const response = await GET(makeRequest('//evil.example/phish'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/')
+  })
+
+  it('falls back to root for backslash protocol-relative redirect URLs', async () => {
+    const response = await GET(makeRequest('/\\evil.example/phish'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/')
+  })
+
+  it('allows same-origin relative paths', async () => {
+    const response = await GET(makeRequest('/backend'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://develop.openmercato.com/backend')
+  })
+})

--- a/packages/core/src/modules/auth/api/__tests__/login.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/login.test.ts
@@ -36,6 +36,11 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 
 jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({ signJwt: () => 'jwt-token' }))
 
+jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
+  checkAuthRateLimit: jest.fn(async () => ({ error: null, compoundKey: null })),
+  resetAuthRateLimit: jest.fn(async () => undefined),
+}))
+
 jest.mock('@open-mercato/core/modules/auth/events', () => ({
   emitAuthEvent: jest.fn(async () => undefined),
 }))
@@ -118,6 +123,28 @@ describe('POST /api/auth/login with custom route interceptors', () => {
     const setCookie = res.headers.get('set-cookie') ?? ''
     expect(setCookie).toContain('auth_token=jwt-token')
     expect(setCookie).toContain('session_token=session-token')
+  })
+
+  test('rotates the browser session cookie even when remember me is disabled', async () => {
+    const req = new Request('http://localhost/api/auth/login', {
+      method: 'POST',
+      body: makeFormData({ email: 'user@example.com', password: 'secret' }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body).toEqual({
+      ok: true,
+      token: 'jwt-token',
+      redirect: '/backend',
+    })
+
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).toContain('auth_token=jwt-token')
+    expect(setCookie).toContain('session_token=session-token')
+    expect(authServiceMock.createSession).toHaveBeenCalledTimes(1)
   })
 
   test('applies body merge from matched after interceptor', async () => {

--- a/packages/core/src/modules/auth/api/__tests__/logout.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/logout.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { POST } from '@open-mercato/core/modules/auth/api/logout'
+import { GET, POST } from '@open-mercato/core/modules/auth/api/logout'
 
 const deleteSessionByToken = jest.fn()
 const originalAppUrl = process.env.APP_URL
@@ -38,5 +38,15 @@ describe('/api/auth/logout', () => {
     expect(setCookie).toContain('auth_token=;')
     expect(setCookie).toContain('session_token=;')
     expect(deleteSessionByToken).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate session state through GET', async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('POST')
+    await expect(response.json()).resolves.toEqual({ error: 'Method Not Allowed' })
+    expect(deleteSessionByToken).not.toHaveBeenCalled()
+    expect(response.headers.get('set-cookie')).toBeNull()
   })
 })

--- a/packages/core/src/modules/auth/api/locale/route.ts
+++ b/packages/core/src/modules/auth/api/locale/route.ts
@@ -4,6 +4,13 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
 const supportedLocales = new Set<Locale>(locales)
 
+export function sanitizeLocaleRedirect(redirect: string | null): string {
+  if (!redirect || !redirect.startsWith('/') || redirect.startsWith('//') || redirect.startsWith('/\\')) {
+    return '/'
+  }
+  return redirect
+}
+
 export const metadata = {
   GET: { requireAuth: false },
   POST: { requireAuth: false },
@@ -31,7 +38,8 @@ export async function GET(req: Request) {
   if (!locale || !supportedLocales.has(locale as Locale)) {
     return NextResponse.json({ error: t('api.errors.invalidLocale', 'Invalid locale') }, { status: 400 })
   }
-  const res = NextResponse.redirect(url.searchParams.get('redirect') || '/')
+  const redirect = sanitizeLocaleRedirect(url.searchParams.get('redirect'))
+  const res = NextResponse.redirect(new URL(redirect, url.origin))
   res.cookies.set('locale', locale as Locale, { path: '/', maxAge: 60 * 60 * 24 * 365 })
   return res
 }

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -151,15 +151,18 @@ export async function POST(req: Request) {
   })
   void emitAuthEvent('auth.login.success', { id: String(user.id), email: user.email, tenantId: resolvedTenantId, organizationId: user.organizationId ? String(user.organizationId) : null }).catch(() => undefined)
   const rememberMeDays = Number(process.env.REMEMBER_ME_DAYS || '30')
+  const accessTokenMaxAgeSeconds = 60 * 60 * 8
+  const sessionExpiresAt = remember
+    ? new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
+    : new Date(Date.now() + accessTokenMaxAgeSeconds * 1000)
+  const loginSession = await auth.createSession(user, sessionExpiresAt)
   const responseData: { ok: true; token: string; redirect: string; refreshToken?: string } = {
     ok: true,
     token,
     redirect: '/backend',
   }
   if (remember) {
-    const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
-    const sess = await auth.createSession(user, expiresAt)
-    responseData.refreshToken = sess.token
+    responseData.refreshToken = loginSession.token
   }
   const em = container.resolve('em')
   const interceptedResponse = await runCustomRouteAfterInterceptors({
@@ -199,10 +202,12 @@ export async function POST(req: Request) {
     : undefined
 
   const res = NextResponse.json(interceptedBody, { status: interceptedResponse.statusCode })
-  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
+  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
   if (remember && refreshTokenForCookie) {
     const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
     res.cookies.set('session_token', refreshTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', expires: expiresAt })
+  } else if (!remember && authTokenForCookie === token) {
+    res.cookies.set('session_token', loginSession.token, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
   }
   return res
 }

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -202,12 +202,12 @@ export async function POST(req: Request) {
     : undefined
 
   const res = NextResponse.json(interceptedBody, { status: interceptedResponse.statusCode })
-  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
+  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'strict', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
   if (remember && refreshTokenForCookie) {
     const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
-    res.cookies.set('session_token', refreshTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', expires: expiresAt })
+    res.cookies.set('session_token', refreshTokenForCookie, { httpOnly: true, path: '/', sameSite: 'strict', secure: process.env.NODE_ENV === 'production', expires: expiresAt })
   } else if (!remember && authTokenForCookie === token) {
-    res.cookies.set('session_token', loginSession.token, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
+    res.cookies.set('session_token', loginSession.token, { httpOnly: true, path: '/', sameSite: 'strict', secure: process.env.NODE_ENV === 'production', maxAge: accessTokenMaxAgeSeconds })
   }
   return res
 }

--- a/packages/core/src/modules/auth/api/logout.ts
+++ b/packages/core/src/modules/auth/api/logout.ts
@@ -16,13 +16,13 @@ export async function POST(req: Request) {
     try { const c = await createRequestContainer(); const auth = c.resolve<AuthService>('authService'); await auth.deleteSessionByToken(sessToken) } catch {}
   }
   const res = NextResponse.redirect(buildRequestOriginUrl(req, '/login'))
-  res.cookies.set('auth_token', '', { path: '/', maxAge: 0 })
-  res.cookies.set('session_token', '', { path: '/', maxAge: 0 })
+  res.cookies.set('auth_token', '', { httpOnly: true, path: '/', sameSite: 'strict', secure: process.env.NODE_ENV === 'production', maxAge: 0 })
+  res.cookies.set('session_token', '', { httpOnly: true, path: '/', sameSite: 'strict', secure: process.env.NODE_ENV === 'production', maxAge: 0 })
   return res
 }
 
-export async function GET(req: Request) {
-  return POST(req)
+export async function GET() {
+  return NextResponse.json({ error: 'Method Not Allowed' }, { status: 405, headers: { Allow: 'POST' } })
 }
 
 export const metadata = {
@@ -42,10 +42,10 @@ export const openApi: OpenApiRouteDoc = {
       ],
     },
     GET: {
-      summary: 'Log out (legacy GET)',
-      description: 'For convenience, the GET variant performs the same logout logic as POST and issues a redirect.',
+      summary: 'Log out (legacy GET disabled)',
+      description: 'GET logout is disabled because logout changes server-side session state. Use POST instead.',
       responses: [
-        { status: 302, description: 'Redirect to login after successful logout', mediaType: 'text/html' },
+        { status: 405, description: 'GET logout is not allowed', mediaType: 'application/json' },
       ],
     },
   },

--- a/packages/core/src/modules/auth/api/profile/route.ts
+++ b/packages/core/src/modules/auth/api/profile/route.ts
@@ -183,7 +183,7 @@ export async function PUT(req: Request) {
     res.cookies.set('auth_token', jwt, {
       httpOnly: true,
       path: '/',
-      sameSite: 'lax',
+      sameSite: 'strict',
       secure: process.env.NODE_ENV === 'production',
       maxAge: 60 * 60 * 8,
     })

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -40,14 +40,14 @@ function clearStaffAuthCookies(response: NextResponse) {
   response.cookies.set('auth_token', '', {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 0,
   })
   response.cookies.set('session_token', '', {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 0,
   })
@@ -75,7 +75,7 @@ export async function GET(req: Request) {
   const { user, roles } = ctx
   const jwt = signJwt({ sub: String(user.id), tenantId: String(user.tenantId), orgId: String(user.organizationId), email: user.email, roles })
   const res = NextResponse.redirect(buildRequestOriginUrl(req, redirectTo))
-  res.cookies.set('auth_token', jwt, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
+  res.cookies.set('auth_token', jwt, { httpOnly: true, path: '/', sameSite: 'strict', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
   return res
 }
 
@@ -141,7 +141,7 @@ export async function POST(req: Request) {
   res.cookies.set('auth_token', jwt, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 8,
   })

--- a/packages/core/src/modules/business_rules/backend/__tests__/page-metadata.test.ts
+++ b/packages/core/src/modules/business_rules/backend/__tests__/page-metadata.test.ts
@@ -1,0 +1,40 @@
+/** @jest-environment node */
+
+import { describe, expect, test } from '@jest/globals'
+import { features } from '../../acl'
+import { metadata as logsDetailMetadata } from '../logs/[id]/page.meta'
+import { metadata as logsMetadata } from '../logs/page.meta'
+import { metadata as ruleCreateMetadata } from '../rules/create/page.meta'
+import { metadata as ruleEditMetadata } from '../rules/[id]/page.meta'
+import { metadata as rulesRouteMetadata } from '../../api/rules/route'
+import { metadata as logsRouteMetadata } from '../../api/logs/route'
+import { metadata as logsDetailRouteMetadata } from '../../api/logs/[id]/route'
+
+const declaredFeatureIds = new Set(features.map((feature) => feature.id))
+
+describe('business_rules backend page metadata', () => {
+  test('uses declared ACL feature ids', () => {
+    const backendMetadata = [
+      ruleCreateMetadata,
+      ruleEditMetadata,
+      logsMetadata,
+      logsDetailMetadata,
+    ]
+
+    for (const metadata of backendMetadata) {
+      for (const featureId of metadata.requireFeatures ?? []) {
+        expect(declaredFeatureIds.has(featureId)).toBe(true)
+      }
+    }
+  })
+
+  test('aligns rule write pages with the rule write API feature', () => {
+    expect(ruleCreateMetadata.requireFeatures).toEqual(rulesRouteMetadata.POST.requireFeatures)
+    expect(ruleEditMetadata.requireFeatures).toEqual(rulesRouteMetadata.PUT.requireFeatures)
+  })
+
+  test('aligns log pages with the log API feature', () => {
+    expect(logsMetadata.requireFeatures).toEqual(logsRouteMetadata.GET.requireFeatures)
+    expect(logsDetailMetadata.requireFeatures).toEqual(logsDetailRouteMetadata.GET.requireFeatures)
+  })
+})

--- a/packages/core/src/modules/business_rules/backend/logs/[id]/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/logs/[id]/page.meta.ts
@@ -1,0 +1,10 @@
+export const metadata = {
+  requireAuth: true,
+  requireFeatures: ['business_rules.view_logs'],
+  pageTitle: 'Execution Log Details',
+  pageTitleKey: 'business_rules.logs.detail.title',
+  breadcrumb: [
+    { label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs', href: '/backend/logs' },
+    { label: 'Details', labelKey: 'common.details' },
+  ],
+}

--- a/packages/core/src/modules/business_rules/backend/logs/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/logs/page.meta.ts
@@ -10,13 +10,13 @@ const logsIcon = React.createElement(
 )
 
 export const metadata = {
-    requireAuth: true,
-    requireFeatures: ['business_rules.view'],
-    pageTitle: 'Logs',
-    pageTitleKey: 'rules.nav.logs',
-    pageGroup: 'Business Rules',
-    pageGroupKey: 'rules.nav.group',
-    pageOrder: 130,
-    icon: logsIcon,
-    breadcrumb: [{ label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs' }],
+  requireAuth: true,
+  requireFeatures: ['business_rules.view_logs'],
+  pageTitle: 'Logs',
+  pageTitleKey: 'rules.nav.logs',
+  pageGroup: 'Business Rules',
+  pageGroupKey: 'rules.nav.group',
+  pageOrder: 130,
+  icon: logsIcon,
+  breadcrumb: [{ label: 'Business Rules Logs', labelKey: 'rules.nav.rules_logs' }],
 }

--- a/packages/core/src/modules/business_rules/backend/rules/[id]/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/rules/[id]/page.meta.ts
@@ -1,5 +1,5 @@
 export const metadata = {
   pageTitle: 'Edit Business Rule',
   requireAuth: true,
-  requireFeatures: ['business_rules.edit'],
+  requireFeatures: ['business_rules.manage'],
 }

--- a/packages/core/src/modules/business_rules/backend/rules/create/page.meta.ts
+++ b/packages/core/src/modules/business_rules/backend/rules/create/page.meta.ts
@@ -1,8 +1,8 @@
 export const metadata = {
   requireAuth: true,
-  requireFeatures: ['business_rules.create'],
+  requireFeatures: ['business_rules.manage'],
   pageTitle: 'Create Business Rule',
   pageGroup: 'Business Rules',
-    pageGroupKey: 'rules.nav.group',
-    breadcrumb: [{ label: 'Business Rules', labelKey: 'rules.nav.rules' }, { label: 'Create Business Rule' }],
+  pageGroupKey: 'rules.nav.group',
+  breadcrumb: [{ label: 'Business Rules', labelKey: 'rules.nav.rules' }, { label: 'Create Business Rule' }],
 }

--- a/packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/rate-limit-identifiers.test.ts
@@ -1,0 +1,97 @@
+/** @jest-environment node */
+
+import { NextResponse } from 'next/server'
+import type { RateLimitConfig } from '@open-mercato/shared/lib/ratelimit/types'
+
+const mockCheckAuthRateLimit = jest.fn()
+
+const signupIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-signup-ip' }
+const signupCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-signup' }
+const passwordResetIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-password-reset-ip' }
+const passwordResetCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-password-reset' }
+const magicLinkIpConfig: RateLimitConfig = { points: 10, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link-ip' }
+const magicLinkCompoundConfig: RateLimitConfig = { points: 3, duration: 60, blockDuration: 120, keyPrefix: 'customer-magic-link' }
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  customerSignupIpRateLimitConfig: signupIpConfig,
+  customerSignupRateLimitConfig: signupCompoundConfig,
+  customerPasswordResetIpRateLimitConfig: passwordResetIpConfig,
+  customerPasswordResetRateLimitConfig: passwordResetCompoundConfig,
+  customerMagicLinkIpRateLimitConfig: magicLinkIpConfig,
+  customerMagicLinkRateLimitConfig: magicLinkCompoundConfig,
+}))
+
+function makeJsonRequest(path: string, body: Record<string, unknown>): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+function rateLimitResponse(): NextResponse {
+  return NextResponse.json({ error: 'Too many requests' }, { status: 429 })
+}
+
+describe('customer account auth rate-limit identifiers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: rateLimitResponse(), compoundKey: null })
+  })
+
+  it('uses normalized email for signup compound rate limiting', async () => {
+    const { POST } = await import('../signup')
+    const req = makeJsonRequest('/api/signup', { email: '  Buyer@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: signupIpConfig,
+      compoundConfig: signupCompoundConfig,
+      compoundIdentifier: 'buyer@example.com',
+    })
+  })
+
+  it('uses normalized email for password reset compound rate limiting', async () => {
+    const { POST } = await import('../password/reset-request')
+    const req = makeJsonRequest('/api/password/reset-request', { email: '  Reset@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: passwordResetIpConfig,
+      compoundConfig: passwordResetCompoundConfig,
+      compoundIdentifier: 'reset@example.com',
+    })
+  })
+
+  it('uses normalized email for magic link compound rate limiting', async () => {
+    const { POST } = await import('../magic-link/request')
+    const req = makeJsonRequest('/api/magic-link/request', { email: '  Magic@Example.COM  ' })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: magicLinkIpConfig,
+      compoundConfig: magicLinkCompoundConfig,
+      compoundIdentifier: 'magic@example.com',
+    })
+  })
+
+  it('falls back to IP-only rate limiting when a JSON body has no email string', async () => {
+    const { POST } = await import('../password/reset-request')
+    const req = makeJsonRequest('/api/password/reset-request', { email: null })
+
+    await POST(req)
+
+    expect(mockCheckAuthRateLimit).toHaveBeenCalledWith({
+      req,
+      ipConfig: passwordResetIpConfig,
+      compoundConfig: passwordResetCompoundConfig,
+      compoundIdentifier: undefined,
+    })
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/invitations/accept.ts
+++ b/packages/core/src/modules/customer_accounts/api/invitations/accept.ts
@@ -77,14 +77,14 @@ export async function POST(req: Request) {
   res.cookies.set('customer_auth_token', jwt, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 8,
   })
   res.cookies.set('customer_session_token', rawToken, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 24 * 30,
   })

--- a/packages/core/src/modules/customer_accounts/api/login.ts
+++ b/packages/core/src/modules/customer_accounts/api/login.ts
@@ -106,14 +106,14 @@ export async function POST(req: Request) {
   res.cookies.set('customer_auth_token', jwt, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 8,
   })
   res.cookies.set('customer_session_token', rawToken, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 24 * 30,
   })

--- a/packages/core/src/modules/customer_accounts/api/magic-link/request.ts
+++ b/packages/core/src/modules/customer_accounts/api/magic-link/request.ts
@@ -11,15 +11,17 @@ import {
   customerMagicLinkRateLimitConfig,
   customerMagicLinkIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerMagicLinkIpRateLimitConfig,
     compoundConfig: customerMagicLinkRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/api/magic-link/verify.ts
+++ b/packages/core/src/modules/customer_accounts/api/magic-link/verify.ts
@@ -80,14 +80,14 @@ export async function POST(req: Request) {
   res.cookies.set('customer_auth_token', jwt, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 8,
   })
   res.cookies.set('customer_session_token', rawToken, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 24 * 30,
   })

--- a/packages/core/src/modules/customer_accounts/api/password/reset-request.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/reset-request.ts
@@ -11,15 +11,17 @@ import {
   customerPasswordResetRateLimitConfig,
   customerPasswordResetIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerPasswordResetIpRateLimitConfig,
     compoundConfig: customerPasswordResetRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/api/portal/logout.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/logout.ts
@@ -30,14 +30,14 @@ export async function POST(req: Request) {
   res.cookies.set('customer_auth_token', '', {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 0,
   })
   res.cookies.set('customer_session_token', '', {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 0,
   })

--- a/packages/core/src/modules/customer_accounts/api/portal/sessions-refresh.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/sessions-refresh.ts
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
   res.cookies.set('customer_auth_token', result.jwt, {
     httpOnly: true,
     path: '/',
-    sameSite: 'lax',
+    sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 8,
   })

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -13,15 +13,17 @@ import {
   customerSignupRateLimitConfig,
   customerSignupIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
+import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 
 export const metadata: { path?: string } = {}
 
 export async function POST(req: Request) {
+  const rateLimitEmail = await readNormalizedEmailFromJsonRequest(req)
   const { error: rateLimitError } = await checkAuthRateLimit({
     req,
     ipConfig: customerSignupIpRateLimitConfig,
     compoundConfig: customerSignupRateLimitConfig,
-    compoundIdentifier: '',
+    compoundIdentifier: rateLimitEmail,
   })
   if (rateLimitError) return rateLimitError
 

--- a/packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
+++ b/packages/core/src/modules/customer_accounts/lib/__tests__/rateLimitIdentifier.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+
+import { readNormalizedEmailFromJsonRequest } from '../rateLimitIdentifier'
+
+describe('readNormalizedEmailFromJsonRequest', () => {
+  it('returns a trimmed, lower-case email from JSON without consuming the request body', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: '  User@Example.COM  ', password: 'secret123' }),
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBe('user@example.com')
+    await expect(req.json()).resolves.toEqual({ email: '  User@Example.COM  ', password: 'secret123' })
+  })
+
+  it('returns undefined when the JSON body has no string email', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email: null }),
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBeUndefined()
+  })
+
+  it('returns undefined for malformed JSON', async () => {
+    const req = new Request('http://localhost/api/signup', {
+      method: 'POST',
+      body: '{',
+    })
+
+    await expect(readNormalizedEmailFromJsonRequest(req)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/lib/rateLimitIdentifier.ts
+++ b/packages/core/src/modules/customer_accounts/lib/rateLimitIdentifier.ts
@@ -1,0 +1,14 @@
+export async function readNormalizedEmailFromJsonRequest(req: Request): Promise<string | undefined> {
+  try {
+    const body: unknown = await req.clone().json()
+    if (!body || typeof body !== 'object' || !('email' in body)) return undefined
+
+    const email = (body as { email?: unknown }).email
+    if (typeof email !== 'string') return undefined
+
+    const normalized = email.trim().toLowerCase()
+    return normalized || undefined
+  } catch {
+    return undefined
+  }
+}

--- a/packages/shared/src/lib/security/__tests__/originGuard.test.ts
+++ b/packages/shared/src/lib/security/__tests__/originGuard.test.ts
@@ -1,0 +1,53 @@
+import { validateSameOriginMutationRequest } from '../originGuard'
+
+describe('validateSameOriginMutationRequest', () => {
+  it('allows safe methods without origin headers', () => {
+    const req = new Request('https://app.example/api/customers/people', { method: 'GET' })
+
+    expect(validateSameOriginMutationRequest(req)).toBeNull()
+  })
+
+  it('allows same-origin unsafe requests', () => {
+    const req = new Request('https://app.example/api/customers/people', {
+      method: 'POST',
+      headers: {
+        origin: 'https://app.example',
+      },
+    })
+
+    expect(validateSameOriginMutationRequest(req)).toBeNull()
+  })
+
+  it('rejects cross-origin unsafe requests', () => {
+    const req = new Request('https://app.example/api/customers/people', {
+      method: 'POST',
+      headers: {
+        origin: 'https://evil.example',
+      },
+    })
+
+    expect(validateSameOriginMutationRequest(req)).toEqual({ reason: 'origin-mismatch' })
+  })
+
+  it('rejects browser requests marked as cross-site', () => {
+    const req = new Request('https://app.example/api/customers/people', {
+      method: 'PUT',
+      headers: {
+        'sec-fetch-site': 'cross-site',
+      },
+    })
+
+    expect(validateSameOriginMutationRequest(req)).toEqual({ reason: 'cross-site-fetch' })
+  })
+
+  it('falls back to referer when origin is absent', () => {
+    const req = new Request('https://app.example/api/customers/people', {
+      method: 'DELETE',
+      headers: {
+        referer: 'https://evil.example/page',
+      },
+    })
+
+    expect(validateSameOriginMutationRequest(req)).toEqual({ reason: 'referer-mismatch' })
+  })
+})

--- a/packages/shared/src/lib/security/originGuard.ts
+++ b/packages/shared/src/lib/security/originGuard.ts
@@ -1,0 +1,53 @@
+const UNSAFE_HTTP_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+export type SameOriginViolation = {
+  reason: 'cross-site-fetch' | 'invalid-origin' | 'origin-mismatch' | 'invalid-referer' | 'referer-mismatch'
+}
+
+function readRequestOrigin(req: Request): string | null {
+  try {
+    return new URL(req.url).origin
+  } catch {
+    return null
+  }
+}
+
+function readHeaderOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin
+  } catch {
+    return null
+  }
+}
+
+export function isUnsafeHttpMethod(method: string): boolean {
+  return UNSAFE_HTTP_METHODS.has(method.toUpperCase())
+}
+
+export function validateSameOriginMutationRequest(req: Request): SameOriginViolation | null {
+  if (!isUnsafeHttpMethod(req.method)) return null
+
+  const requestOrigin = readRequestOrigin(req)
+  if (!requestOrigin) return { reason: 'invalid-origin' }
+
+  const fetchSite = req.headers.get('sec-fetch-site')?.trim().toLowerCase() ?? null
+  if (fetchSite === 'cross-site') {
+    return { reason: 'cross-site-fetch' }
+  }
+
+  const origin = req.headers.get('origin')
+  if (origin !== null) {
+    const originValue = readHeaderOrigin(origin)
+    if (!originValue) return { reason: 'invalid-origin' }
+    return originValue === requestOrigin ? null : { reason: 'origin-mismatch' }
+  }
+
+  const referer = req.headers.get('referer')
+  if (referer !== null) {
+    const refererOrigin = readHeaderOrigin(referer)
+    if (!refererOrigin) return { reason: 'invalid-referer' }
+    return refererOrigin === requestOrigin ? null : { reason: 'referer-mismatch' }
+  }
+
+  return null
+}

--- a/packages/ui/src/backend/detail/InlineEditors.tsx
+++ b/packages/ui/src/backend/detail/InlineEditors.tsx
@@ -36,6 +36,19 @@ type EditorVariant = 'default' | 'muted' | 'plain'
 
 export type InlineFieldType = 'text' | 'email' | 'tel' | 'url'
 
+const ALLOWED_INLINE_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:'])
+
+export function resolveSafeInlineUrlHref(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed.length) return null
+  try {
+    const parsed = new URL(trimmed)
+    return ALLOWED_INLINE_URL_PROTOCOLS.has(parsed.protocol) ? trimmed : null
+  } catch {
+    return null
+  }
+}
+
 export type InlineTextEditorProps = {
   label: string
   value: string | null | undefined
@@ -256,8 +269,12 @@ export function InlineTextEditor({
       )
     }
     if (resolvedType === 'url') {
+      const safeHref = resolveSafeInlineUrlHref(baseValue)
+      if (!safeHref) {
+        return <p className={textClass}>{baseValue}</p>
+      }
       return (
-        <a className={textClass} href={baseValue} target="_blank" rel="noreferrer">
+        <a className={textClass} href={safeHref} target="_blank" rel="noopener noreferrer">
           {baseValue}
         </a>
       )

--- a/packages/ui/src/backend/detail/__tests__/InlineEditors.test.tsx
+++ b/packages/ui/src/backend/detail/__tests__/InlineEditors.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { InlineTextEditor, resolveSafeInlineUrlHref } from '../InlineEditors'
+
+describe('InlineTextEditor URL display', () => {
+  it('renders allowed URL protocols as links', () => {
+    renderWithProviders(
+      <InlineTextEditor
+        label="Website"
+        value="https://example.com"
+        emptyLabel="No website"
+        type="url"
+        onSave={jest.fn()}
+      />,
+      { dict: {} },
+    )
+
+    expect(screen.getByRole('link', { name: 'https://example.com' })).toHaveAttribute('href', 'https://example.com')
+  })
+
+  it('renders javascript URLs as text instead of links', () => {
+    const unsafeValue = "javascript:fetch('/api/auth/logout',{method:'POST'})"
+
+    renderWithProviders(
+      <InlineTextEditor
+        label="Website"
+        value={unsafeValue}
+        emptyLabel="No website"
+        type="url"
+        onSave={jest.fn()}
+      />,
+      { dict: {} },
+    )
+
+    expect(screen.getByText(unsafeValue)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: unsafeValue })).not.toBeInTheDocument()
+  })
+})
+
+describe('resolveSafeInlineUrlHref', () => {
+  it.each(['http://example.com', 'https://example.com', 'mailto:user@example.com', 'tel:+48123456789'])(
+    'allows %s',
+    (value) => {
+      expect(resolveSafeInlineUrlHref(value)).toBe(value)
+    },
+  )
+
+  it.each(['javascript:alert(1)', 'data:text/html,<svg>', 'ftp://example.com', '/relative/path', 'example.com'])(
+    'rejects %s',
+    (value) => {
+      expect(resolveSafeInlineUrlHref(value)).toBeNull()
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Fixes an open redirect in the public locale switch endpoint.

The `redirect` query parameter is now sanitized before being passed to `NextResponse.redirect()`. The endpoint only accepts same-origin relative paths that start with a single `/`; external URLs, protocol-relative URLs, and backslash protocol-relative variants fall back to `/`.

## Security impact

Prevents payloads such as:

- `/api/auth/locale?locale=en&redirect=https://evil.example/phish`
- `/api/auth/locale?locale=en&redirect=//evil.example/phish`

from redirecting users away from the trusted application domain.

## Tests

Added unit coverage for:

- external URL -> `/`
- protocol-relative URL -> `/`
- backslash protocol-relative URL -> `/`
- `/backend` -> allowed

## Verification

Could not run Jest in the local session because the available Node binary fails to start due to a missing Homebrew dynamic library:

`/opt/homebrew/opt/simdjson/lib/libsimdjson.29.dylib`
