### PR TITLE
tests: add low-level coverage for entity-ids.ts

### DIFF
--- a/packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
@@ -10,6 +10,10 @@ function createTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'entity-ids-test-'))
 }
 
+function countMatches(content: string, pattern: RegExp): number {
+  return content.match(pattern)?.length ?? 0
+}
+
 function createMockResolver(tmpRoot: string, enabled: ModuleEntry[]): PackageResolver {
   const outputDir = path.join(tmpRoot, 'app', '.mercato', 'generated')
   fs.mkdirSync(outputDir, { recursive: true })
@@ -164,5 +168,113 @@ export { Organization, Tenant }
     expect(fs.readFileSync(organizationPath, 'utf8')).toContain('export const name = "name"')
     expect(fs.readFileSync(organizationPath, 'utf8')).toContain('export const tenant = "tenant"')
     expect(fs.readFileSync(packageOrganizationPath, 'utf8')).toContain("export const tenant = 'tenant'")
+  })
+
+  it('prefers package generated TypeScript metadata from generated/ in standalone mode', async () => {
+    const moduleEntry: ModuleEntry = { id: 'catalog', from: '@open-mercato/core' }
+    const packageRoot = path.join(tmpDir, 'node_modules', '@open-mercato', 'core')
+    const generatedRoot = path.join(packageRoot, 'generated')
+    const idsFile = path.join(generatedRoot, 'entities.ids.generated.ts')
+    const variantFieldsFile = path.join(generatedRoot, 'entities', 'product_variant', 'index.ts')
+
+    fs.mkdirSync(path.dirname(idsFile), { recursive: true })
+    fs.mkdirSync(path.dirname(variantFieldsFile), { recursive: true })
+
+    fs.writeFileSync(
+      idsFile,
+      `export const E = ({
+  catalog: ({
+    product_variant: 'catalog:product_variant'
+  } as const)
+} as const)
+`
+    )
+    fs.writeFileSync(
+      variantFieldsFile,
+      `export const id = 'id'
+export const sku = 'sku'
+export const duplicateSku = 'sku'
+`
+    )
+
+    const distEntitiesFile = path.join(packageRoot, 'dist', 'modules', 'catalog', 'data', 'entities.js')
+    fs.mkdirSync(path.dirname(distEntitiesFile), { recursive: true })
+    fs.writeFileSync(
+      distEntitiesFile,
+      `class ProductVariant {}
+export { ProductVariant }
+`
+    )
+
+    const resolver = createStandaloneMockResolver(tmpDir, [moduleEntry])
+    const result = await generateEntityIds({ resolver, quiet: true })
+
+    expect(result.errors).toEqual([])
+
+    const rootIdsPath = path.join(tmpDir, '.mercato', 'generated', 'entities.ids.generated.ts')
+    const variantPath = path.join(tmpDir, '.mercato', 'generated', 'entities', 'product_variant', 'index.ts')
+    const registryPath = path.join(tmpDir, '.mercato', 'generated', 'entity-fields-registry.ts')
+    const variantContent = fs.readFileSync(variantPath, 'utf8')
+
+    expect(fs.readFileSync(rootIdsPath, 'utf8')).toContain('"product_variant": "catalog:product_variant"')
+    expect(variantContent).toContain('export const sku = "sku"')
+    expect(countMatches(variantContent, /export const sku = "sku"/g)).toBe(1)
+    expect(fs.readFileSync(registryPath, 'utf8')).toContain('"product_variant": {')
+  })
+
+  it('parses override entity fields, honors decorator names, and removes stale generated entities', async () => {
+    const moduleEntry: ModuleEntry = { id: 'inventory', from: '@open-mercato/core' }
+    const entitiesFile = path.join(tmpDir, 'app', 'src', 'modules', 'inventory', 'data', 'entities.override.ts')
+    fs.mkdirSync(path.dirname(entitiesFile), { recursive: true })
+    fs.writeFileSync(
+      entitiesFile,
+      `export class WarehouseLocation {
+  @Property({ name: 'warehouse_code' })
+  code!: string
+  displayName!: string
+  'legacyTag'!: string
+  static ignored = 'ignored'
+}
+`
+    )
+
+    const staleDir = path.join(tmpDir, 'app', '.mercato', 'generated', 'entities', 'obsolete_entity')
+    fs.mkdirSync(staleDir, { recursive: true })
+    fs.writeFileSync(path.join(staleDir, 'index.ts'), 'export const old_field = "old_field"\n')
+
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+    const result = await generateEntityIds({ resolver, quiet: true })
+
+    expect(result.errors).toEqual([])
+
+    const warehousePath = path.join(tmpDir, 'app', '.mercato', 'generated', 'entities', 'warehouse_location', 'index.ts')
+    const registryPath = path.join(tmpDir, 'app', '.mercato', 'generated', 'entity-fields-registry.ts')
+    const warehouseContent = fs.readFileSync(warehousePath, 'utf8')
+    const registryContent = fs.readFileSync(registryPath, 'utf8')
+
+    expect(warehouseContent).toContain('export const warehouse_code = "warehouse_code"')
+    expect(warehouseContent).toContain('export const display_name = "display_name"')
+    expect(warehouseContent).toContain('export const legacy_tag = "legacy_tag"')
+    expect(warehouseContent).not.toContain('ignored')
+    expect(registryContent).toContain('"warehouse_code": "warehouse_code"')
+    expect(registryContent).toContain('"display_name": "display_name"')
+    expect(fs.existsSync(staleDir)).toBe(false)
+  })
+
+  it('keeps modules without entities in M and marks the ids file unchanged on identical reruns', async () => {
+    const moduleEntry: ModuleEntry = { id: 'empty_module', from: '@open-mercato/core' }
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+
+    const first = await generateEntityIds({ resolver, quiet: true })
+    const second = await generateEntityIds({ resolver, quiet: true })
+
+    const idsPath = path.join(tmpDir, 'app', '.mercato', 'generated', 'entities.ids.generated.ts')
+    const content = fs.readFileSync(idsPath, 'utf8')
+
+    expect(first.errors).toEqual([])
+    expect(second.errors).toEqual([])
+    expect(content).toContain('"empty_module": "empty_module"')
+    expect(content).not.toContain('"empty_module": {')
+    expect(second.filesUnchanged).toContain(idsPath)
   })
 })


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for entity-ids.ts
## Problem Summary
tests: add low-level coverage for entity-ids.ts
## Expected Behavior
packages/cli/src/lib/generators/entity-ids.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/cli/src/lib/generators/entity-ids.ts.
Checked: packages/cli/src/lib/generators/entity-ids.test.ts
packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
packages/cli/src/lib/generators/entity-ids.spec.ts
packages/cli/src/lib/generators/__tests__/entity-ids.spec.ts ...
## What Changed
- packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
- Diff summary: +112 / -0 (112 total lines)
- Branch head: 71388bf602a9c9af99956c72a24cd61955e8153f
## Validation / Tests
- cli-package-checks
## Expected Contribution Classes
- tests
- bugfix