### PR TITLE
tests: add low-level coverage for merger.ts

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -730,3 +730,13 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Backend chrome, breadcrumbs, static settings path discovery, and other route-aware consumers should read `backend-routes.generated.ts` or `getBackendRouteManifests()`. Keep `modules.app.generated.ts` in bootstrap unless the caller truly needs the full module registry beyond route manifests.
 
 **Applies to**: `apps/*/src/bootstrap.ts`, backend layouts, hydrated sidebar/header APIs, route matching helpers, and any future performance optimization around generated registries.
+
+## When a task brief requires Playwright coverage, unit tests are not a substitute
+
+**Context**: `packages/search/src/lib/merger.ts` received new Jest coverage, but the task brief and QA guides explicitly required module-local Playwright integration coverage.
+
+**Problem**: The branch still failed review because the required coverage class was missing even though the low-level tests passed.
+
+**Rule**: When a task brief, review artifact, or QA guide says Playwright or integration coverage is required, add or update a module-local `__integration__/TC-*.spec.ts` in the same change. Treat Jest or other low-level tests as complementary, not a replacement.
+
+**Applies to**: HackOn implementation tasks and any change governed by `.ai/qa/AGENTS.md` or `.ai/skills/integration-tests/SKILL.md`.

--- a/packages/search/src/__tests__/merger.test.ts
+++ b/packages/search/src/__tests__/merger.test.ts
@@ -1,0 +1,252 @@
+import { deduplicateResults, mergeAndRankResults, normalizeScores } from '../lib/merger'
+import type { ResultMergeConfig, SearchResult, SearchStrategyId } from '../types'
+
+const DEFAULT_CONFIG: ResultMergeConfig = {
+  duplicateHandling: 'highest_score',
+}
+
+function createResult(overrides: Partial<SearchResult> = {}): SearchResult {
+  return {
+    entityId: 'customers:company',
+    recordId: 'record-1',
+    score: 0.5,
+    source: 'tokens',
+    ...overrides,
+  }
+}
+
+function createConfig(overrides: Partial<ResultMergeConfig> = {}): ResultMergeConfig {
+  return {
+    ...DEFAULT_CONFIG,
+    ...overrides,
+  }
+}
+
+function rrf(rank: number, weight = 1): number {
+  return weight / (60 + rank + 1)
+}
+
+describe('merger', () => {
+  describe('mergeAndRankResults', () => {
+    it('returns an empty array when there are no results', () => {
+      expect(mergeAndRankResults([], createConfig())).toEqual([])
+    })
+
+    it('combines RRF scores and enriches missing presenter data from another strategy', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({
+            source: 'tokens',
+            score: 0.3,
+            metadata: { origin: 'tokens' },
+          }),
+          createResult({
+            source: 'fulltext',
+            score: 0.9,
+            presenter: { title: 'Acme Corp', badge: 'Company' },
+            url: '/backend/customers/record-1',
+            links: [{ href: '/backend/customers/record-1/edit', label: 'Edit' }],
+          }),
+        ],
+        createConfig({
+          strategyWeights: {
+            tokens: 0.8,
+            fulltext: 1.2,
+          } as Record<SearchStrategyId, number>,
+        }),
+      )
+
+      expect(merged).toHaveLength(1)
+      expect(merged[0]).toMatchObject({
+        source: 'tokens',
+        presenter: { title: 'Acme Corp', badge: 'Company' },
+        url: '/backend/customers/record-1',
+        links: [{ href: '/backend/customers/record-1/edit', label: 'Edit' }],
+      })
+      expect(merged[0].score).toBeCloseTo(rrf(0, 0.8) + rrf(0, 1.2))
+      expect(merged[0].metadata).toEqual(
+        expect.objectContaining({
+          origin: 'tokens',
+          _sources: ['tokens', 'fulltext'],
+          _rrfScore: expect.any(Number),
+        }),
+      )
+      expect(merged[0].metadata?._rrfScore).toBeCloseTo(rrf(0, 0.8) + rrf(0, 1.2))
+    })
+
+    it('prefers the duplicate with the stronger contribution when both results have presenters', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({
+            source: 'tokens',
+            score: 0.95,
+            presenter: { title: 'Token Result' },
+            url: '/tokens/record-1',
+          }),
+          createResult({
+            source: 'fulltext',
+            score: 0.2,
+            presenter: { title: 'Fulltext Result' },
+            url: '/fulltext/record-1',
+          }),
+        ],
+        createConfig({
+          strategyWeights: {
+            tokens: 0.8,
+            fulltext: 1.2,
+          } as Record<SearchStrategyId, number>,
+        }),
+      )
+
+      expect(merged).toHaveLength(1)
+      expect(merged[0]).toMatchObject({
+        source: 'fulltext',
+        presenter: { title: 'Fulltext Result' },
+        url: '/fulltext/record-1',
+      })
+      expect(merged[0].score).toBeCloseTo(rrf(0, 0.8) + rrf(0, 1.2))
+    })
+
+    it('keeps the presented result when a later duplicate lacks presenter data', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({
+            source: 'fulltext',
+            presenter: { title: 'Fulltext Result' },
+            url: '/fulltext/record-1',
+          }),
+          createResult({
+            source: 'tokens',
+            score: 0.9,
+            url: '/tokens/record-1',
+          }),
+        ],
+        createConfig({
+          strategyWeights: {
+            fulltext: 1.2,
+            tokens: 0.8,
+          } as Record<SearchStrategyId, number>,
+        }),
+      )
+
+      expect(merged).toHaveLength(1)
+      expect(merged[0]).toMatchObject({
+        source: 'fulltext',
+        presenter: { title: 'Fulltext Result' },
+        url: '/fulltext/record-1',
+      })
+    })
+
+    it('keeps the duplicate with the stronger contribution when neither result has presenter data', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({
+            source: 'tokens',
+            url: '/tokens/record-1',
+          }),
+          createResult({
+            source: 'fulltext',
+            url: '/fulltext/record-1',
+          }),
+        ],
+        createConfig({
+          strategyWeights: {
+            tokens: 0.8,
+            fulltext: 1.2,
+          } as Record<SearchStrategyId, number>,
+        }),
+      )
+
+      expect(merged).toHaveLength(1)
+      expect(merged[0]).toMatchObject({
+        source: 'fulltext',
+        url: '/fulltext/record-1',
+      })
+    })
+
+    it('filters out results below the configured minimum score threshold', () => {
+      const merged = mergeAndRankResults(
+        [
+          createResult({
+            source: 'fulltext',
+            recordId: 'record-1',
+          }),
+          createResult({
+            source: 'tokens',
+            recordId: 'record-2',
+          }),
+        ],
+        createConfig({
+          minScore: 0.015,
+          strategyWeights: {
+            fulltext: 1.2,
+            tokens: 0.8,
+          } as Record<SearchStrategyId, number>,
+        }),
+      )
+
+      expect(merged).toHaveLength(1)
+      expect(merged[0]?.recordId).toBe('record-1')
+      expect(merged[0]?.score).toBeCloseTo(rrf(0, 1.2))
+    })
+  })
+
+  describe('deduplicateResults', () => {
+    it('keeps the highest-scored duplicate and sorts all remaining results by score', () => {
+      const deduplicated = deduplicateResults([
+        createResult({
+          source: 'tokens',
+          recordId: 'record-1',
+          score: 0.4,
+        }),
+        createResult({
+          source: 'fulltext',
+          recordId: 'record-1',
+          score: 0.9,
+          presenter: { title: 'Preferred Result' },
+        }),
+        createResult({
+          source: 'vector',
+          recordId: 'record-2',
+          score: 0.7,
+        }),
+      ])
+
+      expect(deduplicated).toHaveLength(2)
+      expect(deduplicated.map((result) => [result.recordId, result.score])).toEqual([
+        ['record-1', 0.9],
+        ['record-2', 0.7],
+      ])
+      expect(deduplicated[0]?.presenter?.title).toBe('Preferred Result')
+    })
+  })
+
+  describe('normalizeScores', () => {
+    it('returns an empty array for empty input', () => {
+      expect(normalizeScores([])).toEqual([])
+    })
+
+    it('normalizes scores to the 0-1 range', () => {
+      const normalized = normalizeScores([
+        createResult({ recordId: 'record-1', score: 10 }),
+        createResult({ recordId: 'record-2', score: 15 }),
+        createResult({ recordId: 'record-3', score: 20 }),
+      ])
+
+      expect(normalized.map((result) => [result.recordId, result.score])).toEqual([
+        ['record-1', 0],
+        ['record-2', 0.5],
+        ['record-3', 1],
+      ])
+    })
+
+    it('normalizes equal scores to 1.0', () => {
+      const normalized = normalizeScores([
+        createResult({ recordId: 'record-1', score: 7 }),
+        createResult({ recordId: 'record-2', score: 7 }),
+      ])
+
+      expect(normalized.map((result) => result.score)).toEqual([1, 1])
+    })
+  })
+})

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
@@ -36,6 +36,14 @@ function isRecord(value: unknown): value is JsonRecord {
   return typeof value === 'object' && value !== null
 }
 
+function requireValue<T>(value: T | null | undefined, message: string): NonNullable<T> {
+  if (value == null) {
+    throw new Error(message)
+  }
+
+  return value as NonNullable<T>
+}
+
 async function readJson<T extends JsonRecord>(response: APIResponse): Promise<T> {
   return ((await readJsonSafe<T>(response)) ?? {}) as T
 }
@@ -86,9 +94,10 @@ test.describe('TC-SEARCH-002: search endpoint merges duplicate strategy hits', (
     let mergedResult: SearchResultPayload | null = null
 
     try {
-      token = await getAuthToken(request, 'superadmin')
+      const authToken = await getAuthToken(request, 'superadmin')
+      token = authToken
 
-      const settingsResponse = await apiRequest(request, 'GET', '/api/search/settings', { token })
+      const settingsResponse = await apiRequest(request, 'GET', '/api/search/settings', { token: authToken })
       expect(settingsResponse.ok()).toBeTruthy()
       const settings = await readJson<SearchSettingsResponse>(settingsResponse)
 
@@ -102,12 +111,14 @@ test.describe('TC-SEARCH-002: search endpoint merges duplicate strategy hits', (
         return
       }
 
-      companyId = await createCompanyFixture(request, token, uniqueCompanyName)
+      companyId = await createCompanyFixture(request, authToken, uniqueCompanyName)
 
       await expect
         .poll(
           async () => {
-            const searchResponse = await apiRequest(request, 'GET', buildSearchPath(uniqueCompanyName), { token })
+            const searchResponse = await apiRequest(request, 'GET', buildSearchPath(uniqueCompanyName), {
+              token: authToken,
+            })
             if (!searchResponse.ok()) {
               mergedResult = null
               return 'response-not-ok'
@@ -136,19 +147,23 @@ test.describe('TC-SEARCH-002: search endpoint merges duplicate strategy hits', (
         )
         .toBe('fulltext,tokens')
 
-      expect(mergedResult).toBeTruthy()
-      expect(mergedResult?.source).toBe('fulltext')
-      expect(getPresenterTitle(mergedResult!)).toBe(uniqueCompanyName)
+      const ensuredMergedResult = requireValue<SearchResultPayload>(
+        mergedResult,
+        'Expected merged result from search response',
+      )
 
-      const metadata = isRecord(mergedResult?.metadata) ? mergedResult.metadata : {}
+      expect(ensuredMergedResult.source).toBe('fulltext')
+      expect(getPresenterTitle(ensuredMergedResult)).toBe(uniqueCompanyName)
+
+      const metadata = isRecord(ensuredMergedResult.metadata) ? ensuredMergedResult.metadata : {}
       expect(typeof metadata._rrfScore).toBe('number')
 
-      expect(mergedResult?.entityId).toBe('customers:customer_company_profile')
+      expect(ensuredMergedResult.entityId).toBe('customers:customer_company_profile')
 
-      expect(typeof mergedResult?.url).toBe('string')
-      expect(mergedResult?.url).toContain('/backend/customers/companies/')
+      expect(typeof ensuredMergedResult.url).toBe('string')
+      expect(ensuredMergedResult.url).toContain('/backend/customers/companies/')
 
-      const links = getLinks(mergedResult!)
+      const links = getLinks(ensuredMergedResult)
       expect(
         links.some((link) => typeof link.href === 'string' && link.href.includes('/backend/customers/companies/')),
       ).toBeTruthy()

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test, type APIResponse } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createCompanyFixture,
+  deleteEntityIfExists,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/crmFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+type SearchSettingsResponse = {
+  settings?: {
+    strategies?: Array<{
+      id?: unknown
+      available?: unknown
+    }>
+    tokensEnabled?: unknown
+  }
+}
+
+type SearchResultPayload = {
+  entityId?: unknown
+  recordId?: unknown
+  source?: unknown
+  presenter?: unknown
+  url?: unknown
+  links?: unknown
+  metadata?: unknown
+}
+
+type SearchResponse = {
+  results?: SearchResultPayload[]
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null
+}
+
+async function readJson<T extends JsonRecord>(response: APIResponse): Promise<T> {
+  return ((await readJsonSafe<T>(response)) ?? {}) as T
+}
+
+function getPresenterTitle(result: SearchResultPayload): string | null {
+  if (!isRecord(result.presenter)) return null
+  const title = result.presenter.title
+  return typeof title === 'string' && title.trim().length > 0 ? title : null
+}
+
+function getSources(result: SearchResultPayload): string[] {
+  if (!isRecord(result.metadata)) return []
+  const rawSources = result.metadata._sources
+  if (!Array.isArray(rawSources)) return []
+  return rawSources.filter((source): source is string => typeof source === 'string').sort()
+}
+
+function getLinks(result: SearchResultPayload): Array<{ href?: unknown; label?: unknown; kind?: unknown }> {
+  return Array.isArray(result.links)
+    ? result.links.filter((link): link is { href?: unknown; label?: unknown; kind?: unknown } => isRecord(link))
+    : []
+}
+
+function hasStrategy(
+  settings: SearchSettingsResponse,
+  id: string,
+): boolean {
+  const strategies = Array.isArray(settings.settings?.strategies) ? settings.settings.strategies : []
+  return strategies.some((strategy) => strategy.id === id && strategy.available === true)
+}
+
+function buildSearchPath(query: string): string {
+  const params = new URLSearchParams({
+    q: query,
+    limit: '10',
+    strategies: 'fulltext,tokens',
+    entityTypes: 'customers:customer_company_profile',
+  })
+  return `/api/search/search?${params.toString()}`
+}
+
+test.describe('TC-SEARCH-002: search endpoint merges duplicate strategy hits', () => {
+  test('returns a single merged company result with both token and fulltext sources', async ({ request }) => {
+    let token: string | null = null
+    let companyId: string | null = null
+
+    const uniqueCompanyName = `QATCSEARCH002${Date.now()}`
+    let mergedResult: SearchResultPayload | null = null
+
+    try {
+      token = await getAuthToken(request, 'superadmin')
+
+      const settingsResponse = await apiRequest(request, 'GET', '/api/search/settings', { token })
+      expect(settingsResponse.ok()).toBeTruthy()
+      const settings = await readJson<SearchSettingsResponse>(settingsResponse)
+
+      if (!hasStrategy(settings, 'fulltext')) {
+        test.skip(true, 'Fulltext strategy is not available in this environment')
+        return
+      }
+
+      if (settings.settings?.tokensEnabled !== true) {
+        test.skip(true, 'Token search is disabled in this environment')
+        return
+      }
+
+      companyId = await createCompanyFixture(request, token, uniqueCompanyName)
+
+      await expect
+        .poll(
+          async () => {
+            const searchResponse = await apiRequest(request, 'GET', buildSearchPath(uniqueCompanyName), { token })
+            if (!searchResponse.ok()) {
+              mergedResult = null
+              return 'response-not-ok'
+            }
+
+            const searchBody = await readJson<SearchResponse>(searchResponse)
+            const results = Array.isArray(searchBody.results) ? searchBody.results : []
+            const matchingResults = results.filter((result) => getPresenterTitle(result) === uniqueCompanyName)
+
+            if (matchingResults.length !== 1) {
+              mergedResult = null
+              return `matches:${matchingResults.length}`
+            }
+
+            const candidate = matchingResults[0]
+            const sources = getSources(candidate)
+            if (sources.join(',') !== 'fulltext,tokens') {
+              mergedResult = null
+              return sources.join(',') || 'missing-sources'
+            }
+
+            mergedResult = candidate
+            return sources.join(',')
+          },
+          { timeout: 15_000 },
+        )
+        .toBe('fulltext,tokens')
+
+      expect(mergedResult).toBeTruthy()
+      expect(mergedResult?.source).toBe('fulltext')
+      expect(getPresenterTitle(mergedResult!)).toBe(uniqueCompanyName)
+
+      const metadata = isRecord(mergedResult?.metadata) ? mergedResult.metadata : {}
+      expect(typeof metadata._rrfScore).toBe('number')
+
+      expect(mergedResult?.entityId).toBe('customers:customer_company_profile')
+
+      expect(typeof mergedResult?.url).toBe('string')
+      expect(mergedResult?.url).toContain('/backend/customers/companies/')
+
+      const links = getLinks(mergedResult!)
+      expect(
+        links.some((link) => typeof link.href === 'string' && link.href.includes('/backend/customers/companies/')),
+      ).toBeTruthy()
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId)
+    }
+  })
+})


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for merger.ts
## Problem Summary
tests: add low-level coverage for merger.ts
## Expected Behavior
packages/search/src/lib/merger.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/search/src/lib/merger.ts.
Checked: packages/search/src/lib/merger.test.ts
packages/search/src/lib/__tests__/merger.test.ts
packages/search/src/lib/merger.spec.ts
packages/search/src/lib/__tests__/merger.spec.ts ...
## What Changed
- .ai/lessons.md
- packages/search/src/__tests__/merger.test.ts
- packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
- Diff summary: +436 / -0 (436 total lines)
- Branch head: b044c57b1b9fb5a4d1f581eab7e77c3d6260157a
## Validation / Tests
- search-package-checks
## Expected Contribution Classes
- tests
- bugfix