### PR TITLE
fix(attachments): enforce tenant scope on public-partition file access

### DIFF
--- a/packages/core/src/modules/attachments/lib/__tests__/access.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/access.test.ts
@@ -1,0 +1,72 @@
+import { checkAttachmentAccess } from '../access'
+
+function attachment(overrides: Record<string, unknown> = {}) {
+  return { tenantId: 'tenant-1', organizationId: 'org-1', ...overrides } as any
+}
+
+function partition(isPublic: boolean) {
+  return { isPublic } as any
+}
+
+function auth(overrides: Record<string, unknown> = {}) {
+  return { tenantId: 'tenant-1', orgId: 'org-1', roles: ['admin'], ...overrides } as any
+}
+
+describe('checkAttachmentAccess — cross-tenant public partition fix', () => {
+  it('blocks unauthenticated access to tenant-scoped attachment in public partition', () => {
+    const result = checkAttachmentAccess(null, attachment(), partition(true))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(401)
+  })
+
+  it('allows unauthenticated access to unscoped attachment in public partition', () => {
+    const result = checkAttachmentAccess(
+      null,
+      attachment({ tenantId: null, organizationId: null }),
+      partition(true),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('allows same-tenant authenticated access in public partition', () => {
+    const result = checkAttachmentAccess(auth(), attachment(), partition(true))
+    expect(result.ok).toBe(true)
+  })
+
+  it('blocks cross-tenant authenticated access in public partition', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'other-tenant' }),
+      attachment(),
+      partition(true),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+
+  it('blocks unauthenticated access to private partition', () => {
+    const result = checkAttachmentAccess(null, attachment(), partition(false))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(401)
+  })
+
+  it('allows same-tenant authenticated access in private partition', () => {
+    const result = checkAttachmentAccess(auth(), attachment(), partition(false))
+    expect(result.ok).toBe(true)
+  })
+
+  it('blocks cross-tenant authenticated access in private partition', () => {
+    const result = checkAttachmentAccess(
+      auth({ tenantId: 'other-tenant' }),
+      attachment(),
+      partition(false),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.status).toBe(403)
+  })
+
+  it('allows superadmin access to any attachment in any partition', () => {
+    const superAuth = auth({ isSuperAdmin: true, tenantId: 'other-tenant' })
+    expect(checkAttachmentAccess(superAuth, attachment(), partition(false)).ok).toBe(true)
+    expect(checkAttachmentAccess(superAuth, attachment(), partition(true)).ok).toBe(true)
+  })
+})

--- a/packages/core/src/modules/attachments/lib/access.ts
+++ b/packages/core/src/modules/attachments/lib/access.ts
@@ -34,7 +34,15 @@ export function checkAttachmentAccess(
     return { ok: false, status: 403 }
   }
 
-  if (auth && !superAdmin && !isSameScope(auth, attachment)) {
+  if (!auth) {
+    const isTenantScoped = !!attachment.tenantId || !!attachment.organizationId
+    if (isTenantScoped) {
+      return { ok: false, status: 401 }
+    }
+    return { ok: true }
+  }
+
+  if (!superAdmin && !isSameScope(auth, attachment)) {
     return { ok: false, status: 403 }
   }
   return { ok: true }


### PR DESCRIPTION
checkAttachmentAccess grants unauthenticated requests full read access to any attachment in a partition with isPublic: true. Because AttachmentPartition is a global entity (no tenant_id column), a single isPublic flag exposes files from every tenant sharing that partition.

Fix: when auth is null and partition is public, only allow access to attachments with no tenant scope (tenantId/organizationId both null). Preserves public-asset use case while blocking cross-tenant reads.

Tests: 8 new cases covering all auth/partition/scope combinations.

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
