### PR TITLE
Feature/smart test skill

### DIFF
--- a/.ai/skills/smart-test/SKILL.md
+++ b/.ai/skills/smart-test/SKILL.md
@@ -26,12 +26,12 @@ Before doing any git analysis, check whether a valid cached plan already exists 
 
 ```bash
 CURRENT_HASH=$(git rev-parse HEAD)
-UNCOMMITTED=$(git diff --name-only HEAD)
+UNCOMMITTED=$(git diff --name-only HEAD; git ls-files --others --exclude-standard)
 ```
 
 Read `.test-cache.json` (if it exists). The cache is **valid** when:
 1. `cache.commitHash` equals `CURRENT_HASH`, **and**
-2. `UNCOMMITTED` is empty (no staged/unstaged changes), **and**
+2. `UNCOMMITTED` is empty (no staged/unstaged/untracked changes), **and**
 3. The commit is reachable from HEAD: `git merge-base --is-ancestor <cache.commitHash> HEAD 2>/dev/null` exits 0
 
 ```bash
@@ -51,7 +51,7 @@ Condition 3 guards against stale cache entries after a rebase, amend, or force-p
   "commitHash": "<git rev-parse HEAD>",
   "savedAt": "<ISO timestamp>",
   "scope": "module | wide | test-only | package",
-  "layer": "ui | api-logic | data | mixed",
+  "layer": "ui | ui-component | api-logic | data | mixed",
   "affectedModules": ["auth", "sales"],
   "jestSourceFiles": [
     "packages/core/src/modules/auth/commands/users.ts"
@@ -65,7 +65,7 @@ Condition 3 guards against stale cache entries after a rebase, amend, or force-p
 
 `integrationWide: true` means the Python script returned `--all`; in that case `integrationSpecFiles` is empty and the full integration suite runs.
 
-`layer` values: `ui` = skip Playwright; `api-logic` or `data` or `mixed` = run Playwright.
+`layer` values: `ui` = skip Playwright; `ui-component`, `api-logic`, `data`, or `mixed` = run Playwright.
 
 ### Save Cache
 
@@ -78,7 +78,7 @@ const plan = {
   commitHash: '$(git rev-parse HEAD)',
   savedAt: new Date().toISOString(),
   scope: '<scope>',
-  layer: '<ui|api-logic|data|mixed>',
+  layer: '<ui|ui-component|api-logic|data|mixed>',
   affectedModules: <json-array-of-modules>,
   jestSourceFiles: <json-array>,
   integrationSpecFiles: <json-array>,
@@ -92,17 +92,24 @@ fs.writeFileSync('.test-cache.json', JSON.stringify(plan, null, 2));
 
 ## Step 1 — Determine Changed Files
 
-Default to comparing against the upstream tracking branch:
+Build one changed-file list and reuse it for cache invalidation, classification, Jest, and
+Playwright mapping. Include PR diff, local staged/unstaged changes, and untracked files:
 
 ```bash
-# Changed files vs develop (most common — PR context)
-git diff --name-only origin/develop...HEAD
+CHANGED_FILES=$({
+  git diff --name-only origin/develop...HEAD
+  git diff --name-only HEAD
+  git ls-files --others --exclude-standard
+} | awk '!seen[$0]++')
+```
 
-# Or: staged + unstaged local changes
-git diff --name-only HEAD
+If there is no upstream PR context, use only local changes and untracked files:
 
-# Or: last commit only
-git diff --name-only HEAD~1 HEAD
+```bash
+CHANGED_FILES=$({
+  git diff --name-only HEAD
+  git ls-files --others --exclude-standard
+} | awk '!seen[$0]++')
 ```
 
 ---
@@ -157,7 +164,7 @@ Use Jest's built-in `--findRelatedTests`. It traverses the import graph from cha
 
 ```bash
 # Build the list of changed source files (exclude test files themselves)
-CHANGED=$(git diff --name-only origin/develop...HEAD \
+CHANGED=$(printf '%s\n' "$CHANGED_FILES" \
   | grep -E '\.(ts|tsx)$' \
   | grep -v '\.test\.' \
   | grep -v '\.spec\.' \
@@ -213,11 +220,14 @@ After tests finish, leave the server running — do not kill it.
 
 **Layer gate**: if `layer = ui` (all changed files are UI-only), skip this step entirely — Playwright tests are not affected by pure UI changes.
 
-Otherwise, use the Python script to map changed modules → affected spec files:
+Otherwise, use the Python script to map changed modules → affected spec files.
+Pass `--layer` so the script can apply the correct triggering rules:
 
 ```bash
-SPEC_FILES=$(git diff --name-only origin/develop...HEAD \
-  | python3 .ai/skills/smart-test/scripts/find_affected_integration_tests.py --project-root .)
+SPEC_FILES=$(printf '%s\n' "$CHANGED_FILES" \
+  | python3 .ai/skills/smart-test/scripts/find_affected_integration_tests.py \
+    --project-root . \
+    --layer "$LAYER")
 
 if [ "$SPEC_FILES" = "--all" ]; then
   yarn test:integration
@@ -228,9 +238,23 @@ else
 fi
 ```
 
+`$LAYER` is the value determined in Step 2b (`ui-component`, `api-logic`, `data`, or `mixed`).
+
+**Layer-aware dep filtering**: when `LAYER=ui-component`, the script only runs tests whose
+own module changed — it ignores cross-module `dependsOnModules` declarations. Rationale: a
+changed `page.tsx` or React component cannot break another module's API calls; only tests
+that actually visit those pages need to run.
+
+**Workspace scoping**: the script compares module identity by both module name and runtime
+root. For example, `apps/mercato/src/modules/example` and
+`packages/create-app/template/src/modules/example` are separate `example` modules, so an
+app-specific page change does not trigger template integration specs.
+
 **Wide scope**: if the script outputs `--all` (triggered when shared deps changed), run the full integration suite.
 
-**Data layer**: if `layer = data` (entities/migrations changed), consider that integration tests with database setup may be particularly important. Run normally via the script — the mapping will include all tests for the affected module.
+**Data layer**: if `layer = data` (entities/migrations changed), integration tests are
+particularly important. Run normally via the script — the mapping will include all tests for
+the affected module including any that declare it as a dependency.
 
 ---
 

--- a/.ai/skills/smart-test/SKILL.md
+++ b/.ai/skills/smart-test/SKILL.md
@@ -40,7 +40,9 @@ git merge-base --is-ancestor "${cache.commitHash}" HEAD 2>/dev/null && echo "rea
 
 Condition 3 guards against stale cache entries after a rebase, amend, or force-push. The old hash may still exist as a dangling object in the git store (`git cat-file -e` would return true), but it is no longer part of the branch history — `git merge-base --is-ancestor` correctly rejects it.
 
-**If cache is valid**: skip Steps 1–5, print `[cache hit: <hash>]`, and proceed directly to running tests using `cache.jestSourceFiles` and `cache.integrationSpecFiles`.
+**If cache is valid**: skip Steps 1–5, print `[cache hit: <hash>]`, and run tests from the cached plan:
+- **Jest**: `yarn jest --findRelatedTests <cache.jestSourceFiles> --passWithNoTests`
+- **Playwright**: if `cache.integrationWide` is `true` → `yarn test:integration`; else if `cache.integrationSpecFiles` is non-empty → `yarn playwright test <cache.integrationSpecFiles> --config=.ai/qa/tests/playwright.config.ts`; else skip.
 
 **If cache is invalid or missing**: continue to Step 1. After completing Steps 1–2, write the cache (see "Save Cache" below) before running tests.
 
@@ -148,10 +150,11 @@ CHANGED_FILES=$({
 Read the changed file list and classify scope:
 
 - **Wide scope** (run everything): changes in `packages/shared/`, `packages/events/`, `packages/queue/`, `packages/cache/`, root `jest.config.cjs`, `jest.setup.ts`, `tsconfig*.json`
-- **UI-wide**: changes in `packages/ui/src/` (not inside a module subfolder)
+- **UI-wide** (`packages/ui/src/backend/`): shared React components rendered on every backend page — Jest: `--findRelatedTests`; Playwright: full suite (the Python script outputs `--all` for these paths). For `packages/ui/src/primitives/` or `packages/ui/src/styles/` only, classify as `ui` layer instead (no Playwright).
 - **Module-scoped**: `packages/*/src/modules/<module>/` or `apps/mercato/src/modules/<module>/` → extract `<module>`
 - **Package-scoped** (no module): `packages/<pkg>/src/lib/` or `packages/<pkg>/src/` root — treat as wide scope for that package
-- **Test-only changes**: `.test.ts` or `.spec.ts` files changed → run those specific files directly
+- **Jest-test-only**: only `.test.ts`/`.test.tsx` files changed → run those files directly via Jest; skip Playwright
+- **Playwright-test-only**: only `.spec.ts` files inside `__integration__/` changed → run those files directly via `yarn playwright test <files> --config=.ai/qa/tests/playwright.config.ts`; skip Jest
 
 See `references/test-architecture.md` for module extraction patterns and known cross-module integration dependencies.
 
@@ -168,10 +171,17 @@ After determining scope, classify the **layer** of each changed source file. Int
 | `api-logic` | `/api/` · `/commands/` · `/lib/` · `/services/` · `/subscribers/` · `/workers/` · `events.ts` · `notifications.ts` · `ai-tools.ts` | **Yes** |
 | `data` | `/data/entities` · `/data/migrations` · `/data/validators` · `/data/extensions` · `/data/enrichers` | **Yes** |
 
-**Layer decision rule:**
-- All changed files → `ui` only (CSS / design tokens / primitives) → **skip Playwright**
-- Any file → `ui-component` / `api-logic` / `data` → **run Playwright**
+**Layer decision rule — set `$LAYER` as a shell variable:**
+- All changed files → `ui` only (CSS / design tokens / primitives) → `LAYER=ui`, **skip Playwright**
+- Any file → `data` patterns → `LAYER=data`, **run Playwright**
+- Any file → `api-logic` patterns (and none match `data`) → `LAYER=api-logic`, **run Playwright**
+- Any file → `ui-component` patterns (and none match `api-logic` or `data`) → `LAYER=ui-component`, **run Playwright**
+- Files span multiple non-`ui` layers → `LAYER=mixed`, **run Playwright**
 - Wide scope always → **run everything**
+
+```bash
+LAYER="<ui|ui-component|api-logic|data|mixed>"  # required: used in Step 5 and cache
+```
 
 **Why `ui-component` needs Playwright**: integration tests render full pages. A React component that throws during render, a conditional that hides a button, or a changed DOM structure can all break Playwright selectors — even without touching any API.
 
@@ -233,10 +243,20 @@ APP_PID=$!
 
 # Wait up to 2 minutes for server to become ready
 echo "Waiting for server on port 3000..."
+SERVER_READY=0
 for i in $(seq 1 60); do
-  curl -sf http://localhost:3000 > /dev/null 2>&1 && echo "Server ready." && break
+  if curl -sf http://localhost:3000 > /dev/null 2>&1; then
+    echo "Server ready."
+    SERVER_READY=1
+    break
+  fi
   sleep 2
 done
+
+if [ "$SERVER_READY" -eq 0 ]; then
+  echo "ERROR: Server did not become ready within 2 minutes. Aborting integration tests."
+  exit 1
+fi
 ```
 
 After tests finish, leave the server running — do not kill it.
@@ -310,25 +330,31 @@ Totals come from `references/test-architecture.md`. Round to one decimal place.
 
 ```
 Step 0: .test-cache.json valid (hash + no uncommitted + reachable)?
-  └─ YES → use cached plan, skip to running tests
+  └─ YES → run from cache; check integrationWide flag:
+           integrationWide=true  → Jest: cached files + Playwright: yarn test:integration
+           integrationWide=false → Jest: cached files + Playwright: cached spec files (or skip)
   └─ NO  → analyze:
 
        Step 2a — Scope:
-         └─ Only test files?         → Run those files directly (skip integration check)
+         └─ Only .test.ts/.test.tsx?        → Jest: run those files directly; Playwright: skip
+         └─ Only .spec.ts (__integration__/)? → Jest: skip; Playwright: run those files directly
          └─ shared/events/queue/cache/root config?
-                                     → Full suite (yarn test + yarn test:integration)
-         └─ Module-scoped?           → extract module name(s)
-         └─ Package lib (no module)? → --findRelatedTests for that package
+                                            → Full suite (yarn test + yarn test:integration)
+         └─ packages/ui/src/backend/?       → Jest: --findRelatedTests; Playwright: full suite
+         └─ Module-scoped?                  → extract module name(s)
+         └─ Package lib (no module)?        → --findRelatedTests for that package
 
        Step 2b — Layer (for non-wide, non-test-only scopes):
-         └─ ALL files are pure CSS / design tokens / primitives (layer = ui)?
+         └─ ALL files are pure CSS / design tokens / primitives?
+              → LAYER=ui
               → Jest: --findRelatedTests <changed-src-files>
               → Integration: SKIP (no DOM structure change possible)
          └─ ANY file is ui-component / api-logic / data?
+              → LAYER=<ui-component|api-logic|data|mixed>
               → Jest: --findRelatedTests <changed-src-files>
               → Integration: check server → script maps modules → spec files
 
-       → Save cache (with layer field) → run tests
+       → Set $LAYER → Save cache (with layer field) → run tests
 ```
 
 ---

--- a/.ai/skills/smart-test/SKILL.md
+++ b/.ai/skills/smart-test/SKILL.md
@@ -1,0 +1,245 @@
+---
+name: smart-test
+description: Run only the tests affected by changed code. Use when the user says "run affected tests", "run smart tests", "test only what changed", "run tests for this PR", "run tests for my changes", "selective tests", or asks to run tests without running the full suite.
+---
+
+# Smart Test — Run Only Affected Tests
+
+Runs the minimal set of tests that cover the code changes in the current branch or working tree.
+
+**Execution policy**: Display the test plan (which tests will run and why), then **immediately run them without asking for confirmation**.
+
+**Cache**: Analysis results are persisted to `.test-cache.json` (gitignored). On repeated invocations for the same commit with no uncommitted changes, the cached plan is reused — skip straight to running tests.
+
+## Two Test Types, Two Strategies
+
+| Type | Files | Strategy |
+|------|-------|----------|
+| Jest (unit/component) | `*.test.ts`, `*.test.tsx` | `--findRelatedTests` (Jest traverses import graph) |
+| Playwright (integration) | `*.spec.ts` in `__integration__/` | Module-name matching via `meta.ts` dependency declarations |
+
+---
+
+## Step 0 — Cache Lookup
+
+Before doing any git analysis, check whether a valid cached plan already exists for the current state.
+
+```bash
+CURRENT_HASH=$(git rev-parse HEAD)
+UNCOMMITTED=$(git diff --name-only HEAD)
+```
+
+Read `.test-cache.json` (if it exists). The cache is **valid** when:
+1. `cache.commitHash` equals `CURRENT_HASH`, **and**
+2. `UNCOMMITTED` is empty (no staged/unstaged changes), **and**
+3. The commit is reachable from HEAD: `git merge-base --is-ancestor <cache.commitHash> HEAD 2>/dev/null` exits 0
+
+```bash
+git merge-base --is-ancestor "${cache.commitHash}" HEAD 2>/dev/null && echo "reachable" || echo "stale"
+```
+
+Condition 3 guards against stale cache entries after a rebase, amend, or force-push. The old hash may still exist as a dangling object in the git store (`git cat-file -e` would return true), but it is no longer part of the branch history — `git merge-base --is-ancestor` correctly rejects it.
+
+**If cache is valid**: skip Steps 1–5, print `[cache hit: <hash>]`, and proceed directly to running tests using `cache.jestSourceFiles` and `cache.integrationSpecFiles`.
+
+**If cache is invalid or missing**: continue to Step 1. After completing Steps 1–2, write the cache (see "Save Cache" below) before running tests.
+
+### Cache file format (`.test-cache.json`)
+
+```json
+{
+  "commitHash": "<git rev-parse HEAD>",
+  "savedAt": "<ISO timestamp>",
+  "scope": "module | wide | test-only | package",
+  "affectedModules": ["auth", "sales"],
+  "jestSourceFiles": [
+    "packages/core/src/modules/auth/commands/users.ts"
+  ],
+  "integrationSpecFiles": [
+    "packages/core/src/modules/auth/__integration__/TC-AUTH-001.spec.ts"
+  ],
+  "integrationWide": false
+}
+```
+
+`integrationWide: true` means the Python script returned `--all`; in that case `integrationSpecFiles` is empty and the full integration suite runs.
+
+### Save Cache
+
+After completing the analysis (Steps 1–2), write the plan before running tests:
+
+```bash
+node -e "
+const fs = require('fs');
+const plan = {
+  commitHash: '$(git rev-parse HEAD)',
+  savedAt: new Date().toISOString(),
+  scope: '<scope>',
+  affectedModules: <json-array-of-modules>,
+  jestSourceFiles: <json-array>,
+  integrationSpecFiles: <json-array>,
+  integrationWide: <true|false>
+};
+fs.writeFileSync('.test-cache.json', JSON.stringify(plan, null, 2));
+"
+```
+
+---
+
+## Step 1 — Determine Changed Files
+
+Default to comparing against the upstream tracking branch:
+
+```bash
+# Changed files vs develop (most common — PR context)
+git diff --name-only origin/develop...HEAD
+
+# Or: staged + unstaged local changes
+git diff --name-only HEAD
+
+# Or: last commit only
+git diff --name-only HEAD~1 HEAD
+```
+
+---
+
+## Step 2 — Classify Scope
+
+Read the changed file list and classify:
+
+- **Wide scope** (run everything): changes in `packages/shared/`, `packages/events/`, `packages/queue/`, `packages/cache/`, root `jest.config.cjs`, `jest.setup.ts`, `tsconfig*.json`
+- **UI-wide**: changes in `packages/ui/src/` (not inside a module)
+- **Module-scoped**: `packages/*/src/modules/<module>/` or `apps/mercato/src/modules/<module>/` → extract `<module>`
+- **Package-scoped** (no module): `packages/<pkg>/src/lib/` or `packages/<pkg>/src/` root — treat as wide scope for that package
+- **Test-only changes**: `.test.ts` or `.spec.ts` files changed → run those specific files directly
+
+See `references/test-architecture.md` for module extraction patterns and known cross-module integration dependencies.
+
+→ **Save cache now** (see Step 0 — Save Cache) before proceeding to run tests.
+
+---
+
+## Step 3 — Jest Unit Tests
+
+Use Jest's built-in `--findRelatedTests`. It traverses the import graph from changed source files and discovers every test that (directly or transitively) imports them.
+
+```bash
+# Build the list of changed source files (exclude test files themselves)
+CHANGED=$(git diff --name-only origin/develop...HEAD \
+  | grep -E '\.(ts|tsx)$' \
+  | grep -v '\.test\.' \
+  | grep -v '\.spec\.' \
+  | grep -v '__tests__/' \
+  | grep -v '__integration__/' \
+  | tr '\n' ' ')
+
+# Run related tests (passWithNoTests handles no-match gracefully)
+yarn jest --findRelatedTests $CHANGED --passWithNoTests
+```
+
+**Wide scope fallback**: when `CHANGED` includes shared/events/queue/cache files, run the full Jest suite instead:
+
+```bash
+yarn test
+```
+
+---
+
+## Step 4 — Ensure Server Is Running (Integration Tests Only)
+
+Before running any Playwright tests, verify the app is accessible on port 3000.
+
+```bash
+curl -sf http://localhost:3000 > /dev/null 2>&1
+```
+
+**If the server is running** (exit code 0): proceed directly to Step 5.
+
+**If the server is NOT running**: build the project and start the production server:
+
+```bash
+# Build everything (packages + app)
+yarn build
+
+# Start production server in background
+yarn start &
+APP_PID=$!
+
+# Wait up to 2 minutes for server to become ready
+echo "Waiting for server on port 3000..."
+for i in $(seq 1 60); do
+  curl -sf http://localhost:3000 > /dev/null 2>&1 && echo "Server ready." && break
+  sleep 2
+done
+```
+
+After tests finish, leave the server running — do not kill it.
+
+---
+
+## Step 5 — Integration Tests (Playwright)
+
+Use the Python script to map changed modules → affected spec files:
+
+```bash
+SPEC_FILES=$(git diff --name-only origin/develop...HEAD \
+  | python3 .ai/skills/smart-test/scripts/find_affected_integration_tests.py --project-root .)
+
+if [ "$SPEC_FILES" = "--all" ]; then
+  yarn test:integration
+elif [ -n "$SPEC_FILES" ]; then
+  yarn playwright test $SPEC_FILES --config=.ai/qa/tests/playwright.config.ts
+else
+  echo "No affected integration tests found."
+fi
+```
+
+**Wide scope**: if the script outputs `--all` (triggered when shared deps changed), run the full integration suite.
+
+---
+
+## Step 6 — Report Results
+
+After tests complete, summarize:
+- Whether results came from cache (`[cache hit]`) or fresh analysis
+- How many Jest tests ran vs full suite
+- Which integration spec files ran and why (which changed module triggered each)
+- Whether the server was already running or was built and started
+- Any wide-scope fallback applied and why
+
+**Coverage percentages** (always include at the end):
+
+| Type | Ran | Total | % |
+|------|-----|-------|---|
+| Unit (Jest suites) | `<ran>` | ~485 | `<ran/485 * 100>`% |
+| Integration (Playwright spec files) | `<ran>` | ~323 | `<ran/323 * 100>`% |
+
+Totals come from `references/test-architecture.md`. Round to one decimal place.
+
+---
+
+## Decision Tree
+
+```
+Step 0: .test-cache.json exists AND commitHash matches AND no uncommitted changes AND commit exists in repo?
+  └─ YES → use cached plan, skip to running tests
+  └─ NO  → analyze:
+       Changed files?
+         └─ Only test files?
+              → Run those files directly
+         └─ Includes shared/events/queue/cache/root config?
+              → Full suite (yarn test + yarn test:integration)
+         └─ Module-scoped changes?
+              → Jest: --findRelatedTests <changed-src-files>
+              → Integration: check server → script maps modules → spec files
+         └─ Package lib changes (no module)?
+              → Jest: --findRelatedTests for that package
+              → Integration: check server → script (may expand to --all)
+       → Save cache → run tests
+```
+
+---
+
+## Reference Files
+
+- `references/test-architecture.md` — full test structure, module path patterns, framework configs, known cross-module integration dependencies

--- a/.ai/skills/smart-test/SKILL.md
+++ b/.ai/skills/smart-test/SKILL.md
@@ -95,13 +95,40 @@ fs.writeFileSync('.test-cache.json', JSON.stringify(plan, null, 2));
 Build one changed-file list and reuse it for cache invalidation, classification, Jest, and
 Playwright mapping. Include PR diff, local staged/unstaged changes, and untracked files:
 
+First resolve the comparison base. Do **not** guess `origin/main` when the branch is based on
+`develop`; comparing a develop-based branch to `origin/main` can pull in unrelated
+`packages/shared/` changes from the long-lived develop branch and incorrectly force the full
+suite.
+
 ```bash
+BASE_REF="${SMART_TEST_BASE_REF:-}"
+if [ -z "$BASE_REF" ]; then
+  BASE_REF="$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)"
+fi
+if [ -z "$BASE_REF" ] && git rev-parse --verify --quiet origin/develop >/dev/null; then
+  if git merge-base --fork-point origin/develop HEAD >/dev/null 2>&1 || git merge-base --is-ancestor origin/develop HEAD; then
+    BASE_REF="origin/develop"
+  fi
+fi
+if [ -z "$BASE_REF" ] && git rev-parse --verify --quiet develop >/dev/null; then
+  if git merge-base --fork-point develop HEAD >/dev/null 2>&1 || git merge-base --is-ancestor develop HEAD; then
+    BASE_REF="develop"
+  fi
+fi
+
 CHANGED_FILES=$({
-  git diff --name-only origin/develop...HEAD
+  if [ -n "$BASE_REF" ]; then
+    git diff --name-only "$BASE_REF"...HEAD
+  fi
   git diff --name-only HEAD
   git ls-files --others --exclude-standard
 } | awk '!seen[$0]++')
 ```
+
+If `git diff --name-only origin/main...HEAD` contains `packages/shared/` but `$BASE_REF` is
+`origin/develop`/`develop` and the `$BASE_REF...HEAD` diff does not contain
+`packages/shared/`, do not classify the branch as wide-scope. Report it as a base-ref
+mismatch and use the resolved develop base.
 
 If there is no upstream PR context, use only local changes and untracked files:
 
@@ -227,6 +254,7 @@ Pass `--layer` so the script can apply the correct triggering rules:
 SPEC_FILES=$(printf '%s\n' "$CHANGED_FILES" \
   | python3 .ai/skills/smart-test/scripts/find_affected_integration_tests.py \
     --project-root . \
+    --base auto \
     --layer "$LAYER")
 
 if [ "$SPEC_FILES" = "--all" ]; then

--- a/.ai/skills/smart-test/SKILL.md
+++ b/.ai/skills/smart-test/SKILL.md
@@ -51,6 +51,7 @@ Condition 3 guards against stale cache entries after a rebase, amend, or force-p
   "commitHash": "<git rev-parse HEAD>",
   "savedAt": "<ISO timestamp>",
   "scope": "module | wide | test-only | package",
+  "layer": "ui | api-logic | data | mixed",
   "affectedModules": ["auth", "sales"],
   "jestSourceFiles": [
     "packages/core/src/modules/auth/commands/users.ts"
@@ -64,6 +65,8 @@ Condition 3 guards against stale cache entries after a rebase, amend, or force-p
 
 `integrationWide: true` means the Python script returned `--all`; in that case `integrationSpecFiles` is empty and the full integration suite runs.
 
+`layer` values: `ui` = skip Playwright; `api-logic` or `data` or `mixed` = run Playwright.
+
 ### Save Cache
 
 After completing the analysis (Steps 1–2), write the plan before running tests:
@@ -75,6 +78,7 @@ const plan = {
   commitHash: '$(git rev-parse HEAD)',
   savedAt: new Date().toISOString(),
   scope: '<scope>',
+  layer: '<ui|api-logic|data|mixed>',
   affectedModules: <json-array-of-modules>,
   jestSourceFiles: <json-array>,
   integrationSpecFiles: <json-array>,
@@ -103,19 +107,47 @@ git diff --name-only HEAD~1 HEAD
 
 ---
 
-## Step 2 — Classify Scope
+## Step 2 — Classify Scope and Layer
 
-Read the changed file list and classify:
+### 2a — Scope
+
+Read the changed file list and classify scope:
 
 - **Wide scope** (run everything): changes in `packages/shared/`, `packages/events/`, `packages/queue/`, `packages/cache/`, root `jest.config.cjs`, `jest.setup.ts`, `tsconfig*.json`
-- **UI-wide**: changes in `packages/ui/src/` (not inside a module)
+- **UI-wide**: changes in `packages/ui/src/` (not inside a module subfolder)
 - **Module-scoped**: `packages/*/src/modules/<module>/` or `apps/mercato/src/modules/<module>/` → extract `<module>`
 - **Package-scoped** (no module): `packages/<pkg>/src/lib/` or `packages/<pkg>/src/` root — treat as wide scope for that package
 - **Test-only changes**: `.test.ts` or `.spec.ts` files changed → run those specific files directly
 
 See `references/test-architecture.md` for module extraction patterns and known cross-module integration dependencies.
 
-→ **Save cache now** (see Step 0 — Save Cache) before proceeding to run tests.
+### 2b — Layer (determines whether Playwright runs)
+
+After determining scope, classify the **layer** of each changed source file. Integration (Playwright) tests only need to run when backend logic or data is touched — they are irrelevant for pure UI changes.
+
+**Classify each changed file:**
+
+| Layer | Path indicators | Playwright needed? |
+|-------|----------------|--------------------|
+| `ui` | `**/*.css` · `packages/ui/src/primitives/` · `packages/ui/src/styles/` | **No** |
+| `ui-component` | `packages/ui/src/backend/**/*.tsx` · `/components/` · `/widgets/` · `/frontend/` · `/backend/**/*.tsx` (Next.js pages) | **Yes** — Playwright renders full pages; a broken component can crash a page load or break a selector |
+| `api-logic` | `/api/` · `/commands/` · `/lib/` · `/services/` · `/subscribers/` · `/workers/` · `events.ts` · `notifications.ts` · `ai-tools.ts` | **Yes** |
+| `data` | `/data/entities` · `/data/migrations` · `/data/validators` · `/data/extensions` · `/data/enrichers` | **Yes** |
+
+**Layer decision rule:**
+- All changed files → `ui` only (CSS / design tokens / primitives) → **skip Playwright**
+- Any file → `ui-component` / `api-logic` / `data` → **run Playwright**
+- Wide scope always → **run everything**
+
+**Why `ui-component` needs Playwright**: integration tests render full pages. A React component that throws during render, a conditional that hides a button, or a changed DOM structure can all break Playwright selectors — even without touching any API.
+
+**Only skip Playwright when** the change cannot affect DOM structure or interactivity: pure CSS, design tokens, Tailwind config, color/spacing primitives.
+
+**Special cases:**
+- Module `backend/page.tsx`, `backend/[id]/page.tsx` — Next.js page files → `ui-component` (Playwright visits these pages)
+- Module `api/GET/route.ts`, `api/POST/route.ts` → API routes → `api-logic`
+
+→ **Save cache now** (see Step 0 — Save Cache, include `layer` field) before proceeding to run tests.
 
 ---
 
@@ -179,7 +211,9 @@ After tests finish, leave the server running — do not kill it.
 
 ## Step 5 — Integration Tests (Playwright)
 
-Use the Python script to map changed modules → affected spec files:
+**Layer gate**: if `layer = ui` (all changed files are UI-only), skip this step entirely — Playwright tests are not affected by pure UI changes.
+
+Otherwise, use the Python script to map changed modules → affected spec files:
 
 ```bash
 SPEC_FILES=$(git diff --name-only origin/develop...HEAD \
@@ -195,6 +229,8 @@ fi
 ```
 
 **Wide scope**: if the script outputs `--all` (triggered when shared deps changed), run the full integration suite.
+
+**Data layer**: if `layer = data` (entities/migrations changed), consider that integration tests with database setup may be particularly important. Run normally via the script — the mapping will include all tests for the affected module.
 
 ---
 
@@ -221,21 +257,26 @@ Totals come from `references/test-architecture.md`. Round to one decimal place.
 ## Decision Tree
 
 ```
-Step 0: .test-cache.json exists AND commitHash matches AND no uncommitted changes AND commit exists in repo?
+Step 0: .test-cache.json valid (hash + no uncommitted + reachable)?
   └─ YES → use cached plan, skip to running tests
   └─ NO  → analyze:
-       Changed files?
-         └─ Only test files?
-              → Run those files directly
-         └─ Includes shared/events/queue/cache/root config?
-              → Full suite (yarn test + yarn test:integration)
-         └─ Module-scoped changes?
+
+       Step 2a — Scope:
+         └─ Only test files?         → Run those files directly (skip integration check)
+         └─ shared/events/queue/cache/root config?
+                                     → Full suite (yarn test + yarn test:integration)
+         └─ Module-scoped?           → extract module name(s)
+         └─ Package lib (no module)? → --findRelatedTests for that package
+
+       Step 2b — Layer (for non-wide, non-test-only scopes):
+         └─ ALL files are pure CSS / design tokens / primitives (layer = ui)?
+              → Jest: --findRelatedTests <changed-src-files>
+              → Integration: SKIP (no DOM structure change possible)
+         └─ ANY file is ui-component / api-logic / data?
               → Jest: --findRelatedTests <changed-src-files>
               → Integration: check server → script maps modules → spec files
-         └─ Package lib changes (no module)?
-              → Jest: --findRelatedTests for that package
-              → Integration: check server → script (may expand to --all)
-       → Save cache → run tests
+
+       → Save cache (with layer field) → run tests
 ```
 
 ---

--- a/.ai/skills/smart-test/references/test-architecture.md
+++ b/.ai/skills/smart-test/references/test-architecture.md
@@ -55,6 +55,70 @@ These path prefixes indicate cross-cutting changes that affect all tests:
 - `package.json` (root) — deps/scripts
 - `turbo.json` — monorepo build config
 
+## Layer Classification (→ controls whether Playwright runs)
+
+For any non-wide change, classify each modified source file into a layer to decide if integration tests are needed.
+
+### UI layer — Jest only, **skip Playwright**
+
+Only pure CSS / design tokens / Tailwind primitives qualify. These files cannot affect DOM structure or component interactivity.
+
+| Pattern | Examples |
+|---------|---------|
+| `**/*.css` | Global stylesheets |
+| `packages/ui/src/primitives/**` | Button.tsx, Badge.tsx — Radix/Tailwind primitives |
+| `packages/ui/src/styles/**` | CSS variables, Tailwind config |
+
+### UI-Component layer — Jest + **run Playwright**
+
+React components (`.tsx`) that render into pages visited by Playwright. A broken render, a missing element, or a changed conditional can break Playwright selectors even without touching any API.
+
+| Pattern | Examples |
+|---------|---------|
+| `packages/ui/src/backend/**/*.tsx` | `TruncatedCell.tsx`, `DataTable.tsx`, `FlashMessages.tsx` |
+| `**/frontend/**` | Next.js frontend pages |
+| `**/backend/**/*.tsx` | Next.js backoffice pages |
+| `**/components/**` | React component files |
+| `**/widgets/**` | Widget injection files |
+
+> **Important**: `backend/page.tsx` is a Next.js page (ui-component). `api/GET/route.ts` is an API route (api-logic). Don't confuse them.
+
+### API-Logic layer — Jest + Playwright
+
+| Pattern | Examples |
+|---------|---------|
+| `**/api/**` | `api/GET/route.ts`, `api/POST/route.ts` |
+| `**/commands/**` | `commands/createCustomer.ts` |
+| `**/lib/**` | `lib/pricing.ts`, `lib/utils.ts` |
+| `**/services/**` | `services/emailService.ts` |
+| `**/subscribers/**` | `subscribers/onOrderCreated.ts` |
+| `**/workers/**` | `workers/syncWorker.ts` |
+| `**/events.ts` | Module event declarations |
+| `**/notifications.ts` | Module notification declarations |
+| `**/ai-tools.ts` | MCP tool definitions |
+
+### Data layer — Jest + Playwright (schema-sensitive)
+
+| Pattern | Examples |
+|---------|---------|
+| `**/data/entities*` | `data/entities.ts`, `data/entities/` |
+| `**/data/migrations*` | `data/migrations/Migration001.ts` |
+| `**/data/validators*` | `data/validators.ts` |
+| `**/data/extensions*` | `data/extensions.ts` |
+| `**/data/enrichers*` | `data/enrichers.ts` |
+
+### Decision rule
+
+```
+layer = ui      → only if ALL changed files match UI patterns
+layer = data    → if ANY changed file matches data patterns
+layer = api-logic → if ANY changed file matches api-logic patterns (and none match data)
+layer = mixed   → if changes span multiple layers
+```
+
+When `layer = ui`: skip Step 4 and Step 5 entirely — no Playwright.
+When `layer = data` or `api-logic` or `mixed`: proceed with Playwright as normal.
+
 ## Integration Test Meta Format
 
 Integration tests declare their module dependencies in `meta.ts` (or `index.ts`):

--- a/.ai/skills/smart-test/references/test-architecture.md
+++ b/.ai/skills/smart-test/references/test-architecture.md
@@ -1,0 +1,122 @@
+# Test Architecture — Open Mercato
+
+## Frameworks
+
+| Framework | Purpose | Config |
+|-----------|---------|--------|
+| Jest + ts-jest | Unit and component tests | `jest.config.cjs` (root + 17 packages + 1 app) |
+| Playwright | Integration / E2E tests | `.ai/qa/tests/playwright.config.ts` |
+
+## File Counts (approximate)
+
+- Unit/component tests: ~485 files (`*.test.ts`, `*.test.tsx`)
+- Integration tests: ~323 files (`*.spec.ts` inside `__integration__/`)
+- Total: ~808 test files
+
+## Test File Conventions
+
+```
+packages/<pkg>/src/modules/<module>/
+  __tests__/
+    *.test.ts        # Jest unit tests
+    *.test.tsx       # React component tests
+  __integration__/
+    meta.ts          # Module-level dependency declarations
+    index.ts         # Sometimes used instead of meta.ts
+    *.spec.ts        # Playwright integration tests
+    <subfolder>/
+      index.ts       # Subfolder dependency declarations (cascaded)
+      *.spec.ts
+      *.meta.ts      # Per-test dependency declarations (rare)
+```
+
+## Module Path Extraction
+
+Extract module name from file path by finding `/modules/<name>/`:
+
+| File path | Module |
+|-----------|--------|
+| `packages/core/src/modules/customers/lib/foo.ts` | `customers` |
+| `packages/core/src/modules/sales/api/...` | `sales` |
+| `apps/mercato/src/modules/pos/page.tsx` | `pos` |
+| `packages/enterprise/src/modules/enterprise_pricing/...` | `enterprise_pricing` |
+
+## Wide-Scope Triggers (→ run full suite)
+
+These path prefixes indicate cross-cutting changes that affect all tests:
+
+- `packages/shared/` — utilities, types, DSL helpers, i18n
+- `packages/events/` — event bus
+- `packages/queue/` — background workers
+- `packages/cache/` — caching layer
+- `jest.config.` — test runner config
+- `jest.setup.` — test environment setup
+- `tsconfig` — TypeScript configuration
+- `package.json` (root) — deps/scripts
+- `turbo.json` — monorepo build config
+
+## Integration Test Meta Format
+
+Integration tests declare their module dependencies in `meta.ts` (or `index.ts`):
+
+```typescript
+// packages/core/src/modules/attachments/__integration__/meta.ts
+export const integrationMeta = {
+  dependsOnModules: ['attachments'],
+}
+
+// packages/core/src/modules/catalog/__integration__/meta.ts
+export const integrationMeta = {
+  dependsOnModules: ['shipping_carriers', 'payment_gateways', 'currencies'],
+}
+```
+
+Supported keys (all equivalent): `dependsOnModules`, `requiredModules`, `requiresModules`
+
+The existing discovery system is at `packages/cli/src/lib/testing/integration-discovery.ts`.
+It reads these declarations and filters tests based on enabled modules.
+
+## Known Cross-Module Integration Dependencies
+
+All `__integration__` directories now have `meta.ts` files with explicit dependency declarations.
+The table below documents cross-module dependencies (modules with only self-references are omitted).
+
+| Test module | Also requires |
+|-------------|--------------|
+| `catalog` | `shipping_carriers`, `payment_gateways`, `currencies` |
+| `customers` | `feature_toggles`, `directory`, `dictionaries` |
+| `sales` | `notifications`, `catalog`, `customers` |
+| `auth` | `staff` |
+| `checkout` | `payment_gateways` |
+| `data_sync` | `integrations` |
+| `inbox_ops` | `messages` |
+
+## Jest Run Commands
+
+```bash
+yarn test                              # All Jest tests (turbo)
+yarn jest --findRelatedTests <files>   # Related tests for specific files
+yarn jest <file>                       # Single test file
+yarn workspace @open-mercato/core test # Single package
+```
+
+## Integration Test Run Commands
+
+```bash
+yarn test:integration                  # Full Playwright suite
+yarn playwright test <spec> --config=.ai/qa/tests/playwright.config.ts  # Specific specs
+yarn test:integration:coverage         # With Istanbul coverage
+yarn test:integration:report           # View HTML report
+```
+
+## CI Pipeline
+
+1. `yarn test` — all Jest tests (every PR)
+2. `yarn test:integration:coverage` — Playwright on ephemeral app (every PR)
+
+## Environment Variables Affecting Test Selection
+
+| Variable | Effect |
+|----------|--------|
+| `OM_ENABLE_ENTERPRISE_MODULES=true` | Includes enterprise overlay integration tests |
+| `OM_INTEGRATION_OVERLAY_ROOT` | Overrides overlay detection root (default: `packages/enterprise`) |

--- a/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
+++ b/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+find_affected_integration_tests.py
+
+Maps changed files (from git diff or stdin) to affected Playwright integration test spec files
+by reading module-level dependency declarations in __integration__/meta.ts files.
+
+Usage:
+  # Pipe git diff output
+  git diff --name-only origin/develop...HEAD | python3 find_affected_integration_tests.py --project-root .
+
+  # Let the script call git diff internally
+  python3 find_affected_integration_tests.py --project-root . --base origin/develop
+
+  # Explicit base and head
+  python3 find_affected_integration_tests.py --project-root . --base origin/develop --head HEAD
+
+Output:
+  One relative spec file path per line, e.g.:
+    packages/core/src/modules/customers/__integration__/customers.spec.ts
+
+  Outputs "--all" (single line) when a wide-scope change is detected
+  (shared utilities, build config, etc.) — caller should run the full suite.
+
+  Outputs nothing when no integration tests are affected.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WIDE_SCOPE_PREFIXES = (
+    "packages/shared/",
+    "packages/events/",
+    "packages/queue/",
+    "packages/cache/",
+    "jest.config.",
+    "jest.setup.",
+    "tsconfig",
+    "package.json",
+    "turbo.json",
+)
+
+IGNORED_DIRS = frozenset({
+    "node_modules", ".git", ".next", "dist", ".turbo",
+    "coverage", "test-results", ".yarn", ".cache", "tmp", "temp",
+    ".claude", ".codex",
+})
+
+META_FILE_NAMES = ("meta.ts", "index.ts")
+DEPENDENCY_KEYS = ("dependsOnModules", "requiredModules", "requiresModules")
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_changed_files(base_ref: str | None, head_ref: str | None) -> list[str]:
+    """Return changed file paths from git or stdin."""
+    if not sys.stdin.isatty():
+        return [line.strip() for line in sys.stdin if line.strip()]
+
+    if base_ref and head_ref:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...{head_ref}"],
+            capture_output=True, text=True, check=False,
+        )
+    elif base_ref:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+            capture_output=True, text=True, check=False,
+        )
+    else:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "HEAD"],
+            capture_output=True, text=True, check=False,
+        )
+
+    return [line for line in result.stdout.strip().split("\n") if line]
+
+
+def extract_module_name_from_path(file_path: str) -> str | None:
+    """
+    Extract the module name from a path containing /modules/<name>/.
+
+    Examples:
+      packages/core/src/modules/customers/lib/foo.ts  → "customers"
+      apps/mercato/src/modules/pos/page.tsx            → "pos"
+    """
+    match = re.search(r"/modules/([^/]+)/", file_path)
+    return match.group(1) if match else None
+
+
+def is_wide_scope(file_path: str) -> bool:
+    return any(file_path.startswith(prefix) for prefix in WIDE_SCOPE_PREFIXES)
+
+
+def extract_dependencies_from_source(source: str) -> set[str]:
+    deps: set[str] = set()
+    for key in DEPENDENCY_KEYS:
+        match = re.search(rf"{key}\s*:\s*\[([\s\S]*?)\]", source)
+        if not match:
+            continue
+        for value in re.findall(r"""['"`]([a-zA-Z0-9_.-]+)['"`]""", match.group(1)):
+            cleaned = value.strip().lower()
+            if cleaned:
+                deps.add(cleaned)
+    return deps
+
+
+def read_dependencies_from_file(path: Path) -> set[str]:
+    try:
+        return extract_dependencies_from_source(path.read_text(encoding="utf-8"))
+    except OSError:
+        return set()
+
+
+def is_ignored(path_part: str) -> bool:
+    return path_part in IGNORED_DIRS
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def collect_integration_directories(root: Path) -> list[Path]:
+    """Recursively find all __integration__ directories under root."""
+    result: list[Path] = []
+
+    def _walk(directory: Path) -> None:
+        try:
+            entries = list(directory.iterdir())
+        except PermissionError:
+            return
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            if is_ignored(entry.name):
+                continue
+            if entry.name == "__integration__":
+                result.append(entry)
+            else:
+                _walk(entry)
+
+    _walk(root)
+    return result
+
+
+def collect_spec_files(directory: Path) -> list[Path]:
+    return list(directory.rglob("*.spec.ts"))
+
+
+def resolve_module_name_for_integration_dir(integration_dir: Path) -> str | None:
+    """The module name is the parent directory of __integration__."""
+    return integration_dir.parent.name or None
+
+
+def build_integration_index(project_root: Path) -> list[dict]:
+    """
+    Returns a list of dicts, one per integration directory:
+      {
+        "module": str | None,
+        "deps": set[str],          # declared dependsOnModules etc.
+        "specs": list[Path],       # absolute spec file paths
+      }
+    """
+    entries = []
+    for integration_dir in collect_integration_directories(project_root):
+        if any(is_ignored(part) for part in integration_dir.parts):
+            continue
+
+        module_name = resolve_module_name_for_integration_dir(integration_dir)
+        deps: set[str] = set()
+
+        for meta_name in META_FILE_NAMES:
+            meta_path = integration_dir / meta_name
+            if meta_path.exists():
+                deps.update(read_dependencies_from_file(meta_path))
+
+        # The module itself is always in its own dep set (self-coverage)
+        if module_name:
+            deps.add(module_name.lower())
+
+        specs = collect_spec_files(integration_dir)
+
+        entries.append({"module": module_name, "deps": deps, "specs": specs})
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Main logic
+# ---------------------------------------------------------------------------
+
+def find_affected_specs(project_root: Path, changed_files: list[str]) -> list[str] | str:
+    """
+    Returns either:
+      - "--all"  (string) when a wide-scope change is detected
+      - list of relative spec file paths (may be empty)
+    """
+    # Wide-scope check
+    for f in changed_files:
+        if is_wide_scope(f):
+            return "--all"
+
+    # Collect changed module names
+    changed_modules: set[str] = set()
+    for f in changed_files:
+        module = extract_module_name_from_path(f)
+        if module:
+            changed_modules.add(module.lower())
+
+    # When no module-scoped changes (e.g., only root package lib files), check by
+    # changed packages — if a whole package changed with no module, treat as wide
+    changed_packages: set[str] = set()
+    for f in changed_files:
+        parts = Path(f).parts
+        if len(parts) >= 2 and parts[0] == "packages":
+            changed_packages.add(parts[1])
+
+    if not changed_modules and not changed_packages:
+        return []
+
+    integration_index = build_integration_index(project_root)
+
+    affected_specs: set[str] = set()
+    for entry in integration_index:
+        # A test is affected if:
+        # 1. Its own module is in changed_modules, OR
+        # 2. Any of its declared dependencies is in changed_modules, OR
+        # 3. Its parent package is in changed_packages
+        entry_module = (entry["module"] or "").lower()
+        entry_deps = entry["deps"]
+
+        module_hit = entry_module in changed_modules
+        dep_hit = bool(entry_deps & changed_modules)
+
+        # Package hit: check if any spec lives in a changed package
+        package_hit = False
+        for spec in entry["specs"]:
+            try:
+                rel = spec.relative_to(project_root)
+                rel_parts = rel.parts
+                if len(rel_parts) >= 2 and rel_parts[0] == "packages" and rel_parts[1] in changed_packages:
+                    package_hit = True
+                    break
+            except ValueError:
+                pass
+
+        if module_hit or dep_hit or package_hit:
+            for spec in entry["specs"]:
+                try:
+                    rel = spec.relative_to(project_root)
+                    affected_specs.add(str(rel))
+                except ValueError:
+                    affected_specs.add(str(spec))
+
+    return sorted(affected_specs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Find Playwright integration tests affected by changed files.")
+    parser.add_argument("--project-root", default=".", help="Absolute or relative path to the monorepo root")
+    parser.add_argument("--base", default=None, help="Base git ref (e.g. origin/develop)")
+    parser.add_argument("--head", default=None, help="Head git ref (default: HEAD)")
+    args = parser.parse_args()
+
+    project_root = Path(args.project_root).resolve()
+    changed_files = get_changed_files(args.base, args.head)
+
+    if not changed_files:
+        # Nothing changed
+        sys.exit(0)
+
+    result = find_affected_specs(project_root, changed_files)
+
+    if result == "--all":
+        print("--all")
+    elif isinstance(result, list):
+        for spec in result:
+            print(spec)
+
+
+if __name__ == "__main__":
+    main()

--- a/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
+++ b/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
@@ -40,6 +40,9 @@ WIDE_SCOPE_PREFIXES = (
     "packages/events/",
     "packages/queue/",
     "packages/cache/",
+    # Shared backend UI components (DataTable, CrudForm, etc.) are rendered on every
+    # backend page — a broken render can fail any Playwright test, so run the full suite.
+    "packages/ui/src/backend/",
     "jest.config.",
     "jest.setup.",
     "tsconfig",

--- a/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
+++ b/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
@@ -7,13 +7,13 @@ by reading module-level dependency declarations in __integration__/meta.ts files
 
 Usage:
   # Pipe git diff output
-  git diff --name-only origin/develop...HEAD | python3 find_affected_integration_tests.py --project-root .
+  git diff --name-only origin/develop...HEAD | python3 find_affected_integration_tests.py --project-root . --layer api-logic
 
-  # Let the script call git diff internally
-  python3 find_affected_integration_tests.py --project-root . --base origin/develop
+  # Let the script call git diff internally, including local and untracked files
+  python3 find_affected_integration_tests.py --project-root . --base origin/develop --layer ui-component
 
   # Explicit base and head
-  python3 find_affected_integration_tests.py --project-root . --base origin/develop --head HEAD
+  python3 find_affected_integration_tests.py --project-root . --base origin/develop --head HEAD --layer data
 
 Output:
   One relative spec file path per line, e.g.:
@@ -26,7 +26,6 @@ Output:
 """
 
 import argparse
-import os
 import re
 import subprocess
 import sys
@@ -57,6 +56,28 @@ IGNORED_DIRS = frozenset({
 META_FILE_NAMES = ("meta.ts", "index.ts")
 DEPENDENCY_KEYS = ("dependsOnModules", "requiredModules", "requiresModules")
 
+
+def run_git_names(args: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [line for line in result.stdout.strip().split("\n") if line]
+
+
+def unique_paths(paths: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        normalized = path.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -64,25 +85,53 @@ DEPENDENCY_KEYS = ("dependsOnModules", "requiredModules", "requiresModules")
 def get_changed_files(base_ref: str | None, head_ref: str | None) -> list[str]:
     """Return changed file paths from git or stdin."""
     if not sys.stdin.isatty():
-        return [line.strip() for line in sys.stdin if line.strip()]
+        stdin_paths = unique_paths([line.strip() for line in sys.stdin if line.strip()])
+        if stdin_paths:
+            return stdin_paths
 
+    paths: list[str] = []
+    has_explicit_base = bool(base_ref or head_ref)
     if base_ref and head_ref:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_ref}...{head_ref}"],
-            capture_output=True, text=True, check=False,
-        )
+        paths.extend(run_git_names(["diff", "--name-only", f"{base_ref}...{head_ref}"]))
     elif base_ref:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
-            capture_output=True, text=True, check=False,
-        )
+        paths.extend(run_git_names(["diff", "--name-only", f"{base_ref}...HEAD"]))
     else:
-        result = subprocess.run(
-            ["git", "diff", "--name-only", "HEAD"],
-            capture_output=True, text=True, check=False,
-        )
+        paths.extend(run_git_names(["diff", "--name-only", "HEAD"]))
 
-    return [line for line in result.stdout.strip().split("\n") if line]
+    if has_explicit_base:
+        paths.extend(run_git_names(["diff", "--name-only", "HEAD"]))
+    paths.extend(run_git_names(["ls-files", "--others", "--exclude-standard"]))
+
+    return unique_paths(paths)
+
+
+def extract_module_identity_from_path(file_path: str) -> tuple[str, str] | None:
+    """
+    Extract a workspace-aware module identity from a path.
+
+    The same module name can exist in multiple runtime roots, e.g.
+    apps/mercato/src/modules/example and packages/create-app/template/src/modules/example.
+    """
+    parts = Path(file_path).parts
+    for index, part in enumerate(parts):
+        if part != "modules" or index + 1 >= len(parts):
+            continue
+
+        module_name = parts[index + 1].lower()
+        prefix = parts[:index]
+
+        if len(prefix) >= 3 and prefix[:3] == ("apps", "mercato", "src"):
+            return module_name, "apps/mercato"
+
+        if len(prefix) >= 4 and prefix[:4] == ("packages", "create-app", "template", "src"):
+            return module_name, "packages/create-app/template"
+
+        if len(prefix) >= 3 and prefix[0] == "packages" and prefix[2] == "src":
+            return module_name, f"packages/{prefix[1]}"
+
+        return module_name, "/".join(prefix)
+
+    return None
 
 
 def extract_module_name_from_path(file_path: str) -> str | None:
@@ -93,8 +142,8 @@ def extract_module_name_from_path(file_path: str) -> str | None:
       packages/core/src/modules/customers/lib/foo.ts  → "customers"
       apps/mercato/src/modules/pos/page.tsx            → "pos"
     """
-    match = re.search(r"/modules/([^/]+)/", file_path)
-    return match.group(1) if match else None
+    identity = extract_module_identity_from_path(file_path)
+    return identity[0] if identity else None
 
 
 def is_wide_scope(file_path: str) -> bool:
@@ -161,11 +210,22 @@ def resolve_module_name_for_integration_dir(integration_dir: Path) -> str | None
     return integration_dir.parent.name or None
 
 
+def resolve_module_scope_for_integration_dir(project_root: Path, integration_dir: Path) -> str:
+    try:
+        rel = integration_dir.relative_to(project_root)
+    except ValueError:
+        rel = integration_dir
+
+    identity = extract_module_identity_from_path(str(rel))
+    return identity[1] if identity else ""
+
+
 def build_integration_index(project_root: Path) -> list[dict]:
     """
     Returns a list of dicts, one per integration directory:
       {
         "module": str | None,
+        "scope": str,
         "deps": set[str],          # declared dependsOnModules etc.
         "specs": list[Path],       # absolute spec file paths
       }
@@ -176,6 +236,7 @@ def build_integration_index(project_root: Path) -> list[dict]:
             continue
 
         module_name = resolve_module_name_for_integration_dir(integration_dir)
+        module_scope = resolve_module_scope_for_integration_dir(project_root, integration_dir)
         deps: set[str] = set()
 
         for meta_name in META_FILE_NAMES:
@@ -189,7 +250,7 @@ def build_integration_index(project_root: Path) -> list[dict]:
 
         specs = collect_spec_files(integration_dir)
 
-        entries.append({"module": module_name, "deps": deps, "specs": specs})
+        entries.append({"module": module_name, "scope": module_scope, "deps": deps, "specs": specs})
 
     return entries
 
@@ -198,28 +259,39 @@ def build_integration_index(project_root: Path) -> list[dict]:
 # Main logic
 # ---------------------------------------------------------------------------
 
-def find_affected_specs(project_root: Path, changed_files: list[str]) -> list[str] | str:
+def find_affected_specs(project_root: Path, changed_files: list[str], layer: str = "mixed") -> list[str] | str:
     """
     Returns either:
       - "--all"  (string) when a wide-scope change is detected
       - list of relative spec file paths (may be empty)
+
+    layer controls dependency-based triggering:
+      - "ui" or "ui-component": only tests whose OWN module changed are included;
+        dep_hit is ignored because a UI-only change cannot break another module's API calls.
+      - "api-logic", "data", "mixed" (default): dep_hit is respected — any module
+        that declares the changed module as a dependency will also run.
     """
     # Wide-scope check
     for f in changed_files:
         if is_wide_scope(f):
             return "--all"
 
-    # Collect changed module names
+    # Collect changed module names and workspace-aware module identities.
     changed_modules: set[str] = set()
+    changed_module_identities: set[tuple[str, str]] = set()
     for f in changed_files:
-        module = extract_module_name_from_path(f)
-        if module:
-            changed_modules.add(module.lower())
+        identity = extract_module_identity_from_path(f)
+        if identity:
+            module, scope = identity
+            changed_modules.add(module)
+            changed_module_identities.add((module, scope))
 
     # When no module-scoped changes (e.g., only root package lib files), check by
-    # changed packages — if a whole package changed with no module, treat as wide
+    # changed packages. Do not mark module-scoped package files as package-wide.
     changed_packages: set[str] = set()
     for f in changed_files:
+        if extract_module_identity_from_path(f):
+            continue
         parts = Path(f).parts
         if len(parts) >= 2 and parts[0] == "packages":
             changed_packages.add(parts[1])
@@ -227,19 +299,29 @@ def find_affected_specs(project_root: Path, changed_files: list[str]) -> list[st
     if not changed_modules and not changed_packages:
         return []
 
+    # For UI-layer changes, dependency-based triggering is suppressed.
+    # A changed page.tsx or component cannot break another module's API calls —
+    # only the tests that directly visit those pages need to run.
+    dep_hit_enabled = layer not in ("ui", "ui-component")
+
     integration_index = build_integration_index(project_root)
 
     affected_specs: set[str] = set()
     for entry in integration_index:
         # A test is affected if:
         # 1. Its own module is in changed_modules, OR
-        # 2. Any of its declared dependencies is in changed_modules, OR
+        # 2. (dep_hit_enabled) any of its declared dependencies is in changed_modules, OR
         # 3. Its parent package is in changed_packages
         entry_module = (entry["module"] or "").lower()
+        entry_scope = entry["scope"]
         entry_deps = entry["deps"]
 
-        module_hit = entry_module in changed_modules
-        dep_hit = bool(entry_deps & changed_modules)
+        module_hit = (entry_module, entry_scope) in changed_module_identities
+        dep_hit = dep_hit_enabled and bool(entry_deps & changed_modules)
+        if entry_scope == "packages/create-app/template":
+            dep_hit = dep_hit and any(
+                scope == "packages/create-app/template" for _module, scope in changed_module_identities
+            )
 
         # Package hit: check if any spec lives in a changed package
         package_hit = False
@@ -253,13 +335,17 @@ def find_affected_specs(project_root: Path, changed_files: list[str]) -> list[st
             except ValueError:
                 pass
 
-        if module_hit or dep_hit or package_hit:
-            for spec in entry["specs"]:
-                try:
-                    rel = spec.relative_to(project_root)
-                    affected_specs.add(str(rel))
-                except ValueError:
-                    affected_specs.add(str(spec))
+        if not (module_hit or dep_hit or package_hit):
+            continue
+
+        for spec in entry["specs"]:
+            try:
+                rel = spec.relative_to(project_root)
+                rel_str = str(rel)
+            except ValueError:
+                rel_str = str(spec)
+
+            affected_specs.add(rel_str)
 
     return sorted(affected_specs)
 
@@ -269,6 +355,15 @@ def main() -> None:
     parser.add_argument("--project-root", default=".", help="Absolute or relative path to the monorepo root")
     parser.add_argument("--base", default=None, help="Base git ref (e.g. origin/develop)")
     parser.add_argument("--head", default=None, help="Head git ref (default: HEAD)")
+    parser.add_argument(
+        "--layer",
+        default="mixed",
+        choices=["ui", "ui-component", "api-logic", "data", "mixed"],
+        help=(
+            "Layer of changed files. ui/ui-component suppresses dependency-based "
+            "triggering so only tests for directly changed modules run."
+        ),
+    )
     args = parser.parse_args()
 
     project_root = Path(args.project_root).resolve()
@@ -278,7 +373,7 @@ def main() -> None:
         # Nothing changed
         sys.exit(0)
 
-    result = find_affected_specs(project_root, changed_files)
+    result = find_affected_specs(project_root, changed_files, layer=args.layer)
 
     if result == "--all":
         print("--all")

--- a/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
+++ b/.ai/skills/smart-test/scripts/find_affected_integration_tests.py
@@ -10,7 +10,7 @@ Usage:
   git diff --name-only origin/develop...HEAD | python3 find_affected_integration_tests.py --project-root . --layer api-logic
 
   # Let the script call git diff internally, including local and untracked files
-  python3 find_affected_integration_tests.py --project-root . --base origin/develop --layer ui-component
+  python3 find_affected_integration_tests.py --project-root . --base auto --layer ui-component
 
   # Explicit base and head
   python3 find_affected_integration_tests.py --project-root . --base origin/develop --head HEAD --layer data
@@ -55,6 +55,7 @@ IGNORED_DIRS = frozenset({
 
 META_FILE_NAMES = ("meta.ts", "index.ts")
 DEPENDENCY_KEYS = ("dependsOnModules", "requiredModules", "requiresModules")
+AUTO_BASE_CANDIDATES = ("origin/develop", "develop", "origin/main", "main")
 
 
 def run_git_names(args: list[str]) -> list[str]:
@@ -65,6 +66,16 @@ def run_git_names(args: list[str]) -> list[str]:
         check=False,
     )
     return [line for line in result.stdout.strip().split("\n") if line]
+
+
+def run_git_text(args: list[str]) -> tuple[int, str]:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode, result.stdout.strip()
 
 
 def unique_paths(paths: list[str]) -> list[str]:
@@ -78,6 +89,29 @@ def unique_paths(paths: list[str]) -> list[str]:
         result.append(normalized)
     return result
 
+
+def git_ref_exists(ref: str) -> bool:
+    code, _output = run_git_text(["rev-parse", "--verify", "--quiet", ref])
+    return code == 0
+
+
+def resolve_auto_base_ref() -> str | None:
+    code, upstream = run_git_text(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"])
+    if code == 0 and upstream:
+        return upstream
+
+    for candidate in AUTO_BASE_CANDIDATES:
+        if not git_ref_exists(candidate):
+            continue
+        code, _fork_point = run_git_text(["merge-base", "--fork-point", candidate, "HEAD"])
+        if code == 0:
+            return candidate
+        code, _is_ancestor = run_git_text(["merge-base", "--is-ancestor", candidate, "HEAD"])
+        if code == 0:
+            return candidate
+
+    return None
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -90,6 +124,9 @@ def get_changed_files(base_ref: str | None, head_ref: str | None) -> list[str]:
             return stdin_paths
 
     paths: list[str] = []
+    if base_ref == "auto":
+        base_ref = resolve_auto_base_ref()
+
     has_explicit_base = bool(base_ref or head_ref)
     if base_ref and head_ref:
         paths.extend(run_git_names(["diff", "--name-only", f"{base_ref}...{head_ref}"]))


### PR DESCRIPTION
## What it does
Runs the minimal set of tests that cover only the code actually changed in the current branch or working tree. Handles two test types:

- Jest (unit/component) — via --findRelatedTests, letting Jest traverse the import graph
- Playwright (integration) — via module name matching + dependency declarations in meta.ts
Also caches the test plan to .test-cache.json — on repeated invocations with no new changes, skips analysis and runs straight from cache.

## Problem it solves

The project has ~485 unit suites and ~323 integration spec files. Running the full suite on every change is:

- Slow — full Playwright suite requires building the app and takes a long time
- Noisy — hard to isolate results relevant to the current change
- Wasteful in CI — unnecessary resource consumption

## Solution it provides

The skill:

- Identifies changed files (branch diff vs. base + uncommitted changes)
- Classifies scope — wide (shared/events/cache → full suite), module-scoped, or test-only
- Classifies layer — whether the change touches UI, API logic, data, or mixed → determines whether Playwright runs at all
Runs only what's necessary