### PR TITLE
fix(directory): honor All Organizations for ACL __all__ non-superAdmins

### DIFF
--- a/packages/core/src/modules/directory/api/organization-switcher/route.ts
+++ b/packages/core/src/modules/directory/api/organization-switcher/route.ts
@@ -171,7 +171,7 @@ export async function GET(req: NextRequest) {
         tenantId,
         orgId: scopedOrgId,
       },
-      selectedId: requestedAll ? null : rawSelected,
+      selectedId: rawSelected,
       tenantId,
     })
     const accessible = scope.allowedIds

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -1,0 +1,237 @@
+/** @jest-environment node */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import { ALL_ORGANIZATIONS_COOKIE_VALUE } from '@open-mercato/core/modules/directory/constants'
+import { resolveOrganizationScope } from '../organizationScope'
+
+/**
+ * Creates a mock EntityManager whose `find` returns Organization-like rows
+ * that match the requested ids.
+ */
+function createMockEm(rows: Array<{ id: string; descendantIds: string[] }>) {
+  return {
+    find: jest.fn((_entity: unknown, filter: { id?: { $in: string[] }; tenant?: string }) => {
+      const requestedIds = filter?.id?.$in ?? []
+      return Promise.resolve(
+        rows.filter((row) => requestedIds.includes(row.id)),
+      )
+    }),
+  } as unknown as EntityManager
+}
+
+function createMockRbac(aclResult: { isSuperAdmin: boolean; features: string[]; organizations: string[] | null }) {
+  return {
+    loadAcl: jest.fn().mockResolvedValue(aclResult),
+  } as unknown as RbacService
+}
+
+function createAuth(overrides: Partial<AuthContext> & { sub: string }): AuthContext {
+  return {
+    tenantId: 'tenant-1',
+    orgId: 'org-home',
+    isSuperAdmin: false,
+    ...overrides,
+  } as AuthContext
+}
+
+const ORG_HOME = { id: 'org-home', descendantIds: ['org-home-child'] }
+const ORG_A = { id: 'org-a', descendantIds: [] }
+const ORG_B = { id: 'org-b', descendantIds: ['org-b-child'] }
+const ALL_ORGS = [ORG_HOME, ORG_A, ORG_B]
+
+describe('resolveOrganizationScope', () => {
+  describe('unauthenticated / missing context', () => {
+    it('returns null scope when auth.sub is missing', async () => {
+      const em = createMockEm([])
+      const rbac = createMockRbac({ isSuperAdmin: false, features: [], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: {} as AuthContext,
+      })
+      expect(result).toEqual({ selectedId: null, filterIds: null, allowedIds: null, tenantId: null })
+    })
+
+    it('returns null scope when tenantId is empty', async () => {
+      const em = createMockEm([])
+      const rbac = createMockRbac({ isSuperAdmin: false, features: [], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', tenantId: '' }),
+      })
+      expect(result).toEqual({ selectedId: null, filterIds: null, allowedIds: null, tenantId: null })
+    })
+  })
+
+  describe('superAdmin behavior', () => {
+    it('returns null filterIds when superAdmin selects "All Organizations"', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+      expect(result.tenantId).toBe('tenant-1')
+    })
+
+    it('returns null filterIds when superAdmin has no org selection', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true }),
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+    })
+
+    it('scopes to specific org + descendants when superAdmin selects one', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-b', 'org-b-child']))
+    })
+  })
+
+  describe('non-superAdmin with __all__ ACL access (issue #1112)', () => {
+    it('returns null filterIds when user with unrestricted ACL selects "All Organizations"', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+      expect(result.allowedIds).toBeNull()
+      expect(result.tenantId).toBe('tenant-1')
+    })
+
+    it('returns null filterIds when ACL organizations array contains __all__ token', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: [ALL_ORGANIZATIONS_COOKIE_VALUE],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+      expect(result.allowedIds).toBeNull()
+    })
+
+    it('scopes to specific org when user with unrestricted ACL selects one', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: 'org-a',
+      })
+      expect(result.selectedId).toBe('org-a')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a']))
+    })
+
+    it('falls back to home org when user with unrestricted ACL has no selection', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+      })
+      expect(result.selectedId).toBe('org-home')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-home', 'org-home-child']))
+    })
+  })
+
+  describe('non-superAdmin with restricted ACL (specific org list)', () => {
+    it('does not widen to all orgs when "All Organizations" is selected but ACL is restricted', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a', 'org-b'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).not.toBeNull()
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a', 'org-b', 'org-b-child']))
+    })
+
+    it('scopes to selected org when it is in the allowed list', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a', 'org-b'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-b', 'org-b-child']))
+    })
+
+    it('falls back to allowed set when selected org is not in ACL', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({
+        isSuperAdmin: false,
+        features: ['some.feature'],
+        organizations: ['org-a'],
+      })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).not.toBe('org-b')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a']))
+    })
+  })
+
+  describe('ACL-level superAdmin flag', () => {
+    it('treats ACL-level isSuperAdmin same as auth-level for org scope widening', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false }),
+        selectedId: ALL_ORGANIZATIONS_COOKIE_VALUE,
+      })
+      expect(result.filterIds).toBeNull()
+      expect(result.selectedId).toBeNull()
+    })
+  })
+})

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -98,8 +98,9 @@ export async function resolveOrganizationScope({
   if (!tenantId) {
     return { selectedId: null, filterIds: null, allowedIds: null, tenantId: null }
   }
-  const explicitAllSelection = selectedId === null
-  const normalizedSelectedId = typeof selectedId === 'string' && isAllOrganizationsSelection(selectedId)
+  const explicitAllOrgsChoice =
+    typeof selectedId === 'string' && isAllOrganizationsSelection(selectedId)
+  const normalizedSelectedId = explicitAllOrgsChoice
     ? null
     : (selectedId ?? null)
   const contextOrgId = actorTenantId && actorTenantId === tenantId ? auth.orgId ?? null : null
@@ -144,7 +145,14 @@ export async function resolveOrganizationScope({
     }
   }
 
-  const initialSelected = normalizedSelectedId ?? (explicitAllSelection && effectiveSuperAdmin ? null : accountOrgId ?? null)
+  const hasUnrestrictedAccess = effectiveSuperAdmin || (accessibleList === null)
+  const noOrgSelection = selectedId == null
+  const widenToAllOrgs =
+    (explicitAllOrgsChoice && hasUnrestrictedAccess)
+    || (effectiveSuperAdmin && noOrgSelection)
+  const initialSelected =
+    normalizedSelectedId
+    ?? (widenToAllOrgs ? null : accountOrgId ?? null)
   let effectiveSelected: string | null = null
   if (initialSelected) {
     if (allowedSet === null || allowedSet.has(initialSelected)) {
@@ -157,13 +165,13 @@ export async function resolveOrganizationScope({
     filterSet = await collectWithDescendants(em, tenantId, [effectiveSelected])
   } else if (allowedSet !== null) {
     filterSet = allowedSet
-  } else if (explicitAllSelection && effectiveSuperAdmin) {
+  } else if (widenToAllOrgs) {
     filterSet = null
   } else if (auth.orgId) {
     filterSet = await loadFallbackSet()
   }
 
-  if ((!filterSet || filterSet.size === 0) && fallbackOrgId && !(explicitAllSelection && effectiveSuperAdmin)) {
+  if ((!filterSet || filterSet.size === 0) && fallbackOrgId && !widenToAllOrgs) {
     const computed = await loadFallbackSet()
     if (computed && computed.size > 0) {
       filterSet = computed
@@ -254,12 +262,11 @@ export async function resolveOrganizationScopeForRequest({
   }
 
   const rawSelected = selectedId !== undefined ? selectedId : (request ? getSelectedOrganizationFromRequest(request) : null)
-  const reqSelected = typeof rawSelected === 'string' && isAllOrganizationsSelection(rawSelected) ? null : rawSelected
   const baseScope = await resolveOrganizationScope({
     em,
     rbac,
     auth: scopedAuth,
-    selectedId: reqSelected,
+    selectedId: rawSelected,
     tenantId: effectiveTenantId,
   })
 


### PR DESCRIPTION
## Summary

Fixes #1112

`resolveOrganizationScope` ignored the "All Organizations" selection for non-superAdmin users whose ACL grants unrestricted organization access (`organizations: null` or containing `__all__`). The org switcher UI correctly offered "All Organizations" but the backend scoping fell back to the user's home org.

### Root cause

Three interconnected bugs:

1. **`resolveOrganizationScope`** used `selectedId === null` to detect "all orgs" intent, but the `__all__` cookie value is a string (`'__all__'`), not `null`. This meant the function could never detect an explicit "All Organizations" selection.

2. **`resolveOrganizationScopeForRequest`** pre-converted `__all__` to `null` before passing `selectedId` to `resolveOrganizationScope`, making "explicit all orgs" indistinguishable from "no selection".

3. **Even when** `explicitAllSelection` was `true` (which only happened for `null`), the condition was gated on `effectiveSuperAdmin`, so non-superAdmin users with `__all__` ACL access were always excluded from the all-orgs codepath.

### Fix

- Detect `__all__` token directly in `resolveOrganizationScope` via `isAllOrganizationsSelection(selectedId)` instead of checking `selectedId === null`
- Introduce `hasUnrestrictedAccess = effectiveSuperAdmin || (accessibleList === null)` and `widenToAllOrgs` to handle both explicit All-Orgs selection by unrestricted users and superAdmin default behavior
- Stop pre-converting `__all__` to `null` in `resolveOrganizationScopeForRequest` and organization-switcher route -- let `resolveOrganizationScope` handle the normalization

### Files changed

- `packages/core/src/modules/directory/utils/organizationScope.ts` -- core fix
- `packages/core/src/modules/directory/api/organization-switcher/route.ts` -- stop pre-converting `__all__` to `null`
- `packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts` -- **new**, 13 unit tests

## Test plan

- [x] 13 unit tests covering all user types and selection scenarios (all passing)
- [ ] Verify non-superAdmin with `__all__` ACL sees cross-org data when selecting "All Organizations"
- [ ] Verify non-superAdmin with restricted ACL still cannot widen to all orgs
- [ ] Verify superAdmin behavior unchanged (all orgs by default, specific org when selected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"