### PR TITLE
tests: add low-level coverage for module-registry.ts

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -218,6 +218,16 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 
 **Applies to**: Any AI tool that requires the LLM to construct structured payloads (API calls, database queries, form submissions).
 
+## HackOn tasks that call for Playwright coverage need a real `__integration__` diff
+
+**Context**: A module-registry testing task added only Jest coverage under `packages/cli/src/lib/generators/__tests__`, while the task contract and reviewer notes explicitly required Playwright integration coverage.
+
+**Problem**: The low-level tests passed, but review still blocked because the change never exercised the behavior through the real app runtime and did not update any module-local `__integration__/TC-*.spec.ts` coverage.
+
+**Rule**: When a task explicitly says to create or repair Playwright integration coverage, pair unit or low-level generator tests with at least one `__integration__/TC-*.spec.ts` change that validates the live runtime path. For CLI and generator work, use standalone `create-app` parity when the risk is specific to compiled package discovery.
+
+**Applies to**: HackOn tasks, CLI generator changes, standalone parity work, and any task that references `.ai/qa/AGENTS.md` or the `integration-tests` skill.
+
 ## Format Zod validation errors for LLM consumption
 
 **Context**: When the API returns 400 errors with raw Zod validation output (nested `issues[]` arrays, `fieldErrors` maps, or raw arrays), the LLM struggles to interpret the error structure and extract actionable fix instructions.

--- a/packages/cli/src/lib/generators/__tests__/module-subset.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/module-subset.test.ts
@@ -229,6 +229,46 @@ describe('generateModuleRegistry with module subsets', () => {
     expect(output).toContain('subscriber_meta:on-event')
   })
 
+  it('extracts typed subscriber metadata from source export lists when runtime import fails', async () => {
+    touchFile(
+      path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'subscriber_typed', 'subscribers', 'on-event.ts'),
+      `type SubscriberMeta = {
+  id?: string
+  event: string
+  persistent?: boolean
+  sync?: boolean
+  priority?: number
+}
+
+const metadata: SubscriberMeta = ({
+  id: 'subscriber_typed:on-event',
+  event: 'subscriber.typed.created',
+  persistent: true,
+  sync: true,
+  priority: 7,
+} as SubscriberMeta)
+
+export { metadata }
+
+export default async function handler() {}
+`,
+    )
+
+    const enabled: ModuleEntry[] = [
+      { id: 'subscriber_typed', from: '@open-mercato/core' },
+    ]
+    const resolver = createMockResolver(tmpDir, enabled)
+    const result = await generateModuleRegistry({ resolver, quiet: true })
+
+    expect(result.errors).toEqual([])
+    const output = readGenerated(tmpDir, 'modules.generated.ts')!
+    expect(output).toContain('id: "subscriber_typed:on-event"')
+    expect(output).toContain('event: "subscriber.typed.created"')
+    expect(output).toContain('persistent: true')
+    expect(output).toContain('sync: true')
+    expect(output).toContain('priority: 7')
+  })
+
   it('keeps backend route metadata runtime-backed when icons are non-serializable', async () => {
     touchFile(
       path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'iconic', 'backend', 'dashboard', 'page.tsx'),
@@ -248,6 +288,40 @@ describe('generateModuleRegistry with module subsets', () => {
     expect(result.errors).toEqual([])
     const output = readGenerated(tmpDir, 'backend-routes.generated.ts')!
     expect(output).toMatch(/import \* as .* from "@open-mercato\/core\/modules\/iconic\/backend\/dashboard\/page\.meta"/)
+    expect(output).not.toContain('"pageTitle":"Dashboard"')
+    expect(output).toContain('pattern: "/backend/dashboard"')
+  })
+
+  it('keeps backend route metadata runtime-backed when source metadata includes visible callbacks', async () => {
+    touchFile(
+      path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'gated_pages', 'backend', 'dashboard', 'page.tsx'),
+      'export default function Page() { return null }\n',
+    )
+    touchFile(
+      path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'gated_pages', 'backend', 'dashboard', 'page.meta.ts'),
+      `type PageMetadata = {
+  requireAuth: boolean
+  pageTitle: string
+  visible: () => boolean
+}
+
+export const metadata: PageMetadata = {
+  requireAuth: true,
+  pageTitle: 'Dashboard',
+  visible: () => true,
+}
+`,
+    )
+
+    const enabled: ModuleEntry[] = [
+      { id: 'gated_pages', from: '@open-mercato/core' },
+    ]
+    const resolver = createMockResolver(tmpDir, enabled)
+    const result = await generateModuleRegistry({ resolver, quiet: true })
+
+    expect(result.errors).toEqual([])
+    const output = readGenerated(tmpDir, 'backend-routes.generated.ts')!
+    expect(output).toMatch(/import \* as .* from "@open-mercato\/core\/modules\/gated_pages\/backend\/dashboard\/page\.meta"/)
     expect(output).not.toContain('"pageTitle":"Dashboard"')
     expect(output).toContain('pattern: "/backend/dashboard"')
   })
@@ -655,6 +729,40 @@ export default async function handle(): Promise<void> {}
     expect(output).toContain('concurrency: 2')
     expect(output).toContain('createLazyModuleWorker(() => import("../../src/modules/app_worker_mod/workers/process-job")')
     expect(output).toContain("workers:")
+  })
+
+  it('extracts typed worker metadata from source fallback when runtime import fails', async () => {
+    touchFile(
+      path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'worker_typed', 'workers', 'process-job.ts'),
+      `type WorkerMeta = {
+  id?: string
+  queue: string
+  concurrency?: number
+}
+
+export const metadata = ({
+  id: 'worker_typed:process-job',
+  queue: 'typed.jobs',
+  concurrency: 4,
+} as WorkerMeta)
+
+export default async function handler() {}
+`,
+    )
+
+    const resolver = createMockResolver(tmpDir, [
+      { id: 'worker_typed', from: '@open-mercato/core' },
+    ])
+
+    const result = await generateModuleRegistry({ resolver, quiet: true })
+
+    expect(result.errors).toEqual([])
+    const output = readGenerated(tmpDir, 'modules.generated.ts')!
+    expect(output).toContain('id: "worker_typed"')
+    expect(output).toContain('queue: "typed.jobs"')
+    expect(output).toContain('concurrency: 4')
+    expect(output).toContain('worker_typed:process-job')
+    expect(output).toContain('createLazyModuleWorker(() => import("@open-mercato/core/modules/worker_typed/workers/process-job")')
   })
 
   it('handles disabling a module that was previously enabled', async () => {

--- a/packages/create-app/template/src/modules/example/__integration__/TC-UMES-011.spec.ts
+++ b/packages/create-app/template/src/modules/example/__integration__/TC-UMES-011.spec.ts
@@ -1,8 +1,8 @@
 /**
- * TC-UMES-011: CLI Commands + Conflict Detection (SPEC-041k)
+ * TC-UMES-011: CLI Commands + Generated Registry Parity + Conflict Detection (SPEC-041k)
  *
  * Validates the UMES CLI commands (umes:list, umes:inspect, umes:check)
- * and build-time conflict detection during `yarn generate`.
+ * together with generated module-registry outputs and build-time conflict detection.
  *
  * Spec reference: SPEC-041k — DevTools + Conflict Detection (TC-UMES-DT02)
  */
@@ -10,6 +10,8 @@ import { test, expect } from '@playwright/test'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
 import {
   detectConflicts,
   detectComponentOverrideConflicts,
@@ -46,6 +48,22 @@ function resolveMercatoBin(): string {
 
 const MERCATO_BIN = resolveMercatoBin()
 
+function resolveGeneratedDir(): string {
+  const candidates = [
+    path.join(ROOT, '.mercato', 'generated'),
+    path.join(ROOT, 'apps', 'mercato', '.mercato', 'generated'),
+  ]
+
+  const match = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!match) {
+    throw new Error(`Could not find generated output directory. Checked: ${candidates.join(', ')}`)
+  }
+
+  return match
+}
+
+const GENERATED_DIR = resolveGeneratedDir()
+
 function runMercato(args: string[]): { stdout: string; stderr: string; exitCode: number } {
   const result = spawnSync(MERCATO_BIN, args, {
     cwd: ROOT,
@@ -59,6 +77,10 @@ function runMercato(args: string[]): { stdout: string; stderr: string; exitCode:
     stderr: result.stderr ?? '',
     exitCode: result.status ?? 1,
   }
+}
+
+function readGeneratedOutput(filename: string): string {
+  return fs.readFileSync(path.join(GENERATED_DIR, filename), 'utf8')
 }
 
 test.describe('TC-UMES-011: CLI commands', () => {
@@ -98,6 +120,42 @@ test.describe('TC-UMES-011: CLI commands', () => {
 
     // Should indicate no errors found
     expect(stdout.toLowerCase()).toMatch(/no (conflict|error)|0 error/i)
+  })
+
+  test('generated module-registry outputs include app and package module routes', () => {
+    const modulesOutput = readGeneratedOutput('modules.generated.ts')
+    const frontendRoutesOutput = readGeneratedOutput('frontend-routes.generated.ts')
+    const backendRoutesOutput = readGeneratedOutput('backend-routes.generated.ts')
+    const apiRoutesOutput = readGeneratedOutput('api-routes.generated.ts')
+
+    expect(modulesOutput).toContain('id: "example"')
+    expect(modulesOutput).toContain('id: "customers"')
+    expect(frontendRoutesOutput).toContain('pattern: "/login"')
+    expect(backendRoutesOutput).toContain('pattern: "/backend/example"')
+    expect(backendRoutesOutput).toContain('pattern: "/backend/customers/people"')
+    expect(apiRoutesOutput).toContain('path: "/example/todos"')
+    expect(apiRoutesOutput).toContain('path: "/customers/people"')
+  })
+
+  test('generated module-registry routes resolve through the live app runtime', async ({ page, request }) => {
+    await page.goto('/login', { waitUntil: 'domcontentloaded' })
+    await page.waitForSelector('form[data-auth-ready="1"]', { state: 'visible' })
+
+    await login(page, 'admin')
+    await page.goto('/backend/example', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByRole('heading', { name: 'Example Admin' })).toBeVisible()
+
+    const token = await getAuthToken(request, 'admin')
+
+    const appApiResponse = await apiRequest(request, 'GET', '/api/example/todos?page=1&pageSize=1', { token })
+    expect(appApiResponse.ok()).toBeTruthy()
+    const appApiBody = await appApiResponse.json()
+    expect(Array.isArray(appApiBody.data)).toBe(true)
+
+    const packageApiResponse = await apiRequest(request, 'GET', '/api/customers/people?page=1&pageSize=1', { token })
+    expect(packageApiResponse.ok()).toBeTruthy()
+    const packageApiBody = await packageApiResponse.json()
+    expect(Array.isArray(packageApiBody.data)).toBe(true)
   })
 })
 


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for module-registry.ts
## Problem Summary
tests: add low-level coverage for module-registry.ts
## Expected Behavior
packages/cli/src/lib/generators/module-registry.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/cli/src/lib/generators/module-registry.ts.
Checked: packages/cli/src/lib/generators/module-registry.test.ts
packages/cli/src/lib/generators/__tests__/module-registry.test.ts
packages/cli/src/lib/generators/module-registry.spec.ts
packages/cli/src/lib/generators/__tests__/module-registry.spec.ts ...
## What Changed
- .ai/lessons.md
- packages/cli/src/lib/generators/__tests__/module-subset.test.ts
- packages/create-app/template/src/modules/example/__integration__/TC-UMES-011.spec.ts
- Diff summary: +178 / -2 (180 total lines)
- Branch head: 5a9a4d7966f129edf557566048115b60a21821bf
## Validation / Tests
- cli-package-checks
## Expected Contribution Classes
- tests
- bugfix