### PR TITLE
fix(business_rules): wire CRUD events to rule engine via wildcard subscriber (#662)

### DIFF
--- a/packages/core/src/modules/business_rules/subscribers/__tests__/crud-rule-trigger.test.ts
+++ b/packages/core/src/modules/business_rules/subscribers/__tests__/crud-rule-trigger.test.ts
@@ -1,0 +1,82 @@
+import handler, { metadata } from '../crud-rule-trigger'
+
+jest.mock('../../lib/rule-engine', () => ({
+  executeRules: jest.fn(async () => ({
+    allowed: true,
+    executedRules: [],
+    totalExecutionTime: 0,
+    errors: [],
+  })),
+}))
+
+import { executeRules } from '../../lib/rule-engine'
+const executeRulesMock = executeRules as jest.MockedFunction<typeof executeRules>
+
+describe('business_rules crud-rule-trigger subscriber', () => {
+  const mockEm = {} as any
+
+  function makeCtx(eventName?: string) {
+    return {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        return null
+      }),
+      eventName,
+    }
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('has wildcard event subscription with persistent flag', () => {
+    expect(metadata.event).toBe('*')
+    expect(metadata.persistent).toBe(true)
+    expect(metadata.id).toBe('business_rules:crud-rule-trigger')
+  })
+
+  it('calls executeRules for a CRUD event with tenant scope', async () => {
+    await handler(
+      { tenantId: 't1', organizationId: 'o1', id: 'person-1' },
+      makeCtx('customers.person.created'),
+    )
+    expect(executeRulesMock).toHaveBeenCalledWith(mockEm, {
+      entityType: 'customers.person',
+      eventType: 'created',
+      data: { tenantId: 't1', organizationId: 'o1', id: 'person-1' },
+      tenantId: 't1',
+      organizationId: 'o1',
+    })
+  })
+
+  it('skips excluded internal events', async () => {
+    for (const event of ['query_index.updated', 'search.reindex', 'cache.invalidated', 'business_rules.rule.created', 'workflows.instance.completed']) {
+      await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx(event))
+    }
+    expect(executeRulesMock).not.toHaveBeenCalled()
+  })
+
+  it('skips events without tenantId or organizationId', async () => {
+    await handler({ tenantId: 't1' }, makeCtx('customers.person.created'))
+    await handler({ organizationId: 'o1' }, makeCtx('customers.person.created'))
+    await handler({}, makeCtx('customers.person.created'))
+    expect(executeRulesMock).not.toHaveBeenCalled()
+  })
+
+  it('skips when eventName is missing', async () => {
+    await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx(undefined))
+    expect(executeRulesMock).not.toHaveBeenCalled()
+  })
+
+  it('skips events with fewer than 3 dot-separated parts', async () => {
+    await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx('system.ping'))
+    expect(executeRulesMock).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when executeRules fails', async () => {
+    executeRulesMock.mockRejectedValueOnce(new Error('DB down'))
+    await expect(
+      handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx('sales.order.created')),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/business_rules/subscribers/__tests__/crud-rule-trigger.test.ts
+++ b/packages/core/src/modules/business_rules/subscribers/__tests__/crud-rule-trigger.test.ts
@@ -15,13 +15,20 @@ const executeRulesMock = executeRules as jest.MockedFunction<typeof executeRules
 describe('business_rules crud-rule-trigger subscriber', () => {
   const mockEm = {} as any
 
-  function makeCtx(eventName?: string) {
+  function makeCtx(
+    eventName?: string,
+    scope: { tenantId?: string | null; organizationId?: string | null } = {
+      tenantId: 't1',
+      organizationId: 'o1',
+    },
+  ) {
     return {
       resolve: jest.fn((name: string) => {
         if (name === 'em') return mockEm
         return null
       }),
       eventName,
+      ...scope,
     }
   }
 
@@ -35,31 +42,43 @@ describe('business_rules crud-rule-trigger subscriber', () => {
     expect(metadata.id).toBe('business_rules:crud-rule-trigger')
   })
 
-  it('calls executeRules for a CRUD event with tenant scope', async () => {
+  it('calls executeRules for a CRUD event with trusted subscriber context scope', async () => {
     await handler(
-      { tenantId: 't1', organizationId: 'o1', id: 'person-1' },
+      { id: 'person-1' },
       makeCtx('customers.person.created'),
     )
     expect(executeRulesMock).toHaveBeenCalledWith(mockEm, {
       entityType: 'customers.person',
       eventType: 'created',
-      data: { tenantId: 't1', organizationId: 'o1', id: 'person-1' },
+      data: { id: 'person-1' },
       tenantId: 't1',
       organizationId: 'o1',
     })
   })
 
+  it('does not trust payload tenant scope over subscriber context scope', async () => {
+    await handler(
+      { tenantId: 'spoofed-tenant', organizationId: 'spoofed-org', id: 'person-1' },
+      makeCtx('customers.person.created', { tenantId: 'trusted-tenant', organizationId: 'trusted-org' }),
+    )
+    expect(executeRulesMock).toHaveBeenCalledWith(mockEm, expect.objectContaining({
+      data: { tenantId: 'spoofed-tenant', organizationId: 'spoofed-org', id: 'person-1' },
+      tenantId: 'trusted-tenant',
+      organizationId: 'trusted-org',
+    }))
+  })
+
   it('skips excluded internal events', async () => {
     for (const event of ['query_index.updated', 'search.reindex', 'cache.invalidated', 'business_rules.rule.created', 'workflows.instance.completed']) {
-      await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx(event))
+      await handler({}, makeCtx(event))
     }
     expect(executeRulesMock).not.toHaveBeenCalled()
   })
 
-  it('skips events without tenantId or organizationId', async () => {
-    await handler({ tenantId: 't1' }, makeCtx('customers.person.created'))
-    await handler({ organizationId: 'o1' }, makeCtx('customers.person.created'))
-    await handler({}, makeCtx('customers.person.created'))
+  it('skips events without trusted tenantId or organizationId context', async () => {
+    await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx('customers.person.created', { tenantId: 't1' }))
+    await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx('customers.person.created', { organizationId: 'o1' }))
+    await handler({ tenantId: 't1', organizationId: 'o1' }, makeCtx('customers.person.created', {}))
     expect(executeRulesMock).not.toHaveBeenCalled()
   })
 

--- a/packages/core/src/modules/business_rules/subscribers/crud-rule-trigger.ts
+++ b/packages/core/src/modules/business_rules/subscribers/crud-rule-trigger.ts
@@ -1,0 +1,78 @@
+/**
+ * Business Rules Module - CRUD Event Trigger Subscriber
+ *
+ * Wildcard subscriber that listens to all domain events and evaluates
+ * business rules configured for the matching entity + event type.
+ * Mirrors the pattern used by workflows/subscribers/event-trigger.ts.
+ *
+ * Closes #662 — business rules configured with entity + event triggers
+ * were never executed because no subscriber wired CRUD events to the
+ * rule engine.
+ */
+
+import type { EntityManager } from '@mikro-orm/core'
+import { executeRules } from '../lib/rule-engine'
+
+export const metadata = {
+  event: '*',
+  persistent: true,
+  id: 'business_rules:crud-rule-trigger',
+}
+
+const EXCLUDED_EVENT_PREFIXES = [
+  'query_index.',
+  'search.',
+  'business_rules.',
+  'cache.',
+  'queue.',
+  'workflows.',
+]
+
+function isExcludedEvent(eventName: string): boolean {
+  return EXCLUDED_EVENT_PREFIXES.some((prefix) => eventName.startsWith(prefix))
+}
+
+function parseEventName(eventName: string): { entityType: string; eventType: string } | null {
+  const parts = eventName.split('.')
+  if (parts.length < 3) return null
+  const eventType = parts[parts.length - 1]
+  const entityType = parts.slice(0, -1).join('.')
+  return { entityType, eventType }
+}
+
+type EventPayload = {
+  tenantId?: string
+  organizationId?: string
+  [key: string]: unknown
+}
+
+export default async function handle(
+  payload: unknown,
+  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+): Promise<void> {
+  const eventName = ctx.eventName
+  if (!eventName) return
+  if (isExcludedEvent(eventName)) return
+
+  const parsed = parseEventName(eventName)
+  if (!parsed) return
+
+  const data = (payload ?? {}) as EventPayload
+  const tenantId = data.tenantId
+  const organizationId = data.organizationId
+  if (!tenantId || !organizationId) return
+
+  const em = ctx.resolve<EntityManager>('em')
+
+  try {
+    await executeRules(em, {
+      entityType: parsed.entityType,
+      eventType: parsed.eventType,
+      data,
+      tenantId,
+      organizationId,
+    })
+  } catch (error) {
+    console.error(`[business_rules] Rule execution failed for event ${eventName}:`, error)
+  }
+}

--- a/packages/core/src/modules/business_rules/subscribers/crud-rule-trigger.ts
+++ b/packages/core/src/modules/business_rules/subscribers/crud-rule-trigger.ts
@@ -40,15 +40,16 @@ function parseEventName(eventName: string): { entityType: string; eventType: str
   return { entityType, eventType }
 }
 
-type EventPayload = {
-  tenantId?: string
-  organizationId?: string
-  [key: string]: unknown
+type CrudRuleTriggerContext = {
+  resolve: <T = unknown>(name: string) => T
+  eventName?: string
+  tenantId?: string | null
+  organizationId?: string | null
 }
 
 export default async function handle(
   payload: unknown,
-  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string },
+  ctx: CrudRuleTriggerContext,
 ): Promise<void> {
   const eventName = ctx.eventName
   if (!eventName) return
@@ -57,9 +58,9 @@ export default async function handle(
   const parsed = parseEventName(eventName)
   if (!parsed) return
 
-  const data = (payload ?? {}) as EventPayload
-  const tenantId = data.tenantId
-  const organizationId = data.organizationId
+  const data = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>
+  const tenantId = typeof ctx.tenantId === 'string' && ctx.tenantId.length > 0 ? ctx.tenantId : undefined
+  const organizationId = typeof ctx.organizationId === 'string' && ctx.organizationId.length > 0 ? ctx.organizationId : undefined
   if (!tenantId || !organizationId) return
 
   const em = ctx.resolve<EntityManager>('em')


### PR DESCRIPTION
## Summary
Business rules configured with entity + event triggers never execute because no event subscriber connects domain CRUD events to the rule engine. Adds a wildcard subscriber (`event: '*'`, `persistent: true`) following the same pattern as `workflows/subscribers/event-trigger.ts`. Parses event names, skips internal events, and calls `executeRules()`.

Closes #662

## Test plan
- [x] 7 new test cases (event parsing, exclusion, scope validation, error resilience)
- [x] `yarn test` 19/19 packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)