### PR TITLE
tests: add low-level coverage for agentic-setup.ts

### DIFF
--- a/.ai/qa/tests/integration/TC-INT-008.spec.ts
+++ b/.ai/qa/tests/integration/TC-INT-008.spec.ts
@@ -1,0 +1,218 @@
+import { expect, test } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
+const cliDir = path.join(repoRoot, 'packages', 'cli')
+const cliBin = path.join(cliDir, 'dist', 'bin.js')
+const cliBuildScript = path.join(cliDir, 'build.mjs')
+const agenticRoot = path.join(repoRoot, 'packages', 'create-app', 'agentic')
+const packagesRoot = path.join(repoRoot, 'packages')
+
+function normalizePath(value: string): string {
+  return value.split(path.sep).join('/')
+}
+
+function runCommand(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NODE_NO_WARNINGS: '1',
+    },
+  })
+}
+
+function runMercato(args: string[], cwd: string): string {
+  return runCommand(process.execPath, [cliBin, ...args], cwd)
+}
+
+function writeFile(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+}
+
+function ensureCliBuilt(): void {
+  runCommand(process.execPath, [cliBuildScript], cliDir)
+}
+
+function createStandaloneFixture(rootDir: string): string {
+  const appDir = path.join(rootDir, 'sample-store')
+  writeFile(
+    path.join(appDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'sample-store',
+        private: true,
+      },
+      null,
+      2,
+    ),
+  )
+  writeFile(path.join(appDir, 'src', 'modules.ts'), 'export const enabledModules = []\n')
+  return appDir
+}
+
+function listRelativeFiles(rootDir: string): string[] {
+  if (!fs.existsSync(rootDir)) {
+    return []
+  }
+
+  const collected: string[] = []
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    const absolutePath = path.join(rootDir, entry.name)
+    if (entry.isDirectory()) {
+      for (const nestedPath of listRelativeFiles(absolutePath)) {
+        collected.push(path.join(entry.name, nestedPath))
+      }
+      continue
+    }
+    if (entry.isFile()) {
+      collected.push(entry.name)
+    }
+  }
+
+  return collected.map(normalizePath).sort()
+}
+
+function mapSharedSourceToOutput(relativePath: string): string {
+  if (relativePath === 'AGENTS.md.template') {
+    return 'AGENTS.md'
+  }
+
+  if (!relativePath.startsWith('ai/')) {
+    throw new Error(`Unexpected shared source path: ${relativePath}`)
+  }
+
+  return normalizePath(path.join('.ai', relativePath.slice('ai/'.length)))
+}
+
+function mapClaudeSourceToOutput(relativePath: string): string {
+  if (relativePath === 'CLAUDE.md.template') {
+    return 'CLAUDE.md'
+  }
+  if (relativePath === 'settings.json') {
+    return '.claude/settings.json'
+  }
+  if (relativePath === 'mcp.json.example') {
+    return '.mcp.json.example'
+  }
+  if (relativePath.startsWith('hooks/')) {
+    return normalizePath(path.join('.claude', relativePath))
+  }
+
+  throw new Error(`Unexpected Claude source path: ${relativePath}`)
+}
+
+function mapCursorSourceToOutput(relativePath: string): string {
+  if (relativePath === 'hooks.json') {
+    return '.cursor/hooks.json'
+  }
+  if (relativePath === 'mcp.json.example') {
+    return '.cursor/mcp.json.example'
+  }
+  if (relativePath.startsWith('hooks/') || relativePath.startsWith('rules/')) {
+    return normalizePath(path.join('.cursor', relativePath))
+  }
+
+  throw new Error(`Unexpected Cursor source path: ${relativePath}`)
+}
+
+function mapCodexSourceToOutput(relativePath: string): string | null {
+  if (relativePath === 'mcp.json.example') {
+    return '.codex/mcp.json.example'
+  }
+  if (relativePath === 'enforcement-rules.md') {
+    return null
+  }
+
+  throw new Error(`Unexpected Codex source path: ${relativePath}`)
+}
+
+function expectedGuideOutputNames(): string[] {
+  const collected = new Set<string>()
+
+  for (const packageName of fs.readdirSync(packagesRoot)) {
+    const packageGuide = path.join(packagesRoot, packageName, 'agentic', 'standalone-guide.md')
+    if (fs.existsSync(packageGuide)) {
+      collected.add(`${packageName}.md`)
+    }
+
+    const modulesRoot = path.join(packagesRoot, packageName, 'src', 'modules')
+    if (!fs.existsSync(modulesRoot)) {
+      continue
+    }
+
+    for (const moduleName of fs.readdirSync(modulesRoot)) {
+      const moduleGuide = path.join(modulesRoot, moduleName, 'agentic', 'standalone-guide.md')
+      if (fs.existsSync(moduleGuide)) {
+        collected.add(`${packageName}.${moduleName}.md`)
+      }
+    }
+  }
+
+  return Array.from(collected).sort()
+}
+
+function assertPathsExist(appDir: string, relativePaths: string[]): void {
+  const missingPaths = relativePaths.filter((relativePath) => !fs.existsSync(path.join(appDir, relativePath)))
+  expect(missingPaths).toEqual([])
+}
+
+test.describe('TC-INT-008: CLI agentic init mirrors standalone scaffolding assets', () => {
+  test.beforeAll(() => {
+    ensureCliBuilt()
+  })
+
+  test('should run bootstrap-free and generate the shared, guide, and tool-specific agentic files', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mercato-cli-agentic-'))
+
+    try {
+      const appDir = createStandaloneFixture(tempRoot)
+      const commandOutput = runMercato(['agentic:init', '--tool=claude-code,codex,cursor'], appDir)
+
+      expect(commandOutput).toContain('Agentic setup complete:')
+      expect(fs.existsSync(path.join(appDir, '.mercato', 'generated'))).toBe(false)
+
+      const sharedOutputs = listRelativeFiles(path.join(agenticRoot, 'shared')).map(mapSharedSourceToOutput)
+      const claudeOutputs = listRelativeFiles(path.join(agenticRoot, 'claude-code')).map(mapClaudeSourceToOutput)
+      const cursorOutputs = listRelativeFiles(path.join(agenticRoot, 'cursor')).map(mapCursorSourceToOutput)
+      const codexOutputs = listRelativeFiles(path.join(agenticRoot, 'codex'))
+        .map(mapCodexSourceToOutput)
+        .filter((relativePath): relativePath is string => relativePath !== null)
+
+      assertPathsExist(appDir, [...sharedOutputs, ...claudeOutputs, ...cursorOutputs, ...codexOutputs])
+
+      const generatedGuideNames = listRelativeFiles(path.join(appDir, '.ai', 'guides'))
+      expect(generatedGuideNames).toEqual(expectedGuideOutputNames())
+
+      const agentsSource = fs.readFileSync(path.join(appDir, 'AGENTS.md'), 'utf8')
+      expect(agentsSource).toContain('<!-- CODEX_ENFORCEMENT_RULES_START -->')
+      expect(agentsSource).toContain('.ai/guides/core.md')
+
+      const specsReadmeSource = fs.readFileSync(path.join(appDir, '.ai', 'specs', 'README.md'), 'utf8')
+      expect(specsReadmeSource).toContain('sample-store')
+
+      const cursorRulesSource = fs.readFileSync(path.join(appDir, '.cursor', 'rules', 'open-mercato.mdc'), 'utf8')
+      expect(cursorRulesSource).toContain('sample-store')
+
+      const specWritingSkillSource = fs.readFileSync(
+        path.join(appDir, '.ai', 'skills', 'spec-writing', 'SKILL.md'),
+        'utf8',
+      )
+      expect(specWritingSkillSource).toContain('sample-store')
+
+      for (const toolDir of ['.claude', '.codex', '.cursor']) {
+        const skillsLinkPath = path.join(appDir, toolDir, 'skills')
+        expect(fs.lstatSync(skillsLinkPath).isSymbolicLink()).toBe(true)
+        expect(normalizePath(fs.readlinkSync(skillsLinkPath))).toBe('../.ai/skills')
+      }
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -106,3 +106,4 @@ Rules:
 After modifying generator logic, run the generator and verify the output files in `apps/mercato/.mercato/generated/`. Check that all expected modules, entities, and registrations appear correctly.
 
 When `packages/create-app/agentic/` or standalone guide discovery changes, keep `packages/cli/src/lib/agentic-setup.ts` and `packages/cli/build.mjs` in sync so `yarn mercato agentic:init` matches newly scaffolded standalone apps.
+The standalone QA config contract is `.ai/qa/tests/playwright.config.ts`; keep that path aligned across `packages/create-app/agentic/shared/`, `packages/create-app/template/package.json.template`, and `packages/cli/src/lib/testing/integration.ts`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -104,3 +104,5 @@ Rules:
 ## Testing Generator Changes
 
 After modifying generator logic, run the generator and verify the output files in `apps/mercato/.mercato/generated/`. Check that all expected modules, entities, and registrations appear correctly.
+
+When `packages/create-app/agentic/` or standalone guide discovery changes, keep `packages/cli/src/lib/agentic-setup.ts` and `packages/cli/build.mjs` in sync so `yarn mercato agentic:init` matches newly scaffolded standalone apps.

--- a/packages/cli/build.mjs
+++ b/packages/cli/build.mjs
@@ -1,6 +1,6 @@
 import * as esbuild from 'esbuild'
 import { glob } from 'glob'
-import { readFileSync, writeFileSync, chmodSync, existsSync, cpSync } from 'node:fs'
+import { readFileSync, writeFileSync, chmodSync, existsSync, cpSync, mkdirSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -97,6 +97,34 @@ const agenticSrc = join(__dirname, '..', 'create-app', 'agentic')
 if (existsSync(agenticSrc)) {
   cpSync(agenticSrc, join(outdir, 'agentic'), { recursive: true })
   console.log('Copied create-app/agentic/ → dist/agentic/')
+}
+
+const packagesDir = join(__dirname, '..')
+const guidesDestDir = join(outdir, 'agentic', 'guides')
+mkdirSync(guidesDestDir, { recursive: true })
+
+let guidesFound = 0
+for (const pkg of readdirSync(packagesDir)) {
+  const guideSource = join(packagesDir, pkg, 'agentic', 'standalone-guide.md')
+  if (existsSync(guideSource)) {
+    cpSync(guideSource, join(guidesDestDir, `${pkg}.md`))
+    guidesFound++
+  }
+
+  const modulesDir = join(packagesDir, pkg, 'src', 'modules')
+  if (!existsSync(modulesDir)) continue
+
+  for (const mod of readdirSync(modulesDir)) {
+    const moduleGuideSource = join(modulesDir, mod, 'agentic', 'standalone-guide.md')
+    if (existsSync(moduleGuideSource)) {
+      cpSync(moduleGuideSource, join(guidesDestDir, `${pkg}.${mod}.md`))
+      guidesFound++
+    }
+  }
+}
+
+if (guidesFound > 0) {
+  console.log(`Discovered ${guidesFound} standalone guides → dist/agentic/guides/`)
 }
 
 console.log('CLI built successfully')

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -16,6 +16,7 @@ const BOOTSTRAP_FREE_COMMANDS = [
   'module',
   'db',
   'init',
+  'agentic:init',
   'eject',
   'test',
   'test:integration',

--- a/packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
+++ b/packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
@@ -3,11 +3,15 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const repoRoot = path.resolve(__dirname, '..', '..', '..', '..')
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..', '..')
 const cliDir = path.join(repoRoot, 'packages', 'cli')
 const cliBin = path.join(cliDir, 'dist', 'bin.js')
 const cliBuildScript = path.join(cliDir, 'build.mjs')
+const cliIntegrationRunnerPath = path.join(cliDir, 'src', 'lib', 'testing', 'integration.ts')
+const standaloneTemplatePackageJsonPath = path.join(repoRoot, 'packages', 'create-app', 'template', 'package.json.template')
 const agenticRoot = path.join(repoRoot, 'packages', 'create-app', 'agentic')
 const packagesRoot = path.join(repoRoot, 'packages')
 
@@ -133,6 +137,33 @@ function mapCodexSourceToOutput(relativePath: string): string | null {
   throw new Error(`Unexpected Codex source path: ${relativePath}`)
 }
 
+function readPlaywrightConfigPathFromTemplate(): string {
+  const packageTemplate = JSON.parse(fs.readFileSync(standaloneTemplatePackageJsonPath, 'utf8')) as {
+    scripts?: Record<string, string>
+  }
+  const integrationScript = packageTemplate.scripts?.['test:integration']
+  if (!integrationScript) {
+    throw new Error('Standalone template is missing the test:integration script')
+  }
+
+  const configPathMatch = integrationScript.match(/--config\s+([^\s]+)/)
+  if (!configPathMatch?.[1]) {
+    throw new Error('Standalone template test:integration script is missing --config')
+  }
+
+  return normalizePath(configPathMatch[1])
+}
+
+function readPlaywrightConfigPathFromCliRunner(): string {
+  const integrationRunnerSource = fs.readFileSync(cliIntegrationRunnerPath, 'utf8')
+  const configPathMatch = integrationRunnerSource.match(/const PLAYWRIGHT_INTEGRATION_CONFIG_PATH = '([^']+)'/)
+  if (!configPathMatch?.[1]) {
+    throw new Error('CLI integration runner is missing PLAYWRIGHT_INTEGRATION_CONFIG_PATH')
+  }
+
+  return normalizePath(configPathMatch[1])
+}
+
 function expectedGuideOutputNames(): string[] {
   const collected = new Set<string>()
 
@@ -173,8 +204,11 @@ test.describe('TC-INT-008: CLI agentic init mirrors standalone scaffolding asset
 
     try {
       const appDir = createStandaloneFixture(tempRoot)
+      const standalonePlaywrightConfigPath = readPlaywrightConfigPathFromTemplate()
+      const cliPlaywrightConfigPath = readPlaywrightConfigPathFromCliRunner()
       const commandOutput = runMercato(['agentic:init', '--tool=claude-code,codex,cursor'], appDir)
 
+      expect(cliPlaywrightConfigPath).toBe(standalonePlaywrightConfigPath)
       expect(commandOutput).toContain('Agentic setup complete:')
       expect(fs.existsSync(path.join(appDir, '.mercato', 'generated'))).toBe(false)
 
@@ -185,7 +219,9 @@ test.describe('TC-INT-008: CLI agentic init mirrors standalone scaffolding asset
         .map(mapCodexSourceToOutput)
         .filter((relativePath): relativePath is string => relativePath !== null)
 
+      expect(sharedOutputs).toContain(standalonePlaywrightConfigPath)
       assertPathsExist(appDir, [...sharedOutputs, ...claudeOutputs, ...cursorOutputs, ...codexOutputs])
+      expect(fs.existsSync(path.join(appDir, standalonePlaywrightConfigPath))).toBe(true)
 
       const generatedGuideNames = listRelativeFiles(path.join(appDir, '.ai', 'guides'))
       expect(generatedGuideNames).toEqual(expectedGuideOutputNames())

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -177,7 +177,7 @@ function generateShared(config: AgenticConfig): void {
     join(targetDir, '.ai', 'skills', 'integration-tests', 'SKILL.md'),
   )
 
-  copyFile(srcDir, 'ai/qa/playwright.config.ts', join(targetDir, '.ai', 'qa', 'playwright.config.ts'))
+  copyFile(srcDir, 'ai/qa/tests/playwright.config.ts', join(targetDir, '.ai', 'qa', 'tests', 'playwright.config.ts'))
 
   if (existsSync(GUIDES_DIR)) {
     const guidesDestDir = join(targetDir, '.ai', 'guides')

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -6,7 +6,7 @@
  * This module reads those files at runtime — no embedded string constants.
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, symlinkSync, lstatSync, unlinkSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, symlinkSync, lstatSync, unlinkSync, readdirSync } from 'node:fs'
 import { join, dirname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -14,6 +14,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 // In the built output (dist/lib/agentic-setup.js), __dirname is dist/lib/.
 // agentic/ is copied to dist/agentic/ by build.mjs.
 const AGENTIC_DIR = join(__dirname, '..', 'agentic')
+const GUIDES_DIR = join(AGENTIC_DIR, 'guides')
 
 type AskFn = (question: string) => Promise<string>
 
@@ -108,6 +109,86 @@ function generateShared(config: AgenticConfig): void {
     'ai/skills/integration-builder/references/adapter-contracts.md',
     join(targetDir, '.ai', 'skills', 'integration-builder', 'references', 'adapter-contracts.md'),
   )
+
+  copyFile(
+    srcDir,
+    'ai/skills/system-extension/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'system-extension', 'SKILL.md'),
+  )
+  copyFile(
+    srcDir,
+    'ai/skills/system-extension/references/extension-contracts.md',
+    join(targetDir, '.ai', 'skills', 'system-extension', 'references', 'extension-contracts.md'),
+  )
+
+  copyFile(
+    srcDir,
+    'ai/skills/module-scaffold/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'module-scaffold', 'SKILL.md'),
+  )
+  copyFile(
+    srcDir,
+    'ai/skills/module-scaffold/references/naming-conventions.md',
+    join(targetDir, '.ai', 'skills', 'module-scaffold', 'references', 'naming-conventions.md'),
+  )
+  copyFile(
+    srcDir,
+    'ai/skills/module-scaffold/references/navigation-patterns.md',
+    join(targetDir, '.ai', 'skills', 'module-scaffold', 'references', 'navigation-patterns.md'),
+  )
+
+  copyFile(
+    srcDir,
+    'ai/skills/troubleshooter/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'troubleshooter', 'SKILL.md'),
+  )
+  copyFile(
+    srcDir,
+    'ai/skills/troubleshooter/references/diagnostic-commands.md',
+    join(targetDir, '.ai', 'skills', 'troubleshooter', 'references', 'diagnostic-commands.md'),
+  )
+
+  copyFile(
+    srcDir,
+    'ai/skills/eject-and-customize/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'eject-and-customize', 'SKILL.md'),
+  )
+
+  copyFile(
+    srcDir,
+    'ai/skills/data-model-design/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'data-model-design', 'SKILL.md'),
+  )
+  copyFile(
+    srcDir,
+    'ai/skills/data-model-design/references/mikro-orm-cheatsheet.md',
+    join(targetDir, '.ai', 'skills', 'data-model-design', 'references', 'mikro-orm-cheatsheet.md'),
+  )
+
+  copyFile(
+    srcDir,
+    'ai/skills/implement-spec/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'implement-spec', 'SKILL.md'),
+  )
+
+  copyFile(
+    srcDir,
+    'ai/skills/integration-tests/SKILL.md',
+    join(targetDir, '.ai', 'skills', 'integration-tests', 'SKILL.md'),
+  )
+
+  copyFile(srcDir, 'ai/qa/playwright.config.ts', join(targetDir, '.ai', 'qa', 'playwright.config.ts'))
+
+  if (existsSync(GUIDES_DIR)) {
+    const guidesDestDir = join(targetDir, '.ai', 'guides')
+    for (const file of readdirSync(GUIDES_DIR)) {
+      if (!file.endsWith('.md')) continue
+      const srcPath = join(GUIDES_DIR, file)
+      const destPath = join(guidesDestDir, file)
+      ensureDir(destPath)
+      copyFileSync(srcPath, destPath)
+    }
+  }
 }
 
 function generateClaudeCode(config: AgenticConfig): void {

--- a/packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts
+++ b/packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts
@@ -4,7 +4,7 @@ import { discoverIntegrationSpecFiles } from '@open-mercato/cli/lib/testing/inte
 
 const captureScreenshots = process.env.PW_CAPTURE_SCREENSHOTS === '1'
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
-const projectRoot = path.resolve(__dirname, '..', '..')
+const projectRoot = path.resolve(__dirname, '..', '..', '..')
 const qaTestResultsRoot = path.join(projectRoot, '.ai', 'qa', 'test-results')
 const normalizePath = (value: string) => value.split(path.sep).join('/')
 const STATIC_TEST_IGNORES = [

--- a/packages/create-app/agentic/shared/ai/skills/implement-spec/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/implement-spec/SKILL.md
@@ -67,7 +67,7 @@ If the spec defines integration test scenarios (or the phase adds API endpoints 
 - Place tests in `src/modules/<module>/__integration__/TC-{CATEGORY}-{XXX}.spec.ts`
 - Tests MUST be self-contained: create fixtures in setup, clean up in teardown
 - Tests MUST NOT rely on seeded/demo data
-- Run and verify: `npx playwright test --config .ai/qa/playwright.config.ts <path> --retries=0`
+- Run and verify: `npx playwright test --config .ai/qa/tests/playwright.config.ts <path> --retries=0`
 
 If the spec does not explicitly list integration scenarios but the phase adds significant API or UI behavior, propose test scenarios to the user before writing them.
 

--- a/packages/create-app/agentic/shared/ai/skills/integration-tests/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/integration-tests/SKILL.md
@@ -11,9 +11,9 @@ This skill generates executable Playwright tests in module-local `__integration_
 
 | Action | Command |
 |--------|---------|
-| Run all tests | `npx playwright test --config .ai/qa/playwright.config.ts` |
-| Run single test | `npx playwright test --config .ai/qa/playwright.config.ts <path>` |
-| Debug (fail-fast) | `npx playwright test --config .ai/qa/playwright.config.ts <path> --retries=0` |
+| Run all tests | `npx playwright test --config .ai/qa/tests/playwright.config.ts` |
+| Run single test | `npx playwright test --config .ai/qa/tests/playwright.config.ts <path>` |
+| Debug (fail-fast) | `npx playwright test --config .ai/qa/tests/playwright.config.ts <path> --retries=0` |
 | View report | `npx playwright show-report .ai/qa/test-results/html` |
 | Test files location | `src/modules/<module>/__integration__/TC-XXX.spec.ts` |
 | Scenario sources (optional) | `.ai/qa/scenarios/TC-XXX-*.md` |
@@ -21,7 +21,7 @@ This skill generates executable Playwright tests in module-local `__integration_
 ## Runtime Policy
 
 Default QA runtime policy:
-- Keep global settings in `.ai/qa/playwright.config.ts`:
+- Keep global settings in `.ai/qa/tests/playwright.config.ts`:
   - `timeout: 20_000`
   - `expect.timeout: 20_000`
   - `retries: 1`
@@ -179,13 +179,13 @@ This step is **optional** — skip it if the user only wants the executable test
 Run the new test to confirm it passes:
 
 ```bash
-npx playwright test --config .ai/qa/playwright.config.ts <path-to-test-file>
+npx playwright test --config .ai/qa/tests/playwright.config.ts <path-to-test-file>
 ```
 
 When developing/debugging the test, run fail-fast with no retries:
 
 ```bash
-npx playwright test --config .ai/qa/playwright.config.ts <path-to-test-file> --retries=0
+npx playwright test --config .ai/qa/tests/playwright.config.ts <path-to-test-file> --retries=0
 ```
 
 If it fails, fix it. Do not leave broken tests.

--- a/packages/create-app/src/setup/tools/shared.ts
+++ b/packages/create-app/src/setup/tools/shared.ts
@@ -148,8 +148,8 @@ export function generateShared(config: AgenticConfig): void {
     join(targetDir, '.ai', 'skills', 'integration-tests', 'SKILL.md'),
   )
 
-  // .ai/qa/ — Playwright config for integration tests
-  copyFile('ai/qa/playwright.config.ts', join(targetDir, '.ai', 'qa', 'playwright.config.ts'))
+  // .ai/qa/tests/ — Playwright config for integration tests
+  copyFile('ai/qa/tests/playwright.config.ts', join(targetDir, '.ai', 'qa', 'tests', 'playwright.config.ts'))
 
   // Package guides — auto-discovered from sibling packages during build
   if (existsSync(GUIDES_DIR)) {


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for agentic-setup.ts
## Problem Summary
tests: add low-level coverage for agentic-setup.ts
## Expected Behavior
packages/cli/src/lib/agentic-setup.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/cli/src/lib/agentic-setup.ts.
Checked: packages/cli/src/lib/agentic-setup.test.ts
packages/cli/src/lib/__tests__/agentic-setup.test.ts
packages/cli/src/lib/agentic-setup.spec.ts
packages/cli/src/lib/__tests__/agentic-setup.spec.ts ...
## What Changed
- packages/cli/AGENTS.md
- packages/cli/build.mjs
- packages/cli/src/bin.ts
- packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
- packages/cli/src/lib/agentic-setup.ts
- packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts
- packages/create-app/agentic/shared/ai/skills/implement-spec/SKILL.md
- packages/create-app/agentic/shared/ai/skills/integration-tests/SKILL.md
- packages/create-app/src/setup/tools/shared.ts
- Diff summary: +379 / -12 (391 total lines)
- Branch head: c087bc2642c4182e45115bfbdf97a1a7a214b65b
## Validation / Tests
- cli-package-checks
## Expected Contribution Classes
- tests
- bugfix