### PR TITLE
tests: add low-level coverage for crud.ts

### DIFF
--- a/apps/mercato/src/modules/example/__integration__/TC-UMES-021.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/TC-UMES-021.spec.ts
@@ -13,10 +13,17 @@ type PriorityListResponse = {
   }>
 }
 
-function buildScopeCookie(tenantId: string, organizationId: string | null): string {
+function buildScopeCookie(
+  tenantId: string,
+  organizationId: string | null,
+  options?: { padOrganization?: boolean },
+): string {
   const parts = [`om_selected_tenant=${encodeURIComponent(tenantId)}`]
   if (organizationId) {
-    parts.push(`om_selected_org=${encodeURIComponent(organizationId)}`)
+    const scopedOrganizationId = options?.padOrganization
+      ? ` ${organizationId} `
+      : organizationId
+    parts.push(`om_selected_org=${encodeURIComponent(scopedOrganizationId)}`)
   }
   return parts.join('; ')
 }
@@ -52,6 +59,24 @@ async function createOrganizationInScope(
   const body = await readJsonSafe<IdResponse>(response)
   expect(response.ok(), `POST /api/directory/organizations failed with ${response.status()}`).toBeTruthy()
   return expectId(body?.id, 'Organization create response should include id')
+}
+
+async function createTenant(
+  request: APIRequestContext,
+  token: string,
+  input: { name: string },
+): Promise<string> {
+  const response = await request.fetch('/api/directory/tenants', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: input,
+  })
+  const body = await readJsonSafe<IdResponse>(response)
+  expect(response.ok(), `POST /api/directory/tenants failed with ${response.status()}`).toBeTruthy()
+  return expectId(body?.id, 'Tenant create response should include id')
 }
 
 async function createPersonInScope(
@@ -126,105 +151,93 @@ async function deleteByBodyIfExists(
 }
 
 /**
- * TC-UMES-021: shared CRUD scope helper blocks cross-organization direct mutations
+ * TC-UMES-021: shared CRUD scope helper trims whitespace-padded organization scope during superadmin tenant override
  */
-test.describe('TC-UMES-021: shared CRUD scope helper blocks cross-organization direct mutations', () => {
-  test('should keep direct update/delete scoped to the selected organization', async ({ request }) => {
+test.describe('TC-UMES-021: shared CRUD scope helper trims whitespace-padded organization scope during superadmin tenant override', () => {
+  test('should normalize whitespace-padded selected organization ids for direct update/delete', async ({ request }) => {
     const token = await getAuthToken(request, 'superadmin')
-    const { tenantId, organizationId } = getTokenContext(token)
-    expect(tenantId, 'Superadmin token should include a tenant id').toBeTruthy()
+    const { tenantId: actorTenantId, organizationId: actorOrganizationId } = getTokenContext(token)
+    expect(actorTenantId, 'Superadmin token should include a tenant id').toBeTruthy()
 
-    const rootCookie = buildScopeCookie(tenantId, organizationId || null)
+    const actorScopeCookie = buildScopeCookie(actorTenantId, actorOrganizationId || null)
     const suffix = Date.now()
-    let organizationAId: string | null = null
-    let organizationBId: string | null = null
-    let personAId: string | null = null
-    let personBId: string | null = null
-    let priorityAId: string | null = null
-    let priorityBId: string | null = null
+    let targetTenantId: string | null = null
+    let targetOrganizationId: string | null = null
+    let targetPersonId: string | null = null
+    let targetPriorityId: string | null = null
 
     try {
-      organizationAId = await createOrganizationInScope(request, token, rootCookie, {
-        name: `QA TC-UMES-021 Org A ${suffix}`,
-        tenantId,
+      targetTenantId = await createTenant(request, token, {
+        name: `QA TC-UMES-021 Tenant ${suffix}`,
       })
-      organizationBId = await createOrganizationInScope(request, token, rootCookie, {
-        name: `QA TC-UMES-021 Org B ${suffix}`,
-        tenantId,
+      targetOrganizationId = await createOrganizationInScope(request, token, actorScopeCookie, {
+        name: `QA TC-UMES-021 Org ${suffix}`,
+        tenantId: targetTenantId,
       })
 
-      const organizationACookie = buildScopeCookie(tenantId, organizationAId)
-      const organizationBCookie = buildScopeCookie(tenantId, organizationBId)
+      const exactTargetCookie = buildScopeCookie(targetTenantId, targetOrganizationId)
+      const paddedTargetCookie = buildScopeCookie(targetTenantId, targetOrganizationId, {
+        padOrganization: true,
+      })
 
-      personAId = await createPersonInScope(request, token, organizationACookie, {
+      targetPersonId = await createPersonInScope(request, token, exactTargetCookie, {
         firstName: `QA-${suffix}`,
-        lastName: 'ScopeA',
-        displayName: `QA Scope A ${suffix}`,
-      })
-      personBId = await createPersonInScope(request, token, organizationBCookie, {
-        firstName: `QA-${suffix}`,
-        lastName: 'ScopeB',
-        displayName: `QA Scope B ${suffix}`,
+        lastName: 'ScopeTrim',
+        displayName: `QA Scope Trim ${suffix}`,
       })
 
-      priorityAId = await createPriorityInScope(request, token, organizationACookie, {
-        customerId: personAId,
-        priority: 'high',
-      })
-      priorityBId = await createPriorityInScope(request, token, organizationBCookie, {
-        customerId: personBId,
+      targetPriorityId = await createPriorityInScope(request, token, exactTargetCookie, {
+        customerId: targetPersonId,
         priority: 'normal',
       })
 
-      const blockedUpdate = await scopedApiRequest(request, 'PUT', '/api/example/customer-priorities', {
+      const trimmedScopeUpdate = await scopedApiRequest(request, 'PUT', '/api/example/customer-priorities', {
         token,
-        cookie: organizationBCookie,
-        data: { id: priorityAId, priority: 'critical' },
+        cookie: paddedTargetCookie,
+        data: { id: targetPriorityId, priority: 'critical' },
       })
-      expect(blockedUpdate.status(), 'Cross-organization update should not find the record').toBe(404)
+      expect(
+        trimmedScopeUpdate.ok(),
+        'Whitespace-padded selected organization should still match the target record during superadmin tenant override update',
+      ).toBeTruthy()
 
-      const allowedUpdate = await scopedApiRequest(request, 'PUT', '/api/example/customer-priorities', {
+      const prioritiesAfterUpdate = await listPrioritiesInScope(
+        request,
         token,
-        cookie: organizationBCookie,
-        data: { id: priorityBId, priority: 'critical' },
-      })
-      expect(allowedUpdate.ok(), 'Same-organization update should succeed').toBeTruthy()
+        exactTargetCookie,
+        targetPersonId,
+      )
+      expect(prioritiesAfterUpdate).toHaveLength(1)
+      expect(prioritiesAfterUpdate[0]?.priority).toBe('critical')
 
-      const prioritiesInOrganizationA = await listPrioritiesInScope(request, token, organizationACookie, personAId)
-      expect(prioritiesInOrganizationA).toHaveLength(1)
-      expect(prioritiesInOrganizationA[0]?.priority).toBe('high')
-
-      const prioritiesInOrganizationB = await listPrioritiesInScope(request, token, organizationBCookie, personBId)
-      expect(prioritiesInOrganizationB).toHaveLength(1)
-      expect(prioritiesInOrganizationB[0]?.priority).toBe('critical')
-
-      const blockedDelete = await scopedApiRequest(request, 'DELETE', '/api/example/customer-priorities', {
+      const trimmedScopeDelete = await scopedApiRequest(request, 'DELETE', '/api/example/customer-priorities', {
         token,
-        cookie: organizationBCookie,
-        data: { id: priorityAId },
+        cookie: paddedTargetCookie,
+        data: { id: targetPriorityId },
       })
-      expect(blockedDelete.status(), 'Cross-organization delete should not find the record').toBe(404)
+      expect(
+        trimmedScopeDelete.ok(),
+        'Whitespace-padded selected organization should still match the target record during superadmin tenant override delete',
+      ).toBeTruthy()
+      targetPriorityId = null
 
-      const allowedDelete = await scopedApiRequest(request, 'DELETE', '/api/example/customer-priorities', {
+      const remainingPriorities = await listPrioritiesInScope(
+        request,
         token,
-        cookie: organizationACookie,
-        data: { id: priorityAId },
-      })
-      expect(allowedDelete.ok(), 'Same-organization delete should succeed').toBeTruthy()
-      priorityAId = null
-
-      const remainingPrioritiesInOrganizationA = await listPrioritiesInScope(request, token, organizationACookie, personAId)
-      expect(remainingPrioritiesInOrganizationA).toHaveLength(0)
+        exactTargetCookie,
+        targetPersonId,
+      )
+      expect(remainingPriorities).toHaveLength(0)
     } finally {
-      const organizationACookie = organizationAId ? buildScopeCookie(tenantId, organizationAId) : rootCookie
-      const organizationBCookie = organizationBId ? buildScopeCookie(tenantId, organizationBId) : rootCookie
+      const exactTargetCookie =
+        targetTenantId && targetOrganizationId
+          ? buildScopeCookie(targetTenantId, targetOrganizationId)
+          : actorScopeCookie
 
-      await deleteByBodyIfExists(request, token, organizationBCookie, '/api/example/customer-priorities', priorityBId)
-      await deleteByBodyIfExists(request, token, organizationACookie, '/api/example/customer-priorities', priorityAId)
-      await deleteByQueryIfExists(request, token, organizationBCookie, '/api/customers/people', personBId)
-      await deleteByQueryIfExists(request, token, organizationACookie, '/api/customers/people', personAId)
-      await deleteByQueryIfExists(request, token, rootCookie, '/api/directory/organizations', organizationBId)
-      await deleteByQueryIfExists(request, token, rootCookie, '/api/directory/organizations', organizationAId)
+      await deleteByBodyIfExists(request, token, exactTargetCookie, '/api/example/customer-priorities', targetPriorityId)
+      await deleteByQueryIfExists(request, token, exactTargetCookie, '/api/customers/people', targetPersonId)
+      await deleteByQueryIfExists(request, token, actorScopeCookie, '/api/directory/organizations', targetOrganizationId)
+      await deleteByQueryIfExists(request, token, actorScopeCookie, '/api/directory/tenants', targetTenantId)
     }
   })
 })

--- a/apps/mercato/src/modules/example/__integration__/TC-UMES-021.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/TC-UMES-021.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { expectId, getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+type IdResponse = {
+  id?: string | null
+}
+
+type PriorityListResponse = {
+  items?: Array<{
+    id?: string | null
+    priority?: string | null
+  }>
+}
+
+function buildScopeCookie(tenantId: string, organizationId: string | null): string {
+  const parts = [`om_selected_tenant=${encodeURIComponent(tenantId)}`]
+  if (organizationId) {
+    parts.push(`om_selected_org=${encodeURIComponent(organizationId)}`)
+  }
+  return parts.join('; ')
+}
+
+async function scopedApiRequest(
+  request: APIRequestContext,
+  method: string,
+  path: string,
+  options: { token: string; cookie: string; data?: unknown },
+) {
+  return request.fetch(path, {
+    method,
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      'Content-Type': 'application/json',
+      Cookie: options.cookie,
+    },
+    data: options.data,
+  })
+}
+
+async function createOrganizationInScope(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  input: { name: string; tenantId: string },
+): Promise<string> {
+  const response = await scopedApiRequest(request, 'POST', '/api/directory/organizations', {
+    token,
+    cookie,
+    data: input,
+  })
+  const body = await readJsonSafe<IdResponse>(response)
+  expect(response.ok(), `POST /api/directory/organizations failed with ${response.status()}`).toBeTruthy()
+  return expectId(body?.id, 'Organization create response should include id')
+}
+
+async function createPersonInScope(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  input: { firstName: string; lastName: string; displayName: string },
+): Promise<string> {
+  const response = await scopedApiRequest(request, 'POST', '/api/customers/people', {
+    token,
+    cookie,
+    data: input,
+  })
+  const body = await readJsonSafe<IdResponse>(response)
+  expect(response.ok(), `POST /api/customers/people failed with ${response.status()}`).toBeTruthy()
+  return expectId(body?.id, 'Person create response should include id')
+}
+
+async function createPriorityInScope(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  input: { customerId: string; priority: 'low' | 'normal' | 'high' | 'critical' },
+): Promise<string> {
+  const response = await scopedApiRequest(request, 'POST', '/api/example/customer-priorities', {
+    token,
+    cookie,
+    data: input,
+  })
+  const body = await readJsonSafe<IdResponse>(response)
+  expect(response.ok(), `POST /api/example/customer-priorities failed with ${response.status()}`).toBeTruthy()
+  return expectId(body?.id, 'Priority create response should include id')
+}
+
+async function listPrioritiesInScope(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  customerId: string,
+) {
+  const response = await scopedApiRequest(
+    request,
+    'GET',
+    `/api/example/customer-priorities?customerId=${encodeURIComponent(customerId)}&page=1&pageSize=10`,
+    { token, cookie },
+  )
+  expect(response.ok(), `GET /api/example/customer-priorities failed with ${response.status()}`).toBeTruthy()
+  const body = await readJsonSafe<PriorityListResponse>(response)
+  return Array.isArray(body?.items) ? body.items : []
+}
+
+async function deleteByQueryIfExists(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  path: string,
+  id: string | null,
+): Promise<void> {
+  if (!id) return
+  await scopedApiRequest(request, 'DELETE', `${path}?id=${encodeURIComponent(id)}`, { token, cookie }).catch(() => {})
+}
+
+async function deleteByBodyIfExists(
+  request: APIRequestContext,
+  token: string,
+  cookie: string,
+  path: string,
+  id: string | null,
+): Promise<void> {
+  if (!id) return
+  await scopedApiRequest(request, 'DELETE', path, { token, cookie, data: { id } }).catch(() => {})
+}
+
+/**
+ * TC-UMES-021: shared CRUD scope helper blocks cross-organization direct mutations
+ */
+test.describe('TC-UMES-021: shared CRUD scope helper blocks cross-organization direct mutations', () => {
+  test('should keep direct update/delete scoped to the selected organization', async ({ request }) => {
+    const token = await getAuthToken(request, 'superadmin')
+    const { tenantId, organizationId } = getTokenContext(token)
+    expect(tenantId, 'Superadmin token should include a tenant id').toBeTruthy()
+
+    const rootCookie = buildScopeCookie(tenantId, organizationId || null)
+    const suffix = Date.now()
+    let organizationAId: string | null = null
+    let organizationBId: string | null = null
+    let personAId: string | null = null
+    let personBId: string | null = null
+    let priorityAId: string | null = null
+    let priorityBId: string | null = null
+
+    try {
+      organizationAId = await createOrganizationInScope(request, token, rootCookie, {
+        name: `QA TC-UMES-021 Org A ${suffix}`,
+        tenantId,
+      })
+      organizationBId = await createOrganizationInScope(request, token, rootCookie, {
+        name: `QA TC-UMES-021 Org B ${suffix}`,
+        tenantId,
+      })
+
+      const organizationACookie = buildScopeCookie(tenantId, organizationAId)
+      const organizationBCookie = buildScopeCookie(tenantId, organizationBId)
+
+      personAId = await createPersonInScope(request, token, organizationACookie, {
+        firstName: `QA-${suffix}`,
+        lastName: 'ScopeA',
+        displayName: `QA Scope A ${suffix}`,
+      })
+      personBId = await createPersonInScope(request, token, organizationBCookie, {
+        firstName: `QA-${suffix}`,
+        lastName: 'ScopeB',
+        displayName: `QA Scope B ${suffix}`,
+      })
+
+      priorityAId = await createPriorityInScope(request, token, organizationACookie, {
+        customerId: personAId,
+        priority: 'high',
+      })
+      priorityBId = await createPriorityInScope(request, token, organizationBCookie, {
+        customerId: personBId,
+        priority: 'normal',
+      })
+
+      const blockedUpdate = await scopedApiRequest(request, 'PUT', '/api/example/customer-priorities', {
+        token,
+        cookie: organizationBCookie,
+        data: { id: priorityAId, priority: 'critical' },
+      })
+      expect(blockedUpdate.status(), 'Cross-organization update should not find the record').toBe(404)
+
+      const allowedUpdate = await scopedApiRequest(request, 'PUT', '/api/example/customer-priorities', {
+        token,
+        cookie: organizationBCookie,
+        data: { id: priorityBId, priority: 'critical' },
+      })
+      expect(allowedUpdate.ok(), 'Same-organization update should succeed').toBeTruthy()
+
+      const prioritiesInOrganizationA = await listPrioritiesInScope(request, token, organizationACookie, personAId)
+      expect(prioritiesInOrganizationA).toHaveLength(1)
+      expect(prioritiesInOrganizationA[0]?.priority).toBe('high')
+
+      const prioritiesInOrganizationB = await listPrioritiesInScope(request, token, organizationBCookie, personBId)
+      expect(prioritiesInOrganizationB).toHaveLength(1)
+      expect(prioritiesInOrganizationB[0]?.priority).toBe('critical')
+
+      const blockedDelete = await scopedApiRequest(request, 'DELETE', '/api/example/customer-priorities', {
+        token,
+        cookie: organizationBCookie,
+        data: { id: priorityAId },
+      })
+      expect(blockedDelete.status(), 'Cross-organization delete should not find the record').toBe(404)
+
+      const allowedDelete = await scopedApiRequest(request, 'DELETE', '/api/example/customer-priorities', {
+        token,
+        cookie: organizationACookie,
+        data: { id: priorityAId },
+      })
+      expect(allowedDelete.ok(), 'Same-organization delete should succeed').toBeTruthy()
+      priorityAId = null
+
+      const remainingPrioritiesInOrganizationA = await listPrioritiesInScope(request, token, organizationACookie, personAId)
+      expect(remainingPrioritiesInOrganizationA).toHaveLength(0)
+    } finally {
+      const organizationACookie = organizationAId ? buildScopeCookie(tenantId, organizationAId) : rootCookie
+      const organizationBCookie = organizationBId ? buildScopeCookie(tenantId, organizationBId) : rootCookie
+
+      await deleteByBodyIfExists(request, token, organizationBCookie, '/api/example/customer-priorities', priorityBId)
+      await deleteByBodyIfExists(request, token, organizationACookie, '/api/example/customer-priorities', priorityAId)
+      await deleteByQueryIfExists(request, token, organizationBCookie, '/api/customers/people', personBId)
+      await deleteByQueryIfExists(request, token, organizationACookie, '/api/customers/people', personAId)
+      await deleteByQueryIfExists(request, token, rootCookie, '/api/directory/organizations', organizationBId)
+      await deleteByQueryIfExists(request, token, rootCookie, '/api/directory/organizations', organizationAId)
+    }
+  })
+})

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -1,0 +1,59 @@
+import type { AwilixContainer } from 'awilix'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '../organizationScope'
+
+describe('resolveOrganizationScopeForRequest', () => {
+  it('trims whitespace-padded selected organization cookies during superadmin tenant override', async () => {
+    const em = {
+      find: jest.fn(async (_entity: unknown, where: { id?: { $in?: string[] } }) => {
+        const ids = Array.isArray(where.id?.$in) ? where.id.$in : []
+        if (!ids.includes('org-1')) return []
+        return [{ id: 'org-1', descendantIds: ['org-1-child'] }]
+      }),
+    }
+    const rbac = {
+      loadAcl: jest.fn(async () => ({ isSuperAdmin: true, organizations: null })),
+    }
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'rbacService') return rbac
+        throw new Error(`Unexpected dependency: ${name}`)
+      },
+    }
+
+    const scope = await resolveOrganizationScopeForRequest({
+      container: container as unknown as AwilixContainer,
+      auth: {
+        sub: 'superadmin-user',
+        tenantId: 'actor-tenant',
+        orgId: 'actor-org',
+        isSuperAdmin: true,
+        roles: ['superadmin'],
+      } as unknown as AuthContext,
+      request: {
+        headers: {
+          get: (name: string) => name === 'cookie'
+            ? 'om_selected_tenant=target-tenant; om_selected_org=%20org-1%20'
+            : null,
+        },
+      },
+    })
+
+    expect(rbac.loadAcl).toHaveBeenCalledWith('superadmin-user', {
+      tenantId: 'target-tenant',
+      organizationId: null,
+    })
+    expect(em.find).toHaveBeenCalledWith(expect.anything(), {
+      tenant: 'target-tenant',
+      id: { $in: ['org-1'] },
+      deletedAt: null,
+    })
+    expect(scope).toEqual({
+      selectedId: 'org-1',
+      filterIds: ['org-1', 'org-1-child'],
+      allowedIds: null,
+      tenantId: 'target-tenant',
+    })
+  })
+})

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -1,6 +1,241 @@
+/** @jest-environment node */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
 import type { AwilixContainer } from 'awilix'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
-import { resolveOrganizationScopeForRequest } from '../organizationScope'
+import { ALL_ORGANIZATIONS_COOKIE_VALUE } from '@open-mercato/core/modules/directory/constants'
+import { resolveOrganizationScope, resolveOrganizationScopeForRequest } from '../organizationScope'
+
+/**
+ * Creates a mock EntityManager whose `find` returns Organization-like rows
+ * that match the requested ids.
+ */
+function createMockEm(rows: Array<{ id: string; descendantIds: string[] }>) {
+  return {
+    find: jest.fn((_entity: unknown, filter: { id?: { $in: string[] }; tenant?: string }) => {
+      const requestedIds = filter?.id?.$in ?? []
+      return Promise.resolve(
+        rows.filter((row) => requestedIds.includes(row.id)),
+      )
+    }),
+  } as unknown as EntityManager
+}
+
+function createMockRbac(aclResult: { isSuperAdmin: boolean; features: string[]; organizations: string[] | null }) {
+  return {
+    loadAcl: jest.fn().mockResolvedValue(aclResult),
+  } as unknown as RbacService
+}
+
+function createAuth(overrides: Partial<AuthContext> & { sub: string }): AuthContext {
+  return {
+    tenantId: 'tenant-1',
+    orgId: 'org-home',
+    isSuperAdmin: false,
+    ...overrides,
+  } as AuthContext
+}
+
+const ORG_HOME = { id: 'org-home', descendantIds: ['org-home-child'] }
+const ORG_A = { id: 'org-a', descendantIds: [] }
+const ORG_B = { id: 'org-b', descendantIds: ['org-b-child'] }
+const ALL_ORGS = [ORG_HOME, ORG_A, ORG_B]
+
+describe('resolveOrganizationScope', () => {
+  describe('unauthenticated / missing context', () => {
+    it('returns null scope when auth.sub is missing', async () => {
+      const em = createMockEm([])
+      const rbac = createMockRbac({ isSuperAdmin: false, features: [], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: {} as AuthContext,
+      })
+      expect(result).toEqual({ selectedId: null, filterIds: null, allowedIds: null, tenantId: null })
+    })
+
+    it('returns null scope when tenantId is empty', async () => {
+      const em = createMockEm([])
+      const rbac = createMockRbac({ isSuperAdmin: false, features: [], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', tenantId: '' }),
+      })
+      expect(result).toEqual({ selectedId: null, filterIds: null, allowedIds: null, tenantId: null })
+    })
+  })
+
+  describe('superAdmin behavior', () => {
+    it('returns null filterIds when superAdmin selects "All Organizations"', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+      expect(result.tenantId).toBe('tenant-1')
+    })
+
+    it('returns null filterIds when superAdmin has no org selection', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true }),
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+    })
+
+    it('scopes to specific org + descendants when superAdmin selects one', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-b', 'org-b-child']))
+    })
+  })
+
+  describe('non-superAdmin with __all__ ACL access (issue #1112)', () => {
+    it('returns null filterIds when user with unrestricted ACL selects "All Organizations"', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+      expect(result.allowedIds).toBeNull()
+      expect(result.tenantId).toBe('tenant-1')
+    })
+
+    it('returns null filterIds when ACL organizations array contains __all__ token', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: [ALL_ORGANIZATIONS_COOKIE_VALUE],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+      expect(result.allowedIds).toBeNull()
+    })
+
+    it('scopes to specific org when user with unrestricted ACL selects one', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: 'org-a',
+      })
+      expect(result.selectedId).toBe('org-a')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a']))
+    })
+
+    it('falls back to home org when user with unrestricted ACL has no selection', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+      })
+      expect(result.selectedId).toBe('org-home')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-home', 'org-home-child']))
+    })
+  })
+
+  describe('non-superAdmin with restricted ACL (specific org list)', () => {
+    it('does not widen to all orgs when "All Organizations" is selected but ACL is restricted', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a', 'org-b'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).not.toBeNull()
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a', 'org-b', 'org-b-child']))
+    })
+
+    it('scopes to selected org when it is in the allowed list', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a', 'org-b'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-b', 'org-b-child']))
+    })
+
+    it('falls back to allowed set when selected org is not in ACL', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).not.toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a']))
+    })
+  })
+
+  describe('ACL-level superAdmin flag', () => {
+    it('treats ACL-level isSuperAdmin same as auth-level for org scope widening', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+    })
+  })
+})
 
 describe('resolveOrganizationScopeForRequest', () => {
   it('trims whitespace-padded selected organization cookies during superadmin tenant override', async () => {

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -16,6 +16,12 @@ export type OrganizationScope = {
   tenantId: string | null
 }
 
+function normalizeOrganizationId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
 export function getSelectedOrganizationFromRequest(req: Request | { cookies?: { get: (name: string) => { value: string } | undefined }; headers?: { get(name: string): string | null } }): string | null {
   const cookieContainer = (req as { cookies?: { get: (name: string) => { value: string } | undefined } }).cookies
   if (cookieContainer && typeof cookieContainer.get === 'function') {
@@ -43,7 +49,7 @@ export function getSelectedTenantFromRequest(
 async function collectWithDescendants(em: EntityManager, tenantId: string, ids: string[]): Promise<Set<string>> {
   if (!ids.length) return new Set()
   const unique = Array.from(new Set(
-    ids.filter((value): value is string => {
+    ids.map((value) => normalizeOrganizationId(value)).filter((value): value is string => {
       if (!value) return false
       if (isAllOrganizationsSelection(value)) return false
       return true
@@ -98,27 +104,30 @@ export async function resolveOrganizationScope({
   if (!tenantId) {
     return { selectedId: null, filterIds: null, allowedIds: null, tenantId: null }
   }
+  const normalizedRequestedSelection = normalizeOrganizationId(selectedId)
   const explicitAllOrgsChoice =
-    typeof selectedId === 'string' && isAllOrganizationsSelection(selectedId)
+    normalizedRequestedSelection !== null && isAllOrganizationsSelection(normalizedRequestedSelection)
   const normalizedSelectedId = explicitAllOrgsChoice
     ? null
-    : (selectedId ?? null)
-  const contextOrgId = actorTenantId && actorTenantId === tenantId ? auth.orgId ?? null : null
+    : normalizedRequestedSelection
+  const contextOrgId = actorTenantId && actorTenantId === tenantId ? normalizeOrganizationId(auth.orgId) : null
   const acl = await rbac.loadAcl(auth.sub, { tenantId, organizationId: contextOrgId })
   const aclIsSuperAdmin = acl?.isSuperAdmin === true
   const effectiveSuperAdmin = aclIsSuperAdmin || isSuperAdminActor
-  const rawAccessible = effectiveSuperAdmin
+  const normalizedAccessible = effectiveSuperAdmin
     ? null
     : Array.isArray(acl?.organizations)
-      ? acl.organizations.filter(Boolean)
+      ? acl.organizations
+        .map((value) => normalizeOrganizationId(value))
+        .filter((value): value is string => value !== null)
       : null
   const accessibleList = effectiveSuperAdmin
     ? null
-    : rawAccessible && rawAccessible.some((value) => typeof value === 'string' && isAllOrganizationsSelection(value))
+    : normalizedAccessible && normalizedAccessible.some((value) => isAllOrganizationsSelection(value))
       ? null
-      : rawAccessible?.filter((value): value is string => typeof value === 'string' && !isAllOrganizationsSelection(value)) ?? null
+      : normalizedAccessible?.filter((value) => !isAllOrganizationsSelection(value)) ?? null
 
-  const accountOrgId = actorTenantId && actorTenantId === tenantId ? auth.orgId ?? null : null
+  const accountOrgId = actorTenantId && actorTenantId === tenantId ? normalizeOrganizationId(auth.orgId) : null
   const fallbackOrgId = accountOrgId ?? null
   let fallbackSet: Set<string> | null = null
   const loadFallbackSet = async (): Promise<Set<string> | null> => {
@@ -146,7 +155,7 @@ export async function resolveOrganizationScope({
   }
 
   const hasUnrestrictedAccess = effectiveSuperAdmin || (accessibleList === null)
-  const noOrgSelection = selectedId == null
+  const noOrgSelection = normalizedSelectedId === null && !explicitAllOrgsChoice
   const widenToAllOrgs =
     (explicitAllOrgsChoice && hasUnrestrictedAccess)
     || (effectiveSuperAdmin && noOrgSelection)
@@ -210,19 +219,18 @@ export async function resolveOrganizationScopeForRequest({
   let rbac: RbacService | null = null
   try { em = container.resolve<EntityManager>('em') } catch { em = null }
   try { rbac = container.resolve<RbacService>('rbacService') } catch { rbac = null }
+  const normalizeString = (value: unknown): string | null => {
+    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
+    return null
+  }
   if (!em || !rbac) {
-    const fallbackSelected = selectedId ?? auth.orgId ?? null
+    const fallbackSelected = normalizeOrganizationId(selectedId ?? auth.orgId ?? null)
     return {
       selectedId: fallbackSelected,
       filterIds: fallbackSelected ? [fallbackSelected] : null,
       allowedIds: fallbackSelected ? [fallbackSelected] : null,
-      tenantId: auth.tenantId ?? null,
+      tenantId: normalizeString(auth.tenantId),
     }
-  }
-
-  const normalizeString = (value: unknown): string | null => {
-    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
-    return null
   }
 
   const actorTenantField = (auth as { actorTenantId?: string | null }).actorTenantId

--- a/packages/shared/src/lib/api/__tests__/crud.test.ts
+++ b/packages/shared/src/lib/api/__tests__/crud.test.ts
@@ -29,11 +29,11 @@ describe('buildScopedWhere', () => {
     expect(base).toEqual({ id: 'entity-1' })
   })
 
-  it('prefers organizationIds and collapses them to scalar or $in filters after sanitizing empty values', () => {
+  it('prefers organizationIds and collapses them to scalar or $in filters after trimming and sanitizing empty values', () => {
     expect(
       buildScopedWhere(
         { id: 'entity-1' },
-        { organizationId: 'org-ignored', organizationIds: ['org-1'], tenantId: 'tenant-1' }
+        { organizationId: 'org-ignored', organizationIds: [' org-1 '], tenantId: 'tenant-1' }
       )
     ).toEqual({
       id: 'entity-1',
@@ -45,7 +45,7 @@ describe('buildScopedWhere', () => {
     expect(
       buildScopedWhere(
         { id: 'entity-1' },
-        { organizationIds: ['org-1', '', 'org-2'], tenantId: 'tenant-1' }
+        { organizationIds: [' org-1 ', '   ', '', 'org-2  '], tenantId: 'tenant-1' }
       )
     ).toEqual({
       id: 'entity-1',

--- a/packages/shared/src/lib/api/crud.ts
+++ b/packages/shared/src/lib/api/crud.ts
@@ -13,7 +13,9 @@ export function buildScopedWhere(
 
   if (orgField) {
     if (scope.organizationIds !== undefined) {
-      const ids = (scope.organizationIds ?? []).filter((id): id is string => typeof id === 'string' && id.length > 0)
+      const ids = (scope.organizationIds ?? [])
+        .map((id) => (typeof id === 'string' ? id.trim() : id))
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
       if (ids.length === 0) {
         where[orgField] = { $in: [] }
       } else if (ids.length === 1) {

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -4,12 +4,21 @@ import { z } from 'zod'
 
 // ---- Mocks ----
 const mockEventBus = { emitEvent: jest.fn() }
+const defaultOrganizationId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const defaultTenantId = '123e4567-e89b-12d3-a456-426614174000'
+type MockOrganizationScope = {
+  selectedId: string | null
+  filterIds: string[] | null
+  allowedIds: string[] | null
+  tenantId: string | null
+}
 
 type Rec = { id: string; organizationId: string; tenantId: string; title?: string; isDone?: boolean; deletedAt?: Date | null }
 let db: Record<string, Rec>
 let idSeq = 1
 let commandBus: { execute: jest.Mock }
 let crudMutationGuardService: { validateMutation: jest.Mock; afterMutationSuccess: jest.Mock } | null
+let mockOrganizationScopeOverride: MockOrganizationScope | null
 
 const em = {
   create: (_cls: any, data: any) => ({ ...data, id: `id-${idSeq++}` }),
@@ -112,12 +121,26 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => {
-  const auth = { sub: 'u1', orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', tenantId: '123e4567-e89b-12d3-a456-426614174000', roles: ['admin'] }
+  const auth = {
+    sub: 'u1',
+    orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    tenantId: '123e4567-e89b-12d3-a456-426614174000',
+    roles: ['admin'],
+  }
   return {
     getAuthFromCookies: async () => auth,
     getAuthFromRequest: async () => auth,
   }
 })
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => mockOrganizationScopeOverride ?? ({
+    selectedId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    filterIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    allowedIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    tenantId: '123e4567-e89b-12d3-a456-426614174000',
+  })),
+}))
 
 const setRecordCustomFields = jest.fn(async () => {})
 jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
@@ -134,6 +157,7 @@ describe('CRUD Factory', () => {
     jest.clearAllMocks()
     accessLogService.log.mockClear()
     mockDataEngine.__pendingSideEffects = []
+    mockOrganizationScopeOverride = null
     commandBus = {
       execute: jest.fn(async () => ({ result: {}, logEntry: { id: 'log-1' } })),
     }
@@ -348,7 +372,7 @@ describe('CRUD Factory', () => {
 
   it('PUT updates entity, saves custom fields, emits updated event', async () => {
     // Seed
-    const created = em.create(Todo, { title: 'X', organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', tenantId: '123e4567-e89b-12d3-a456-426614174000' }) as Rec
+    const created = em.create(Todo, { title: 'X', organizationId: defaultOrganizationId, tenantId: defaultTenantId }) as Rec
     // Force UUID id to satisfy validation
     created.id = '123e4567-e89b-12d3-a456-426614174001'
     await em.persistAndFlush(created)
@@ -366,7 +390,7 @@ describe('CRUD Factory', () => {
   })
 
   it('DELETE soft-deletes entity and emits deleted event', async () => {
-    const created = em.create(Todo, { title: 'Y', organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', tenantId: '123e4567-e89b-12d3-a456-426614174000' }) as Rec
+    const created = em.create(Todo, { title: 'Y', organizationId: defaultOrganizationId, tenantId: defaultTenantId }) as Rec
     created.id = '123e4567-e89b-12d3-a456-426614174002'
     await em.persistAndFlush(created)
     const res = await route.DELETE(new Request(`http://x/api/example/todos?id=${created.id}`, { method: 'DELETE' }))
@@ -379,6 +403,46 @@ describe('CRUD Factory', () => {
     expect(deletedArgs.identifiers.id).toBe(created.id)
     expect(deletedArgs.indexer?.entityType).toBe('example.todo')
     expect(db[created.id].deletedAt).toBeInstanceOf(Date)
+  })
+
+  it('trims padded selected organization ids when scope resolution falls back from empty filter ids', async () => {
+    const created = em.create(Todo, { title: 'Scoped', organizationId: defaultOrganizationId, tenantId: defaultTenantId }) as Rec
+    created.id = '123e4567-e89b-12d3-a456-426614174052'
+    await em.persistAndFlush(created)
+    mockOrganizationScopeOverride = {
+      selectedId: ` ${defaultOrganizationId} `,
+      filterIds: [],
+      allowedIds: null,
+      tenantId: defaultTenantId,
+    }
+
+    const updateResponse = await route.PUT(new Request('http://x/api/example/todos', {
+      method: 'PUT',
+      body: JSON.stringify({ id: created.id, title: 'Scoped Updated' }),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(updateResponse.status).toBe(200)
+    expect(mockDataEngine.updateOrmEntity).toHaveBeenLastCalledWith(expect.objectContaining({
+      where: {
+        id: created.id,
+        organizationId: defaultOrganizationId,
+        tenantId: defaultTenantId,
+        deletedAt: null,
+      },
+    }))
+
+    const deleteResponse = await route.DELETE(new Request(`http://x/api/example/todos?id=${created.id}`, { method: 'DELETE' }))
+
+    expect(deleteResponse.status).toBe(200)
+    expect(mockDataEngine.deleteOrmEntity).toHaveBeenLastCalledWith(expect.objectContaining({
+      where: {
+        id: created.id,
+        organizationId: defaultOrganizationId,
+        tenantId: defaultTenantId,
+        deletedAt: null,
+      },
+    }))
   })
 
   it('PUT mutation guard uses route resource identity instead of spoofed lock headers', async () => {


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for crud.ts
## Problem Summary
tests: add low-level coverage for crud.ts
## Expected Behavior
packages/shared/src/lib/api/crud.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/shared/src/lib/api/crud.ts.
Checked: packages/shared/src/lib/api/crud.test.ts
packages/shared/src/lib/api/__tests__/crud.test.ts
packages/shared/src/lib/api/crud.spec.ts
packages/shared/src/lib/api/__tests__/crud.spec.ts ...
## What Changed
- apps/mercato/src/modules/example/__integration__/TC-UMES-021.spec.ts
- packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
- packages/core/src/modules/directory/utils/organizationScope.ts
- packages/shared/src/lib/api/__tests__/crud.test.ts
- packages/shared/src/lib/api/crud.ts
- packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
- Diff summary: +400 / -24 (424 total lines)
- Branch head: af5c32e1d66e7e1457c123970123d639fdcb2047
## Validation / Tests
- shared-package-checks
## Expected Contribution Classes
- tests
- bugfix