### PR TITLE
test: regression test for quote-to-order document number (#919)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/quoteConvertNumber.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/quoteConvertNumber.test.ts
@@ -1,0 +1,244 @@
+/** @jest-environment node */
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string, fallback?: string) => fallback ?? key,
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    sales: {
+      sales_order: 'sales.sales_order',
+      sales_order_line: 'sales.sales_order_line',
+      sales_quote: 'sales.sales_quote',
+      sales_quote_line: 'sales.sales_quote_line',
+      sales_quote_adjustment: 'sales.sales_quote_adjustment',
+    },
+  },
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn().mockResolvedValue({}),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+  findOneWithDecryption: jest.fn().mockResolvedValue(null),
+}))
+
+function buildQuote(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    organizationId: '11111111-1111-4111-8111-111111111111',
+    tenantId: '00000000-0000-4000-8000-000000000000',
+    quoteNumber: 'QUOTE-20260310-00007',
+    statusEntryId: null,
+    status: 'draft',
+    customerEntityId: null,
+    customerContactId: null,
+    customerSnapshot: null,
+    billingAddressId: null,
+    shippingAddressId: null,
+    billingAddressSnapshot: null,
+    shippingAddressSnapshot: null,
+    currencyCode: 'USD',
+    validFrom: null,
+    validUntil: null,
+    comments: null,
+    taxInfo: null,
+    shippingMethodId: null,
+    shippingMethodCode: null,
+    deliveryWindowId: null,
+    deliveryWindowCode: null,
+    paymentMethodId: null,
+    paymentMethodCode: null,
+    channelId: null,
+    shippingMethodSnapshot: null,
+    deliveryWindowSnapshot: null,
+    paymentMethodSnapshot: null,
+    metadata: null,
+    customFieldSetId: null,
+    subtotalNetAmount: '100',
+    subtotalGrossAmount: '100',
+    discountTotalAmount: '0',
+    taxTotalAmount: '0',
+    grandTotalNetAmount: '100',
+    grandTotalGrossAmount: '100',
+    lineItemCount: 1,
+    totalsSnapshot: null,
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }
+}
+
+describe('sales.quotes.convert_to_order — document number generation (#919)', () => {
+  let createdEntities: Array<Record<string, unknown>>
+  let removedEntities: unknown[]
+  let mockGenerator: { generate: jest.Mock }
+
+  const mockEm = {
+    findOne: jest.fn(),
+    find: jest.fn().mockResolvedValue([]),
+    create: jest.fn(),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    fork: jest.fn(),
+    nativeDelete: jest.fn().mockResolvedValue(0),
+    getConnection: jest.fn().mockReturnValue({
+      execute: jest.fn().mockResolvedValue([]),
+    }),
+  }
+
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createdEntities = []
+    removedEntities = []
+
+    mockEm.fork.mockReturnValue(mockEm)
+    mockEm.create.mockImplementation((_Entity: unknown, data: Record<string, unknown>) => {
+      createdEntities.push(data)
+      return data
+    })
+    mockEm.remove.mockImplementation((entity: unknown) => {
+      removedEntities.push(entity)
+    })
+
+    mockGenerator = {
+      generate: jest.fn().mockResolvedValue({
+        number: 'ORDER-20260310-00001',
+        format: 'ORDER-{yyyy}{mm}{dd}-{seq:5}',
+        sequence: 1,
+      }),
+    }
+  })
+
+  function buildCtx() {
+    return {
+      container: {
+        resolve: (token: string) => {
+          if (token === 'em') return mockEm
+          if (token === 'salesDocumentNumberGenerator') return mockGenerator
+          if (token === 'eventBus') return { emit: jest.fn() }
+          return null
+        },
+      },
+      auth: {
+        sub: 'user-1',
+        tenantId: '00000000-0000-4000-8000-000000000000',
+        orgId: '11111111-1111-4111-8111-111111111111',
+      },
+      organizationScope: null,
+      selectedOrganizationId: '11111111-1111-4111-8111-111111111111',
+      organizationIds: ['11111111-1111-4111-8111-111111111111'],
+    }
+  }
+
+  it('generates a new ORDER-prefixed number instead of copying the quote number', async () => {
+    const handler = commandRegistry.get<any, any>('sales.quotes.convert_to_order')
+    expect(handler).toBeTruthy()
+
+    const quote = buildQuote()
+
+    // findOne calls: (1) SalesQuote by quoteId, (2) SalesQuote in loadQuoteSnapshot, (3) SalesOrder existence check
+    let callCount = 0
+    mockEm.findOne.mockImplementation(async () => {
+      callCount++
+      if (callCount <= 2) return quote
+      return null
+    })
+
+    const result = await handler!.execute(
+      { quoteId: quote.id },
+      buildCtx() as any,
+    )
+
+    expect(result).toEqual({ orderId: quote.id })
+
+    // Verify the generator was called with kind: 'order'
+    expect(mockGenerator.generate).toHaveBeenCalledWith({
+      kind: 'order',
+      organizationId: quote.organizationId,
+      tenantId: quote.tenantId,
+    })
+
+    // Find the created SalesOrder entity (the first created entity should be the order)
+    const orderEntity = createdEntities.find(
+      (entity) => 'orderNumber' in entity,
+    )
+    expect(orderEntity).toBeTruthy()
+    expect(orderEntity!.orderNumber).toBe('ORDER-20260310-00001')
+    expect(orderEntity!.orderNumber).not.toMatch(/^QUOTE-/)
+  })
+
+  it('does not use the quote number as the order number', async () => {
+    const handler = commandRegistry.get<any, any>('sales.quotes.convert_to_order')
+    expect(handler).toBeTruthy()
+
+    const quote = buildQuote({ quoteNumber: 'QUOTE-20260101-99999' })
+
+    let callCount = 0
+    mockEm.findOne.mockImplementation(async () => {
+      callCount++
+      if (callCount <= 2) return quote
+      return null
+    })
+
+    mockGenerator.generate.mockResolvedValue({
+      number: 'ORDER-20260101-00042',
+      format: 'ORDER-{yyyy}{mm}{dd}-{seq:5}',
+      sequence: 42,
+    })
+
+    await handler!.execute({ quoteId: quote.id }, buildCtx() as any)
+
+    const orderEntity = createdEntities.find(
+      (entity) => 'orderNumber' in entity,
+    )
+    expect(orderEntity).toBeTruthy()
+    expect(orderEntity!.orderNumber).toBe('ORDER-20260101-00042')
+    expect(orderEntity!.orderNumber).not.toBe(quote.quoteNumber)
+  })
+
+  it('allows explicit orderNumber override from the caller', async () => {
+    const handler = commandRegistry.get<any, any>('sales.quotes.convert_to_order')
+    expect(handler).toBeTruthy()
+
+    const quote = buildQuote()
+
+    let callCount = 0
+    mockEm.findOne.mockImplementation(async () => {
+      callCount++
+      if (callCount <= 2) return quote
+      return null
+    })
+
+    await handler!.execute(
+      { quoteId: quote.id, orderNumber: 'CUSTOM-001' },
+      buildCtx() as any,
+    )
+
+    const orderEntity = createdEntities.find(
+      (entity) => 'orderNumber' in entity,
+    )
+    expect(orderEntity).toBeTruthy()
+    expect(orderEntity!.orderNumber).toBe('CUSTOM-001')
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a regression test for issue #919 (quote-to-order conversion copying the QUOTE-prefixed document number)
- The code fix was already merged in PR #1097 (commit `08d9acfc2`) but lacked test coverage
- The test verifies three scenarios:
  1. Converting a quote generates a new ORDER-prefixed number (not copied from the quote)
  2. The generated order number never matches the original quote number
  3. An explicit `orderNumber` override from the caller is respected

## Root cause (already fixed)

In `packages/core/src/modules/sales/commands/documents.ts`, the `sales.quotes.convert_to_order` command had a conditional that checked if the quote already had a `quoteNumber` — if it did, it was passed through as the order number verbatim, retaining the `QUOTE-` prefix. PR #1097 removed this conditional so a new order number is always generated via `salesDocumentNumberGenerator` with `kind: 'order'`.

## Test plan

- [x] New unit test in `packages/core/src/modules/sales/commands/__tests__/quoteConvertNumber.test.ts`
- [x] Tests the command handler directly via the command registry
- [x] Mocks EntityManager and SalesDocumentNumberGenerator to verify correct call arguments and created entity fields

Closes #919