### PR TITLE
fix(sales): product search in quote/order item dialog drops valid results

### DIFF
--- a/packages/core/src/modules/sales/components/documents/LineItemDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/LineItemDialog.tsx
@@ -538,7 +538,6 @@ export function LineItemDialog({
       const items = Array.isArray(response.result?.items)
         ? (response.result?.items ?? [])
         : [];
-      const needle = query?.trim().toLowerCase() ?? "";
       return items
         .map((item) => {
           const id = typeof item.id === "string" ? item.id : null;
@@ -595,11 +594,6 @@ export function LineItemDialog({
           const defaultUnit = uomFields.defaultUnit;
           const defaultSalesUnit = uomFields.defaultSalesUnit;
           const defaultSalesUnitQuantity = uomFields.defaultSalesUnitQuantity;
-          const matches =
-            !needle ||
-            title.toLowerCase().includes(needle) ||
-            (sku ? sku.toLowerCase().includes(needle) : false);
-          if (!matches) return null;
           return {
             id,
             title,


### PR DESCRIPTION
## Summary

- Remove redundant client-side product search filter in `LineItemDialog` that caused valid API results to be dropped
- The API searches across 5 fields (`title`, `subtitle`, `description`, `sku`, `handle`) using case-insensitive `$ilike`, but the client-side `matches` filter only checked `title` and `sku`, silently discarding products that matched on other fields

## Root Cause

In `loadProductOptions` inside `LineItemDialog.tsx`, after fetching products from `/api/catalog/products?search=...`, a `needle` variable was used to re-filter the results client-side:

```typescript
const matches =
  !needle ||
  title.toLowerCase().includes(needle) ||
  (sku ? sku.toLowerCase().includes(needle) : false);
if (!matches) return null;
```

This filter only checked `title` and `sku`, but the server-side search also matches on `subtitle`, `description`, and `handle`. Products matching on those fields were returned by the API but then incorrectly removed by the client.

**Example**: A product with title "Premium Headphones" and handle "aurora-123" would be found by the API when searching "aurora", but the client filter would discard it because neither title nor SKU contains "aurora".

## Fix

Remove the redundant `needle`/`matches` client-side filter entirely. The server already performs the authoritative case-insensitive search via `$ilike` queries — there is no need to re-filter on the client.

## Test plan

- [ ] Search for a product by a term that appears in its handle but not title/SKU
- [ ] Search for a product by a term in its description
- [ ] Search for a product by title (case-insensitive) — should still work
- [ ] Search for a product by SKU — should still work
- [ ] Verify no results shown for truly non-existent terms

Closes #1350