### PR TITLE
tests: add low-level coverage for agentic-init.ts

### DIFF
--- a/packages/cli/src/lib/__tests__/agentic-init.test.ts
+++ b/packages/cli/src/lib/__tests__/agentic-init.test.ts
@@ -1,20 +1,76 @@
-import { resolveRelevantAgenticFiles } from '../agentic-init'
+import path from 'node:path'
+
+const loadActualModule = () => jest.requireActual('../agentic-init') as typeof import('../agentic-init')
+
+type AgenticInitTestContext = {
+  closeInterface: jest.Mock
+  createInterface: jest.Mock
+  runAgenticInit: typeof import('../agentic-init').runAgenticInit
+  runAgenticSetup: jest.Mock
+  readlineQuestion: jest.Mock
+}
+
+const loadRunAgenticInit = async ({
+  existingPaths,
+  questionAnswer = '',
+  runAgenticSetupImplementation,
+}: {
+  existingPaths: Set<string>
+  questionAnswer?: string
+  runAgenticSetupImplementation?: (targetDir: string, ask: (question: string) => Promise<string>, options?: { tool?: string; force?: boolean }) => Promise<void>
+}): Promise<AgenticInitTestContext> => {
+  jest.resetModules()
+
+  const existsSync = jest.fn((candidatePath: string) => existingPaths.has(candidatePath))
+  const closeInterface = jest.fn()
+  const readlineQuestion = jest.fn((question: string, onAnswer: (answer: string) => void) => {
+    onAnswer(questionAnswer)
+  })
+  const createInterface = jest.fn(() => ({
+    close: closeInterface,
+    question: readlineQuestion,
+  }))
+  const runAgenticSetup = jest.fn(
+    runAgenticSetupImplementation ?? (async () => undefined),
+  )
+
+  jest.doMock('node:fs', () => ({
+    existsSync,
+  }))
+  jest.doMock('node:readline', () => ({
+    createInterface,
+  }))
+  jest.doMock('../agentic-setup.js', () => ({
+    __esModule: true,
+    runAgenticSetup,
+  }), { virtual: true })
+
+  const { runAgenticInit } = await import('../agentic-init')
+
+  return {
+    closeInterface,
+    createInterface,
+    runAgenticInit,
+    runAgenticSetup,
+    readlineQuestion,
+  }
+}
 
 describe('resolveRelevantAgenticFiles', () => {
   it('returns only codex files for codex setup', () => {
-    expect(resolveRelevantAgenticFiles('codex')).toEqual([
+    expect(loadActualModule().resolveRelevantAgenticFiles('codex')).toEqual([
       '.codex/mcp.json.example',
     ])
   })
 
   it('returns only cursor files for cursor setup', () => {
-    expect(resolveRelevantAgenticFiles('cursor')).toEqual([
+    expect(loadActualModule().resolveRelevantAgenticFiles('cursor')).toEqual([
       '.cursor/hooks.json',
     ])
   })
 
   it('returns combined files for multiple selected tools', () => {
-    expect(resolveRelevantAgenticFiles('claude-code,cursor')).toEqual([
+    expect(loadActualModule().resolveRelevantAgenticFiles('claude-code,cursor')).toEqual([
       'CLAUDE.md',
       '.claude/settings.json',
       '.mcp.json.example',
@@ -22,13 +78,148 @@ describe('resolveRelevantAgenticFiles', () => {
     ])
   })
 
+  it('trims tool ids and removes duplicates', () => {
+    expect(loadActualModule().resolveRelevantAgenticFiles(' codex , cursor , codex ')).toEqual([
+      '.codex/mcp.json.example',
+      '.cursor/hooks.json',
+    ])
+  })
+
   it('falls back to the full known file list when no tool is provided', () => {
-    expect(resolveRelevantAgenticFiles()).toEqual([
+    expect(loadActualModule().resolveRelevantAgenticFiles()).toEqual([
       'CLAUDE.md',
       '.claude/settings.json',
       '.mcp.json.example',
       '.codex/mcp.json.example',
       '.cursor/hooks.json',
     ])
+  })
+
+  it('falls back to the full known file list when all selected tools are unknown', () => {
+    expect(loadActualModule().resolveRelevantAgenticFiles('unknown-tool')).toEqual([
+      'CLAUDE.md',
+      '.claude/settings.json',
+      '.mcp.json.example',
+      '.codex/mcp.json.example',
+      '.cursor/hooks.json',
+    ])
+  })
+})
+
+describe('runAgenticInit', () => {
+  const targetDir = path.resolve('.')
+  const appModulesPath = path.join(targetDir, 'src', 'modules.ts')
+  const codexConfigPath = path.join(targetDir, '.codex', 'mcp.json.example')
+  const cursorHooksPath = path.join(targetDir, '.cursor', 'hooks.json')
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.resetModules()
+    jest.dontMock('node:fs')
+    jest.dontMock('node:readline')
+    jest.dontMock('../agentic-setup.js')
+  })
+
+  it('returns an error when the current directory is not an Open Mercato app', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>(),
+    })
+
+    const exitCode = await testContext.runAgenticInit([])
+
+    expect(exitCode).toBe(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '❌  Not an Open Mercato app directory (src/modules.ts not found)',
+    )
+    expect(testContext.createInterface).not.toHaveBeenCalled()
+    expect(testContext.runAgenticSetup).not.toHaveBeenCalled()
+  })
+
+  it('warns and exits early when relevant agentic files already exist without force', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>([appModulesPath, codexConfigPath]),
+    })
+
+    const exitCode = await testContext.runAgenticInit(['--tool=codex'])
+
+    expect(exitCode).toBe(0)
+    expect(testContext.createInterface).not.toHaveBeenCalled()
+    expect(testContext.runAgenticSetup).not.toHaveBeenCalled()
+    expect(consoleLogSpy.mock.calls.flat()).toEqual(expect.arrayContaining([
+      '⚠️  Agentic files already exist:',
+      '   • .codex/mcp.json.example',
+      'Run with --force to regenerate from current templates.',
+    ]))
+  })
+
+  it('invokes setup with parsed options and trims readline answers passed to ask', async () => {
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>([appModulesPath]),
+      questionAnswer: '  cursor  ',
+      runAgenticSetupImplementation: async (currentTargetDir, ask, options) => {
+        expect(currentTargetDir).toBe(targetDir)
+        expect(options).toEqual({ tool: undefined, force: undefined })
+        await expect(ask('Select a tool')).resolves.toBe('cursor')
+      },
+    })
+
+    const exitCode = await testContext.runAgenticInit([])
+
+    expect(exitCode).toBe(0)
+    expect(testContext.createInterface).toHaveBeenCalledTimes(1)
+    expect(testContext.readlineQuestion).toHaveBeenCalledWith(
+      'Select a tool',
+      expect.any(Function),
+    )
+    expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores existing files from other tool selections when checking for overwrite warnings', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>([appModulesPath, cursorHooksPath]),
+    })
+
+    const exitCode = await testContext.runAgenticInit(['--tool', 'codex'])
+
+    expect(exitCode).toBe(0)
+    expect(testContext.runAgenticSetup).toHaveBeenCalledWith(
+      targetDir,
+      expect.any(Function),
+      { tool: 'codex', force: undefined },
+    )
+    expect(consoleLogSpy.mock.calls.flat()).not.toContain('⚠️  Agentic files already exist:')
+    expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
+  })
+
+  it('bypasses overwrite warnings when force is provided', async () => {
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>([appModulesPath, codexConfigPath]),
+    })
+
+    const exitCode = await testContext.runAgenticInit(['--tool', 'codex', '--force'])
+
+    expect(exitCode).toBe(0)
+    expect(testContext.runAgenticSetup).toHaveBeenCalledWith(
+      targetDir,
+      expect.any(Function),
+      { tool: 'codex', force: true },
+    )
+    expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes the readline interface when setup fails', async () => {
+    const setupError = new Error('setup failed')
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>([appModulesPath]),
+      runAgenticSetupImplementation: async () => {
+        throw setupError
+      },
+    })
+
+    await expect(testContext.runAgenticInit(['--tool=codex'])).rejects.toThrow(setupError)
+    expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/cli/src/lib/agentic-init.ts
+++ b/packages/cli/src/lib/agentic-init.ts
@@ -91,8 +91,11 @@ export async function runAgenticInit(args: string[]): Promise<number> {
   const rl = createInterface({ input: process.stdin, output: process.stdout })
   const ask = (q: string) => new Promise<string>((res) => rl.question(q, (a) => res(a.trim())))
 
-  await runAgenticSetup(targetDir, ask, { tool: options.tool, force: options.force })
-  rl.close()
+  try {
+    await runAgenticSetup(targetDir, ask, { tool: options.tool, force: options.force })
+  } finally {
+    rl.close()
+  }
 
   return 0
 }

--- a/packages/create-app/template/.ai/qa/tests/integration/TC-CLI-001-agentic-init.spec.ts
+++ b/packages/create-app/template/.ai/qa/tests/integration/TC-CLI-001-agentic-init.spec.ts
@@ -30,7 +30,11 @@ function countMatches(source: string, pattern: RegExp): number {
   return source.match(pattern)?.length ?? 0
 }
 
-function runMercato(mercatoBin: string, args: string[], cwd: string): { exitCode: number; stdout: string; stderr: string } {
+function runMercato(
+  mercatoBin: string,
+  args: string[],
+  cwd: string,
+): { exitCode: number; stdout: string; stderr: string } {
   const result = spawnSync(mercatoBin, args, {
     cwd,
     encoding: 'utf-8',

--- a/packages/create-app/template/src/modules/example/__integration__/TC-CLI-001-agentic-init.spec.ts
+++ b/packages/create-app/template/src/modules/example/__integration__/TC-CLI-001-agentic-init.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+function isStandaloneAppRoot(rootDir: string): boolean {
+  return fs.existsSync(path.join(rootDir, 'package.json'))
+    && fs.existsSync(path.join(rootDir, 'src', 'modules.ts'))
+}
+
+function resolveMercatoBin(rootDir: string): string {
+  const candidates = [
+    path.join(rootDir, 'node_modules', '.bin', process.platform === 'win32' ? 'mercato.cmd' : 'mercato'),
+    path.join(rootDir, 'node_modules', '@open-mercato', 'cli', 'bin', 'mercato'),
+  ]
+
+  const match = candidates.find((candidate) => fs.existsSync(candidate))
+  if (!match) {
+    throw new Error(`Could not find mercato bin. Checked: ${candidates.join(', ')}`)
+  }
+
+  return match
+}
+
+function readFile(filePath: string): string {
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+function countMatches(source: string, pattern: RegExp): number {
+  return source.match(pattern)?.length ?? 0
+}
+
+function runMercato(mercatoBin: string, args: string[], cwd: string): { exitCode: number; stdout: string; stderr: string } {
+  const result = spawnSync(mercatoBin, args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 60_000,
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NODE_NO_WARNINGS: '1',
+    },
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  return {
+    exitCode: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  }
+}
+
+test.describe('TC-CLI-001: Standalone agentic:init parity', () => {
+  test('agentic:init generates files, scopes overwrite warnings by tool, and honors --force', () => {
+    const standaloneRoot = process.cwd()
+    test.skip(!isStandaloneAppRoot(standaloneRoot), 'Standalone create-app parity only')
+    test.skip(
+      fs.existsSync(path.join(standaloneRoot, '.codex', 'mcp.json.example'))
+        || fs.existsSync(path.join(standaloneRoot, '.cursor', 'hooks.json')),
+      'This standalone app already has agentic files configured',
+    )
+
+    const mercatoBin = resolveMercatoBin(standaloneRoot)
+    const initialCodexRun = runMercato(mercatoBin, ['agentic:init', '--tool', 'codex'], standaloneRoot)
+    expect(initialCodexRun.exitCode).toBe(0)
+    expect(initialCodexRun.stderr).toBe('')
+    expect(initialCodexRun.stdout).toContain('Agentic setup complete:')
+    expect(initialCodexRun.stdout).toContain('✓ Codex')
+    expect(fs.existsSync(path.join(standaloneRoot, 'AGENTS.md'))).toBe(true)
+    expect(fs.existsSync(path.join(standaloneRoot, '.ai', 'specs', 'README.md'))).toBe(true)
+    expect(fs.existsSync(path.join(standaloneRoot, '.codex', 'mcp.json.example'))).toBe(true)
+
+    const initialAgentsSource = readFile(path.join(standaloneRoot, 'AGENTS.md'))
+    expect(initialAgentsSource).toContain('CODEX_ENFORCEMENT_RULES_START')
+    expect(countMatches(initialAgentsSource, /CODEX_ENFORCEMENT_RULES_START/g)).toBe(1)
+
+    const warningRun = runMercato(mercatoBin, ['agentic:init', '--tool=codex'], standaloneRoot)
+    expect(warningRun.exitCode).toBe(0)
+    expect(warningRun.stderr).toBe('')
+    expect(warningRun.stdout).toContain('⚠️  Agentic files already exist:')
+    expect(warningRun.stdout).toContain('.codex/mcp.json.example')
+    expect(warningRun.stdout).toContain('Run with --force to regenerate from current templates.')
+
+    const forcedRun = runMercato(mercatoBin, ['agentic:init', '--tool', 'codex', '--force'], standaloneRoot)
+    expect(forcedRun.exitCode).toBe(0)
+    expect(forcedRun.stderr).toBe('')
+    expect(forcedRun.stdout).toContain('Agentic setup complete:')
+    expect(forcedRun.stdout).not.toContain('⚠️  Agentic files already exist:')
+
+    const forcedAgentsSource = readFile(path.join(standaloneRoot, 'AGENTS.md'))
+    expect(countMatches(forcedAgentsSource, /CODEX_ENFORCEMENT_RULES_START/g)).toBe(1)
+
+    const cursorRun = runMercato(mercatoBin, ['agentic:init', '--tool', 'cursor'], standaloneRoot)
+    expect(cursorRun.exitCode).toBe(0)
+    expect(cursorRun.stderr).toBe('')
+    expect(cursorRun.stdout).toContain('Agentic setup complete:')
+    expect(cursorRun.stdout).toContain('✓ Cursor')
+    expect(cursorRun.stdout).not.toContain('⚠️  Agentic files already exist:')
+    expect(fs.existsSync(path.join(standaloneRoot, '.cursor', 'hooks.json'))).toBe(true)
+    expect(fs.existsSync(path.join(standaloneRoot, '.cursor', 'hooks', 'entity-migration-check.mjs'))).toBe(true)
+    expect(fs.existsSync(path.join(standaloneRoot, '.cursor', 'mcp.json.example'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for agentic-init.ts
## Problem Summary
tests: add low-level coverage for agentic-init.ts
## Expected Behavior
packages/cli/src/lib/agentic-init.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/cli/src/lib/agentic-init.ts.
Checked: packages/cli/src/lib/agentic-init.test.ts
packages/cli/src/lib/__tests__/agentic-init.test.ts
packages/cli/src/lib/agentic-init.spec.ts
packages/cli/src/lib/__tests__/agentic-init.spec.ts ...
## What Changed
- packages/cli/src/lib/__tests__/agentic-init.test.ts
- packages/cli/src/lib/agentic-init.ts
- packages/create-app/template/.ai/qa/tests/integration/TC-CLI-001-agentic-init.spec.ts
- Diff summary: +311 / -7 (318 total lines)
- Branch head: b8ba1708ba212504b848c0921ba0c3c1095c145b
## Validation / Tests
- cli-package-checks
## Expected Contribution Classes
- tests
- bugfix