### PR TITLE
Enforce endpoint RBAC in code mode api requests

### DIFF
--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -46,6 +46,7 @@ registerMcpTool({
 - MUST use zod schemas for `inputSchema` — never use raw JSON Schema
 - MUST return a serializable object from the handler
 - MUST use `moduleId` matching the module's `id` field
+- Code Mode `api.request()` MUST enforce endpoint-level RBAC before fetch and fail closed for undocumented or featureless mutation endpoints
 
 ### Modify OpenCode Configuration
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tools.test.ts
@@ -1,0 +1,244 @@
+import type { McpToolContext } from '../types'
+import { getApiEndpoints } from '../api-endpoint-index'
+import {
+  authorizeCodeModeApiRequest,
+  CODE_MODE_REQUIRED_FEATURES,
+  matchApiEndpointPath,
+} from '../codemode-tools'
+
+jest.mock('../api-endpoint-index', () => ({
+  getApiEndpoints: jest.fn(),
+  getRawOpenApiSpec: jest.fn(),
+}))
+
+const mockedGetApiEndpoints = jest.mocked(getApiEndpoints)
+
+type MockRbacService = {
+  hasAllFeatures: jest.Mock<boolean, [string[], string[]]>
+}
+
+function createContext(
+  overrides: Partial<McpToolContext> = {},
+  rbacService?: MockRbacService
+): McpToolContext {
+  const defaultRbacService: MockRbacService = rbacService ?? {
+    hasAllFeatures: jest.fn((requiredFeatures: string[], userFeatures: string[]) =>
+      requiredFeatures.every((feature) => userFeatures.includes(feature))
+    ),
+  }
+
+  return {
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    userId: 'user-1',
+    userFeatures: ['ai_assistant.view'],
+    isSuperAdmin: false,
+    apiKeySecret: 'omk_test.secret',
+    container: {
+      resolve: jest.fn((name: string) => {
+        if (name === 'rbacService') {
+          return defaultRbacService
+        }
+        throw new Error(`Unknown dependency: ${name}`)
+      }),
+    } as unknown as McpToolContext['container'],
+    ...overrides,
+  }
+}
+
+describe('CODE_MODE_REQUIRED_FEATURES', () => {
+  it('requires ai_assistant.view for Code Mode tools', () => {
+    expect(CODE_MODE_REQUIRED_FEATURES).toEqual(['ai_assistant.view'])
+  })
+})
+
+describe('matchApiEndpointPath', () => {
+  it('matches OpenAPI path params against concrete request paths', () => {
+    expect(
+      matchApiEndpointPath('/api/customers/companies/{id}', '/api/customers/companies/company-1')
+    ).toBe(true)
+  })
+
+  it('normalizes missing /api prefixes and query strings', () => {
+    expect(
+      matchApiEndpointPath('/api/customers/companies/{id}', 'customers/companies/company-1?expand=1')
+    ).toBe(true)
+  })
+
+  it('rejects different resource paths', () => {
+    expect(
+      matchApiEndpointPath('/api/customers/companies/{id}', '/api/customers/people/person-1')
+    ).toBe(false)
+  })
+})
+
+describe('authorizeCodeModeApiRequest', () => {
+  beforeEach(() => {
+    mockedGetApiEndpoints.mockReset()
+  })
+
+  it('denies undocumented endpoints', async () => {
+    mockedGetApiEndpoints.mockResolvedValue([])
+
+    const result = await authorizeCodeModeApiRequest(
+      createContext(),
+      'DELETE',
+      '/api/customers/companies'
+    )
+
+    expect(result).toEqual({
+      allowed: false,
+      statusCode: 403,
+      error: 'Code Mode cannot call undocumented API endpoint DELETE /api/customers/companies',
+    })
+  })
+
+  it('denies access when endpoint features are missing', async () => {
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'delete_companies',
+        operationId: 'delete_companies',
+        method: 'DELETE',
+        path: '/api/customers/companies',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: ['customers.companies.delete'],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+
+    const result = await authorizeCodeModeApiRequest(
+      createContext({ userFeatures: ['ai_assistant.view'] }),
+      'DELETE',
+      '/api/customers/companies'
+    )
+
+    expect(result).toEqual({
+      allowed: false,
+      statusCode: 403,
+      error: 'Insufficient permissions for DELETE /api/customers/companies',
+      details: {
+        requiredFeatures: ['customers.companies.delete'],
+        operationId: 'delete_companies',
+      },
+    })
+  })
+
+  it('denies mutation endpoints that do not declare required features', async () => {
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'accept_quote',
+        operationId: 'accept_quote',
+        method: 'POST',
+        path: '/api/sales/quotes/accept',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: [],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+
+    const result = await authorizeCodeModeApiRequest(
+      createContext(),
+      'POST',
+      '/api/sales/quotes/accept'
+    )
+
+    expect(result).toEqual({
+      allowed: false,
+      statusCode: 403,
+      error: 'Code Mode cannot call mutation endpoint without declared required features: POST /api/sales/quotes/accept',
+      details: {
+        operationId: 'accept_quote',
+      },
+    })
+  })
+
+  it('allows documented reads without endpoint features', async () => {
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'list_companies',
+        operationId: 'list_companies',
+        method: 'GET',
+        path: '/api/customers/companies',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: [],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+
+    const result = await authorizeCodeModeApiRequest(
+      createContext(),
+      'GET',
+      '/api/customers/companies'
+    )
+
+    expect(result).toEqual({
+      allowed: true,
+      endpoint: {
+        id: 'list_companies',
+        operationId: 'list_companies',
+        method: 'GET',
+        path: '/api/customers/companies',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: [],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    })
+  })
+
+  it('allows endpoint calls when user has the required feature', async () => {
+    mockedGetApiEndpoints.mockResolvedValue([
+      {
+        id: 'delete_company',
+        operationId: 'delete_company',
+        method: 'DELETE',
+        path: '/api/customers/companies/{id}',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: ['customers.companies.delete'],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    ])
+
+    const result = await authorizeCodeModeApiRequest(
+      createContext({ userFeatures: ['ai_assistant.view', 'customers.companies.delete'] }),
+      'DELETE',
+      '/api/customers/companies/company-1'
+    )
+
+    expect(result).toEqual({
+      allowed: true,
+      endpoint: {
+        id: 'delete_company',
+        operationId: 'delete_company',
+        method: 'DELETE',
+        path: '/api/customers/companies/{id}',
+        summary: '',
+        description: '',
+        tags: [],
+        requiredFeatures: ['customers.companies.delete'],
+        parameters: [],
+        requestBodySchema: null,
+        deprecated: false,
+      },
+    })
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
@@ -9,11 +9,13 @@
  */
 
 import { z } from 'zod'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { registerMcpTool } from './tool-registry'
 import type { McpToolContext } from './types'
 import { createSandbox } from './sandbox'
 import { truncateResult } from './truncate'
-import { getRawOpenApiSpec } from './api-endpoint-index'
+import { hasRequiredFeatures } from './auth'
+import { getApiEndpoints, getRawOpenApiSpec, type ApiEndpoint } from './api-endpoint-index'
 import {
   getCachedEntityGraph,
   inferModuleFromEntity,
@@ -37,6 +39,8 @@ let cachedCodeModeSpec: Record<string, unknown> | null = null
  * Generated once at startup from the OpenAPI spec.
  */
 let cachedCommonTypes: string | null = null
+
+export const CODE_MODE_REQUIRED_FEATURES = ['ai_assistant.view'] as const
 
 /**
  * Build the merged spec object for the search tool.
@@ -584,7 +588,7 @@ Use BEFORE execute to learn endpoint schemas for CREATE/UPDATE. Skip for common 
             'An async arrow function that queries spec, e.g. async () => spec.paths["/api/customers/companies"]'
           ),
       }),
-      requiredFeatures: [],
+      requiredFeatures: [...CODE_MODE_REQUIRED_FEATURES],
       handler: async (input: { code: string }, ctx: McpToolContext) => {
         const codePreview = input.code.slice(0, 120).replace(/\n/g, ' ')
         console.error(`[AI Usage] search: code="${codePreview}${input.code.length > 120 ? '...' : ''}"`)
@@ -672,7 +676,7 @@ RULES: For FIND/LIST → GET only (1 call). For UPDATE → PUT to collection pat
             'Async arrow function. For reads: async () => api.request({ method: "GET", path: "/api/customers/companies" }). For updates: async () => api.request({ method: "PUT", path: "/api/customers/companies", body: { id: "<uuid>", name: "New Name" } }). id goes in BODY not URL.'
           ),
       }),
-      requiredFeatures: [], // ACL checked at API level
+      requiredFeatures: [...CODE_MODE_REQUIRED_FEATURES],
       handler: async (input: { code: string }, ctx: McpToolContext) => {
         const codePreview = input.code.slice(0, 120).replace(/\n/g, ' ')
         console.error(`[AI Usage] execute: code="${codePreview}${input.code.length > 120 ? '...' : ''}" user=${ctx.userId || 'unknown'}`)
@@ -770,15 +774,29 @@ function createApiRequestFn(
 
     const { method, path, query, body } = params
     const callStart = Date.now()
+    const normalizedMethod = method.toUpperCase()
+    const apiPath = normalizeApiRequestPath(path)
+    const authorization = await authorizeCodeModeApiRequest(ctx, normalizedMethod, apiPath)
 
-    // Ensure path starts with /api
-    const apiPath = path.startsWith('/api') ? path : `/api${path}`
+    if (!authorization.allowed) {
+      const callDuration = Date.now() - callStart
+      console.error(
+        `[AI Usage] api.request: ${normalizedMethod} ${apiPath} → ${authorization.statusCode} in ${callDuration}ms (blocked by Code Mode RBAC)`
+      )
+      return {
+        success: false,
+        statusCode: authorization.statusCode,
+        error: authorization.error,
+        details: authorization.details,
+      }
+    }
+
     let url = `${baseUrl}${apiPath}`
 
     // Build query parameters
     const queryParams: Record<string, string> = { ...query }
 
-    if (method === 'GET') {
+    if (normalizedMethod === 'GET') {
       if (ctx.tenantId) queryParams.tenantId = ctx.tenantId
       if (ctx.organizationId) queryParams.organizationId = ctx.organizationId
     }
@@ -790,7 +808,7 @@ function createApiRequestFn(
 
     // Build request body with context injection
     let requestBody: Record<string, unknown> | undefined
-    if (['POST', 'PUT', 'PATCH'].includes(method.toUpperCase())) {
+    if (['POST', 'PUT', 'PATCH'].includes(normalizedMethod)) {
       requestBody = { ...body }
       if (ctx.tenantId) requestBody.tenantId = ctx.tenantId
       if (ctx.organizationId) requestBody.organizationId = ctx.organizationId
@@ -806,7 +824,7 @@ function createApiRequestFn(
 
     // Execute request using host fetch (not sandbox)
     const response = await globalThis.fetch(url, {
-      method: method.toUpperCase(),
+      method: normalizedMethod,
       headers,
       body: requestBody ? JSON.stringify(requestBody) : undefined,
     })
@@ -816,7 +834,7 @@ function createApiRequestFn(
     const callDuration = Date.now() - callStart
 
     if (!response.ok) {
-      console.error(`[AI Usage] api.request: ${method.toUpperCase()} ${apiPath} → ${response.status} in ${callDuration}ms`)
+      console.error(`[AI Usage] api.request: ${normalizedMethod} ${apiPath} → ${response.status} in ${callDuration}ms`)
 
       // Format 400 validation errors into a clear fix instruction for the LLM
       if (response.status === 400) {
@@ -835,10 +853,10 @@ function createApiRequestFn(
       }
     }
 
-    console.error(`[AI Usage] api.request: ${method.toUpperCase()} ${apiPath} → ${response.status} in ${callDuration}ms (${responseText.length} bytes)`)
+    console.error(`[AI Usage] api.request: ${normalizedMethod} ${apiPath} → ${response.status} in ${callDuration}ms (${responseText.length} bytes)`)
 
     // Add mutation warning for non-GET calls
-    if (!['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase())) {
+    if (!['GET', 'HEAD', 'OPTIONS'].includes(normalizedMethod)) {
       return {
         success: true,
         statusCode: response.status,
@@ -853,6 +871,124 @@ function createApiRequestFn(
       data,
     }
   }
+}
+
+type CodeModeApiAuthorization =
+  | { allowed: true; endpoint: ApiEndpoint }
+  | { allowed: false; statusCode: number; error: string; details?: Record<string, unknown> }
+
+export async function authorizeCodeModeApiRequest(
+  ctx: McpToolContext,
+  method: string,
+  path: string
+): Promise<CodeModeApiAuthorization> {
+  const normalizedMethod = method.toUpperCase()
+  const normalizedPath = normalizeApiRequestPath(path)
+  const endpoint = await findCodeModeApiEndpoint(normalizedMethod, normalizedPath)
+
+  if (!endpoint) {
+    return {
+      allowed: false,
+      statusCode: 403,
+      error: `Code Mode cannot call undocumented API endpoint ${normalizedMethod} ${normalizedPath}`,
+    }
+  }
+
+  const rbacService = resolveRbacService(ctx)
+  const requiredFeatures = endpoint.requiredFeatures ?? []
+
+  if (requiredFeatures.length > 0) {
+    if (hasRequiredFeatures(requiredFeatures, ctx.userFeatures, ctx.isSuperAdmin, rbacService)) {
+      return { allowed: true, endpoint }
+    }
+
+    return {
+      allowed: false,
+      statusCode: 403,
+      error: `Insufficient permissions for ${normalizedMethod} ${normalizedPath}`,
+      details: { requiredFeatures, operationId: endpoint.operationId },
+    }
+  }
+
+  if (isUnsafeHttpMethod(normalizedMethod)) {
+    return {
+      allowed: false,
+      statusCode: 403,
+      error: `Code Mode cannot call mutation endpoint without declared required features: ${normalizedMethod} ${normalizedPath}`,
+      details: { operationId: endpoint.operationId },
+    }
+  }
+
+  return { allowed: true, endpoint }
+}
+
+function resolveRbacService(ctx: McpToolContext): RbacService | undefined {
+  try {
+    return ctx.container.resolve('rbacService') as RbacService
+  } catch {
+    return undefined
+  }
+}
+
+async function findCodeModeApiEndpoint(
+  method: string,
+  path: string
+): Promise<ApiEndpoint | null> {
+  const endpoints = await getApiEndpoints()
+  const exactMatch = endpoints.find((endpoint) => endpoint.method === method && endpoint.path === path)
+  if (exactMatch) {
+    return exactMatch
+  }
+
+  return endpoints.find((endpoint) => endpoint.method === method && matchApiEndpointPath(endpoint.path, path)) ?? null
+}
+
+export function matchApiEndpointPath(endpointPath: string, requestPath: string): boolean {
+  const normalizedEndpointPath = normalizeApiRequestPath(endpointPath)
+  const normalizedRequestPath = normalizeApiRequestPath(requestPath)
+
+  if (normalizedEndpointPath === normalizedRequestPath) {
+    return true
+  }
+
+  const endpointSegments = normalizedEndpointPath.split('/').filter(Boolean)
+  const requestSegments = normalizedRequestPath.split('/').filter(Boolean)
+
+  if (endpointSegments.length !== requestSegments.length) {
+    return false
+  }
+
+  return endpointSegments.every((segment, index) => {
+    if (isPathParameterSegment(segment)) {
+      return requestSegments[index].length > 0
+    }
+    return segment === requestSegments[index]
+  })
+}
+
+function normalizeApiRequestPath(path: string): string {
+  const [rawPath] = path.split('?')
+  const normalizedPath = rawPath.startsWith('/api')
+    ? rawPath
+    : `/api${rawPath.startsWith('/') ? rawPath : `/${rawPath}`}`
+
+  if (normalizedPath.length > 1 && normalizedPath.endsWith('/')) {
+    return normalizedPath.slice(0, -1)
+  }
+
+  return normalizedPath
+}
+
+function isPathParameterSegment(segment: string): boolean {
+  return (
+    (segment.startsWith('{') && segment.endsWith('}')) ||
+    (segment.startsWith('[') && segment.endsWith(']')) ||
+    segment.startsWith(':')
+  )
+}
+
+function isUnsafeHttpMethod(method: string): boolean {
+  return !['GET', 'HEAD', 'OPTIONS'].includes(method.toUpperCase())
 }
 
 function tryParseJson(text: string): unknown {


### PR DESCRIPTION
## Summary
Closes a privilege-escalation path in AI Code Mode API tools by enforcing feature gates and endpoint-level access checks.

## Root cause
Code Mode API execution accepted arbitrary documented API calls without per-tool RBAC enforcement. A user with `ai_assistant.view` could use the AI tool as a conduit to hit privileged endpoints.

## Changes
- require `ai_assistant.view` for Code Mode execute/search tools
- enforce endpoint-level required feature checks before executing API requests
- block unsafe fallback access for endpoints without explicit tool authorization
- add regression coverage for allowed and denied API calls

## Risk
Low to medium. Access becomes stricter for AI-driven API execution, but behavior now matches existing endpoint authorization expectations.

## Validation
- added unit tests for Code Mode authorization paths
