### PR TITLE
fix(security): MFA login interceptor must fail closed on challenge er…

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/login.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/login.test.ts
@@ -154,6 +154,48 @@ describe('POST /api/auth/login with custom route interceptors', () => {
     })
   })
 
+  test('does not leak original JWT in cookie when interceptor replaces body without token', async () => {
+    registerApiInterceptors([
+      {
+        moduleId: 'example',
+        interceptors: [
+          {
+            id: 'example.auth.login.block',
+            targetRoute: 'auth/login',
+            methods: ['POST'],
+            async after() {
+              return {
+                replace: {
+                  ok: false,
+                  error: 'mfa_challenge_unavailable',
+                },
+              }
+            },
+          },
+        ],
+      },
+    ])
+
+    const req = new Request('http://localhost/api/auth/login', {
+      method: 'POST',
+      body: makeFormData({ email: 'user@example.com', password: 'secret', remember: '1' }),
+    })
+
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body).toEqual({
+      ok: false,
+      error: 'mfa_challenge_unavailable',
+    })
+
+    const setCookie = res.headers.get('set-cookie') ?? ''
+    expect(setCookie).not.toContain('auth_token=')
+    expect(setCookie).not.toContain('jwt-token')
+    expect(setCookie).not.toContain('session_token=')
+  })
+
   test('applies body replace from matched after interceptor and keeps cookies valid', async () => {
     registerApiInterceptors([
       {

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -193,13 +193,15 @@ export async function POST(req: Request) {
   const interceptedBody = interceptedResponse.body
   const authTokenForCookie = typeof interceptedBody.token === 'string' && interceptedBody.token.length > 0
     ? interceptedBody.token
-    : token
+    : null
   const refreshTokenForCookie = typeof interceptedBody.refreshToken === 'string'
     ? interceptedBody.refreshToken
     : undefined
 
   const res = NextResponse.json(interceptedBody, { status: interceptedResponse.statusCode })
-  res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
+  if (authTokenForCookie) {
+    res.cookies.set('auth_token', authTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
+  }
   if (remember && refreshTokenForCookie) {
     const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)
     res.cookies.set('session_token', refreshTokenForCookie, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', expires: expiresAt })

--- a/packages/enterprise/src/modules/security/api/__tests__/interceptors.test.ts
+++ b/packages/enterprise/src/modules/security/api/__tests__/interceptors.test.ts
@@ -92,7 +92,7 @@ describe('security auth/login api interceptor', () => {
     })
   })
 
-  test('fails closed to no-op when challenge creation fails', async () => {
+  test('fails closed with blocking replace when challenge creation fails', async () => {
     if (!interceptor?.after) throw new Error('Expected security auth/login interceptor')
 
     const createChallenge = jest.fn(async () => {
@@ -106,7 +106,38 @@ describe('security auth/login api interceptor', () => {
       buildContext(createChallenge),
     )
 
-    expect(result).toEqual({})
+    expect(result.replace).toBeDefined()
+    expect(result.replace?.ok).toBe(false)
+    expect(result.replace?.token).toBeUndefined()
+    expect(result.replace?.error).toBe('mfa_challenge_unavailable')
+  })
+
+  test('fails closed with blocking replace when mfa verification service is unavailable', async () => {
+    if (!interceptor?.after) throw new Error('Expected security auth/login interceptor')
+
+    const fullToken = signJwt({ sub: 'user-1', tenantId: 'tenant-1' })
+    const brokenContext = {
+      userId: '',
+      organizationId: '',
+      tenantId: '',
+      em: {} as InterceptorContext['em'],
+      container: {
+        resolve() {
+          throw new Error('container not initialized')
+        },
+      },
+    } as InterceptorContext
+
+    const result = await interceptor.after(
+      { method: 'POST', url: 'http://localhost/api/auth/login', headers: {} },
+      { statusCode: 200, body: { ok: true, token: fullToken }, headers: {} },
+      brokenContext,
+    )
+
+    expect(result.replace).toBeDefined()
+    expect(result.replace?.ok).toBe(false)
+    expect(result.replace?.token).toBeUndefined()
+    expect(result.replace?.error).toBe('mfa_challenge_unavailable')
   })
 
   test('skips MFA challenge injection when emergency bypass is enabled', async () => {

--- a/packages/enterprise/src/modules/security/api/interceptors.ts
+++ b/packages/enterprise/src/modules/security/api/interceptors.ts
@@ -1,6 +1,14 @@
-import type { ApiInterceptor } from '@open-mercato/shared/lib/crud/api-interceptor'
+import type { ApiInterceptor, InterceptorAfterResult } from '@open-mercato/shared/lib/crud/api-interceptor'
 import { signJwt, verifyJwt } from '@open-mercato/shared/lib/auth/jwt'
 import { readSecurityModuleConfig } from '../lib/security-config'
+
+const MFA_CHALLENGE_UNAVAILABLE: InterceptorAfterResult = {
+  replace: {
+    ok: false,
+    error: 'mfa_challenge_unavailable',
+    message: 'Multi-factor authentication is required but the challenge could not be issued.',
+  },
+}
 
 type JwtClaims = {
   sub: string
@@ -57,13 +65,17 @@ export const interceptors: ApiInterceptor[] = [
       if (response.statusCode !== 200) return {}
       if (response.body.ok !== true || response.body.mfa_required === true) return {}
       if (typeof response.body.token !== 'string' || response.body.token.length === 0) return {}
-      if (readSecurityModuleConfig().mfa.emergencyBypass) return {}
+      if (readSecurityModuleConfig().mfa.emergencyBypass) {
+        // eslint-disable-next-line no-console
+        console.warn('[security.mfa] Emergency bypass active — MFA challenge skipped on successful login. Source: OM_SECURITY_MFA_EMERGENCY_BYPASS env flag.')
+        return {}
+      }
 
       const claims = readClaims(response.body.token)
-      if (!claims) return {}
+      if (!claims) return MFA_CHALLENGE_UNAVAILABLE
 
       const mfaVerificationService = resolveMfaVerificationService(context.container as { resolve: (name: string) => unknown })
-      if (!mfaVerificationService) return {}
+      if (!mfaVerificationService) return MFA_CHALLENGE_UNAVAILABLE
 
       try {
         const challenge = await mfaVerificationService.createChallenge(claims.sub)
@@ -90,7 +102,7 @@ export const interceptors: ApiInterceptor[] = [
           },
         }
       } catch {
-        return {}
+        return MFA_CHALLENGE_UNAVAILABLE
       }
     },
   },


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                          
  The enterprise security module's `auth/login` after-interceptor silently                                                                                                
  fails open on transient errors. `packages/enterprise/src/modules/security/api/interceptors.ts:92-94`
  catches all `createChallenge` errors and returns `{}`. The interceptor                                                                                                  
  runner at `packages/shared/src/lib/crud/interceptor-runner.ts:244-249`                                                                                                  
  treats `{}` as "no modification" — so the original `200 OK` body with                                                                                                   
  the full non-MFA JWT flows through untouched. Any DB spike, DNS flap,                                                                                                   
  or broken DI resolution → login succeeds with a JWT that skipped MFA.                                                                                                   
                                                                                                                                                                          
  The leak is doubled by `packages/core/src/modules/auth/api/login.ts:194-196`,                                                                                           
  which falls back to the server-local `token` when building the                                                                                                          
  `auth_token` cookie. Even if the interceptor correctly stripped the                                                                                                     
  token from the body, the cookie still carried the unchallenged JWT,
  making any interceptor-level protection a no-op end-to-end.                                                                                                             
                                                                                                                                                                          
  This PR closes both paths and adds regression tests.                                                                                                                    
                                                                                                                                                                          
  ## Changes                                                                                                                                                              
                                                            
  - **`packages/enterprise/src/modules/security/api/interceptors.ts`**                                                                                                    
    - Introduced `MFA_CHALLENGE_UNAVAILABLE`: a blocking `replace`
      carrying `{ ok: false, error: 'mfa_challenge_unavailable' }` and                                                                                                    
      **no token**.                                                                                                                                                       
    - `createChallenge` catch → returns `MFA_CHALLENGE_UNAVAILABLE`.                                                                                                      
    - `readClaims` null (JWT verification failure) → returns                                                                                                              
      `MFA_CHALLENGE_UNAVAILABLE`.                                                                                                                                        
    - `resolveMfaVerificationService` null (DI broken / service missing)                                                                                                  
      → returns `MFA_CHALLENGE_UNAVAILABLE`.                                                                                                                              
    - Emergency bypass (`OM_SECURITY_MFA_EMERGENCY_BYPASS`) now emits a                                                                                                   
      `console.warn` on activation for operational visibility (the flag                                                                                                   
      previously bypassed MFA with zero audit trail).                                                                                                                     
  - **`packages/core/src/modules/auth/api/login.ts`**                                                                                                                     
    - Removed the `: token` fallback when the intercepted body lacks a                                                                                                    
      token. If the after-interceptor stripped the token, no `auth_token`                                                                                                 
      cookie is set. Success paths (including the MFA pending-token replace)                                                                                              
      continue to work because the replace body still contains `token`.                                                                                                   
  - **`packages/enterprise/src/modules/security/api/__tests__/interceptors.test.ts`**                                                                                     
    - Fixed misnamed test `fails closed to no-op when challenge creation                                                                                                  
      fails`. The label claimed "fails closed" but the assertion                                                                                                          
      `expect(result).toEqual({})` actually cemented the fail-open                                                                                                        
      behavior. Renamed and now asserts the blocking replace                                                                                                              
      (`ok:false`, absent `token`, `mfa_challenge_unavailable`).                                                                                                          
    - Added a new test covering fail-closed when the MFA service cannot                                                                                                   
      be resolved from the DI container.                                                                                                                                  
  - **`packages/core/src/modules/auth/api/__tests__/login.test.ts`**                                                                                                      
    - Added regression test: when an after-interceptor replaces the body                                                                                                  
      without a token, the response must NOT carry `auth_token=` in                                                                                                       
      `Set-Cookie` and must NOT leak the original signed JWT.                                                                                                             
                                                                                                                                                                          
  ## Why this is security-critical                                                                                                                                        
                                                            
  Before the fix, all of the following paths resulted in a successful                                                                                                     
  login with a full non-MFA JWT (bypassing enrolled MFA entirely):
                                                                                                                                                                          
  1. Database connectivity blip during `createChallenge`.                                                                                                                 
  2. MFA verification service container resolution failure.                                                                                                               
  3. `verifyJwt` returning null on a token we just issued (edge case,                                                                                                     
     e.g. JWT secret rotation mid-request).                                                                                                                               
  4. Any exception thrown inside `createChallenge` (tenant with no
     enrolled methods, provider API timeout, etc.).                                                                                                                       
                                                                                                                                                                          
  After the fix all of those paths return a body the client cannot act                                                                                                    
  on (`ok: false`, no token), and the cookie fallback in `login.ts` no                                                                                                    
  longer masks the intended block.   