### PR TITLE
fix(tests): stabilize flaky TC-ADMIN-008 custom entity records test

### DIFF
--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-008.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-008.spec.ts
@@ -108,14 +108,15 @@ test.describe('TC-ADMIN-008: Create Custom Entity Record', () => {
       expect(recordId).toBeTruthy();
 
       await page.goto(`/backend/entities/user/${encodeURIComponent(entityId)}/records`, {
-        waitUntil: 'domcontentloaded',
+        waitUntil: 'networkidle',
       });
       await page.getByText('Loading data...').waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});
+      await page.waitForLoadState('networkidle');
       await expect(page.getByRole('link', { name: 'Create' })).toBeVisible();
       await expect(page).toHaveURL(new RegExp(`/backend/entities/user/${encodeURIComponent(entityId)}/records$`, 'i'));
       await expect(page.getByRole('row', { name: new RegExp(location, 'i') })).toBeVisible();
       await page.goto(`/backend/entities/user/${encodeURIComponent(entityId)}/records/${encodeURIComponent(recordId!)}`, {
-        waitUntil: 'domcontentloaded',
+        waitUntil: 'networkidle',
       });
       await expect(page).toHaveURL(new RegExp(`/backend/entities/user/${encodeURIComponent(entityId)}/records/[^/]+$`, 'i'));
       await page.getByText(/Loading record/i).waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});


### PR DESCRIPTION
## Summary

- Fix intermittent timeout in TC-ADMIN-008 caused by `waitUntil: 'domcontentloaded'` returning before React Query's `useCustomFieldDefs` async fetch completes
- Switch both `page.goto()` calls to `waitUntil: 'networkidle'` so all API responses (records + custom field definitions) are received before assertions
- Add explicit `page.waitForLoadState('networkidle')` after \"Loading data...\" disappears as a secondary guard against late-firing React Query requests

## Root cause

- The records list page renders the \"Create\" link conditionally based on `hasAnyFormFields`, which depends on `useCustomFieldDefs(entityId)` — a React Query hook that fetches `/api/entities/definitions`. This is a separate network request from the records data fetch. Using `waitUntil: 'domcontentloaded'` allowed the test to proceed before this request completed, leaving `cfDefs` as an empty array and the \"Create\" link unrendered.

## Test plan

- [ ] TC-ADMIN-008 passes consistently in CI without timeout
- [ ] No per-test timeout or retry overrides added


🤖 Generated with [Claude Code](https://claude.com/claude-code)"