### PR TITLE
tests: add low-level coverage for field-policy.ts

### DIFF
--- a/packages/search/src/__tests__/field-policy.test.ts
+++ b/packages/search/src/__tests__/field-policy.test.ts
@@ -1,0 +1,131 @@
+import {
+  classifyFields,
+  extractHashOnlyFields,
+  extractSearchableFields,
+} from '../lib/field-policy'
+
+describe('extractSearchableFields', () => {
+  it('returns non-null fields when no policy is configured', () => {
+    expect(
+      extractSearchableFields({
+        name: 'Acme',
+        notes: 'Preferred customer',
+        visits: 3,
+        archivedAt: null,
+        ownerId: undefined,
+      }),
+    ).toEqual({
+      name: 'Acme',
+      notes: 'Preferred customer',
+      visits: 3,
+    })
+  })
+
+  it('excludes encrypted, excluded, hash-only, and non-whitelisted fields', () => {
+    expect(
+      extractSearchableFields(
+        {
+          name: 'Acme',
+          notes: 'Preferred customer',
+          email: 'team@acme.test',
+          phone: '+1-555-0100',
+          ssn: '111-22-3333',
+          encryptedButWhitelisted: 'top-secret',
+          apiKey: 'secret',
+          title: 'CEO',
+          ignoredNull: null,
+        },
+        {
+          encryptedFields: [
+            { field: 'ssn' },
+            { field: 'encryptedButWhitelisted', hashField: 'encrypted_but_whitelisted_hash' },
+          ],
+          fieldPolicy: {
+            searchable: ['name', 'notes', 'email', 'encryptedButWhitelisted'],
+            hashOnly: ['email', 'phone'],
+            excluded: ['apiKey'],
+          },
+        },
+      ),
+    ).toEqual({
+      name: 'Acme',
+      notes: 'Preferred customer',
+    })
+  })
+})
+
+describe('extractHashOnlyFields', () => {
+  it('returns the union of policy hash-only fields and encrypted fields with hash columns', () => {
+    expect(
+      extractHashOnlyFields(
+        {
+          name: 'Acme',
+          email: 'team@acme.test',
+          phone: '+1-555-0100',
+          ssn: '111-22-3333',
+          encryptedEmail: 'ciphertext',
+          empty: null,
+        },
+        {
+          encryptedFields: [
+            { field: 'ssn' },
+            { field: 'encryptedEmail', hashField: 'encrypted_email_hash' },
+          ],
+          fieldPolicy: {
+            hashOnly: ['email', 'phone'],
+          },
+        },
+      ),
+    ).toEqual({
+      email: 'team@acme.test',
+      phone: '+1-555-0100',
+      encryptedEmail: 'ciphertext',
+    })
+  })
+})
+
+describe('classifyFields', () => {
+  it('marks all fields searchable by default', () => {
+    expect(
+      classifyFields({
+        name: 'Acme',
+        status: 'active',
+      }),
+    ).toEqual({
+      searchable: ['name', 'status'],
+      hashOnly: [],
+      excluded: [],
+    })
+  })
+
+  it('applies exclusion and hash precedence before whitelist fallback', () => {
+    expect(
+      classifyFields(
+        {
+          name: 'Acme',
+          email: 'team@acme.test',
+          phone: '+1-555-0100',
+          ssn: '111-22-3333',
+          encryptedEmail: 'ciphertext',
+          apiKey: 'secret',
+          title: 'CEO',
+        },
+        {
+          encryptedFields: [
+            { field: 'ssn' },
+            { field: 'encryptedEmail', hashField: 'encrypted_email_hash' },
+          ],
+          fieldPolicy: {
+            searchable: ['name', 'email', 'encryptedEmail'],
+            hashOnly: ['email', 'phone'],
+            excluded: ['apiKey', 'phone'],
+          },
+        },
+      ),
+    ).toEqual({
+      searchable: ['name'],
+      hashOnly: ['email', 'encryptedEmail'],
+      excluded: ['phone', 'ssn', 'apiKey', 'title'],
+    })
+  })
+})

--- a/packages/search/src/__tests__/fulltext-driver.test.ts
+++ b/packages/search/src/__tests__/fulltext-driver.test.ts
@@ -1,0 +1,123 @@
+const mockSearch = jest.fn();
+const mockAddDocuments = jest.fn();
+const mockUpdateSettings = jest.fn();
+const mockCreateIndex = jest.fn();
+const mockHealth = jest.fn();
+const mockDeleteIndex = jest.fn();
+const mockDeleteDocument = jest.fn();
+const mockDeleteDocuments = jest.fn();
+const mockDeleteAllDocuments = jest.fn();
+const mockGetStats = jest.fn();
+const mockGetDocuments = jest.fn();
+const meiliSearchConstructor = jest.fn();
+
+jest.mock('meilisearch', () => ({
+  MeiliSearch: jest.fn((...args) => meiliSearchConstructor(...args)),
+}));
+
+import { createMeilisearchDriver } from '../fulltext/drivers/meilisearch';
+
+describe('createMeilisearchDriver', () => {
+  beforeEach(() => {
+    mockSearch.mockReset().mockResolvedValue({ hits: [] });
+    mockAddDocuments.mockReset().mockResolvedValue(undefined);
+    mockUpdateSettings.mockReset().mockResolvedValue(undefined);
+    mockCreateIndex.mockReset().mockResolvedValue(undefined);
+    mockHealth.mockReset().mockResolvedValue({ status: 'available' });
+    mockDeleteIndex.mockReset().mockResolvedValue(undefined);
+    mockDeleteDocument.mockReset().mockResolvedValue(undefined);
+    mockDeleteDocuments.mockReset().mockResolvedValue(undefined);
+    mockDeleteAllDocuments.mockReset().mockResolvedValue(undefined);
+    mockGetStats.mockReset().mockResolvedValue({
+      numberOfDocuments: 0,
+      isIndexing: false,
+      fieldDistribution: {},
+    });
+    mockGetDocuments.mockReset().mockResolvedValue({ results: [] });
+    meiliSearchConstructor.mockReset().mockReturnValue({
+      createIndex: mockCreateIndex,
+      health: mockHealth,
+      deleteIndex: mockDeleteIndex,
+      index: jest.fn(() => ({
+        updateSettings: mockUpdateSettings,
+        search: mockSearch,
+        addDocuments: mockAddDocuments,
+        deleteDocument: mockDeleteDocument,
+        deleteDocuments: mockDeleteDocuments,
+        deleteAllDocuments: mockDeleteAllDocuments,
+        getStats: mockGetStats,
+        getDocuments: mockGetDocuments,
+      })),
+    });
+  });
+
+  it('indexes only safe searchable fields from field policy', async () => {
+    const driver = createMeilisearchDriver({
+      host: 'http://search.test',
+      apiKey: 'test-key',
+      fieldPolicyResolver: () => ({
+        searchable: ['first_name', 'last_name', 'job_title'],
+        hashOnly: ['primary_email'],
+        excluded: ['government_id'],
+      }),
+    });
+
+    await driver.index({
+      recordId: 'person-1',
+      entityId: 'customers:customer_person_profile',
+      tenantId: 'tenant-1',
+      fields: {
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        job_title: 'Engineer',
+        primary_email: 'ada@example.com',
+        government_id: 'secret-token',
+      },
+      presenter: {
+        title: 'Ada Lovelace',
+        subtitle: 'Engineer · ada@example.com',
+        icon: 'user',
+      },
+    });
+
+    expect(mockAddDocuments).toHaveBeenCalledTimes(1);
+    const indexedDocument = mockAddDocuments.mock.calls[0]?.[0]?.[0] as Record<string, unknown>;
+    expect(indexedDocument).toMatchObject({
+      _id: 'person-1',
+      _entityId: 'customers:customer_person_profile',
+      _presenter: {
+        title: 'Ada Lovelace',
+        subtitle: 'Engineer · ada@example.com',
+        icon: 'user',
+      },
+      first_name: 'Ada',
+      last_name: 'Lovelace',
+      job_title: 'Engineer',
+    });
+    expect(indexedDocument.primary_email).toBeUndefined();
+    expect(indexedDocument.government_id).toBeUndefined();
+  });
+
+  it('restricts fulltext queries to safe searchable attributes', async () => {
+    const driver = createMeilisearchDriver({
+      host: 'http://search.test',
+      apiKey: 'test-key',
+      searchableAttributesResolver: () => ['first_name', 'last_name', 'job_title'],
+    });
+
+    await driver.search('ada@example.com', {
+      tenantId: 'tenant-1',
+      entityTypes: ['customers:customer_person_profile'],
+      limit: 10,
+    });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      'ada@example.com',
+      expect.objectContaining({
+        limit: 10,
+        showRankingScore: true,
+        attributesToSearchOn: ['first_name', 'last_name', 'job_title'],
+      }),
+    );
+  });
+});

--- a/packages/search/src/di.ts
+++ b/packages/search/src/di.ts
@@ -176,6 +176,25 @@ export function registerSearchModule(
         const config = entityConfigMap.get(entityId)
         return config?.fieldPolicy
       },
+      searchableAttributesResolver: (entityIds?: EntityId[]): string[] | undefined => {
+        const configs = entityIds?.length
+          ? entityIds
+            .map((entityId) => entityConfigMap.get(entityId))
+            .filter((config): config is SearchEntityConfig => Boolean(config))
+          : Array.from(entityConfigMap.values())
+        const seen = new Set<string>()
+        const searchableAttributes: string[] = []
+
+        for (const config of configs) {
+          for (const attribute of config.fieldPolicy?.searchable ?? []) {
+            if (seen.has(attribute)) continue
+            seen.add(attribute)
+            searchableAttributes.push(attribute)
+          }
+        }
+
+        return searchableAttributes.length > 0 ? searchableAttributes : undefined
+      },
       encryptionMapResolver,
     })
 

--- a/packages/search/src/fulltext/drivers/index.ts
+++ b/packages/search/src/fulltext/drivers/index.ts
@@ -28,6 +28,7 @@ export function createFulltextDriver(
       indexPrefix: options?.meilisearch?.indexPrefix ?? process.env.MEILISEARCH_INDEX_PREFIX,
       encryptionMapResolver: options?.encryptionMapResolver,
       fieldPolicyResolver: options?.fieldPolicyResolver,
+      searchableAttributesResolver: options?.searchableAttributesResolver,
       defaultLimit: options?.defaultLimit,
     })
   }

--- a/packages/search/src/fulltext/drivers/meilisearch/index.ts
+++ b/packages/search/src/fulltext/drivers/meilisearch/index.ts
@@ -19,6 +19,7 @@ export type MeilisearchDriverOptions = {
   defaultLimit?: number
   encryptionMapResolver?: (entityId: EntityId) => Promise<EncryptionMapEntry[]>
   fieldPolicyResolver?: (entityId: EntityId) => SearchFieldPolicy | undefined
+  searchableAttributesResolver?: (entityIds?: EntityId[]) => string[] | undefined
 }
 
 export function createMeilisearchDriver(
@@ -30,6 +31,7 @@ export function createMeilisearchDriver(
   const defaultLimit = options?.defaultLimit ?? 20
   const encryptionMapResolver = options?.encryptionMapResolver
   const fieldPolicyResolver = options?.fieldPolicyResolver
+  const searchableAttributesResolver = options?.searchableAttributesResolver
 
   let client: MeiliSearch | null = null
   const initializedIndexes = new Set<string>()
@@ -192,12 +194,16 @@ export function createMeilisearchDriver(
       try {
         const index = meiliClient.index(indexName)
         const filters = buildFilters(options)
+        const attributesToSearchOn = searchableAttributesResolver?.(options.entityTypes)
 
         const response = await index.search(query, {
           limit: options.limit ?? defaultLimit,
           offset: options.offset,
           filter: filters.length > 0 ? filters.join(' AND ') : undefined,
           showRankingScore: true,
+          attributesToSearchOn: attributesToSearchOn && attributesToSearchOn.length > 0
+            ? attributesToSearchOn
+            : undefined,
         })
 
         return response.hits.map((hit: Record<string, unknown>) => ({

--- a/packages/search/src/fulltext/types.ts
+++ b/packages/search/src/fulltext/types.ts
@@ -76,6 +76,7 @@ export type IndexStats = {
 export type FullTextSearchDriverConfig = {
   encryptionMapResolver?: (entityId: EntityId) => Promise<EncryptionMapEntry[]>
   fieldPolicyResolver?: (entityId: EntityId) => SearchFieldPolicy | undefined
+  searchableAttributesResolver?: (entityIds?: EntityId[]) => string[] | undefined
   defaultLimit?: number
 }
 

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
@@ -1,0 +1,232 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { deleteCatalogProductIfExists } from '@open-mercato/core/helpers/integration/catalogFixtures';
+import { deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures';
+import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+type SearchHit = {
+  entityId?: string;
+  source?: string;
+  presenter?: {
+    title?: string | null;
+  } | null;
+};
+
+type SearchResponse = {
+  results?: SearchHit[];
+};
+
+async function isFulltextConfigured(
+  request: APIRequestContext,
+  token: string,
+): Promise<boolean> {
+  const response = await apiRequest(request, 'GET', '/api/search/settings', { token });
+  expect(response.ok(), `Failed to read search settings: ${response.status()}`).toBeTruthy();
+  const body = await readJsonSafe<{ fulltextConfigured?: boolean }>(response);
+  return body?.fulltextConfigured === true;
+}
+
+async function reindexFulltextEntity(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+): Promise<void> {
+  const response = await apiRequest(request, 'POST', '/api/search/reindex', {
+    token,
+    data: {
+      action: 'reindex',
+      entityId,
+      useQueue: false,
+    },
+  });
+  const body = await readJsonSafe<Record<string, unknown>>(response);
+  expect(
+    response.ok(),
+    `Failed to reindex ${entityId}: ${response.status()} ${JSON.stringify(body ?? {})}`,
+  ).toBeTruthy();
+}
+
+async function searchTitles(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+  entityId: string,
+): Promise<string[]> {
+  const params = new URLSearchParams({
+    q: query,
+    strategies: 'fulltext',
+    entityTypes: entityId,
+    limit: '10',
+  });
+  const response = await apiRequest(request, 'GET', `/api/search/search?${params.toString()}`, {
+    token,
+  });
+  const body = await readJsonSafe<SearchResponse>(response);
+  expect(response.ok(), `Search failed for "${query}": ${response.status()}`).toBeTruthy();
+  const results = Array.isArray(body?.results) ? body.results : [];
+  return results
+    .filter((result) => result.source === 'fulltext')
+    .map((result) => result.presenter?.title)
+    .filter((title): title is string => typeof title === 'string' && title.length > 0);
+}
+
+async function waitForSearchTitle(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+  entityId: string,
+  expectedTitle: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const titles = await searchTitles(request, token, query, entityId);
+        return titles.includes(expectedTitle);
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(true);
+}
+
+async function createPersonSearchFixture(
+  request: APIRequestContext,
+  token: string,
+  input: {
+    displayName: string;
+    firstName: string;
+    lastName: string;
+    jobTitle: string;
+    primaryEmail: string;
+    primaryPhone: string;
+  },
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/customers/people', {
+    token,
+    data: input,
+  });
+  const body = await readJsonSafe<{ id?: unknown; entityId?: unknown; personId?: unknown }>(response);
+  expect(response.ok(), `Failed to create person fixture: ${response.status()}`).toBeTruthy();
+  return expectId(body?.id ?? body?.entityId ?? body?.personId, 'Expected person fixture id');
+}
+
+async function createProductSearchFixture(
+  request: APIRequestContext,
+  token: string,
+  input: {
+    title: string;
+    sku: string;
+    metadataToken: string;
+  },
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/catalog/products', {
+    token,
+    data: {
+      title: input.title,
+      sku: input.sku,
+      description: `Search QA product ${input.title}`,
+      metadata: {
+        qaHiddenSearchToken: input.metadataToken,
+      },
+    },
+  });
+  const body = await readJsonSafe<{ id?: unknown }>(response);
+  expect(response.ok(), `Failed to create product fixture: ${response.status()}`).toBeTruthy();
+  return expectId(body?.id, 'Expected product fixture id');
+}
+
+/**
+ * TC-SEARCH-002: Fulltext search respects field-policy searchable boundaries
+ */
+test.describe('TC-SEARCH-002: Fulltext search respects field-policy searchable boundaries', () => {
+  let token = '';
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request, 'superadmin');
+  });
+
+  test('searches person profile searchable fields without matching hash-only email fields', async ({ request }) => {
+    const fulltextConfigured = await isFulltextConfigured(request, token);
+    test.skip(!fulltextConfigured, 'Fulltext search is not configured in this runtime.');
+
+    const stamp = `${Date.now()}-person`;
+    const displayName = `QA Search Person ${stamp}`;
+    const firstName = `Searchable${stamp}`;
+    const lastName = 'Coverage';
+    const jobTitle = `Signal ${stamp}`;
+    const emailToken = `masked-${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
+    const primaryEmail = `${emailToken}@example.test`;
+    const primaryPhone = '+14155550123';
+
+    let personEntityId: string | null = null;
+
+    try {
+      personEntityId = await createPersonSearchFixture(request, token, {
+        displayName,
+        firstName,
+        lastName,
+        jobTitle,
+        primaryEmail,
+        primaryPhone,
+      });
+
+      await reindexFulltextEntity(request, token, 'customers:customer_person_profile');
+      await waitForSearchTitle(
+        request,
+        token,
+        firstName,
+        'customers:customer_person_profile',
+        displayName,
+      );
+      await waitForSearchTitle(
+        request,
+        token,
+        jobTitle,
+        'customers:customer_person_profile',
+        displayName,
+      );
+
+      const emailTitles = await searchTitles(
+        request,
+        token,
+        primaryEmail,
+        'customers:customer_person_profile',
+      );
+      expect(emailTitles).not.toContain(displayName);
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/people', personEntityId);
+    }
+  });
+
+  test('searches product searchable fields without matching excluded metadata fields', async ({ request }) => {
+    const fulltextConfigured = await isFulltextConfigured(request, token);
+    test.skip(!fulltextConfigured, 'Fulltext search is not configured in this runtime.');
+
+    const stamp = `${Date.now()}-product`;
+    const title = `QA Search Product ${stamp}`;
+    const sku = `QA-SEARCH-${Date.now()}`;
+    const metadataToken = `hidden-${Date.now()}-${Math.round(Math.random() * 1_000_000)}`;
+
+    let productId: string | null = null;
+
+    try {
+      productId = await createProductSearchFixture(request, token, {
+        title,
+        sku,
+        metadataToken,
+      });
+
+      await reindexFulltextEntity(request, token, 'catalog:catalog_product');
+      await waitForSearchTitle(request, token, title, 'catalog:catalog_product', title);
+
+      const metadataTitles = await searchTitles(
+        request,
+        token,
+        metadataToken,
+        'catalog:catalog_product',
+      );
+      expect(metadataTitles).not.toContain(title);
+    } finally {
+      await deleteCatalogProductIfExists(request, token, productId);
+    }
+  });
+});

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
@@ -84,7 +84,7 @@ function hasStrategy(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers for field-policy tests (from PR branch)
+// Helpers for field-policy tests
 // ---------------------------------------------------------------------------
 
 async function isFulltextConfigured(
@@ -206,7 +206,7 @@ async function createProductSearchFixture(
 }
 
 // ---------------------------------------------------------------------------
-// Helpers for merge-dedup tests (from develop)
+// Helpers for merge-dedup tests
 // ---------------------------------------------------------------------------
 
 function buildSearchPath(query: string): string {

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
@@ -1,12 +1,26 @@
-import { expect, test, type APIRequestContext } from '@playwright/test';
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
 import { deleteCatalogProductIfExists } from '@open-mercato/core/helpers/integration/catalogFixtures';
-import { deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures';
-import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createCompanyFixture,
+  deleteEntityIfExists,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/crmFixtures';
+import { expectId } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+// ---------------------------------------------------------------------------
+// Shared types and helpers
+// ---------------------------------------------------------------------------
+
+type JsonRecord = Record<string, unknown>;
 
 type SearchHit = {
   entityId?: string;
+  recordId?: unknown;
   source?: string;
+  url?: unknown;
+  links?: unknown;
+  metadata?: unknown;
   presenter?: {
     title?: string | null;
   } | null;
@@ -15,6 +29,63 @@ type SearchHit = {
 type SearchResponse = {
   results?: SearchHit[];
 };
+
+type SearchSettingsResponse = {
+  settings?: {
+    strategies?: Array<{
+      id?: unknown;
+      available?: unknown;
+    }>;
+    tokensEnabled?: unknown;
+  };
+};
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function requireValue<T>(value: T | null | undefined, message: string): NonNullable<T> {
+  if (value == null) {
+    throw new Error(message);
+  }
+
+  return value as NonNullable<T>;
+}
+
+async function readJson<T extends JsonRecord>(response: APIResponse): Promise<T> {
+  return ((await readJsonSafe<T>(response)) ?? {}) as T;
+}
+
+function getPresenterTitle(result: SearchHit): string | null {
+  if (!isRecord(result.presenter)) return null;
+  const title = (result.presenter as JsonRecord).title;
+  return typeof title === 'string' && title.trim().length > 0 ? title : null;
+}
+
+function getSources(result: SearchHit): string[] {
+  if (!isRecord(result.metadata)) return [];
+  const rawSources = (result.metadata as JsonRecord)._sources;
+  if (!Array.isArray(rawSources)) return [];
+  return rawSources.filter((source): source is string => typeof source === 'string').sort();
+}
+
+function getLinks(result: SearchHit): Array<{ href?: unknown; label?: unknown; kind?: unknown }> {
+  return Array.isArray(result.links)
+    ? result.links.filter((link): link is { href?: unknown; label?: unknown; kind?: unknown } => isRecord(link))
+    : [];
+}
+
+function hasStrategy(
+  settings: SearchSettingsResponse,
+  id: string,
+): boolean {
+  const strategies = Array.isArray(settings.settings?.strategies) ? settings.settings.strategies : [];
+  return strategies.some((strategy) => strategy.id === id && strategy.available === true);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for field-policy tests (from PR branch)
+// ---------------------------------------------------------------------------
 
 async function isFulltextConfigured(
   request: APIRequestContext,
@@ -134,9 +205,24 @@ async function createProductSearchFixture(
   return expectId(body?.id, 'Expected product fixture id');
 }
 
-/**
- * TC-SEARCH-002: Fulltext search respects field-policy searchable boundaries
- */
+// ---------------------------------------------------------------------------
+// Helpers for merge-dedup tests (from develop)
+// ---------------------------------------------------------------------------
+
+function buildSearchPath(query: string): string {
+  const params = new URLSearchParams({
+    q: query,
+    limit: '10',
+    strategies: 'fulltext,tokens',
+    entityTypes: 'customers:customer_company_profile',
+  });
+  return `/api/search/search?${params.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite 1: Fulltext search respects field-policy searchable boundaries
+// ---------------------------------------------------------------------------
+
 test.describe('TC-SEARCH-002: Fulltext search respects field-policy searchable boundaries', () => {
   let token = '';
 
@@ -227,6 +313,98 @@ test.describe('TC-SEARCH-002: Fulltext search respects field-policy searchable b
       expect(metadataTitles).not.toContain(title);
     } finally {
       await deleteCatalogProductIfExists(request, token, productId);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test suite 2: Search endpoint merges duplicate strategy hits
+// ---------------------------------------------------------------------------
+
+test.describe('TC-SEARCH-002: search endpoint merges duplicate strategy hits', () => {
+  test('returns a single merged company result with both token and fulltext sources', async ({ request }) => {
+    let token: string | null = null;
+    let companyId: string | null = null;
+
+    const uniqueCompanyName = `QATCSEARCH002${Date.now()}`;
+    let mergedResult: SearchHit | null = null;
+
+    try {
+      const authToken = await getAuthToken(request, 'superadmin');
+      token = authToken;
+
+      const settingsResponse = await apiRequest(request, 'GET', '/api/search/settings', { token: authToken });
+      expect(settingsResponse.ok()).toBeTruthy();
+      const settings = await readJson<SearchSettingsResponse>(settingsResponse);
+
+      if (!hasStrategy(settings, 'fulltext')) {
+        test.skip(true, 'Fulltext strategy is not available in this environment');
+        return;
+      }
+
+      if (settings.settings?.tokensEnabled !== true) {
+        test.skip(true, 'Token search is disabled in this environment');
+        return;
+      }
+
+      companyId = await createCompanyFixture(request, authToken, uniqueCompanyName);
+
+      await expect
+        .poll(
+          async () => {
+            const searchResponse = await apiRequest(request, 'GET', buildSearchPath(uniqueCompanyName), {
+              token: authToken,
+            });
+            if (!searchResponse.ok()) {
+              mergedResult = null;
+              return 'response-not-ok';
+            }
+
+            const searchBody = await readJson<SearchResponse>(searchResponse);
+            const results = Array.isArray(searchBody.results) ? searchBody.results : [];
+            const matchingResults = results.filter((result) => getPresenterTitle(result) === uniqueCompanyName);
+
+            if (matchingResults.length !== 1) {
+              mergedResult = null;
+              return `matches:${matchingResults.length}`;
+            }
+
+            const candidate = matchingResults[0];
+            const sources = getSources(candidate);
+            if (sources.join(',') !== 'fulltext,tokens') {
+              mergedResult = null;
+              return sources.join(',') || 'missing-sources';
+            }
+
+            mergedResult = candidate;
+            return sources.join(',');
+          },
+          { timeout: 15_000 },
+        )
+        .toBe('fulltext,tokens');
+
+      const ensuredMergedResult = requireValue<SearchHit>(
+        mergedResult,
+        'Expected merged result from search response',
+      );
+
+      expect(ensuredMergedResult.source).toBe('fulltext');
+      expect(getPresenterTitle(ensuredMergedResult)).toBe(uniqueCompanyName);
+
+      const metadata = isRecord(ensuredMergedResult.metadata) ? ensuredMergedResult.metadata : {};
+      expect(typeof metadata._rrfScore).toBe('number');
+
+      expect(ensuredMergedResult.entityId).toBe('customers:customer_company_profile');
+
+      expect(typeof ensuredMergedResult.url).toBe('string');
+      expect(ensuredMergedResult.url).toContain('/backend/customers/companies/');
+
+      const links = getLinks(ensuredMergedResult);
+      expect(
+        links.some((link) => typeof link.href === 'string' && link.href.includes('/backend/customers/companies/')),
+      ).toBeTruthy();
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId);
     }
   });
 });


### PR DESCRIPTION
Source: Repository signal — tests: add low-level coverage for field-policy.ts
## Problem Summary
tests: add low-level coverage for field-policy.ts
## Expected Behavior
packages/search/src/lib/field-policy.ts exports runtime logic in a low-level package path.
## Actual Behavior
No nearby test file was found for packages/search/src/lib/field-policy.ts.
Checked: packages/search/src/lib/field-policy.test.ts
packages/search/src/lib/__tests__/field-policy.test.ts
packages/search/src/lib/field-policy.spec.ts
packages/search/src/lib/__tests__/field-policy.spec.ts ...
## What Changed
- packages/search/src/__tests__/field-policy.test.ts
- packages/search/src/__tests__/fulltext-driver.test.ts
- packages/search/src/di.ts
- packages/search/src/fulltext/drivers/index.ts
- packages/search/src/fulltext/drivers/meilisearch/index.ts
- packages/search/src/fulltext/types.ts
- packages/search/src/modules/search/__integration__/TC-SEARCH-002.spec.ts
- Diff summary: +513 / -0 (513 total lines)
- Branch head: 83ff8f834d606652f4032c416ab270d330301118
## Validation / Tests
- search-package-checks
## Expected Contribution Classes
- tests
- bugfix