### PR TITLE
fix(ai-assistant): backport isolated-vm sandbox from main to develop …

### DIFF
--- a/packages/ai-assistant/package.json
+++ b/packages/ai-assistant/package.json
@@ -2,6 +2,9 @@
   "name": "@open-mercato/ai-assistant",
   "version": "0.4.10",
   "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "main": "./dist/index.js",
   "scripts": {
     "build": "node build.mjs",
@@ -89,6 +92,7 @@
     "ai": "^6.0.33",
     "cmdk": "^1.0.0",
     "framer-motion": "^11.0.0",
+    "isolated-vm": "^6.1.2",
     "react-json-view-lite": "^2.5.0",
     "react-markdown": "^9.0.0",
     "zod-to-json-schema": "^3.25.1"

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/sandbox.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/sandbox.test.ts
@@ -182,6 +182,44 @@ describe('createSandbox', () => {
       )
       expect(result.error).toBeDefined()
     })
+
+    it('blocks prototype-chain escape via Object.constructor.constructor', async () => {
+      const sandbox = createSandbox({})
+      const result = await sandbox.execute(
+        "async () => Object.constructor('return process')()"
+      )
+      expect(result.result).toBeFalsy()
+      expect(result.error).toBeDefined()
+    })
+
+    it('blocks prototype-chain escape via Array.constructor.constructor', async () => {
+      const sandbox = createSandbox({})
+      const result = await sandbox.execute(
+        "async () => Array.constructor('return this')()"
+      )
+      const leaked = result.result as Record<string, unknown> | null | undefined
+      const gotHostProcess = typeof leaked === 'object' && leaked !== null
+        && typeof (leaked as { process?: unknown }).process === 'object'
+        && (leaked as { process?: { pid?: unknown } }).process?.pid !== undefined
+      expect(gotHostProcess).toBe(false)
+    })
+
+    it('blocks prototype-chain escape via Promise.constructor.constructor', async () => {
+      const sandbox = createSandbox({})
+      const result = await sandbox.execute(
+        "async () => Promise.constructor('return process.env')()"
+      )
+      const leaked = result.result as Record<string, unknown> | null | undefined
+      expect(leaked === undefined || leaked === null || Object.keys(leaked as object).length === 0).toBe(true)
+    })
+
+    it('blocks (() => {}).constructor escape', async () => {
+      const sandbox = createSandbox({})
+      const result = await sandbox.execute(
+        "async () => ((()=>{}).constructor)('return process.mainModule.require(\"child_process\").execSync(\"id\").toString()')()"
+      )
+      expect(result.error).toBeDefined()
+    })
   })
 
   describe('allowed built-ins', () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/sandbox.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/sandbox.ts
@@ -1,11 +1,13 @@
 /**
  * Sandboxed Code Execution Engine
  *
- * Uses node:vm to run AI-generated JavaScript in a restricted sandbox.
- * Only whitelisted globals are available — no file system, network, or process access.
+ * Uses isolated-vm to run AI-generated JavaScript inside a separate V8 isolate.
+ * Each execution gets a fresh isolate with no shared prototype chain, heap, or
+ * handle access to the host process — preventing the node:vm escape via the
+ * Promise prototype chain (NEW-01, CVSS 9.9).
  */
 
-import vm from 'node:vm'
+import ivm from 'isolated-vm'
 
 export interface SandboxOptions {
   /** Execution timeout in milliseconds (default: 30_000) */
@@ -24,6 +26,7 @@ export interface SandboxResult {
   apiCallCount?: number
 }
 
+const MEMORY_LIMIT_MB = parseInt(process.env.SANDBOX_MEMORY_MB ?? '32', 10)
 const MAX_LOG_ENTRIES = 100
 const MAX_LOG_ENTRY_LENGTH = 1000
 
@@ -33,95 +36,40 @@ const MAX_LOG_ENTRY_LENGTH = 1000
  * @param globals - Custom globals to inject (e.g., spec, api, context)
  * @param options - Sandbox configuration
  */
-export function createSandbox(
-  globals: Record<string, unknown>,
-  options: SandboxOptions = {}
-) {
-  const { timeout = 30_000, maxApiCalls = 50 } = options
+export function createSandbox(globals: Record<string, unknown>, options: SandboxOptions = {}) {
+  const { timeout = 30_000 } = options
 
   return {
     async execute(code: string): Promise<SandboxResult> {
       const logs: string[] = []
       const start = Date.now()
 
-      // Capture console output
-      const consolProxy = {
-        log: (...args: unknown[]) => pushLog(logs, args),
-        info: (...args: unknown[]) => pushLog(logs, args),
-        warn: (...args: unknown[]) => pushLog(logs, args),
-        error: (...args: unknown[]) => pushLog(logs, args),
-        debug: (...args: unknown[]) => pushLog(logs, args),
-      }
-
-      // Build context with safe globals + caller-provided globals
-      const contextGlobals: Record<string, unknown> = {
-        // Safe built-ins
-        JSON,
-        Object,
-        Array,
-        Map,
-        Set,
-        Promise,
-        Math,
-        Date,
-        RegExp,
-        String,
-        Number,
-        Boolean,
-        parseInt,
-        parseFloat,
-        isNaN,
-        isFinite,
-        encodeURIComponent,
-        decodeURIComponent,
-        Error,
-        TypeError,
-        RangeError,
-        undefined,
-        NaN,
-        Infinity,
-
-        // Sandboxed console
-        console: consolProxy,
-
-        // Blocked — explicitly set to undefined
-        require: undefined,
-        process: undefined,
-        global: undefined,
-        globalThis: undefined,
-        fetch: undefined,
-        XMLHttpRequest: undefined,
-        WebSocket: undefined,
-        Buffer: undefined,
-        setTimeout: undefined,
-        setInterval: undefined,
-        __dirname: undefined,
-        __filename: undefined,
-
-        // Caller-provided globals (spec, api, context, etc.)
-        ...globals,
-      }
-
-      const ctx = vm.createContext(contextGlobals)
+      const isolate = new ivm.Isolate({ memoryLimit: MEMORY_LIMIT_MB })
 
       try {
+        const ctx = await isolate.createContext()
+
+        // Console proxy — fire-and-forget so logging never blocks the isolate
+        await bootstrapConsole(ctx, logs)
+
+        // Inject caller-provided globals (spec, api, context, etc.)
+        await injectGlobals(ctx, globals)
+
+        // Shadow globalThis so user code cannot navigate to the isolate's global
+        // object and inspect/escape via its properties
+        await ctx.global.set('globalThis', undefined)
+
         const normalized = normalizeCode(code)
 
-        // Invoke the normalized async function directly
-        const wrapped = `(${normalized})()`
+        const script = await isolate.compileScript(`(${normalized})()`)
 
-        const script = new vm.Script(wrapped, {
-          filename: 'sandbox.js',
-        })
-
-        // Run the script — returns a Promise
-        const promise = script.runInContext(ctx, { timeout })
-
-        // Await with secondary timeout (for async operations like api.request)
+        // promise: true  — user code is async; awaits the returned Promise
+        // copy: true     — structured-clones the result back to the outer heap
+        //                  before isolate.dispose() is called; required for
+        //                  object/array returns (primitives work without it)
         const result = await Promise.race([
-          promise,
-          new Promise((_, reject) =>
-            // Use global setTimeout (not the blocked sandbox one)
+          script.run(ctx, { promise: true, copy: true }),
+          new Promise<never>((_, reject) =>
             globalThis.setTimeout(
               () => reject(new Error(`Execution timed out after ${timeout}ms`)),
               timeout
@@ -135,12 +83,16 @@ export function createSandbox(
           durationMs: Date.now() - start,
         }
       } catch (error) {
+        const err = error as any
         return {
           result: null,
-          error: error instanceof Error ? error.message : String(error),
+          error: err?.message ?? String(err),
           logs,
           durationMs: Date.now() - start,
         }
+      } finally {
+        // Always release the V8 isolate to avoid memory leaks
+        isolate.dispose()
       }
     },
   }
@@ -161,13 +113,163 @@ export function normalizeCode(code: string): string {
   // Auto-wrap bare code into async arrow functions
   if (!/^\s*async\s*\(/.test(normalized)) {
     // Detect statement-leading keywords — these cannot follow `return`
-    const isStatement = /^\s*(const|let|var|for|while|if|try|switch|return|throw|class|function)\b/.test(normalized)
+    const isStatement =
+      /^\s*(const|let|var|for|while|if|try|switch|return|throw|class|function)\b/.test(normalized)
     normalized = isStatement
       ? `async () => { ${normalized} }`
       : `async () => { return ${normalized} }`
   }
 
   return normalized
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Inject a console proxy into the isolate that forwards to the outer logs array.
+ * Uses ivm.Callback with { ignored: true } (fire-and-forget) so logging never
+ * blocks the isolate event loop. Arguments are deep-copied automatically.
+ */
+async function bootstrapConsole(ctx: ivm.Context, logs: string[]): Promise<void> {
+  const cb = new ivm.Callback((...args: unknown[]) => pushLog(logs, args), { ignored: true })
+
+  await ctx.evalClosure(
+    `globalThis.console = {
+      log:   (...a) => $0(...a),
+      info:  (...a) => $0(...a),
+      warn:  (...a) => $0(...a),
+      error: (...a) => $0(...a),
+      debug: (...a) => $0(...a),
+    }`,
+    [cb]
+  )
+}
+
+/**
+ * Inject all caller-provided globals into the isolate context.
+ *
+ * Strategy per value type:
+ *   null / undefined / primitive → jail.set directly
+ *   function                     → SAB bridge (see injectFn) — synchronous-looking
+ *                                  call inside the isolate that blocks on Atomics.wait
+ *                                  while the host resolves the async work, then returns
+ *                                  the result via a sync Callback
+ *   object                       → split: data properties via ExternalCopy,
+ *                                  function properties via SAB bridge wrappers
+ */
+async function injectGlobals(
+  ctx: ivm.Context,
+  globals: Record<string, unknown>
+): Promise<void> {
+  const jail = ctx.global
+
+  for (const [key, value] of Object.entries(globals)) {
+    if (value === null || value === undefined) {
+      await jail.set(key, value as null | undefined)
+      continue
+    }
+
+    if (typeof value === 'function') {
+      await injectFn(ctx, value as (...a: unknown[]) => unknown, `globalThis[${JSON.stringify(key)}]`)
+      continue
+    }
+
+    if (typeof value === 'object') {
+      const obj = value as Record<string, unknown>
+      const dataEntries: Record<string, unknown> = {}
+      const fnProps: Array<[string, (...a: unknown[]) => unknown]> = []
+
+      for (const [prop, propVal] of Object.entries(obj)) {
+        if (typeof propVal === 'function') {
+          fnProps.push([prop, propVal as (...a: unknown[]) => unknown])
+        } else {
+          dataEntries[prop] = propVal
+        }
+      }
+
+      // Copy data properties into the isolate first (object must exist before properties are added)
+      await jail.set(key, new ivm.ExternalCopy(dataEntries).copyInto())
+
+      // Add function-property SAB bridges one by one
+      for (const [prop, fn] of fnProps) {
+        await injectFn(ctx, fn, `globalThis[${JSON.stringify(key)}][${JSON.stringify(prop)}]`)
+      }
+      continue
+    }
+
+    // Primitive (string, number, boolean)
+    await jail.set(key, value as string | number | boolean)
+  }
+}
+
+/**
+ * Wire a single host function into the isolate at `target` using a SAB bridge.
+ *
+ * How it works:
+ *   1. A SharedArrayBuffer(4) acts as a one-bit signal (0 = pending, 1 = ready).
+ *   2. `startCb` (fire-and-forget) launches the host async fn; when it settles it
+ *      stores the result in `pending` then sets signal[0] = 1 and notifies.
+ *   3. `getResultCb` (sync) reads the result from `pending` and returns it as an
+ *      ExternalCopy so the value crosses the isolate boundary.
+ *   4. Inside the isolate, `target` becomes a regular function that calls startCb,
+ *      blocks on Atomics.wait (does NOT block the host event loop — only the
+ *      isolate's worker thread), then calls getResultCb and returns or throws.
+ */
+async function injectFn(
+  ctx: ivm.Context,
+  fn: (...a: unknown[]) => unknown,
+  target: string
+): Promise<void> {
+  const sab = new SharedArrayBuffer(4)
+  const signal = new Int32Array(sab)
+  const pending: { result: { ok: boolean; v?: unknown; e?: string } | null } = { result: null }
+
+  const startCb = new ivm.Callback(
+    (...args: unknown[]) => {
+      try {
+        const ret = fn(...args)
+        const p = ret instanceof Promise ? ret : Promise.resolve(ret)
+        p.then(
+          (v) => {
+            pending.result = { ok: true, v }
+            Atomics.store(signal, 0, 1)
+            Atomics.notify(signal, 0)
+          },
+          (e: unknown) => {
+            const err = e as any
+            pending.result = { ok: false, e: err?.message ?? String(err) }
+            Atomics.store(signal, 0, 1)
+            Atomics.notify(signal, 0)
+          }
+        )
+      } catch (e) {
+        const err = e as any
+        pending.result = { ok: false, e: err?.message ?? String(err) }
+        Atomics.store(signal, 0, 1)
+        Atomics.notify(signal, 0)
+      }
+    },
+    { ignored: true }
+  )
+
+  const getResultCb = new ivm.Callback(() => {
+    const r = pending.result!
+    pending.result = null
+    Atomics.store(signal, 0, 0)
+    return new ivm.ExternalCopy(r).copyInto()
+  })
+
+  await ctx.evalClosure(
+    `const _s=$0,_sig=new Int32Array(_s),_start=$1,_get=$2
+     ${target} = function(...a) {
+       _start(...a)
+       Atomics.wait(_sig, 0, 0)
+       const r = _get()
+       if (!r.ok) throw new Error(r.e)
+       return r.v
+     }`,
+    [new ivm.ExternalCopy(sab).copyInto(), startCb, getResultCb]
+  )
 }
 
 function pushLog(logs: string[], args: unknown[]): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5653,6 +5653,7 @@ __metadata:
     ai: "npm:^6.0.33"
     cmdk: "npm:^1.0.0"
     framer-motion: "npm:^11.0.0"
+    isolated-vm: "npm:^6.1.2"
     react-json-view-lite: "npm:^2.5.0"
     react-markdown: "npm:^9.0.0"
     tsx: "npm:^4.21.0"
@@ -17175,6 +17176,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"isolated-vm@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "isolated-vm@npm:6.1.2"
+  dependencies:
+    node-gyp: "npm:latest"
+    node-gyp-build: "npm:^4.8.4"
+  checksum: 10/705c93375a6342d54d2381efebba45d965147d5a6e534dc5c1e622b625ad02ee8878cacd03a8fd09f9929a3fc2d039b26a900d976632b14a51a94005371ec1d9
+  languageName: node
+  linkType: hard
+
 "istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
@@ -20226,7 +20237,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:^4.8.1":
+"node-gyp-build@npm:^4.8.1, node-gyp-build@npm:^4.8.4":
   version: 4.8.4
   resolution: "node-gyp-build@npm:4.8.4"
   bin:


### PR DESCRIPTION
…(RCE fix)

PR #1127 replaced the node:vm sandbox with isolated-vm on main but never reached develop. The node:vm implementation passes host object references (Object, Array, JSON, etc.) into vm.createContext, exposing the host-realm Function constructor via Object.constructor — a trivial one-line escape to process.env, child_process, and full RCE.

This commit ports the exact sandbox.ts from commit 78b7da437, replacing node:vm with a fresh ivm.Isolate per execution (32 MB memory limit, no shared prototype chain). Also adds isolated-vm ^6.1.2 dependency and engines.node >=22.0.0.

Regression tests exercise four canonical prototype-chain escapes that succeed on node:vm but fail on isolated-vm.

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
