### PR TITLE
fix(webhooks): block SSRF in outbound webhook delivery URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       OM_ENABLE_ENTERPRISE_MODULES: 'true'
       OM_ENABLE_ENTERPRISE_MODULES_SSO: 'true'
       OM_ENABLE_ENTERPRISE_MODULES_SECURITY: 'true'
+      OM_WEBHOOKS_ALLOW_PRIVATE_URLS: '1'
       JWT_SECRET: 'ci-ephemeral-test-jwt-secret'
       OM_SECURITY_MFA_SETUP_SECRET: 'ci-ephemeral-test-mfa-setup-secret'
     steps:

--- a/apps/docs/docs/user-guide/webhooks.mdx
+++ b/apps/docs/docs/user-guide/webhooks.mdx
@@ -44,6 +44,12 @@ In the create form:
 - Keep the default retry and timeout values unless your receiver is known to be slow.
 - Add **Custom Headers** only for static metadata such as environment or source identifiers.
 
+## Outbound URL safety
+
+Open Mercato rejects webhook URLs that point at localhost, private networks, reserved IP ranges, or internal hostnames. This protects the delivery worker from sending server-side requests to services that only the Open Mercato host can reach.
+
+For local development or CI, set `OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1` to allow endpoints such as `http://localhost:3000/webhooks`. Keep this disabled in production. Use a public HTTPS endpoint or a temporary public tunnel when testing a production-like environment.
+
 ## Step 3 — Store the signing secret immediately
 
 After creating a webhook, Open Mercato reveals the signing secret only once. The same one-time reveal appears again after a secret rotation.

--- a/packages/shared/src/lib/__tests__/network.test.ts
+++ b/packages/shared/src/lib/__tests__/network.test.ts
@@ -1,0 +1,90 @@
+import {
+  isBlockedHostname,
+  isPrivateIpAddress,
+  isPrivateUrl,
+} from '../network'
+
+describe('network helpers', () => {
+  const privateV4 = [
+    '0.0.0.0',
+    '10.0.0.1',
+    '10.255.255.255',
+    '100.64.0.1',
+    '100.127.255.255',
+    '127.0.0.1',
+    '169.254.169.254',
+    '172.16.0.1',
+    '172.31.255.254',
+    '192.0.0.1',
+    '192.0.0.255',
+    '192.0.2.1',
+    '192.168.1.1',
+    '198.18.0.1',
+    '198.19.255.255',
+    '198.51.100.1',
+    '203.0.113.5',
+    '224.0.0.1',
+    '239.255.255.255',
+    '240.0.0.1',
+    '255.255.255.255',
+  ]
+
+  const publicV4 = [
+    '1.1.1.1',
+    '8.8.8.8',
+    '93.184.216.34',
+    '100.63.255.255',
+    '100.128.0.1',
+    '172.15.255.255',
+    '172.32.0.1',
+    '192.0.1.1',
+    '198.17.255.255',
+    '198.20.0.1',
+  ]
+
+  it.each(privateV4)('flags private or reserved IPv4 %s', (address) => {
+    expect(isPrivateIpAddress(address)).toBe(true)
+  })
+
+  it.each(publicV4)('allows public IPv4 %s', (address) => {
+    expect(isPrivateIpAddress(address)).toBe(false)
+  })
+
+  it('flags private or reserved IPv6 ranges without regex shortcuts', () => {
+    expect(isPrivateIpAddress('::')).toBe(true)
+    expect(isPrivateIpAddress('::1')).toBe(true)
+    expect(isPrivateIpAddress('fc00::1')).toBe(true)
+    expect(isPrivateIpAddress('fd12:3456::1')).toBe(true)
+    expect(isPrivateIpAddress('fe80::1')).toBe(true)
+    expect(isPrivateIpAddress('ff02::1')).toBe(true)
+    expect(isPrivateIpAddress('2001:db8::1')).toBe(true)
+    expect(isPrivateIpAddress('::ffff:127.0.0.1')).toBe(true)
+    expect(isPrivateIpAddress('::ffff:7f00:1')).toBe(true)
+    expect(isPrivateIpAddress('64:ff9b::a9fe:a9fe')).toBe(true)
+    expect(isPrivateIpAddress('2002:0a00:0001::1')).toBe(true)
+    expect(isPrivateIpAddress('::8.8.8.8')).toBe(true)
+    expect(isPrivateIpAddress('::808:808')).toBe(true)
+  })
+
+  it('allows public IPv6 ranges', () => {
+    expect(isPrivateIpAddress('2606:4700:4700::1111')).toBe(false)
+    expect(isPrivateIpAddress('2001:4860:4860::8888')).toBe(false)
+  })
+
+  it('blocks internal hostnames and suffixes', () => {
+    expect(isBlockedHostname('localhost')).toBe(true)
+    expect(isBlockedHostname('localhost.')).toBe(true)
+    expect(isBlockedHostname('api.localhost')).toBe(true)
+    expect(isBlockedHostname('metadata.google.internal')).toBe(true)
+    expect(isBlockedHostname('service.internal')).toBe(true)
+    expect(isBlockedHostname('printer.local')).toBe(true)
+    expect(isBlockedHostname('hooks.example.com')).toBe(false)
+  })
+
+  it('detects private URLs from normalized URL hostnames', () => {
+    expect(isPrivateUrl('http://2130706433/')).toBe(true)
+    expect(isPrivateUrl('http://0177.0.0.1/')).toBe(true)
+    expect(isPrivateUrl('http://0x7f.0.0.1/')).toBe(true)
+    expect(isPrivateUrl('https://hooks.example.com/endpoint')).toBe(false)
+  })
+})

--- a/packages/shared/src/lib/network.ts
+++ b/packages/shared/src/lib/network.ts
@@ -1,0 +1,173 @@
+import { isIP } from 'node:net'
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'broadcasthost',
+])
+
+export function isPrivateIpAddress(address: string): boolean {
+  const family = isIP(address)
+  if (family === 4) return isPrivateIPv4(address)
+  if (family === 6) return isPrivateIPv6(address)
+  return false
+}
+
+export function isBlockedHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname)
+  if (!normalized) return true
+  if (BLOCKED_HOSTNAMES.has(normalized)) return true
+  if (normalized.endsWith('.localhost')) return true
+  if (normalized.endsWith('.internal')) return true
+  if (normalized.endsWith('.local')) return true
+  return false
+}
+
+export function isPrivateUrl(rawUrl: string): boolean {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return false
+  }
+
+  const hostname = normalizeHostname(url.hostname)
+  if (isBlockedHostname(hostname)) return true
+  return isPrivateIpAddress(hostname)
+}
+
+function normalizeHostname(hostname: string): string {
+  let normalized = hostname.trim().toLowerCase()
+  if (normalized.startsWith('[') && normalized.endsWith(']')) {
+    normalized = normalized.slice(1, -1)
+  }
+  while (normalized.endsWith('.')) {
+    normalized = normalized.slice(0, -1)
+  }
+  return normalized
+}
+
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split('.')
+  if (parts.length !== 4) return false
+  const octets = parts.map((part) => Number(part))
+  if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) return false
+
+  const [a, b, c] = octets
+  if (a === 0) return true
+  if (a === 10) return true
+  if (a === 100 && b >= 64 && b <= 127) return true
+  if (a === 127) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 0 && (c === 0 || c === 2)) return true
+  if (a === 192 && b === 168) return true
+  if (a === 198 && (b === 18 || b === 19)) return true
+  if (a === 198 && b === 51 && c === 100) return true
+  if (a === 203 && b === 0 && c === 113) return true
+  if (a >= 224) return true
+  return false
+}
+
+function isPrivateIPv6(address: string): boolean {
+  const segments = expandIPv6(address)
+  if (!segments) return false
+
+  if (segments.every((segment) => segment === 0)) return true
+  if (segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1) return true
+  if (isIPv4CompatibleIPv6(segments)) return true
+
+  const embedded = embeddedIPv4FromIPv6(segments)
+  if (embedded && isPrivateIPv4(embedded)) return true
+
+  const [a, b] = segments
+  if ((a & 0xfe00) === 0xfc00) return true
+  if ((a & 0xffc0) === 0xfe80) return true
+  if ((a & 0xff00) === 0xff00) return true
+  if (a === 0x2001 && b === 0x0db8) return true
+  return false
+}
+
+function expandIPv6(address: string): number[] | null {
+  let normalized = address.toLowerCase()
+  if (normalized.includes('.')) {
+    const lastColon = normalized.lastIndexOf(':')
+    if (lastColon === -1) return null
+    const ipv4Segments = ipv4ToHexSegments(normalized.slice(lastColon + 1))
+    if (!ipv4Segments) return null
+    normalized = `${normalized.slice(0, lastColon)}:${ipv4Segments[0].toString(16)}:${ipv4Segments[1].toString(16)}`
+  }
+
+  const doubleColonParts = normalized.split('::')
+  if (doubleColonParts.length > 2) return null
+
+  const head = doubleColonParts[0] ? doubleColonParts[0].split(':') : []
+  const tail = doubleColonParts[1] ? doubleColonParts[1].split(':') : []
+  const headSegments = parseIPv6SegmentList(head)
+  const tailSegments = parseIPv6SegmentList(tail)
+  if (!headSegments || !tailSegments) return null
+
+  if (doubleColonParts.length === 1) {
+    return headSegments.length === 8 ? headSegments : null
+  }
+
+  const missing = 8 - headSegments.length - tailSegments.length
+  if (missing < 1) return null
+  return [
+    ...headSegments,
+    ...Array.from({ length: missing }, () => 0),
+    ...tailSegments,
+  ]
+}
+
+function parseIPv6SegmentList(parts: string[]): number[] | null {
+  const segments: number[] = []
+  for (const part of parts) {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) return null
+    const value = Number.parseInt(part, 16)
+    if (!Number.isInteger(value) || value < 0 || value > 0xffff) return null
+    segments.push(value)
+  }
+  return segments
+}
+
+function ipv4ToHexSegments(address: string): [number, number] | null {
+  const octets = address.split('.').map((part) => Number(part))
+  if (octets.length !== 4) return null
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null
+  return [
+    (octets[0] << 8) + octets[1],
+    (octets[2] << 8) + octets[3],
+  ]
+}
+
+function embeddedIPv4FromIPv6(segments: number[]): string | null {
+  const firstFiveZero = segments.slice(0, 5).every((segment) => segment === 0)
+  const isMapped = firstFiveZero && segments[5] === 0xffff
+  const isNat64 = segments[0] === 0x0064
+    && segments[1] === 0xff9b
+    && segments.slice(2, 6).every((segment) => segment === 0)
+  const isSixToFour = segments[0] === 0x2002
+
+  if (isMapped || isNat64) {
+    return ipv4FromHexSegments(segments[6], segments[7])
+  }
+  if (isSixToFour) {
+    return ipv4FromHexSegments(segments[1], segments[2])
+  }
+  return null
+}
+
+function isIPv4CompatibleIPv6(segments: number[]): boolean {
+  return segments.slice(0, 6).every((segment) => segment === 0)
+}
+
+function ipv4FromHexSegments(high: number, low: number): string {
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join('.')
+}

--- a/packages/webhooks/jest.config.cjs
+++ b/packages/webhooks/jest.config.cjs
@@ -5,6 +5,9 @@ module.exports = {
   watchman: false,
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/packages/webhooks/src/modules/webhooks/data/__tests__/validators.test.ts
+++ b/packages/webhooks/src/modules/webhooks/data/__tests__/validators.test.ts
@@ -10,6 +10,16 @@ function baseInput(overrides: Partial<Record<string, unknown>> = {}) {
 }
 
 describe('webhookCreateSchema — URL safety', () => {
+  const originalAllowPrivateUrls = process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS
+
+  afterEach(() => {
+    if (originalAllowPrivateUrls === undefined) {
+      delete process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS
+    } else {
+      process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS = originalAllowPrivateUrls
+    }
+  })
+
   it('accepts safe public URLs', () => {
     const result = webhookCreateSchema.safeParse(baseInput())
     expect(result.success).toBe(true)
@@ -61,5 +71,19 @@ describe('webhookCreateSchema — URL safety', () => {
   it('rejects unsafe URLs on update', () => {
     const result = webhookUpdateSchema.safeParse({ url: 'http://[::ffff:127.0.0.1]/' })
     expect(result.success).toBe(false)
+  })
+
+  it('accepts private create and update URLs when the development override is enabled', () => {
+    process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS = '1'
+
+    expect(webhookCreateSchema.safeParse(baseInput({ url: 'http://localhost:3000/webhooks' })).success).toBe(true)
+    expect(webhookUpdateSchema.safeParse({ url: 'http://10.0.0.5:3000/webhooks' }).success).toBe(true)
+  })
+
+  it('still rejects forbidden protocols and embedded credentials when the development override is enabled', () => {
+    process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS = '1'
+
+    expect(webhookCreateSchema.safeParse(baseInput({ url: 'ftp://localhost/webhooks' })).success).toBe(false)
+    expect(webhookCreateSchema.safeParse(baseInput({ url: 'https://user:pass@localhost/webhooks' })).success).toBe(false)
   })
 })

--- a/packages/webhooks/src/modules/webhooks/data/__tests__/validators.test.ts
+++ b/packages/webhooks/src/modules/webhooks/data/__tests__/validators.test.ts
@@ -1,0 +1,65 @@
+import { webhookCreateSchema, webhookUpdateSchema } from '../validators'
+
+function baseInput(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    name: 'Test hook',
+    url: 'https://hooks.example.com/endpoint',
+    subscribedEvents: ['customers.person.created'],
+    ...overrides,
+  }
+}
+
+describe('webhookCreateSchema — URL safety', () => {
+  it('accepts safe public URLs', () => {
+    const result = webhookCreateSchema.safeParse(baseInput())
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects loopback IPv4 literal', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'http://127.0.0.1:3000/x' }))
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toMatch(/private|reserved/i)
+    }
+  })
+
+  it('rejects AWS metadata literal', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'http://169.254.169.254/latest/meta-data/iam' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects private RFC1918 literal', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'http://10.0.0.5/ingest' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects localhost hostname', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'http://localhost:9200/_search' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects .internal DNS suffix', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'http://metadata.google.internal/' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-http(s) protocols', () => {
+    expect(webhookCreateSchema.safeParse(baseInput({ url: 'ftp://example.test/x' })).success).toBe(false)
+    expect(webhookCreateSchema.safeParse(baseInput({ url: 'gopher://example.test/x' })).success).toBe(false)
+  })
+
+  it('rejects URLs with embedded basic-auth credentials', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'https://user:pass@example.test/hook' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects IPv6 loopback literal', () => {
+    const result = webhookCreateSchema.safeParse(baseInput({ url: 'http://[::1]:9200/' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unsafe URLs on update', () => {
+    const result = webhookUpdateSchema.safeParse({ url: 'http://[::ffff:127.0.0.1]/' })
+    expect(result.success).toBe(false)
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/data/validators.ts
+++ b/packages/webhooks/src/modules/webhooks/data/validators.ts
@@ -1,9 +1,21 @@
 import { z } from 'zod'
+import { assertStaticallySafeWebhookUrl, UnsafeWebhookUrlError } from '../lib/url-safety'
+
+const safeWebhookUrl = z.string().url().superRefine((value, ctx) => {
+  try {
+    assertStaticallySafeWebhookUrl(value)
+  } catch (error) {
+    const message = error instanceof UnsafeWebhookUrlError
+      ? error.message
+      : 'Webhook URL is not allowed'
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message })
+  }
+})
 
 export const webhookCreateSchema = z.object({
   name: z.string().min(1).max(255),
   description: z.string().max(1000).optional().nullable(),
-  url: z.string().url(),
+  url: safeWebhookUrl,
   subscribedEvents: z.array(z.string().min(1)).min(1),
   httpMethod: z.enum(['POST', 'PUT', 'PATCH'] as const).default('POST'),
   customHeaders: z.record(z.string(), z.string()).optional().nullable(),

--- a/packages/webhooks/src/modules/webhooks/lib/__tests__/delivery-url-safety.test.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/__tests__/delivery-url-safety.test.ts
@@ -1,0 +1,212 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { processWebhookDeliveryJob } from '../delivery'
+
+jest.mock('../../events', () => ({
+  emitWebhooksEvent: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('../integration-state', () => ({
+  isWebhookIntegrationEnabled: jest.fn(async () => true),
+  WEBHOOK_INTEGRATION_DISABLED_MESSAGE: 'disabled',
+}))
+
+jest.mock('@open-mercato/shared/lib/webhooks', () => ({
+  buildWebhookHeaders: jest.fn(() => ({})),
+  generateMessageId: jest.fn(() => 'msg-1'),
+}))
+
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { emitWebhooksEvent } from '../../events'
+
+const findOneWithDecryptionMock = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+const emitWebhooksEventMock = emitWebhooksEvent as jest.MockedFunction<typeof emitWebhooksEvent>
+
+describe('processWebhookDeliveryJob — URL safety guard', () => {
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    globalThis.fetch = jest.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    delete process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS
+  })
+
+  function buildEm(delivery: Record<string, unknown>) {
+    return {
+      findOne: jest.fn(async () => delivery),
+      flush: jest.fn(async () => undefined),
+    } as unknown as EntityManager
+  }
+
+  it('blocks delivery to a webhook whose URL is a private IP literal', async () => {
+    const delivery = {
+      id: 'delivery-1',
+      tenantId: 't',
+      organizationId: 'o',
+      webhookId: 'w-1',
+      status: 'pending',
+      payload: { type: 'x', timestamp: new Date().toISOString(), data: {} },
+      enqueuedAt: new Date(),
+      eventType: 'x',
+      maxAttempts: 3,
+      attemptNumber: 0,
+      messageId: 'msg-1',
+      responseBody: null,
+      responseHeaders: null,
+      responseStatus: null,
+      nextRetryAt: null,
+      errorMessage: null,
+      lastAttemptAt: null,
+      deliveredAt: null,
+      durationMs: null,
+    }
+    const webhook = {
+      id: 'w-1',
+      url: 'http://169.254.169.254/latest/meta-data/',
+      isActive: true,
+      timeoutMs: 1000,
+      httpMethod: 'POST',
+      customHeaders: null,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastSuccessAt: null,
+      autoDisableThreshold: 0,
+      maxRetries: 3,
+      secret: 'secret',
+      previousSecret: null,
+      tenantId: 't',
+      organizationId: 'o',
+    }
+    findOneWithDecryptionMock.mockResolvedValueOnce(webhook as never)
+
+    const em = buildEm(delivery)
+    const result = await processWebhookDeliveryJob(em, {
+      deliveryId: 'delivery-1',
+      tenantId: 't',
+      organizationId: 'o',
+    }, { scheduleRetries: false })
+
+    expect(result?.status).toBe('failed')
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(0)
+    expect(delivery.errorMessage).toMatch(/private or reserved/i)
+    expect(emitWebhooksEventMock).toHaveBeenCalledWith(
+      'webhooks.delivery.failed',
+      expect.objectContaining({ willRetry: false, errorMessage: expect.stringMatching(/private/i) }),
+    )
+  })
+
+  it('blocks delivery to a localhost hostname', async () => {
+    const delivery = {
+      id: 'delivery-2',
+      tenantId: 't',
+      organizationId: 'o',
+      webhookId: 'w-2',
+      status: 'pending',
+      payload: { type: 'x', timestamp: new Date().toISOString(), data: {} },
+      enqueuedAt: new Date(),
+      eventType: 'x',
+      maxAttempts: 3,
+      attemptNumber: 0,
+      messageId: 'msg-1',
+      responseBody: null,
+      responseHeaders: null,
+      responseStatus: null,
+      nextRetryAt: null,
+      errorMessage: null,
+      lastAttemptAt: null,
+      deliveredAt: null,
+      durationMs: null,
+    }
+    const webhook = {
+      id: 'w-2',
+      url: 'http://localhost:6379/',
+      isActive: true,
+      timeoutMs: 1000,
+      httpMethod: 'POST',
+      customHeaders: null,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastSuccessAt: null,
+      autoDisableThreshold: 0,
+      maxRetries: 3,
+      secret: 'secret',
+      previousSecret: null,
+      tenantId: 't',
+      organizationId: 'o',
+    }
+    findOneWithDecryptionMock.mockResolvedValueOnce(webhook as never)
+
+    const em = buildEm(delivery)
+    const result = await processWebhookDeliveryJob(em, {
+      deliveryId: 'delivery-2',
+      tenantId: 't',
+      organizationId: 'o',
+    }, { scheduleRetries: false })
+
+    expect(result?.status).toBe('failed')
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(0)
+  })
+
+  it('allows delivery when OM_WEBHOOKS_ALLOW_PRIVATE_URLS is set', async () => {
+    process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS = '1'
+    const delivery = {
+      id: 'delivery-3',
+      tenantId: 't',
+      organizationId: 'o',
+      webhookId: 'w-3',
+      status: 'pending',
+      payload: { type: 'x', timestamp: new Date().toISOString(), data: {} },
+      enqueuedAt: new Date(),
+      eventType: 'x',
+      maxAttempts: 3,
+      attemptNumber: 0,
+      messageId: 'msg-1',
+      responseBody: null,
+      responseHeaders: null,
+      responseStatus: null,
+      nextRetryAt: null,
+      errorMessage: null,
+      lastAttemptAt: null,
+      deliveredAt: null,
+      durationMs: null,
+    }
+    const webhook = {
+      id: 'w-3',
+      url: 'http://127.0.0.1:3001/dev',
+      isActive: true,
+      timeoutMs: 1000,
+      httpMethod: 'POST',
+      customHeaders: null,
+      consecutiveFailures: 0,
+      lastFailureAt: null,
+      lastSuccessAt: null,
+      autoDisableThreshold: 0,
+      maxRetries: 3,
+      secret: 'secret',
+      previousSecret: null,
+      tenantId: 't',
+      organizationId: 'o',
+    }
+    findOneWithDecryptionMock.mockResolvedValueOnce(webhook as never)
+
+    const em = buildEm(delivery)
+    const result = await processWebhookDeliveryJob(em, {
+      deliveryId: 'delivery-3',
+      tenantId: 't',
+      organizationId: 'o',
+    }, { scheduleRetries: false })
+
+    expect(result?.status).toBe('delivered')
+    expect((globalThis.fetch as jest.Mock).mock.calls).toHaveLength(1)
+    expect((globalThis.fetch as jest.Mock).mock.calls[0][1]).toEqual(
+      expect.objectContaining({ redirect: 'manual' }),
+    )
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/lib/__tests__/url-safety.test.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/__tests__/url-safety.test.ts
@@ -1,0 +1,181 @@
+import {
+  assertSafeWebhookDeliveryUrl,
+  assertStaticallySafeWebhookUrl,
+  isPrivateIpAddress,
+  parseWebhookUrl,
+  UnsafeWebhookUrlError,
+} from '../url-safety'
+
+describe('url-safety — parseWebhookUrl', () => {
+  it('accepts plain http and https URLs', () => {
+    expect(parseWebhookUrl('https://example.test/hook').hostname).toBe('example.test')
+    expect(parseWebhookUrl('http://hooks.example.com:8080/in').hostname).toBe('hooks.example.com')
+  })
+
+  it('rejects non-http(s) protocols', () => {
+    expect(() => parseWebhookUrl('ftp://example.test/hook')).toThrow(UnsafeWebhookUrlError)
+    expect(() => parseWebhookUrl('file:///etc/passwd')).toThrow(UnsafeWebhookUrlError)
+    expect(() => parseWebhookUrl('gopher://example.test/')).toThrow(UnsafeWebhookUrlError)
+  })
+
+  it('rejects embedded basic-auth credentials', () => {
+    expect(() => parseWebhookUrl('https://user:pass@example.test/hook')).toThrow(UnsafeWebhookUrlError)
+  })
+
+  it('rejects garbage', () => {
+    expect(() => parseWebhookUrl('not-a-url')).toThrow(UnsafeWebhookUrlError)
+    expect(() => parseWebhookUrl('')).toThrow(UnsafeWebhookUrlError)
+  })
+})
+
+describe('url-safety — isPrivateIpAddress', () => {
+  const privateV4 = [
+    '0.0.0.0',
+    '10.0.0.1',
+    '10.255.255.255',
+    '100.64.0.1',
+    '100.127.0.1',
+    '127.0.0.1',
+    '127.1.2.3',
+    '169.254.169.254',
+    '172.16.0.1',
+    '172.31.255.254',
+    '192.168.1.1',
+    '198.18.0.1',
+    '198.51.100.1',
+    '203.0.113.5',
+    '224.0.0.1',
+    '239.255.255.255',
+    '255.255.255.255',
+  ]
+  const publicV4 = ['8.8.8.8', '1.1.1.1', '172.15.0.1', '172.32.0.1', '100.63.255.255', '100.128.0.1', '93.184.216.34']
+
+  it.each(privateV4)('flags private IPv4 %s', (addr) => {
+    expect(isPrivateIpAddress(addr)).toBe(true)
+  })
+
+  it.each(publicV4)('allows public IPv4 %s', (addr) => {
+    expect(isPrivateIpAddress(addr)).toBe(false)
+  })
+
+  it('flags private IPv6 ranges', () => {
+    expect(isPrivateIpAddress('::1')).toBe(true)
+    expect(isPrivateIpAddress('::')).toBe(true)
+    expect(isPrivateIpAddress('fc00::1')).toBe(true)
+    expect(isPrivateIpAddress('fd12:3456::1')).toBe(true)
+    expect(isPrivateIpAddress('fe80::1')).toBe(true)
+    expect(isPrivateIpAddress('ff02::1')).toBe(true)
+    expect(isPrivateIpAddress('2001:db8::1')).toBe(true)
+    expect(isPrivateIpAddress('::ffff:127.0.0.1')).toBe(true)
+    expect(isPrivateIpAddress('::ffff:7f00:1')).toBe(true)
+    expect(isPrivateIpAddress('::ffff:169.254.169.254')).toBe(true)
+    expect(isPrivateIpAddress('::ffff:a9fe:a9fe')).toBe(true)
+    expect(isPrivateIpAddress('64:ff9b::a9fe:a9fe')).toBe(true)
+    expect(isPrivateIpAddress('2002:0a00:0001::1')).toBe(true)
+    expect(isPrivateIpAddress('::8.8.8.8')).toBe(true)
+    expect(isPrivateIpAddress('::808:808')).toBe(true)
+  })
+
+  it('allows public IPv6', () => {
+    expect(isPrivateIpAddress('2606:4700:4700::1111')).toBe(false)
+    expect(isPrivateIpAddress('2001:4860:4860::8888')).toBe(false)
+  })
+})
+
+describe('url-safety — assertStaticallySafeWebhookUrl', () => {
+  it('accepts plain public hostnames', () => {
+    expect(() => assertStaticallySafeWebhookUrl('https://hooks.example.com/endpoint')).not.toThrow()
+    expect(() => assertStaticallySafeWebhookUrl('https://api.stripe.com/v1/webhook')).not.toThrow()
+  })
+
+  it('rejects private IPv4 literals', () => {
+    expect(() => assertStaticallySafeWebhookUrl('http://127.0.0.1:8080/steal')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://169.254.169.254/latest/meta-data/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://10.0.0.5/admin')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://192.168.1.1/')).toThrow(UnsafeWebhookUrlError)
+  })
+
+  it('rejects IPv6 loopback literal', () => {
+    expect(() => assertStaticallySafeWebhookUrl('http://[::1]/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://[fc00::1]/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://[::ffff:127.0.0.1]/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://[::ffff:0a00:0001]/')).toThrow(UnsafeWebhookUrlError)
+  })
+
+  it('rejects non-standard IPv4 literals normalized by URL parsing', () => {
+    expect(() => assertStaticallySafeWebhookUrl('http://2130706433/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://0177.0.0.1/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://0x7f.0.0.1/')).toThrow(UnsafeWebhookUrlError)
+  })
+
+  it('rejects well-known blocked hostnames', () => {
+    expect(() => assertStaticallySafeWebhookUrl('http://localhost/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://metadata.google.internal/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://foo.local/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://service.internal/')).toThrow(UnsafeWebhookUrlError)
+  })
+})
+
+describe('url-safety — assertSafeWebhookDeliveryUrl (DNS rebinding guard)', () => {
+  it('rejects hostnames that resolve to private IPs', async () => {
+    const lookupHost = async () => [{ address: '10.0.0.5', family: 4 }]
+    await expect(
+      assertSafeWebhookDeliveryUrl('https://rebind.evil.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+  })
+
+  it('rejects AWS metadata even if only one resolved address is private', async () => {
+    const lookupHost = async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ]
+    await expect(
+      assertSafeWebhookDeliveryUrl('https://mixed.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+  })
+
+  it('accepts hostnames that resolve to public IPs', async () => {
+    const lookupHost = async () => [{ address: '93.184.216.34', family: 4 }]
+    await expect(
+      assertSafeWebhookDeliveryUrl('https://good.example/', { lookupHost, allowPrivate: false }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects hostnames whose DNS lookup fails', async () => {
+    const lookupHost = async () => {
+      throw new Error('ENOTFOUND')
+    }
+    await expect(
+      assertSafeWebhookDeliveryUrl('https://broken.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'dns_resolution_failed' })
+  })
+
+  it('rejects hostnames whose DNS lookup returns nothing', async () => {
+    const lookupHost = async () => []
+    await expect(
+      assertSafeWebhookDeliveryUrl('https://empty.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'dns_resolution_empty' })
+  })
+
+  it('short-circuits direct private IP literal without DNS lookup', async () => {
+    const lookupHost = jest.fn(async () => [{ address: '93.184.216.34', family: 4 }])
+    await expect(
+      assertSafeWebhookDeliveryUrl('http://169.254.169.254/latest/meta-data/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'private_ip_literal' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('bypasses checks when OM_WEBHOOKS_ALLOW_PRIVATE_URLS is enabled', async () => {
+    const lookupHost = jest.fn()
+    await expect(
+      assertSafeWebhookDeliveryUrl('http://127.0.0.1:8080/dev', { lookupHost, allowPrivate: true }),
+    ).resolves.toBeUndefined()
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('still rejects invalid protocols when private URL delivery override is enabled', async () => {
+    await expect(
+      assertSafeWebhookDeliveryUrl('file:///etc/passwd', { allowPrivate: true }),
+    ).rejects.toMatchObject({ reason: 'forbidden_protocol' })
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/lib/__tests__/url-safety.test.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/__tests__/url-safety.test.ts
@@ -40,8 +40,11 @@ describe('url-safety — isPrivateIpAddress', () => {
     '169.254.169.254',
     '172.16.0.1',
     '172.31.255.254',
+    '192.0.0.1',
+    '192.0.2.1',
     '192.168.1.1',
     '198.18.0.1',
+    '198.19.255.255',
     '198.51.100.1',
     '203.0.113.5',
     '224.0.0.1',
@@ -111,8 +114,18 @@ describe('url-safety — assertStaticallySafeWebhookUrl', () => {
   it('rejects well-known blocked hostnames', () => {
     expect(() => assertStaticallySafeWebhookUrl('http://localhost/')).toThrow(UnsafeWebhookUrlError)
     expect(() => assertStaticallySafeWebhookUrl('http://metadata.google.internal/')).toThrow(UnsafeWebhookUrlError)
+    expect(() => assertStaticallySafeWebhookUrl('http://localhost./')).toThrow(UnsafeWebhookUrlError)
     expect(() => assertStaticallySafeWebhookUrl('http://foo.local/')).toThrow(UnsafeWebhookUrlError)
     expect(() => assertStaticallySafeWebhookUrl('http://service.internal/')).toThrow(UnsafeWebhookUrlError)
+  })
+
+  it('bypasses private host checks when OM_WEBHOOKS_ALLOW_PRIVATE_URLS is enabled', () => {
+    expect(() => assertStaticallySafeWebhookUrl('http://localhost:3000/dev', { allowPrivate: true })).not.toThrow()
+    expect(() => assertStaticallySafeWebhookUrl('http://10.0.0.5/dev', { allowPrivate: true })).not.toThrow()
+  })
+
+  it('still rejects invalid protocols when the static private URL override is enabled', () => {
+    expect(() => assertStaticallySafeWebhookUrl('file:///etc/passwd', { allowPrivate: true })).toThrow(UnsafeWebhookUrlError)
   })
 })
 

--- a/packages/webhooks/src/modules/webhooks/lib/delivery.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/delivery.ts
@@ -5,6 +5,7 @@ import { WebhookDeliveryEntity, WebhookEntity } from '../data/entities'
 import { emitWebhooksEvent } from '../events'
 import { enqueueWebhookDelivery } from './queue'
 import { isWebhookIntegrationEnabled, WEBHOOK_INTEGRATION_DISABLED_MESSAGE } from './integration-state'
+import { assertSafeWebhookDeliveryUrl, UnsafeWebhookUrlError } from './url-safety'
 
 export interface WebhookDeliveryJob {
   deliveryId: string
@@ -119,6 +120,33 @@ export async function processWebhookDeliveryJob(
     return { status: delivery.status, deliveryId: delivery.id }
   }
 
+  try {
+    await assertSafeWebhookDeliveryUrl(webhook.url)
+  } catch (error) {
+    const message = error instanceof UnsafeWebhookUrlError
+      ? error.message
+      : 'Webhook URL rejected by safety check'
+    delivery.status = 'failed'
+    delivery.errorMessage = message
+    delivery.nextRetryAt = null
+    delivery.lastAttemptAt = new Date()
+    delivery.attemptNumber += 1
+    webhook.consecutiveFailures += 1
+    webhook.lastFailureAt = new Date()
+    await em.flush()
+    await emitWebhooksEvent('webhooks.delivery.failed', {
+      deliveryId: delivery.id,
+      webhookId: webhook.id,
+      eventType: delivery.eventType,
+      errorMessage: message,
+      durationMs: 0,
+      organizationId: delivery.organizationId,
+      tenantId: delivery.tenantId,
+      willRetry: false,
+    })
+    return { status: delivery.status, deliveryId: delivery.id }
+  }
+
   const bodyPayload = normalizeWebhookBody(delivery.eventType, delivery.payload)
   delivery.payload = bodyPayload
   delivery.status = 'sending'
@@ -144,6 +172,7 @@ export async function processWebhookDeliveryJob(
 
     const response = await fetch(webhook.url, {
       method: webhook.httpMethod,
+      redirect: 'manual',
       headers: {
         'content-type': 'application/json',
         ...headers,

--- a/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
@@ -1,5 +1,11 @@
-import { isIP } from 'node:net'
 import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+import {
+  isBlockedHostname,
+  isPrivateIpAddress,
+} from '@open-mercato/shared/lib/network'
+
+export { isPrivateIpAddress } from '@open-mercato/shared/lib/network'
 
 export class UnsafeWebhookUrlError extends Error {
   public readonly reason: string
@@ -12,13 +18,6 @@ export class UnsafeWebhookUrlError extends Error {
 }
 
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
-
-const BLOCKED_HOSTNAMES = new Set([
-  'localhost',
-  'ip6-localhost',
-  'ip6-loopback',
-  'broadcasthost',
-])
 
 type ParsedWebhookUrl = {
   url: URL
@@ -54,150 +53,19 @@ export function parseWebhookUrl(rawUrl: string): ParsedWebhookUrl {
   return { url, hostname }
 }
 
-export function isPrivateIpAddress(address: string): boolean {
-  const family = isIP(address)
-  if (family === 4) return isPrivateIPv4(address)
-  if (family === 6) return isPrivateIPv6(address)
-  return false
+export type AssertStaticWebhookUrlDeps = {
+  allowPrivate?: boolean
 }
 
-function isPrivateIPv4(address: string): boolean {
-  const parts = address.split('.')
-  if (parts.length !== 4) return true
-  const octets = parts.map((part) => Number(part))
-  if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) return true
-  const [a, b] = octets
-  if (a === 0) return true
-  if (a === 10) return true
-  if (a === 127) return true
-  if (a === 169 && b === 254) return true
-  if (a === 172 && b >= 16 && b <= 31) return true
-  if (a === 192 && b === 0) return true
-  if (a === 192 && b === 168) return true
-  if (a === 198 && (b === 18 || b === 19)) return true
-  if (a === 198 && b === 51 && octets[2] === 100) return true
-  if (a === 203 && b === 0 && octets[2] === 113) return true
-  if (a === 100 && b >= 64 && b <= 127) return true
-  if (a >= 224) return true
-  if (a === 255 && b === 255 && octets[2] === 255 && octets[3] === 255) return true
-  return false
-}
-
-function isPrivateIPv6(address: string): boolean {
-  const segments = expandIPv6(address)
-  if (!segments) return true
-
-  if (segments.every((segment) => segment === 0)) return true
-  if (segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1) return true
-
-  if (isIPv4CompatibleIPv6(segments)) return true
-
-  const embedded = embeddedIPv4FromIPv6(segments)
-  if (embedded && isPrivateIPv4(embedded)) return true
-
-  const [a, b] = segments
-  if ((a & 0xfe00) === 0xfc00) return true
-  if ((a & 0xffc0) === 0xfe80) return true
-  if ((a & 0xff00) === 0xff00) return true
-  if (a === 0x2001 && b === 0x0db8) return true
-  return false
-}
-
-function expandIPv6(address: string): number[] | null {
-  let normalized = address.toLowerCase()
-  if (normalized.includes('.')) {
-    const lastColon = normalized.lastIndexOf(':')
-    if (lastColon === -1) return null
-    const ipv4Segments = ipv4ToHexSegments(normalized.slice(lastColon + 1))
-    if (!ipv4Segments) return null
-    normalized = `${normalized.slice(0, lastColon)}:${ipv4Segments[0].toString(16)}:${ipv4Segments[1].toString(16)}`
-  }
-
-  const doubleColonParts = normalized.split('::')
-  if (doubleColonParts.length > 2) return null
-
-  const head = doubleColonParts[0] ? doubleColonParts[0].split(':') : []
-  const tail = doubleColonParts[1] ? doubleColonParts[1].split(':') : []
-  const headSegments = parseIPv6SegmentList(head)
-  const tailSegments = parseIPv6SegmentList(tail)
-  if (!headSegments || !tailSegments) return null
-
-  if (doubleColonParts.length === 1) {
-    return headSegments.length === 8 ? headSegments : null
-  }
-
-  const missing = 8 - headSegments.length - tailSegments.length
-  if (missing < 1) return null
-  return [
-    ...headSegments,
-    ...Array.from({ length: missing }, () => 0),
-    ...tailSegments,
-  ]
-}
-
-function parseIPv6SegmentList(parts: string[]): number[] | null {
-  const segments: number[] = []
-  for (const part of parts) {
-    if (!/^[0-9a-f]{1,4}$/.test(part)) return null
-    const value = Number.parseInt(part, 16)
-    if (!Number.isInteger(value) || value < 0 || value > 0xffff) return null
-    segments.push(value)
-  }
-  return segments
-}
-
-function ipv4ToHexSegments(address: string): [number, number] | null {
-  const octets = address.split('.').map((part) => Number(part))
-  if (octets.length !== 4) return null
-  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null
-  return [
-    (octets[0] << 8) + octets[1],
-    (octets[2] << 8) + octets[3],
-  ]
-}
-
-function embeddedIPv4FromIPv6(segments: number[]): string | null {
-  const firstFiveZero = segments.slice(0, 5).every((segment) => segment === 0)
-  const isMapped = firstFiveZero && segments[5] === 0xffff
-  const isNat64 = segments[0] === 0x0064
-    && segments[1] === 0xff9b
-    && segments.slice(2, 6).every((segment) => segment === 0)
-  const isSixToFour = segments[0] === 0x2002
-
-  if (isMapped || isNat64) {
-    return ipv4FromHexSegments(segments[6], segments[7])
-  }
-  if (isSixToFour) {
-    return ipv4FromHexSegments(segments[1], segments[2])
-  }
-  return null
-}
-
-function isIPv4CompatibleIPv6(segments: number[]): boolean {
-  return segments.slice(0, 6).every((segment) => segment === 0)
-}
-
-function ipv4FromHexSegments(high: number, low: number): string {
-  return [
-    (high >> 8) & 0xff,
-    high & 0xff,
-    (low >> 8) & 0xff,
-    low & 0xff,
-  ].join('.')
-}
-
-function hostnameLooksBlocked(hostname: string): boolean {
-  if (BLOCKED_HOSTNAMES.has(hostname)) return true
-  if (hostname === 'metadata.google.internal') return true
-  if (hostname.endsWith('.localhost')) return true
-  if (hostname.endsWith('.internal')) return true
-  if (hostname.endsWith('.local')) return true
-  return false
-}
-
-export function assertStaticallySafeWebhookUrl(rawUrl: string): void {
+export function assertStaticallySafeWebhookUrl(
+  rawUrl: string,
+  deps: AssertStaticWebhookUrlDeps = {},
+): void {
   const { hostname } = parseWebhookUrl(rawUrl)
-  if (hostnameLooksBlocked(hostname)) {
+  const allowPrivate = deps.allowPrivate ?? isAllowPrivateWebhookUrlsEnabled()
+  if (allowPrivate) return
+
+  if (isBlockedHostname(hostname)) {
     throw new UnsafeWebhookUrlError(
       'blocked_hostname',
       `Webhook URL host "${hostname}" is not allowed`,
@@ -232,7 +100,7 @@ export async function assertSafeWebhookDeliveryUrl(
   const allowPrivate = deps.allowPrivate ?? isAllowPrivateWebhookUrlsEnabled()
   if (allowPrivate) return
 
-  if (hostnameLooksBlocked(hostname)) {
+  if (isBlockedHostname(hostname)) {
     throw new UnsafeWebhookUrlError(
       'blocked_hostname',
       `Webhook URL host "${hostname}" is not allowed`,

--- a/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
@@ -1,0 +1,282 @@
+import { isIP } from 'node:net'
+import { lookup } from 'node:dns/promises'
+
+export class UnsafeWebhookUrlError extends Error {
+  public readonly reason: string
+
+  constructor(reason: string, message?: string) {
+    super(message ?? `Webhook URL rejected: ${reason}`)
+    this.name = 'UnsafeWebhookUrlError'
+    this.reason = reason
+  }
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'ip6-localhost',
+  'ip6-loopback',
+  'broadcasthost',
+])
+
+type ParsedWebhookUrl = {
+  url: URL
+  hostname: string
+}
+
+export function parseWebhookUrl(rawUrl: string): ParsedWebhookUrl {
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new UnsafeWebhookUrlError('invalid_url', 'Webhook URL is not a valid URL')
+  }
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    throw new UnsafeWebhookUrlError(
+      'forbidden_protocol',
+      `Webhook URL protocol "${url.protocol.replace(':', '')}" is not allowed; use http or https`,
+    )
+  }
+  if (url.username || url.password) {
+    throw new UnsafeWebhookUrlError(
+      'credentials_in_url',
+      'Webhook URL must not embed basic-auth credentials',
+    )
+  }
+  let hostname = url.hostname.trim().toLowerCase()
+  if (!hostname) {
+    throw new UnsafeWebhookUrlError('missing_host', 'Webhook URL must include a hostname')
+  }
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1)
+  }
+  return { url, hostname }
+}
+
+export function isPrivateIpAddress(address: string): boolean {
+  const family = isIP(address)
+  if (family === 4) return isPrivateIPv4(address)
+  if (family === 6) return isPrivateIPv6(address)
+  return false
+}
+
+function isPrivateIPv4(address: string): boolean {
+  const parts = address.split('.')
+  if (parts.length !== 4) return true
+  const octets = parts.map((part) => Number(part))
+  if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) return true
+  const [a, b] = octets
+  if (a === 0) return true
+  if (a === 10) return true
+  if (a === 127) return true
+  if (a === 169 && b === 254) return true
+  if (a === 172 && b >= 16 && b <= 31) return true
+  if (a === 192 && b === 0) return true
+  if (a === 192 && b === 168) return true
+  if (a === 198 && (b === 18 || b === 19)) return true
+  if (a === 198 && b === 51 && octets[2] === 100) return true
+  if (a === 203 && b === 0 && octets[2] === 113) return true
+  if (a === 100 && b >= 64 && b <= 127) return true
+  if (a >= 224) return true
+  if (a === 255 && b === 255 && octets[2] === 255 && octets[3] === 255) return true
+  return false
+}
+
+function isPrivateIPv6(address: string): boolean {
+  const segments = expandIPv6(address)
+  if (!segments) return true
+
+  if (segments.every((segment) => segment === 0)) return true
+  if (segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1) return true
+
+  if (isIPv4CompatibleIPv6(segments)) return true
+
+  const embedded = embeddedIPv4FromIPv6(segments)
+  if (embedded && isPrivateIPv4(embedded)) return true
+
+  const [a, b] = segments
+  if ((a & 0xfe00) === 0xfc00) return true
+  if ((a & 0xffc0) === 0xfe80) return true
+  if ((a & 0xff00) === 0xff00) return true
+  if (a === 0x2001 && b === 0x0db8) return true
+  return false
+}
+
+function expandIPv6(address: string): number[] | null {
+  let normalized = address.toLowerCase()
+  if (normalized.includes('.')) {
+    const lastColon = normalized.lastIndexOf(':')
+    if (lastColon === -1) return null
+    const ipv4Segments = ipv4ToHexSegments(normalized.slice(lastColon + 1))
+    if (!ipv4Segments) return null
+    normalized = `${normalized.slice(0, lastColon)}:${ipv4Segments[0].toString(16)}:${ipv4Segments[1].toString(16)}`
+  }
+
+  const doubleColonParts = normalized.split('::')
+  if (doubleColonParts.length > 2) return null
+
+  const head = doubleColonParts[0] ? doubleColonParts[0].split(':') : []
+  const tail = doubleColonParts[1] ? doubleColonParts[1].split(':') : []
+  const headSegments = parseIPv6SegmentList(head)
+  const tailSegments = parseIPv6SegmentList(tail)
+  if (!headSegments || !tailSegments) return null
+
+  if (doubleColonParts.length === 1) {
+    return headSegments.length === 8 ? headSegments : null
+  }
+
+  const missing = 8 - headSegments.length - tailSegments.length
+  if (missing < 1) return null
+  return [
+    ...headSegments,
+    ...Array.from({ length: missing }, () => 0),
+    ...tailSegments,
+  ]
+}
+
+function parseIPv6SegmentList(parts: string[]): number[] | null {
+  const segments: number[] = []
+  for (const part of parts) {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) return null
+    const value = Number.parseInt(part, 16)
+    if (!Number.isInteger(value) || value < 0 || value > 0xffff) return null
+    segments.push(value)
+  }
+  return segments
+}
+
+function ipv4ToHexSegments(address: string): [number, number] | null {
+  const octets = address.split('.').map((part) => Number(part))
+  if (octets.length !== 4) return null
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null
+  return [
+    (octets[0] << 8) + octets[1],
+    (octets[2] << 8) + octets[3],
+  ]
+}
+
+function embeddedIPv4FromIPv6(segments: number[]): string | null {
+  const firstFiveZero = segments.slice(0, 5).every((segment) => segment === 0)
+  const isMapped = firstFiveZero && segments[5] === 0xffff
+  const isNat64 = segments[0] === 0x0064
+    && segments[1] === 0xff9b
+    && segments.slice(2, 6).every((segment) => segment === 0)
+  const isSixToFour = segments[0] === 0x2002
+
+  if (isMapped || isNat64) {
+    return ipv4FromHexSegments(segments[6], segments[7])
+  }
+  if (isSixToFour) {
+    return ipv4FromHexSegments(segments[1], segments[2])
+  }
+  return null
+}
+
+function isIPv4CompatibleIPv6(segments: number[]): boolean {
+  return segments.slice(0, 6).every((segment) => segment === 0)
+}
+
+function ipv4FromHexSegments(high: number, low: number): string {
+  return [
+    (high >> 8) & 0xff,
+    high & 0xff,
+    (low >> 8) & 0xff,
+    low & 0xff,
+  ].join('.')
+}
+
+function hostnameLooksBlocked(hostname: string): boolean {
+  if (BLOCKED_HOSTNAMES.has(hostname)) return true
+  if (hostname === 'metadata.google.internal') return true
+  if (hostname.endsWith('.localhost')) return true
+  if (hostname.endsWith('.internal')) return true
+  if (hostname.endsWith('.local')) return true
+  return false
+}
+
+export function assertStaticallySafeWebhookUrl(rawUrl: string): void {
+  const { hostname } = parseWebhookUrl(rawUrl)
+  if (hostnameLooksBlocked(hostname)) {
+    throw new UnsafeWebhookUrlError(
+      'blocked_hostname',
+      `Webhook URL host "${hostname}" is not allowed`,
+    )
+  }
+  const family = isIP(hostname)
+  if (family && isPrivateIpAddress(hostname)) {
+    throw new UnsafeWebhookUrlError(
+      'private_ip_literal',
+      `Webhook URL host "${hostname}" resolves to a private or reserved IP range`,
+    )
+  }
+}
+
+export function isAllowPrivateWebhookUrlsEnabled(): boolean {
+  const raw = process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS
+  if (!raw) return false
+  const normalized = raw.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes'
+}
+
+export type AssertSafeWebhookDeliveryDeps = {
+  lookupHost?: (hostname: string) => Promise<ReadonlyArray<{ address: string; family: number }>>
+  allowPrivate?: boolean
+}
+
+export async function assertSafeWebhookDeliveryUrl(
+  rawUrl: string,
+  deps: AssertSafeWebhookDeliveryDeps = {},
+): Promise<void> {
+  const { hostname } = parseWebhookUrl(rawUrl)
+  const allowPrivate = deps.allowPrivate ?? isAllowPrivateWebhookUrlsEnabled()
+  if (allowPrivate) return
+
+  if (hostnameLooksBlocked(hostname)) {
+    throw new UnsafeWebhookUrlError(
+      'blocked_hostname',
+      `Webhook URL host "${hostname}" is not allowed`,
+    )
+  }
+
+  if (isIP(hostname)) {
+    if (isPrivateIpAddress(hostname)) {
+      throw new UnsafeWebhookUrlError(
+        'private_ip_literal',
+        `Webhook URL host "${hostname}" resolves to a private or reserved IP range`,
+      )
+    }
+    return
+  }
+
+  const resolver = deps.lookupHost ?? (async (host: string) => {
+    const records = await lookup(host, { all: true, verbatim: true })
+    return records
+  })
+
+  let addresses: ReadonlyArray<{ address: string; family: number }>
+  try {
+    addresses = await resolver(hostname)
+  } catch (error) {
+    throw new UnsafeWebhookUrlError(
+      'dns_resolution_failed',
+      `Webhook URL host "${hostname}" could not be resolved: ${error instanceof Error ? error.message : 'lookup failed'}`,
+    )
+  }
+
+  if (!addresses || addresses.length === 0) {
+    throw new UnsafeWebhookUrlError(
+      'dns_resolution_empty',
+      `Webhook URL host "${hostname}" has no DNS A/AAAA records`,
+    )
+  }
+
+  for (const record of addresses) {
+    if (isPrivateIpAddress(record.address)) {
+      throw new UnsafeWebhookUrlError(
+        'private_ip_resolved',
+        `Webhook URL host "${hostname}" resolves to a private or reserved IP address (${record.address})`,
+      )
+    }
+  }
+}


### PR DESCRIPTION
The outbound webhooks module accepted any syntactically valid URL via z.string().url() and the delivery worker issued fetch(webhook.url) without verifying the target address. A user with webhooks.manage could register a webhook pointing at internal infrastructure and exfiltrate cloud metadata, Redis data, or scan the internal network.

Three-layer defense:
1. Static Zod validation rejects private IPs, blocked hostnames, non-http(s) protocols, and embedded basic-auth credentials
2. Runtime DNS guard before fetch catches DNS rebinding attacks
3. redirect: 'manual' prevents HTTP 3xx to internal targets

Escape hatch: OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1 for local dev.
Tests: 52 new cases across url-safety, delivery, and validator suites.

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
