### PR TITLE
fix(business_rules): allow creating rules without conditionExpression

### DIFF
--- a/packages/core/src/modules/business_rules/api/__tests__/rules.route.test.ts
+++ b/packages/core/src/modules/business_rules/api/__tests__/rules.route.test.ts
@@ -203,6 +203,64 @@ describe('Business Rules API - /api/business_rules/rules', () => {
       expect(mockEm.persistAndFlush).toHaveBeenCalled()
     })
 
+    test('should create a rule without conditionExpression', async () => {
+      const newRule = {
+        ruleId: 'RULE-NO-COND',
+        ruleName: 'Rule Without Conditions',
+        ruleType: 'VALIDATION',
+        entityType: 'Customer',
+        enabled: true,
+        priority: 100,
+        version: 1,
+      }
+
+      mockEm.create.mockReturnValue({ id: '323e4567-e89b-12d3-a456-426614174005', ...newRule, conditionExpression: null })
+      mockEm.persistAndFlush.mockResolvedValue(undefined)
+
+      const request = new Request('http://localhost:3000/api/business_rules/rules', {
+        method: 'POST',
+        body: JSON.stringify(newRule),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(201)
+      const body = await response.json()
+      expect(body.id).toBe('323e4567-e89b-12d3-a456-426614174005')
+      expect(mockEm.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          conditionExpression: null,
+          ruleId: 'RULE-NO-COND',
+          tenantId: validTenantId,
+          organizationId: validOrgId,
+        })
+      )
+      expect(mockEm.persistAndFlush).toHaveBeenCalled()
+    })
+
+    test('should create a rule with explicit null conditionExpression', async () => {
+      const newRule = {
+        ruleId: 'RULE-NULL-COND',
+        ruleName: 'Rule With Null Conditions',
+        ruleType: 'ACTION',
+        entityType: 'Order',
+        conditionExpression: null,
+      }
+
+      mockEm.create.mockReturnValue({ id: '423e4567-e89b-12d3-a456-426614174006', ...newRule })
+      mockEm.persistAndFlush.mockResolvedValue(undefined)
+
+      const request = new Request('http://localhost:3000/api/business_rules/rules', {
+        method: 'POST',
+        body: JSON.stringify(newRule),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(201)
+      const body = await response.json()
+      expect(body.id).toBe('423e4567-e89b-12d3-a456-426614174006')
+    })
+
     test('should return 400 for invalid rule data', async () => {
       const invalidRule = {
         ruleId: '',
@@ -246,6 +304,29 @@ describe('Business Rules API - /api/business_rules/rules', () => {
           createdBy: 'user-1',
         })
       )
+    })
+
+    test('should return 500 with JSON error when persistAndFlush fails', async () => {
+      const newRule = {
+        ruleId: 'RULE-DB-FAIL',
+        ruleName: 'DB Failure Rule',
+        ruleType: 'GUARD',
+        entityType: 'WorkOrder',
+        conditionExpression: { field: 'status', operator: '=', value: 'ACTIVE' },
+      }
+
+      mockEm.create.mockReturnValue({ id: '523e4567-e89b-12d3-a456-426614174007', ...newRule })
+      mockEm.persistAndFlush.mockRejectedValue(new Error('NOT NULL constraint violation'))
+
+      const request = new Request('http://localhost:3000/api/business_rules/rules', {
+        method: 'POST',
+        body: JSON.stringify(newRule),
+      })
+      const response = await POST(request)
+
+      expect(response.status).toBe(500)
+      const body = await response.json()
+      expect(body.error).toContain('Failed to create rule')
     })
   })
 

--- a/packages/core/src/modules/business_rules/api/rules/route.ts
+++ b/packages/core/src/modules/business_rules/api/rules/route.ts
@@ -203,8 +203,19 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: `Validation failed: ${errors.join(', ')}` }, { status: 400 })
   }
 
-  const rule = em.create(BusinessRule, parsed.data)
-  await em.persistAndFlush(rule)
+  const data = {
+    ...parsed.data,
+    conditionExpression: parsed.data.conditionExpression ?? null,
+  }
+
+  const rule = em.create(BusinessRule, data)
+
+  try {
+    await em.persistAndFlush(rule)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: `Failed to create rule: ${message}` }, { status: 500 })
+  }
 
   return NextResponse.json({ id: rule.id }, { status: 201 })
 }
@@ -254,7 +265,13 @@ export async function PUT(req: Request) {
   }
 
   em.assign(rule, parsed.data)
-  await em.persistAndFlush(rule)
+
+  try {
+    await em.persistAndFlush(rule)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: `Failed to update rule: ${message}` }, { status: 500 })
+  }
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/business_rules/data/entities.ts
+++ b/packages/core/src/modules/business_rules/data/entities.ts
@@ -23,7 +23,7 @@ export type ExecutionResult = 'SUCCESS' | 'FAILURE' | 'ERROR'
 @Index({ name: 'business_rules_tenant_org_idx', properties: ['tenantId', 'organizationId'] })
 @Index({ name: 'business_rules_type_enabled_idx', properties: ['ruleType', 'enabled', 'priority'] })
 export class BusinessRule {
-  [OptionalProps]?: 'enabled' | 'priority' | 'version' | 'createdAt' | 'updatedAt' | 'deletedAt'
+  [OptionalProps]?: 'conditionExpression' | 'enabled' | 'priority' | 'version' | 'createdAt' | 'updatedAt' | 'deletedAt'
 
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -49,8 +49,8 @@ export class BusinessRule {
   @Property({ name: 'event_type', type: 'varchar', length: 50, nullable: true })
   eventType?: string | null
 
-  @Property({ name: 'condition_expression', type: 'jsonb' })
-  conditionExpression!: any
+  @Property({ name: 'condition_expression', type: 'jsonb', nullable: true })
+  conditionExpression?: any | null
 
   @Property({ name: 'success_actions', type: 'jsonb', nullable: true })
   successActions?: any | null

--- a/packages/core/src/modules/business_rules/data/validators.ts
+++ b/packages/core/src/modules/business_rules/data/validators.ts
@@ -61,6 +61,8 @@ export type ExecutionResult = z.infer<typeof executionResultSchema>
 // Uses runtime validation to check structure, nesting, and field paths
 function createConditionExpressionSchema(t?: TranslatorFn) {
   return z.any()
+    .optional()
+    .nullable()
     .superRefine((val, ctx) => {
       // Null/undefined is allowed (optional field)
       if (val === null || val === undefined) return


### PR DESCRIPTION
## Summary

Fixes #1033 -- Creating a Business Rule without a `conditionExpression` returned a 500 Internal Server Error with an empty response body.

**Root cause:** The `conditionExpression` Zod validator accepted `null`/`undefined` values (treated as optional), but the `BusinessRule` entity declared the database column as `NOT NULL` jsonb. When a user submitted a rule without conditions, validation passed but MikroORM attempted to insert `NULL` into the non-nullable column, causing an unhandled database constraint violation that crashed the handler and produced an empty response.

**Changes:**
- **`data/entities.ts`**: Made `conditionExpression` column nullable (`nullable: true`) and added it to `OptionalProps`
- **`data/validators.ts`**: Made the condition expression schema explicitly `.optional().nullable()` so the Zod type correctly reflects that the field is optional
- **`api/rules/route.ts`**: Coerce `undefined` conditionExpression to `null` before entity creation; wrapped `persistAndFlush` in try-catch in POST/PUT handlers to return proper JSON error responses instead of crashing
- **`api/__tests__/rules.route.test.ts`**: Added regression tests for creating rules without conditionExpression, with explicit null, and for DB error handling

## Test plan
- [x] Unit test: create rule without conditionExpression returns 201
- [ ] - [x] Unit test: create rule with explicit null conditionExpression returns 201
- [ ] - [x] Unit test: persistAndFlush failure returns 500 with JSON error body
- [ ] Manual: create a business rule via UI without adding conditions
- [ ] Manual: create a business rule via UI with conditions (no regression)

---> **Note:** This change makes the `condition_expression` column nullable, which requires a database migration (`yarn db:generate` + `yarn db:migrate`). The rule engine already handles null conditions gracefully (treats them as \"always true\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)"