### PR TITLE
fix(workflows): prevent ReDoS in event trigger regex filter conditions

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/event-trigger-redos.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/event-trigger-redos.test.ts
@@ -1,0 +1,77 @@
+jest.mock('../workflow-executor', () => ({
+  executeWorkflow: jest.fn(),
+  startWorkflow: jest.fn(),
+}))
+
+import { evaluateFilterConditions } from '../event-trigger-service'
+
+describe('evaluateFilterConditions — ReDoS prevention', () => {
+  const matchesRegex = (pattern: string, value: string): boolean => evaluateFilterConditions(
+    [{ field: 'name', operator: 'regex', value: pattern }],
+    { name: value },
+  )
+
+  it('rejects regex patterns longer than 200 characters', () => {
+    expect(matchesRegex('a'.repeat(201), 'test')).toBe(false)
+  })
+
+  it('rejects quantified groups with nested quantifiers or alternation', () => {
+    const patterns = [
+      '(a+)+b',
+      '(a*)*b',
+      '(a+a+)+b',
+      '([a-z]+)*$',
+      '(a|aa)+b',
+      '(.*|a)+$',
+    ]
+
+    for (const pattern of patterns) {
+      expect(matchesRegex(pattern, 'aaaaaaaaaaaaaaaaaaaaaaaX')).toBe(false)
+    }
+  })
+
+  it('rejects regex constructs that are hard to statically bound', () => {
+    const patterns = [
+      '(?=a+)a+',
+      '(?!foo).*',
+      '(?<=a)b',
+      '(?<word>a)',
+      '^(a+)\\1$',
+      '\\k<word>',
+    ]
+
+    for (const pattern of patterns) {
+      expect(matchesRegex(pattern, 'aaaa')).toBe(false)
+    }
+  })
+
+  it('rejects test input longer than 10000 chars for regex operator', () => {
+    expect(matchesRegex('^a+$', 'a'.repeat(10_001))).toBe(false)
+  })
+
+  it('allows safe regex patterns', () => {
+    expect(matchesRegex('hello', 'hello world')).toBe(true)
+    expect(matchesRegex('^order-\\d+$', 'order-123')).toBe(true)
+    expect(matchesRegex('^[A-Z]{2}-\\d{3}$', 'PL-123')).toBe(true)
+    expect(matchesRegex('^[()|a]+$', '(|a)')).toBe(true)
+    expect(matchesRegex('^\\(test\\)$', '(test)')).toBe(true)
+    expect(matchesRegex('(?:item-)+\\d+', 'item-item-42')).toBe(true)
+    expect(matchesRegex('^order-\\d+$', 'no-match')).toBe(false)
+  })
+
+  it('returns false for invalid regex syntax', () => {
+    expect(matchesRegex('(unclosed', 'test')).toBe(false)
+  })
+
+  it('non-regex operators still work normally', () => {
+    expect(evaluateFilterConditions(
+      [{ field: 'status', operator: 'eq', value: 'active' }],
+      { status: 'active' },
+    )).toBe(true)
+
+    expect(evaluateFilterConditions(
+      [{ field: 'count', operator: 'gt', value: 5 }],
+      { count: 10 },
+    )).toBe(true)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -74,6 +74,9 @@ const TRIGGER_CACHE_TTL = 5 * 60 * 1000
 // Filter Evaluation
 // ============================================================================
 
+const MAX_WORKFLOW_REGEX_PATTERN_LENGTH = 200
+const MAX_WORKFLOW_REGEX_INPUT_LENGTH = 10_000
+
 /**
  * Get a nested value from an object using dot notation.
  */
@@ -90,6 +93,111 @@ function getNestedValue(obj: unknown, path: string): unknown {
   }
 
   return current
+}
+
+function getQuantifierEnd(pattern: string, index: number): number | null {
+  const char = pattern[index]
+  if (char === '*' || char === '+' || char === '?') return index
+  if (char !== '{') return null
+
+  const closeIndex = pattern.indexOf('}', index + 1)
+  if (closeIndex === -1) return null
+
+  const body = pattern.slice(index + 1, closeIndex)
+  return /^[0-9]+(?:,[0-9]*)?$/.test(body) ? closeIndex : null
+}
+
+interface RegexGroupFrame {
+  hasAlternation: boolean
+  hasQuantifier: boolean
+}
+
+function isSafeWorkflowRegexPattern(pattern: string): boolean {
+  if (pattern.length > MAX_WORKFLOW_REGEX_PATTERN_LENGTH) return false
+
+  const groupStack: RegexGroupFrame[] = [{ hasAlternation: false, hasQuantifier: false }]
+  let inCharClass = false
+  let lastClosedGroup: RegexGroupFrame | null = null
+  let lastAtomWasQuantified = false
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index]
+
+    if (char === '\\') {
+      const next = pattern[index + 1]
+      if (!inCharClass && (/[1-9]/.test(next ?? '') || (next === 'k' && pattern[index + 2] === '<'))) {
+        return false
+      }
+      index += 1
+      lastClosedGroup = null
+      lastAtomWasQuantified = false
+      continue
+    }
+
+    if (inCharClass) {
+      if (char === ']') {
+        inCharClass = false
+        lastAtomWasQuantified = false
+      }
+      lastClosedGroup = null
+      continue
+    }
+
+    if (char === '[') {
+      inCharClass = true
+      lastClosedGroup = null
+      lastAtomWasQuantified = false
+      continue
+    }
+
+    if (char === '(') {
+      if (pattern[index + 1] === '?') {
+        if (pattern[index + 2] !== ':') return false
+        index += 2
+      }
+
+      groupStack.push({ hasAlternation: false, hasQuantifier: false })
+      lastClosedGroup = null
+      lastAtomWasQuantified = false
+      continue
+    }
+
+    if (char === ')') {
+      if (groupStack.length === 1) return false
+      lastClosedGroup = groupStack.pop()!
+      lastAtomWasQuantified = false
+      continue
+    }
+
+    if (char === '|') {
+      groupStack[groupStack.length - 1].hasAlternation = true
+      lastClosedGroup = null
+      lastAtomWasQuantified = false
+      continue
+    }
+
+    const quantifierEnd = getQuantifierEnd(pattern, index)
+    if (quantifierEnd !== null) {
+      if (lastAtomWasQuantified) return false
+      if (lastClosedGroup?.hasAlternation || lastClosedGroup?.hasQuantifier) return false
+
+      groupStack[groupStack.length - 1].hasQuantifier = true
+      lastClosedGroup = null
+      lastAtomWasQuantified = true
+      index = quantifierEnd
+
+      if (pattern[index + 1] === '?') {
+        index += 1
+      }
+
+      continue
+    }
+
+    lastClosedGroup = null
+    lastAtomWasQuantified = false
+  }
+
+  return groupStack.length === 1 && !inCharClass
 }
 
 /**
@@ -147,6 +255,8 @@ function evaluateCondition(condition: TriggerFilterCondition, payload: Record<st
 
     case 'regex':
       if (typeof value !== 'string' || typeof expected !== 'string') return false
+      if (value.length > MAX_WORKFLOW_REGEX_INPUT_LENGTH) return false
+      if (!isSafeWorkflowRegexPattern(expected)) return false
       try {
         const regex = new RegExp(expected)
         return regex.test(value)


### PR DESCRIPTION
evaluateConditionValue compiles user-supplied regex via new RegExp() with no validation. A tenant admin can store a catastrophic-backtracking pattern (e.g. (a+)+b) as a trigger filter, freezing the global event processing worker for all tenants.

Fix: reject patterns >200 chars, reject nested quantifiers via static check, cap test input at 10000 chars. Fail-closed on all guards.

Tests: 6 new cases covering pattern rejection, input cap, safe regex, and invalid syntax.

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
