### PR TITLE
tests: add low-level coverage for module-di.ts

### DIFF
--- a/packages/cli/src/lib/generators/__tests__/module-di.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/module-di.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { ModuleEntry, PackageResolver } from '../../resolver'
+import { generateModuleDi } from '../module-di'
+
+let tmpDir: string
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'module-di-test-'))
+}
+
+function touchFile(filePath: string, content = 'export function register(container: any) {}\n'): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+}
+
+function createMockResolver(tmpRoot: string, enabled: ModuleEntry[]): PackageResolver {
+  const outputDir = path.join(tmpRoot, 'app', '.mercato', 'generated')
+  fs.mkdirSync(outputDir, { recursive: true })
+
+  return {
+    isMonorepo: () => true,
+    getRootDir: () => tmpRoot,
+    getAppDir: () => path.join(tmpRoot, 'app'),
+    getOutputDir: () => outputDir,
+    getModulesConfigPath: () => path.join(tmpRoot, 'app', 'src', 'modules.ts'),
+    discoverPackages: () => [],
+    loadEnabledModules: () => enabled,
+    getModulePaths: (entry: ModuleEntry) => ({
+      appBase: path.join(tmpRoot, 'app', 'src', 'modules', entry.id),
+      pkgBase: path.join(tmpRoot, 'packages', 'core', 'src', 'modules', entry.id),
+    }),
+    getModuleImportBase: (entry: ModuleEntry) => ({
+      appBase: `@/modules/${entry.id}`,
+      pkgBase: `@open-mercato/core/modules/${entry.id}`,
+    }),
+    getPackageOutputDir: () => outputDir,
+    getPackageRoot: () => path.join(tmpRoot, 'packages', 'core'),
+  }
+}
+
+function readGenerated(tmpRoot: string): string {
+  return fs.readFileSync(path.join(tmpRoot, 'app', '.mercato', 'generated', 'di.generated.ts'), 'utf8')
+}
+
+beforeEach(() => {
+  tmpDir = createTmpDir()
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('generateModuleDi', () => {
+  it('prefers app di files over package di files for package-backed modules', async () => {
+    const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
+
+    touchFile(path.join(tmpDir, 'app', 'src', 'modules', 'orders', 'di.ts'))
+    touchFile(path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'di.ts'))
+
+    const result = await generateModuleDi({ resolver: createMockResolver(tmpDir, [moduleEntry]), quiet: true })
+    const output = readGenerated(tmpDir)
+
+    expect(result.errors).toEqual([])
+    expect(output).toContain('from "@/modules/orders/di"')
+    expect(output).not.toContain('@open-mercato/core/modules/orders/di')
+    expect(output).toContain('D_orders_0.register')
+  })
+
+  it('uses relative imports for app-backed modules', async () => {
+    const moduleEntry: ModuleEntry = { id: 'custom_app', from: '@app' }
+
+    touchFile(path.join(tmpDir, 'app', 'src', 'modules', 'custom_app', 'di.ts'))
+
+    const result = await generateModuleDi({ resolver: createMockResolver(tmpDir, [moduleEntry]), quiet: true })
+    const output = readGenerated(tmpDir)
+
+    expect(result.errors).toEqual([])
+    expect(output).toContain('from "../../src/modules/custom_app/di"')
+    expect(output).not.toContain('@/modules/custom_app/di')
+  })
+
+  it('discovers package di files that use non-ts extensions', async () => {
+    const moduleEntry: ModuleEntry = { id: 'inventory', from: '@open-mercato/core' }
+
+    touchFile(path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'inventory', 'di.js'))
+
+    const result = await generateModuleDi({ resolver: createMockResolver(tmpDir, [moduleEntry]), quiet: true })
+    const output = readGenerated(tmpDir)
+
+    expect(result.errors).toEqual([])
+    expect(output).toContain('from "@open-mercato/core/modules/inventory/di"')
+    expect(output).toContain('D_inventory_0.register')
+  })
+
+  it('marks the generated file as unchanged when the checksum matches', async () => {
+    const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
+
+    touchFile(path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'di.ts'))
+
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+    const outFile = path.join(tmpDir, 'app', '.mercato', 'generated', 'di.generated.ts')
+    const checksumFile = path.join(tmpDir, 'app', '.mercato', 'generated', 'di.generated.checksum')
+
+    const firstResult = await generateModuleDi({ resolver, quiet: true })
+    const firstStat = fs.statSync(outFile)
+    const secondResult = await generateModuleDi({ resolver, quiet: true })
+    const secondStat = fs.statSync(outFile)
+
+    expect(firstResult.errors).toEqual([])
+    expect(firstResult.filesWritten).toEqual([outFile])
+    expect(fs.existsSync(checksumFile)).toBe(true)
+    expect(secondResult.errors).toEqual([])
+    expect(secondResult.filesWritten).toEqual([])
+    expect(secondResult.filesUnchanged).toEqual([outFile])
+    expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs)
+  })
+})

--- a/packages/create-app/template/.ai/qa/tests/TC-UMES-021.spec.ts
+++ b/packages/create-app/template/.ai/qa/tests/TC-UMES-021.spec.ts
@@ -1,0 +1,177 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+
+type ProjectContext = {
+  appRoot: string
+  commandCwd: string
+  mercatoBin?: string
+  useSourceCli: boolean
+}
+
+type CommandResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+type OverrideTarget = {
+  appImport: string
+  moduleDir: string
+  moduleId: string
+  packageImport: string
+}
+
+const packageOverrideCandidates = ['customers', 'catalog', 'sales', 'auth'] as const
+
+function resolveProjectContext(): ProjectContext {
+  let directory = process.cwd()
+
+  for (let depth = 0; depth < 10; depth += 1) {
+    const monorepoAppRoot = path.join(directory, 'apps', 'mercato')
+    if (
+      fs.existsSync(path.join(directory, 'turbo.json'))
+      && fs.existsSync(path.join(monorepoAppRoot, 'src', 'modules.ts'))
+    ) {
+      return {
+        appRoot: monorepoAppRoot,
+        commandCwd: directory,
+        useSourceCli: true,
+      }
+    }
+
+    if (
+      fs.existsSync(path.join(directory, 'package.json'))
+      && fs.existsSync(path.join(directory, 'src', 'modules.ts'))
+    ) {
+      return {
+        appRoot: directory,
+        commandCwd: directory,
+        mercatoBin: resolveMercatoBin([directory]),
+        useSourceCli: false,
+      }
+    }
+
+    const parentDirectory = path.dirname(directory)
+    if (parentDirectory === directory) {
+      break
+    }
+    directory = parentDirectory
+  }
+
+  throw new Error(`Could not resolve project context from ${process.cwd()}`)
+}
+
+function resolveMercatoBin(baseDirectories: string[]): string {
+  const candidates = Array.from(new Set(baseDirectories.flatMap((baseDirectory) => [
+    path.join(baseDirectory, 'node_modules', '.bin', 'mercato'),
+    path.join(baseDirectory, 'node_modules', '@open-mercato', 'cli', 'bin', 'mercato'),
+    path.join(baseDirectory, 'packages', 'cli', 'bin', 'mercato'),
+  ])))
+
+  const match = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!match) {
+    throw new Error(`Could not find mercato bin. Checked: ${candidates.join(', ')}`)
+  }
+
+  return match
+}
+
+function runMercato(context: ProjectContext, args: string[]): CommandResult {
+  const command = context.useSourceCli ? 'yarn' : context.mercatoBin
+  const commandArgs = context.useSourceCli
+    ? ['tsx', 'packages/cli/src/bin.ts', ...args]
+    : args
+
+  const result = spawnSync(command, commandArgs, {
+    cwd: context.commandCwd,
+    encoding: 'utf-8',
+    timeout: 15_000,
+    env: { ...process.env, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
+  })
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+function expectCommandSucceeded(result: CommandResult, args: string[]): void {
+  expect(
+    result.exitCode,
+    [
+      `mercato ${args.join(' ')} failed`,
+      result.stdout && `stdout:\n${result.stdout.trimEnd()}`,
+      result.stderr && `stderr:\n${result.stderr.trimEnd()}`,
+    ].filter(Boolean).join('\n\n'),
+  ).toBe(0)
+}
+
+function readGeneratedDi(appRoot: string): string {
+  return fs.readFileSync(path.join(appRoot, '.mercato', 'generated', 'di.generated.ts'), 'utf8')
+}
+
+function selectOverrideTarget(appRoot: string, diOutput: string): OverrideTarget {
+  for (const moduleId of packageOverrideCandidates) {
+    const moduleDir = path.join(appRoot, 'src', 'modules', moduleId)
+    const packageImport = `@open-mercato/core/modules/${moduleId}/di`
+    if (fs.existsSync(moduleDir)) {
+      continue
+    }
+    if (!diOutput.includes(`from "${packageImport}"`)) {
+      continue
+    }
+    return {
+      appImport: `@/modules/${moduleId}/di`,
+      moduleDir,
+      moduleId,
+      packageImport,
+    }
+  }
+
+  throw new Error(`Could not find a package-backed DI module without an app override in ${appRoot}`)
+}
+
+test.describe('TC-UMES-021: DI generator parity', () => {
+  test('mercato generate di keeps app imports relative and prefers app overrides over package registrars', () => {
+    const context = resolveProjectContext()
+    const generateArgs = ['generate', 'di', '--quiet']
+
+    const baselineResult = runMercato(context, generateArgs)
+    expectCommandSucceeded(baselineResult, generateArgs)
+
+    const baselineOutput = readGeneratedDi(context.appRoot)
+    expect(baselineOutput).toContain('from "../../src/modules/example/di"')
+
+    const overrideTarget = selectOverrideTarget(context.appRoot, baselineOutput)
+    expect(baselineOutput).toContain(`from "${overrideTarget.packageImport}"`)
+    expect(baselineOutput).not.toContain(`from "${overrideTarget.appImport}"`)
+
+    try {
+      fs.mkdirSync(overrideTarget.moduleDir, { recursive: true })
+      fs.writeFileSync(path.join(overrideTarget.moduleDir, 'di.ts'), 'export function register() {}\n')
+
+      const overrideResult = runMercato(context, generateArgs)
+      expectCommandSucceeded(overrideResult, generateArgs)
+
+      const overrideOutput = readGeneratedDi(context.appRoot)
+      expect(overrideOutput).toContain('from "../../src/modules/example/di"')
+      expect(overrideOutput).toContain(`from "${overrideTarget.appImport}"`)
+      expect(overrideOutput).not.toContain(`from "${overrideTarget.packageImport}"`)
+
+      fs.rmSync(overrideTarget.moduleDir, { recursive: true, force: true })
+
+      const restoreResult = runMercato(context, generateArgs)
+      expectCommandSucceeded(restoreResult, generateArgs)
+
+      const restoredOutput = readGeneratedDi(context.appRoot)
+      expect(restoredOutput).toContain(`from "${overrideTarget.packageImport}"`)
+      expect(restoredOutput).not.toContain(`from "${overrideTarget.appImport}"`)
+    } finally {
+      fs.rmSync(overrideTarget.moduleDir, { recursive: true, force: true })
+      runMercato(context, generateArgs)
+    }
+  })
+})

--- a/packages/create-app/template/src/modules/example/__integration__/TC-UMES-021.spec.ts
+++ b/packages/create-app/template/src/modules/example/__integration__/TC-UMES-021.spec.ts
@@ -1,0 +1,177 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+
+type ProjectContext = {
+  appRoot: string
+  commandCwd: string
+  mercatoBin?: string
+  useSourceCli: boolean
+}
+
+type CommandResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+type OverrideTarget = {
+  appImport: string
+  moduleDir: string
+  moduleId: string
+  packageImport: string
+}
+
+const packageOverrideCandidates = ['customers', 'catalog', 'sales', 'auth'] as const
+
+function resolveProjectContext(): ProjectContext {
+  let directory = process.cwd()
+
+  for (let depth = 0; depth < 10; depth += 1) {
+    const monorepoAppRoot = path.join(directory, 'apps', 'mercato')
+    if (
+      fs.existsSync(path.join(directory, 'turbo.json'))
+      && fs.existsSync(path.join(monorepoAppRoot, 'src', 'modules.ts'))
+    ) {
+      return {
+        appRoot: monorepoAppRoot,
+        commandCwd: directory,
+        useSourceCli: true,
+      }
+    }
+
+    if (
+      fs.existsSync(path.join(directory, 'package.json'))
+      && fs.existsSync(path.join(directory, 'src', 'modules.ts'))
+    ) {
+      return {
+        appRoot: directory,
+        commandCwd: directory,
+        mercatoBin: resolveMercatoBin([directory]),
+        useSourceCli: false,
+      }
+    }
+
+    const parentDirectory = path.dirname(directory)
+    if (parentDirectory === directory) {
+      break
+    }
+    directory = parentDirectory
+  }
+
+  throw new Error(`Could not resolve project context from ${process.cwd()}`)
+}
+
+function resolveMercatoBin(baseDirectories: string[]): string {
+  const candidates = Array.from(new Set(baseDirectories.flatMap((baseDirectory) => [
+    path.join(baseDirectory, 'node_modules', '.bin', 'mercato'),
+    path.join(baseDirectory, 'node_modules', '@open-mercato', 'cli', 'bin', 'mercato'),
+    path.join(baseDirectory, 'packages', 'cli', 'bin', 'mercato'),
+  ])))
+
+  const match = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!match) {
+    throw new Error(`Could not find mercato bin. Checked: ${candidates.join(', ')}`)
+  }
+
+  return match
+}
+
+function runMercato(context: ProjectContext, args: string[]): CommandResult {
+  const command = context.useSourceCli ? 'yarn' : context.mercatoBin
+  const commandArgs = context.useSourceCli
+    ? ['tsx', 'packages/cli/src/bin.ts', ...args]
+    : args
+
+  const result = spawnSync(command, commandArgs, {
+    cwd: context.commandCwd,
+    encoding: 'utf-8',
+    timeout: 15_000,
+    env: { ...process.env, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
+  })
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+function expectCommandSucceeded(result: CommandResult, args: string[]): void {
+  expect(
+    result.exitCode,
+    [
+      `mercato ${args.join(' ')} failed`,
+      result.stdout && `stdout:\n${result.stdout.trimEnd()}`,
+      result.stderr && `stderr:\n${result.stderr.trimEnd()}`,
+    ].filter(Boolean).join('\n\n'),
+  ).toBe(0)
+}
+
+function readGeneratedDi(appRoot: string): string {
+  return fs.readFileSync(path.join(appRoot, '.mercato', 'generated', 'di.generated.ts'), 'utf8')
+}
+
+function selectOverrideTarget(appRoot: string, diOutput: string): OverrideTarget {
+  for (const moduleId of packageOverrideCandidates) {
+    const moduleDir = path.join(appRoot, 'src', 'modules', moduleId)
+    const packageImport = `@open-mercato/core/modules/${moduleId}/di`
+    if (fs.existsSync(moduleDir)) {
+      continue
+    }
+    if (!diOutput.includes(`from "${packageImport}"`)) {
+      continue
+    }
+    return {
+      appImport: `@/modules/${moduleId}/di`,
+      moduleDir,
+      moduleId,
+      packageImport,
+    }
+  }
+
+  throw new Error(`Could not find a package-backed DI module without an app override in ${appRoot}`)
+}
+
+test.describe('TC-UMES-021: DI generator parity', () => {
+  test('mercato generate di keeps app imports relative and prefers app overrides over package registrars', () => {
+    const context = resolveProjectContext()
+    const generateArgs = ['generate', 'di', '--quiet']
+
+    const baselineResult = runMercato(context, generateArgs)
+    expectCommandSucceeded(baselineResult, generateArgs)
+
+    const baselineOutput = readGeneratedDi(context.appRoot)
+    expect(baselineOutput).toContain('from "../../src/modules/example/di"')
+
+    const overrideTarget = selectOverrideTarget(context.appRoot, baselineOutput)
+    expect(baselineOutput).toContain(`from "${overrideTarget.packageImport}"`)
+    expect(baselineOutput).not.toContain(`from "${overrideTarget.appImport}"`)
+
+    try {
+      fs.mkdirSync(overrideTarget.moduleDir, { recursive: true })
+      fs.writeFileSync(path.join(overrideTarget.moduleDir, 'di.ts'), 'export function register() {}\n')
+
+      const overrideResult = runMercato(context, generateArgs)
+      expectCommandSucceeded(overrideResult, generateArgs)
+
+      const overrideOutput = readGeneratedDi(context.appRoot)
+      expect(overrideOutput).toContain('from "../../src/modules/example/di"')
+      expect(overrideOutput).toContain(`from "${overrideTarget.appImport}"`)
+      expect(overrideOutput).not.toContain(`from "${overrideTarget.packageImport}"`)
+
+      fs.rmSync(overrideTarget.moduleDir, { recursive: true, force: true })
+
+      const restoreResult = runMercato(context, generateArgs)
+      expectCommandSucceeded(restoreResult, generateArgs)
+
+      const restoredOutput = readGeneratedDi(context.appRoot)
+      expect(restoredOutput).toContain(`from "${overrideTarget.packageImport}"`)
+      expect(restoredOutput).not.toContain(`from "${overrideTarget.appImport}"`)
+    } finally {
+      fs.rmSync(overrideTarget.moduleDir, { recursive: true, force: true })
+      runMercato(context, generateArgs)
+    }
+  })
+})


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for module-di.ts
## Problem Summary
tests: add low-level coverage for module-di.ts
## Expected Behavior
packages/cli/src/lib/generators/module-di.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/cli/src/lib/generators/module-di.ts.
Checked: packages/cli/src/lib/generators/module-di.test.ts
packages/cli/src/lib/generators/__tests__/module-di.test.ts
packages/cli/src/lib/generators/module-di.spec.ts
packages/cli/src/lib/generators/__tests__/module-di.spec.ts ...
## What Changed
- packages/cli/src/lib/generators/__tests__/module-di.test.ts
- packages/create-app/template/.ai/qa/tests/TC-UMES-021.spec.ts
- packages/create-app/template/src/modules/example/__integration__/TC-UMES-021.spec.ts
- Diff summary: +473 / -0 (473 total lines)
- Branch head: f63b166eed52e9bc80ddb3eda69970a8f1a6847d
## Validation / Tests
- cli-package-checks
## Expected Contribution Classes
- tests
- bugfix