### PR TITLE
fix(security): cap one-time API key TTL and use soft-delete for cleanup

### DIFF
--- a/packages/core/src/modules/api_keys/services/__tests__/onetime-key-expiry.test.ts
+++ b/packages/core/src/modules/api_keys/services/__tests__/onetime-key-expiry.test.ts
@@ -1,0 +1,75 @@
+import { withOnetimeApiKey } from '../apiKeyService'
+
+describe('withOnetimeApiKey — expiry guard', () => {
+  let createdInput: Record<string, unknown> | null = null
+  let createdRecord: Record<string, unknown> | null = null
+
+  const mockEm: any = {
+    create: jest.fn((_Entity: unknown, data: Record<string, unknown>) => {
+      createdInput = data
+      createdRecord = { id: 'key-1', ...data, deletedAt: null }
+      return createdRecord
+    }),
+    persistAndFlush: jest.fn(async () => undefined),
+    removeAndFlush: jest.fn(async () => undefined),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createdInput = null
+    createdRecord = null
+  })
+
+  it('caps expiresAt to max 5 minutes even when caller passes null', async () => {
+    await withOnetimeApiKey(
+      mockEm,
+      { name: 'test', tenantId: 't1', organizationId: 'o1', roles: ['r1'], expiresAt: null } as any,
+      async () => 'done',
+    )
+
+    expect(createdInput).not.toBeNull()
+    const expiresAt = createdInput!.expiresAt as Date
+    expect(expiresAt).toBeInstanceOf(Date)
+    const ttlMs = expiresAt.getTime() - Date.now()
+    expect(ttlMs).toBeLessThanOrEqual(5 * 60 * 1000 + 2000)
+    expect(ttlMs).toBeGreaterThan(0)
+  })
+
+  it('soft-deletes the key after execution', async () => {
+    await withOnetimeApiKey(
+      mockEm,
+      { name: 'test', tenantId: 't1', organizationId: 'o1', roles: ['r1'] } as any,
+      async () => 'done',
+    )
+
+    expect(createdRecord!.deletedAt).toBeInstanceOf(Date)
+    expect(mockEm.persistAndFlush).toHaveBeenCalled()
+  })
+
+  it('soft-deletes even when the function throws', async () => {
+    await expect(
+      withOnetimeApiKey(
+        mockEm,
+        { name: 'test', tenantId: 't1', organizationId: 'o1', roles: ['r1'] } as any,
+        async () => { throw new Error('boom') },
+      ),
+    ).rejects.toThrow('boom')
+
+    expect(createdRecord!.deletedAt).toBeInstanceOf(Date)
+    expect(mockEm.persistAndFlush).toHaveBeenCalled()
+  })
+
+  it('does not exceed 5 minute TTL even when caller requests longer', async () => {
+    const farFuture = new Date(Date.now() + 60 * 60 * 1000)
+
+    await withOnetimeApiKey(
+      mockEm,
+      { name: 'test', tenantId: 't1', organizationId: 'o1', roles: ['r1'], expiresAt: farFuture } as any,
+      async () => 'done',
+    )
+
+    const expiresAt = createdInput!.expiresAt as Date
+    const ttlMs = expiresAt.getTime() - Date.now()
+    expect(ttlMs).toBeLessThanOrEqual(5 * 60 * 1000 + 2000)
+  })
+})

--- a/packages/core/src/modules/api_keys/services/apiKeyService.ts
+++ b/packages/core/src/modules/api_keys/services/apiKeyService.ts
@@ -283,28 +283,34 @@ export async function deleteSessionApiKey(
  * @param fn - Function to execute with the API key secret
  * @returns Result of the function
  */
+const ONETIME_KEY_MAX_TTL_MS = 5 * 60 * 1000
+
 export async function withOnetimeApiKey<T>(
   em: EntityManager,
   input: CreateApiKeyInput,
   fn: (secret: string) => Promise<T>
 ): Promise<T> {
+  const maxExpiresAt = new Date(Date.now() + ONETIME_KEY_MAX_TTL_MS)
+  const safeExpiresAt = input.expiresAt && input.expiresAt < maxExpiresAt
+    ? input.expiresAt
+    : maxExpiresAt
+
   const { record, secret } = await createApiKey(em, {
     ...input,
     name: input.name || '__onetime__',
     description: input.description || 'One-time API key',
+    expiresAt: safeExpiresAt,
   })
 
   try {
-    // Execute the function with the API key
     const result = await fn(secret)
     return result
   } finally {
-    // Always delete the API key, even if the function throws
     try {
-      await em.removeAndFlush(record)
+      record.deletedAt = new Date()
+      await em.persistAndFlush(record)
     } catch (error) {
-      // Log but don't throw - we don't want cleanup errors to mask the original error
-      console.error('[withOnetimeApiKey] Failed to delete one-time API key:', error)
+      console.error('[withOnetimeApiKey] Failed to soft-delete one-time API key:', error)
     }
   }
 }

--- a/packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts
@@ -110,8 +110,9 @@ describe('executeCallApi', () => {
     expect(createdApiKeys[0].tenantId).toBe('tenant-456')
     expect(createdApiKeys[0].organizationId).toBe('org-789')
 
-    // Verify API key was deleted
-    expect(mockEm.removeAndFlush).toHaveBeenCalledWith(createdApiKeys[0])
+    // Verify API key was soft-deleted
+    expect(createdApiKeys[0].deletedAt).toBeInstanceOf(Date)
+    expect(mockEm.persistAndFlush).toHaveBeenCalled()
   })
 
   it('should interpolate workflow variables in request body', async () => {


### PR DESCRIPTION
## Summary
`withOnetimeApiKey` creates temporary API keys with `expiresAt: null` (never expire). If cleanup fails in the `finally` block (DB error, EM closed), the key persists forever with full role permissions. Forces max 5-minute TTL on all one-time keys and switches to soft-delete for more resilient cleanup.

## Test plan
- [x] 4 new test cases (TTL cap, soft-delete, error resilience, override rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)