### PR TITLE
Enforce trusted tenant scope in subscribers

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts
@@ -1,0 +1,118 @@
+import {
+  QueryIndexScopeError,
+  resolveQueryIndexRecordScope,
+  resolveQueryIndexReindexScope,
+} from '../lib/subscriber-scope'
+
+describe('resolveQueryIndexRecordScope', () => {
+  it('fills missing payload scope from the source row', () => {
+    expect(
+      resolveQueryIndexRecordScope({
+        payloadTenantId: undefined,
+        payloadOrganizationId: 'org-1',
+        hasPayloadTenantId: false,
+        hasPayloadOrganizationId: true,
+        rowScope: {
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        },
+      })
+    ).toEqual({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+
+  it('rejects tenant mismatches between payload and source row', () => {
+    expect(() =>
+      resolveQueryIndexRecordScope({
+        payloadTenantId: 'tenant-b',
+        payloadOrganizationId: 'org-1',
+        hasPayloadTenantId: true,
+        hasPayloadOrganizationId: true,
+        rowScope: {
+          tenantId: 'tenant-a',
+          organizationId: 'org-1',
+        },
+      })
+    ).toThrow(QueryIndexScopeError)
+  })
+
+  it('rejects organization mismatches between payload and source row', () => {
+    expect(() =>
+      resolveQueryIndexRecordScope({
+        payloadTenantId: 'tenant-1',
+        payloadOrganizationId: 'org-b',
+        hasPayloadTenantId: true,
+        hasPayloadOrganizationId: true,
+        rowScope: {
+          tenantId: 'tenant-1',
+          organizationId: 'org-a',
+        },
+      })
+    ).toThrow(QueryIndexScopeError)
+  })
+
+  it('rejects partial payload scope when the source row scope cannot be resolved', () => {
+    expect(() =>
+      resolveQueryIndexRecordScope({
+        payloadTenantId: undefined,
+        payloadOrganizationId: 'org-1',
+        hasPayloadTenantId: false,
+        hasPayloadOrganizationId: true,
+        rowScope: null,
+      })
+    ).toThrow('missing tenantId/organizationId')
+  })
+
+  it('allows explicit full scope when the source row no longer exists', () => {
+    expect(
+      resolveQueryIndexRecordScope({
+        payloadTenantId: 'tenant-1',
+        payloadOrganizationId: 'org-1',
+        hasPayloadTenantId: true,
+        hasPayloadOrganizationId: true,
+        rowScope: null,
+      })
+    ).toEqual({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+})
+
+describe('resolveQueryIndexReindexScope', () => {
+  it('rejects implicit all-tenant reindex payloads', () => {
+    expect(() =>
+      resolveQueryIndexReindexScope({
+        tenantId: undefined,
+        organizationId: undefined,
+      })
+    ).toThrow('all-tenant reindex must opt in')
+  })
+
+  it('allows explicit all-tenant reindex payloads', () => {
+    expect(
+      resolveQueryIndexReindexScope({
+        tenantId: undefined,
+        organizationId: undefined,
+        allowAllTenants: true,
+      })
+    ).toEqual({
+      tenantId: undefined,
+      organizationId: undefined,
+    })
+  })
+
+  it('preserves explicit global scope', () => {
+    expect(
+      resolveQueryIndexReindexScope({
+        tenantId: null,
+        organizationId: null,
+      })
+    ).toEqual({
+      tenantId: null,
+      organizationId: null,
+    })
+  })
+})

--- a/packages/core/src/modules/query_index/lib/subscriber-scope.ts
+++ b/packages/core/src/modules/query_index/lib/subscriber-scope.ts
@@ -1,0 +1,110 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
+
+export type QueryIndexScope = {
+  tenantId: string | null
+  organizationId: string | null
+}
+
+export class QueryIndexScopeError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'QueryIndexScopeError'
+  }
+}
+
+type ResolveRecordScopeInput = {
+  payloadTenantId: string | null | undefined
+  payloadOrganizationId: string | null | undefined
+  hasPayloadTenantId: boolean
+  hasPayloadOrganizationId: boolean
+  rowScope: QueryIndexScope | null
+}
+
+type ResolveReindexScopeInput = {
+  tenantId: string | null | undefined
+  organizationId: string | null | undefined
+  allowAllTenants?: boolean
+}
+
+export async function loadQueryIndexRowScope(
+  em: EntityManager,
+  entityType: string,
+  recordId: string
+): Promise<QueryIndexScope | null> {
+  const knex = (em as any).getConnection().getKnex()
+  const table = resolveEntityTableName(em, entityType)
+  const row = await knex(table)
+    .select(['organization_id', 'tenant_id'])
+    .where({ id: recordId })
+    .first()
+
+  if (!row) {
+    return null
+  }
+
+  return {
+    organizationId: row.organization_id ?? null,
+    tenantId: row.tenant_id ?? null,
+  }
+}
+
+export function resolveQueryIndexRecordScope(input: ResolveRecordScopeInput): QueryIndexScope {
+  const {
+    payloadTenantId,
+    payloadOrganizationId,
+    hasPayloadTenantId,
+    hasPayloadOrganizationId,
+    rowScope,
+  } = input
+
+  if (!rowScope) {
+    if (!hasPayloadTenantId || !hasPayloadOrganizationId) {
+      throw new QueryIndexScopeError(
+        'Query index event is missing tenantId/organizationId and source row scope could not be resolved'
+      )
+    }
+
+    return {
+      tenantId: payloadTenantId ?? null,
+      organizationId: payloadOrganizationId ?? null,
+    }
+  }
+
+  if (hasPayloadTenantId && !isSameScopeValue(payloadTenantId, rowScope.tenantId)) {
+    throw new QueryIndexScopeError(
+      `Query index event tenantId does not match source row scope (payload=${String(payloadTenantId ?? null)}, row=${String(rowScope.tenantId)})`
+    )
+  }
+
+  if (hasPayloadOrganizationId && !isSameScopeValue(payloadOrganizationId, rowScope.organizationId)) {
+    throw new QueryIndexScopeError(
+      `Query index event organizationId does not match source row scope (payload=${String(payloadOrganizationId ?? null)}, row=${String(rowScope.organizationId)})`
+    )
+  }
+
+  return {
+    tenantId: hasPayloadTenantId ? (payloadTenantId ?? null) : rowScope.tenantId,
+    organizationId: hasPayloadOrganizationId ? (payloadOrganizationId ?? null) : rowScope.organizationId,
+  }
+}
+
+export function resolveQueryIndexReindexScope(input: ResolveReindexScopeInput): {
+  tenantId: string | null | undefined
+  organizationId: string | null | undefined
+} {
+  if (input.tenantId === undefined && input.allowAllTenants !== true) {
+    throw new QueryIndexScopeError(
+      'Query index reindex requires tenantId to be set explicitly; all-tenant reindex must opt in with allowAllTenants=true'
+    )
+  }
+
+  return {
+    tenantId: input.tenantId,
+    organizationId: input.organizationId,
+  }
+}
+
+function isSameScopeValue(left: string | null | undefined, right: string | null): boolean {
+  return (left ?? null) === right
+}

--- a/packages/core/src/modules/query_index/subscribers/delete_one.ts
+++ b/packages/core/src/modules/query_index/subscribers/delete_one.ts
@@ -2,6 +2,7 @@ import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { markDeleted } from '../lib/indexer'
 import { applyCoverageAdjustments, createCoverageAdjustments } from '../lib/coverage'
+import { loadQueryIndexRowScope, resolveQueryIndexRecordScope } from '../lib/subscriber-scope'
 
 export const metadata = { event: 'query_index.delete_one', persistent: false }
 
@@ -10,20 +11,23 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
   const entityType = String(payload?.entityType || '')
   const recordId = String(payload?.recordId || '')
   if (!entityType || !recordId) return
-  let organizationId = payload?.organizationId ?? null
-  let tenantId = payload?.tenantId ?? null
+  let organizationId: string | null = payload?.organizationId ?? null
+  let tenantId: string | null = payload?.tenantId ?? null
   const coverageDelayMs = typeof payload?.coverageDelayMs === 'number' ? payload.coverageDelayMs : undefined
-  // Fill missing org from base table if needed
-  if (organizationId == null || tenantId == null) {
-    try {
-      const knex = (em as any).getConnection().getKnex()
-      const table = resolveEntityTableName(em, entityType)
-      const row = await knex(table).select(['organization_id', 'tenant_id']).where({ id: recordId }).first()
-      if (organizationId == null) organizationId = row?.organization_id ?? organizationId
-      if (tenantId == null) tenantId = row?.tenant_id ?? tenantId
-    } catch {}
-  }
   try {
+    const hasPayloadOrganizationId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'organizationId')
+    const hasPayloadTenantId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'tenantId')
+    const rowScope = await loadQueryIndexRowScope(em, entityType, recordId).catch(() => null)
+    const resolvedScope = resolveQueryIndexRecordScope({
+      payloadOrganizationId: payload?.organizationId,
+      payloadTenantId: payload?.tenantId,
+      hasPayloadOrganizationId,
+      hasPayloadTenantId,
+      rowScope,
+    })
+    organizationId = resolvedScope.organizationId
+    tenantId = resolvedScope.tenantId
+
     const { wasActive } = await markDeleted(em, { entityType, recordId, organizationId, tenantId })
 
     let baseDelta = 0
@@ -31,7 +35,11 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
     try {
       const knex = (em as any).getConnection().getKnex()
       const table = resolveEntityTableName(em, entityType)
-      const row = await knex(table).select(['deleted_at']).where({ id: recordId }).first()
+      const row = await knex(table)
+        .select(['deleted_at'])
+        .where({ id: recordId, organization_id: organizationId })
+        .andWhereRaw('tenant_id is not distinct from ?', [tenantId])
+        .first()
       const baseMissing = !row
       const baseDeleted = baseMissing || (row && row.deleted_at != null)
       baseCheckSucceeded = true

--- a/packages/core/src/modules/query_index/subscribers/reindex.ts
+++ b/packages/core/src/modules/query_index/subscribers/reindex.ts
@@ -4,6 +4,7 @@ import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 import { reindexEntity } from '../lib/reindexer'
 import type { VectorIndexService } from '@open-mercato/search/vector'
 import type { ProgressService } from '@open-mercato/core/modules/progress/lib/progressService'
+import { resolveQueryIndexReindexScope } from '../lib/subscriber-scope'
 
 export const metadata = { event: 'query_index.reindex', persistent: true }
 
@@ -18,9 +19,8 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
   }
   const entityType = String(payload?.entityType || '')
   if (!entityType) return
-  // Keep undefined to mean "no filter"; null to mean "global-only"
-  const tenantId: string | null | undefined = payload?.tenantId
-  const organizationId: string | null | undefined = payload?.organizationId
+  let tenantId: string | null | undefined = payload?.tenantId
+  let organizationId: string | null | undefined = payload?.organizationId
   const forceFull: boolean = Boolean(payload?.force)
   const batchSize = Number.isFinite(payload?.batchSize) ? Number(payload.batchSize) : undefined
   const partitionCount = Number.isFinite(payload?.partitionCount) ? Math.max(1, Math.trunc(payload.partitionCount)) : undefined
@@ -115,6 +115,14 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
   }
 
   try {
+    const resolvedScope = resolveQueryIndexReindexScope({
+      tenantId: payload?.tenantId,
+      organizationId: payload?.organizationId,
+      allowAllTenants: payload?.allowAllTenants === true,
+    })
+    tenantId = resolvedScope.tenantId
+    organizationId = resolvedScope.organizationId
+
     await recordIndexerLog(
       { em },
       {

--- a/packages/core/src/modules/query_index/subscribers/upsert_one.ts
+++ b/packages/core/src/modules/query_index/subscribers/upsert_one.ts
@@ -1,7 +1,7 @@
-import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import { upsertIndexRow } from '../lib/indexer'
 import { applyCoverageAdjustments, createCoverageAdjustments } from '../lib/coverage'
+import { loadQueryIndexRowScope, resolveQueryIndexRecordScope } from '../lib/subscriber-scope'
 
 export const metadata = { event: 'query_index.upsert_one', persistent: false }
 
@@ -10,21 +10,24 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
   const entityType = String(payload?.entityType || '')
   const recordId = String(payload?.recordId || '')
   if (!entityType || !recordId) return
-  let organizationId = payload?.organizationId ?? null
-  let tenantId = payload?.tenantId ?? null
+  let organizationId: string | null = payload?.organizationId ?? null
+  let tenantId: string | null = payload?.tenantId ?? null
   const suppressCoverage = payload?.suppressCoverage === true
   const coverageDelayMs = typeof payload?.coverageDelayMs === 'number' ? payload.coverageDelayMs : undefined
-  // Fill missing scope from base table if needed
-  if (organizationId == null || tenantId == null) {
-    try {
-      const knex = (em as any).getConnection().getKnex()
-      const table = resolveEntityTableName(em, entityType)
-      const row = await knex(table).select(['organization_id', 'tenant_id']).where({ id: recordId }).first()
-      if (organizationId == null) organizationId = row?.organization_id ?? organizationId
-      if (tenantId == null) tenantId = row?.tenant_id ?? tenantId
-    } catch {}
-  }
   try {
+    const hasPayloadOrganizationId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'organizationId')
+    const hasPayloadTenantId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'tenantId')
+    const rowScope = await loadQueryIndexRowScope(em, entityType, recordId).catch(() => null)
+    const resolvedScope = resolveQueryIndexRecordScope({
+      payloadOrganizationId: payload?.organizationId,
+      payloadTenantId: payload?.tenantId,
+      hasPayloadOrganizationId,
+      hasPayloadTenantId,
+      rowScope,
+    })
+    organizationId = resolvedScope.organizationId
+    tenantId = resolvedScope.tenantId
+
     const result = await upsertIndexRow(em, { entityType, recordId, organizationId, tenantId })
     if (!suppressCoverage) {
       const doc = result.doc

--- a/packages/search/src/vector/services/vector-index.service.ts
+++ b/packages/search/src/vector/services/vector-index.service.ts
@@ -880,6 +880,7 @@ export class VectorIndexService {
         payload.resetCoverage = true
       }
       if (args.tenantId !== undefined) payload.tenantId = args.tenantId
+      else payload.allowAllTenants = true
       if (args.organizationId !== undefined) payload.organizationId = args.organizationId
       await this.opts.eventBus.emitEvent('query_index.reindex', payload)
       return


### PR DESCRIPTION
## Summary
Prevents query index writes and reindex operations from crossing tenant boundaries when event payload scope is missing or mismatched.

## Root cause
Query-index subscribers filled missing tenant / organization scope from source rows using only record IDs, without verifying that payload scope matched row scope. Missing tenant scope in reindex could also fan out into all-tenant reindex behavior.

## Changes
- add strict subscriber scope validation helpers
- reject mismatched or missing tenant/organization scope for indexed writes
- stop broad reindex behavior when tenant scope is not explicitly trusted
- add regression tests for scope mismatch and missing-scope paths

## Risk
Low. The change narrows indexing behavior to trusted tenant scope only.

## Validation
- added regression tests for query-index subscriber scope handling
