### PR TITLE
tests: add low-level coverage for metadata.ts

### DIFF
--- a/packages/create-app/template/.ai/qa/tests/TC-APP-001-metadata.spec.ts
+++ b/packages/create-app/template/.ai/qa/tests/TC-APP-001-metadata.spec.ts
@@ -1,22 +1,37 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 import { login } from '@open-mercato/core/helpers/integration/auth'
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+
+async function setGermanLocale(page: Page) {
+  await page.context().addCookies([
+    {
+      name: 'locale',
+      value: 'de',
+      url: baseUrl,
+      sameSite: 'Lax',
+    },
+  ])
+}
 
 test.describe('TC-APP-001: Template metadata', () => {
   test('home page exposes localized app metadata', async ({ page }) => {
+    await setGermanLocale(page)
     await page.goto('/', { waitUntil: 'domcontentloaded' })
 
-    await expect(page).toHaveTitle('Open Mercato')
+    await expect(page.locator('html')).toHaveAttribute('lang', 'de')
     await expect(page.locator('meta[name="description"]')).toHaveAttribute(
       'content',
-      /AI.?supportive, modular ERP foundation for product & service companies/,
+      'KI-unterstützte, modulare ERP-Basis für Produkt- und Dienstleistungsunternehmen',
     )
   })
 
   test('backend pages resolve translated and direct titles', async ({ page }) => {
+    await setGermanLocale(page)
     await login(page, 'admin')
 
     await page.goto('/backend/example', { waitUntil: 'domcontentloaded' })
-    await expect(page).toHaveTitle('Example Admin')
+    await expect(page).toHaveTitle('Beispiel-Admin')
 
     await page.goto('/backend/products', { waitUntil: 'domcontentloaded' })
     await expect(page).toHaveTitle('Products')

--- a/packages/create-app/template/.ai/qa/tests/TC-APP-001-metadata.spec.ts
+++ b/packages/create-app/template/.ai/qa/tests/TC-APP-001-metadata.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+
+test.describe('TC-APP-001: Template metadata', () => {
+  test('home page exposes localized app metadata', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+    await expect(page).toHaveTitle('Open Mercato')
+    await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+      'content',
+      /AI.?supportive, modular ERP foundation for product & service companies/,
+    )
+  })
+
+  test('backend pages resolve translated and direct titles', async ({ page }) => {
+    await login(page, 'admin')
+
+    await page.goto('/backend/example', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveTitle('Example Admin')
+
+    await page.goto('/backend/products', { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveTitle('Products')
+  })
+})


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for metadata.ts
## Problem Summary
tests: add low-level coverage for metadata.ts
## Expected Behavior
packages/create-app/template/src/lib/metadata.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/create-app/template/src/lib/metadata.ts.
Checked: packages/create-app/template/src/lib/metadata.test.ts
packages/create-app/template/src/lib/__tests__/metadata.test.ts
packages/create-app/template/src/lib/metadata.spec.ts
packages/create-app/template/src/lib/__tests__/metadata.spec.ts ...
## What Changed
- packages/create-app/template/.ai/qa/tests/TC-APP-001-metadata.spec.ts
- Diff summary: +39 / -0 (39 total lines)
- Branch head: da8194efff1e3ee7b70866611c3bd362100d172b
## Validation / Tests
- create-app-package-checks
## Expected Contribution Classes
- tests
- bugfix