### PR TITLE
fix flaky test

### DIFF
--- a/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-008.spec.ts
+++ b/packages/core/src/modules/core/__integration__/admin/TC-ADMIN-008.spec.ts
@@ -26,6 +26,7 @@ async function waitForRecordForm(page: Page, fieldIds: string[]): Promise<void> 
  * Source: .ai/qa/scenarios/TC-ADMIN-008-custom-entity-record.md
  */
 test.describe('TC-ADMIN-008: Create Custom Entity Record', () => {
+  test.setTimeout(60_000);
   test('should create and edit a record for a custom entity', async ({ page, request }) => {
     const stamp = Date.now();
     const entityId = `user:qa_admin_008_${stamp}`;
@@ -110,40 +111,54 @@ test.describe('TC-ADMIN-008: Create Custom Entity Record', () => {
       await page.goto(`/backend/entities/user/${encodeURIComponent(entityId)}/records`, {
         waitUntil: 'domcontentloaded',
       });
-      await page.getByText('Loading data...').waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});
-      await expect(page.getByRole('link', { name: 'Create' })).toBeVisible();
+      // Wait for the DataTable loading indicator to appear then disappear.
+      // The records page initialises loading=false then flips it in an effect,
+      // so we must wait for the text to be attached before waiting for it to hide —
+      // otherwise Playwright resolves 'hidden' immediately on the initial render.
+      const listLoadingLocator = page.getByText('Loading data...');
+      await listLoadingLocator.waitFor({ state: 'attached', timeout: 5_000 }).catch(() => {});
+      await listLoadingLocator.waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});
+      // 'Create' button only renders once the cfDefs hook has resolved; give it time.
+      await expect(page.getByRole('link', { name: 'Create' })).toBeVisible({ timeout: 20_000 });
       await expect(page).toHaveURL(new RegExp(`/backend/entities/user/${encodeURIComponent(entityId)}/records$`, 'i'));
       await expect(page.getByRole('row', { name: new RegExp(location, 'i') })).toBeVisible();
       await page.goto(`/backend/entities/user/${encodeURIComponent(entityId)}/records/${encodeURIComponent(recordId!)}`, {
         waitUntil: 'domcontentloaded',
       });
       await expect(page).toHaveURL(new RegExp(`/backend/entities/user/${encodeURIComponent(entityId)}/records/[^/]+$`, 'i'));
-      await page.getByText(/Loading record/i).waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});
+      // Same two-phase wait: the edit form starts with loading=true immediately,
+      // so 'attached' resolves quickly and then we wait for it to disappear.
+      const editLoadingLocator = page.getByText(/Loading record/i);
+      await editLoadingLocator.waitFor({ state: 'attached', timeout: 5_000 }).catch(() => {});
+      await editLoadingLocator.waitFor({ state: 'hidden', timeout: 20_000 }).catch(() => {});
       await waitForRecordForm(page, expectedFieldIds);
 
       await fillCustomEntityField(page, 'title', updatedTitle);
       const updateResponsePromise = page.waitForResponse((response) => {
         return response.request().method() === 'PUT' && response.url().includes('/api/entities/records') && response.ok();
-      });
+      }, { timeout: 15_000 });
       await page.getByRole('button', { name: 'Save' }).first().click();
       await updateResponsePromise;
 
       await expect(page).toHaveURL(new RegExp(`/backend/entities/user/${encodeURIComponent(entityId)}/records$`, 'i'));
       await expect
-        .poll(async () => {
-          const updatedRecordResponse = await apiRequest(
-            request,
-            'GET',
-            `/api/entities/records?entityId=${encodeURIComponent(entityId)}&id=${encodeURIComponent(recordId!)}`,
-            { token: authToken },
-          );
-          if (!updatedRecordResponse.ok()) return null;
-          const updatedRecordPayload = (await updatedRecordResponse.json()) as {
-            items?: Array<{ id?: string; title?: string }>;
-          };
-          const updatedRecord = (updatedRecordPayload.items ?? []).find((item) => String(item.id) === recordId);
-          return updatedRecord?.title ?? null;
-        })
+        .poll(
+          async () => {
+            const updatedRecordResponse = await apiRequest(
+              request,
+              'GET',
+              `/api/entities/records?entityId=${encodeURIComponent(entityId)}&id=${encodeURIComponent(recordId!)}`,
+              { token: authToken },
+            );
+            if (!updatedRecordResponse.ok()) return null;
+            const updatedRecordPayload = (await updatedRecordResponse.json()) as {
+              items?: Array<{ id?: string; title?: string }>;
+            };
+            const updatedRecord = (updatedRecordPayload.items ?? []).find((item) => String(item.id) === recordId);
+            return updatedRecord?.title ?? null;
+          },
+          { timeout: 15_000 },
+        )
         .toBe(updatedTitle);
     } finally {
       if (token && recordId) {


### PR DESCRIPTION
What was wrong and what was fixed

  1. test.setTimeout(60_000) added (line 29)

  Why: playwright.config.ts sets a global timeout: 20_000. This test performs 10+ async operations across two full page
  navigations. In CI or under any load, 20 s is simply not enough. A 60 s per-test budget gives the test room to breathe
  without affecting other (simpler) tests.

  2. Two-phase loading wait on the records list (lines 118–120)

  Why (the real bug): records/page.tsx initialises loading as useState(false), so the first render passes
  isLoading={false} to DataTable. "Loading data..." doesn't exist in the DOM yet. Playwright's waitFor({ state: 'hidden'
  }) sees a non-existent element as already hidden and resolves immediately, providing zero protection — the test rushed
  to assert the row before data ever loaded. Fix: waitFor({ state: 'attached' }) first (waits up to 5 s for the text to
  appear after the effect fires), then waitFor({ state: 'hidden' }) (waits for it to disappear). The .catch(() => {}) on
  both handles the edge case where loading finishes before either state is observed.

  3. Explicit { timeout: 20_000 } on the "Create" button assertion (line 122)

  Why: The "Create" link only renders when cfDefs (loaded by useCustomFieldDefs) resolves and contains form-eligible
  fields. Without an explicit timeout, this assertion used the global expect.timeout which is already the same 20 s as
  the whole test — making it indistinguishable from a total timeout. The explicit value makes the intent clear and
  consistent.

  4. Same two-phase wait on the record edit page (lines 131–133)

  Why: The edit page ([recordId]/page.tsx) starts with loading = true immediately, so "Loading record..." is attached on
  first render — but the old single waitFor({ state: 'hidden' }) was already correct here. The two-phase approach is
  still safer: if navigation is very fast and the component renders and resolves before the locator is evaluated, the
  attached wait catches the edge case.

  5. { timeout: 15_000 } on waitForResponse (line 139)

  Why: Without an explicit timeout, if the PUT never fires (e.g., server returns a non-2xx so response.ok() never
  matches, or a form validation error prevents submission), Playwright uses its 30 s default — but the test is killed at
  20 s first. The error message says "20 000 ms timeout" with a stack trace pointing nowhere useful. A 15 s explicit
  timeout surfaces the real failure immediately.

  6. { timeout: 15_000 } on the final expect.poll (line 160)

  Why: expect.poll defaults to 5 s regardless of the global expect.timeout. On a slow server this poll fails well within
  the expected window. Explicit 15 s aligns it with the rest of the test's intent.