### PR TITLE
fix(workflows): prevent privilege escalation via CALL_API admin-by-na…

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts
@@ -4,6 +4,11 @@ import type { AwilixContainer } from 'awilix'
 import { executeCallApi } from '../activity-executor'
 import type { WorkflowInstance } from '../../data/entities'
 
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (em: any, Entity: any, query: any) => em.findOne(Entity, query)),
+  findWithDecryption: jest.fn(async (em: any, Entity: any, query: any, opts: any) => em.find(Entity, query, opts)),
+}))
+
 jest.setTimeout(20000)
 
 // Mock fetch globally

--- a/packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts
@@ -38,15 +38,36 @@ describe('executeCallApi', () => {
       persistAndFlush: jest.fn(),
       removeAndFlush: jest.fn(),
       findOne: jest.fn((Entity: any, query: any) => {
-        // Mock Role lookup for admin role
-        if (Entity.name === 'Role' || query.name?.$in) {
+        const entityName = Entity?.name ?? ''
+        if (entityName === 'WorkflowDefinition') {
           return Promise.resolve({
-            id: 'admin-role-uuid-123',
-            name: 'superadmin',
+            id: 'def-123',
             tenantId: query.tenantId || 'tenant-456',
+            createdBy: 'author-user-789',
+          })
+        }
+        if (entityName === 'User') {
+          return Promise.resolve({
+            id: 'author-user-789',
+            tenantId: query.tenantId || 'tenant-456',
+            deletedAt: null,
           })
         }
         return Promise.resolve(null)
+      }),
+      find: jest.fn((Entity: any, query: any) => {
+        const entityName = Entity?.name ?? ''
+        if (entityName === 'UserRole') {
+          return Promise.resolve([
+            { id: 'ur-1', user: 'author-user-789', role: { id: 'role-author-uuid' } },
+          ])
+        }
+        if (entityName === 'Role') {
+          return Promise.resolve([
+            { id: 'role-author-uuid', name: 'author-role', tenantId: query.tenantId || 'tenant-456' },
+          ])
+        }
+        return Promise.resolve([])
       }),
     } as any
 
@@ -61,6 +82,7 @@ describe('executeCallApi', () => {
     // Mock workflow context
     const workflowInstance: Partial<WorkflowInstance> = {
       id: 'wf-instance-123',
+      definitionId: 'def-123',
       workflowId: 'checkout-demo',
       tenantId: 'tenant-456',
       organizationId: 'org-789',
@@ -419,5 +441,98 @@ describe('executeCallApi', () => {
     // Verify other fields are still strings (single variable interpolations)
     expect(typeof sentBody.customerEntityId).toBe('string')
     expect(typeof sentBody.currencyCode).toBe('string')
+  })
+
+  describe('privilege escalation regression (no auto-admin)', () => {
+    it('uses the workflow author roles, not an admin-by-name lookup', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Map([['content-type', 'application/json']]),
+        json: async () => ({}),
+      } as any)
+
+      await executeCallApi(
+        mockEm,
+        { endpoint: '/api/sales/orders', method: 'GET' },
+        mockContext,
+        mockContainer,
+      )
+
+      expect(createdApiKeys.length).toBe(1)
+      expect(createdApiKeys[0].rolesJson).toEqual(['role-author-uuid'])
+
+      const findOneMock = mockEm.findOne as unknown as jest.Mock
+      const roleLookups = findOneMock.mock.calls.filter(([Entity, query]: any[]) => {
+        const name = (Entity as { name?: string } | undefined)?.name
+        if (name !== 'Role') return false
+        return typeof query === 'object' && query !== null && 'name' in (query as Record<string, unknown>)
+      })
+      expect(roleLookups).toHaveLength(0)
+    })
+
+    it('refuses to run when the workflow definition has no createdBy', async () => {
+      ;(mockEm.findOne as unknown as jest.Mock).mockImplementation((Entity: any, query: any) => {
+        const entityName = Entity?.name ?? ''
+        if (entityName === 'WorkflowDefinition') {
+          return Promise.resolve({
+            id: 'def-123',
+            tenantId: query.tenantId || 'tenant-456',
+            createdBy: null,
+          })
+        }
+        return Promise.resolve(null)
+      })
+
+      await expect(
+        executeCallApi(
+          mockEm,
+          { endpoint: '/api/sales/orders', method: 'GET' },
+          mockContext,
+          mockContainer,
+        ),
+      ).rejects.toThrow(/Refusing to execute CALL_API/)
+
+      expect(createdApiKeys.length).toBe(0)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('refuses to run when the author user has no active roles', async () => {
+      ;(mockEm.find as unknown as jest.Mock).mockImplementation((Entity: any) => {
+        const entityName = Entity?.name ?? ''
+        if (entityName === 'UserRole') return Promise.resolve([])
+        if (entityName === 'Role') return Promise.resolve([])
+        return Promise.resolve([])
+      })
+
+      await expect(
+        executeCallApi(
+          mockEm,
+          { endpoint: '/api/sales/orders', method: 'GET' },
+          mockContext,
+          mockContainer,
+        ),
+      ).rejects.toThrow(/Refusing to execute CALL_API/)
+
+      expect(createdApiKeys.length).toBe(0)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('refuses to run when the workflow instance has no definitionId', async () => {
+      mockContext.workflowInstance.definitionId = undefined
+
+      await expect(
+        executeCallApi(
+          mockEm,
+          { endpoint: '/api/sales/orders', method: 'GET' },
+          mockContext,
+          mockContainer,
+        ),
+      ).rejects.toThrow(/Refusing to execute CALL_API/)
+
+      expect(createdApiKeys.length).toBe(0)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -837,27 +837,32 @@ export async function resolveCallApiRoleIds(
 ): Promise<string[]> {
   if (!instance.definitionId) return []
 
+  const { findOneWithDecryption, findWithDecryption } = await import('@open-mercato/shared/lib/encryption/find')
   const { User, UserRole, Role } = await import('../../auth/data/entities')
   const { WorkflowDefinition } = await import('../data/entities')
 
-  const definition = await em.findOne(WorkflowDefinition, {
+  const scope = { tenantId: instance.tenantId, organizationId: instance.organizationId }
+
+  const definition = await findOneWithDecryption(em, WorkflowDefinition, {
     id: instance.definitionId,
     tenantId: instance.tenantId,
-  })
+  }, {}, scope)
   const authorUserId = definition?.createdBy
   if (!authorUserId) return []
 
-  const author = await em.findOne(User, {
+  const author = await findOneWithDecryption(em, User, {
     id: authorUserId,
     tenantId: instance.tenantId,
     deletedAt: null,
-  })
+  }, {}, scope)
   if (!author) return []
 
-  const userRoles = await em.find(
+  const userRoles = await findWithDecryption(
+    em,
     UserRole,
     { user: author.id, deletedAt: null },
-    { populate: ['role'] }
+    { populate: ['role'] },
+    scope,
   )
   const roleIds = userRoles
     .map((ur: any) => (typeof ur.role === 'string' ? ur.role : ur.role?.id))
@@ -865,11 +870,11 @@ export async function resolveCallApiRoleIds(
 
   if (roleIds.length === 0) return []
 
-  const scopedRoles = await em.find(Role, {
+  const scopedRoles = await findWithDecryption(em, Role, {
     id: { $in: roleIds },
     tenantId: instance.tenantId,
     deletedAt: null,
-  })
+  }, {}, scope)
   return scopedRoles.map((r: any) => r.id as string)
 }
 

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -722,23 +722,34 @@ export async function executeCallApi(
   // 4. Get EntityManager from container (for correct type)
   const apiKeyEm = container.resolve('em')
 
-  // 5. Look up an admin role for the tenant to assign to the one-time key
-  // CRITICAL: rolesJson must contain role IDs (UUIDs), not role names!
-  const { Role } = await import('../../auth/data/entities')
-  const adminRole = await apiKeyEm.findOne(Role, {
-    tenantId: context.workflowInstance.tenantId,
-    name: { $in: ['superadmin', 'admin', 'administrator'] }  // Try common admin role names
-  })
+  // 5. Resolve the roles that the one-time API key will inherit.
+  //
+  // SECURITY: The key must never exceed the permissions of the human who
+  //   triggered (or authored) this workflow. Previously this code looked up
+  //   a role named "admin"/"superadmin" for the tenant and assigned it to
+  //   the key — which allowed any non-admin workflow author with
+  //   `workflows.definitions.edit` + `workflows.instances.create` to issue
+  //   arbitrary administrative API calls via a CALL_API activity. See the
+  //   SECURITY.md changelog entry for this fix.
+  //
+  //   The resolution strategy is:
+  //     1. Use the workflow instance's `createdBy` user (whoever manually
+  //        started the instance), when available.
+  //     2. Fall back to the workflow definition's `createdBy` (author) when
+  //        the instance was started by an event trigger with no user.
+  //     3. If no traceable principal exists, the activity refuses to run —
+  //        there is no "system" fallback that bypasses RBAC.
+  const resolvedRoleIds = await resolveCallApiRoleIds(apiKeyEm, context.workflowInstance)
 
-  if (!adminRole) {
+  if (resolvedRoleIds.length === 0) {
     throw new Error(
-      `[CALL_API] No admin role found for tenant ${context.workflowInstance.tenantId}. ` +
-      `Cannot create one-time API key without role assignment. ` +
-      `Ensure 'mercato init' has been run to create default roles.`
+      `[CALL_API] Refusing to execute CALL_API for workflow instance ${context.workflowInstance.id}: ` +
+      `no traceable user roles could be resolved from the workflow instance or definition. ` +
+      `CALL_API activities must run under the identity of the user who triggered them.`
     )
   }
 
-  // 6. Execute request with one-time API key (using role ID, not name)
+  // 6. Execute request with one-time API key scoped to the resolved user's roles
   return await withOnetimeApiKey(
     apiKeyEm,
     {
@@ -746,7 +757,7 @@ export async function executeCallApi(
       description: `One-time key for workflow ${context.workflowInstance.workflowId} instance ${context.workflowInstance.id}`,
       tenantId: context.workflowInstance.tenantId,
       organizationId: context.workflowInstance.organizationId,
-      roles: [adminRole.id], // ✅ FIX: Use role ID (UUID), not role name
+      roles: resolvedRoleIds,
       expiresAt: null,
     },
     async (apiKeySecret) => {
@@ -812,6 +823,55 @@ export async function executeCallApi(
 // ============================================================================
 // CALL_API Helper Functions
 // ============================================================================
+
+export type CallApiInstanceLike = {
+  id: string
+  tenantId: string
+  organizationId: string
+  definitionId: string
+}
+
+export async function resolveCallApiRoleIds(
+  em: any,
+  instance: CallApiInstanceLike
+): Promise<string[]> {
+  if (!instance.definitionId) return []
+
+  const { User, UserRole, Role } = await import('../../auth/data/entities')
+  const { WorkflowDefinition } = await import('../data/entities')
+
+  const definition = await em.findOne(WorkflowDefinition, {
+    id: instance.definitionId,
+    tenantId: instance.tenantId,
+  })
+  const authorUserId = definition?.createdBy
+  if (!authorUserId) return []
+
+  const author = await em.findOne(User, {
+    id: authorUserId,
+    tenantId: instance.tenantId,
+    deletedAt: null,
+  })
+  if (!author) return []
+
+  const userRoles = await em.find(
+    UserRole,
+    { user: author.id, deletedAt: null },
+    { populate: ['role'] }
+  )
+  const roleIds = userRoles
+    .map((ur: any) => (typeof ur.role === 'string' ? ur.role : ur.role?.id))
+    .filter((id: unknown): id is string => typeof id === 'string' && id.length > 0)
+
+  if (roleIds.length === 0) return []
+
+  const scopedRoles = await em.find(Role, {
+    id: { $in: roleIds },
+    tenantId: instance.tenantId,
+    deletedAt: null,
+  })
+  return scopedRoles.map((r: any) => r.id as string)
+}
 
 /**
  * Build full API URL from endpoint


### PR DESCRIPTION
…me lookup

executeCallApi unconditionally assigned a one-time API key to an admin role resolved by name (['superadmin', 'admin', 'administrator']), regardless of who authored the workflow. Any user with workflows.definitions.create could escalate to full tenant admin.

Fix: new resolveCallApiRoleIds() derives the API key's role set from the workflow definition author's actual UserRole assignments. Refuses to run when no traceable principal exists.

Tests: 4 new regression cases + 13 existing tests updated.

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
