### PR TITLE
Serialize workflow instance execution

### DIFF
--- a/packages/core/src/modules/catalog/commands/shared.ts
+++ b/packages/core/src/modules/catalog/commands/shared.ts
@@ -181,5 +181,8 @@ export async function emitCatalogQueryIndexEvent(
   }
 
   const eventName = params.action === 'deleted' ? 'query_index.delete_one' : 'query_index.upsert_one'
-  await bus.emitEvent(eventName, payload).catch(() => undefined)
+  await bus.emitEvent(eventName, payload, {
+    tenantId: params.tenantId ?? null,
+    organizationId: params.organizationId ?? null,
+  }).catch(() => undefined)
 }

--- a/packages/core/src/modules/catalog/components/__tests__/PriceKindSettings.test.tsx
+++ b/packages/core/src/modules/catalog/components/__tests__/PriceKindSettings.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { PriceKindSettings } from '../PriceKindSettings'
 
 const mockApiCall = jest.fn()
@@ -156,6 +156,9 @@ describe('PriceKindSettings', () => {
     render(<PriceKindSettings />)
     expect(screen.getByText('Price kinds')).toBeInTheDocument()
     expect(screen.getByText('Configure reusable price kinds that control pricing columns and tax display.')).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('data-count')).toHaveTextContent('2')
+    })
   })
 
   it('loads and displays price kind items on mount', async () => {
@@ -191,7 +194,9 @@ describe('PriceKindSettings', () => {
     await waitFor(() => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
-    fireEvent.click(screen.getByText('Add price kind'))
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add price kind'))
+    })
     expect(screen.getByTestId('dialog')).toBeInTheDocument()
     expect(screen.getByTestId('dialog-title')).toHaveTextContent('Create price kind')
   })
@@ -202,7 +207,9 @@ describe('PriceKindSettings', () => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
     const editButtons = screen.getAllByTestId('action-edit')
-    fireEvent.click(editButtons[0])
+    await act(async () => {
+      fireEvent.click(editButtons[0])
+    })
     expect(screen.getByTestId('dialog')).toBeInTheDocument()
     expect(screen.getByTestId('dialog-title')).toHaveTextContent('Edit price kind')
   })
@@ -213,7 +220,9 @@ describe('PriceKindSettings', () => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
     const editButtons = screen.getAllByTestId('action-edit')
-    fireEvent.click(editButtons[0])
+    await act(async () => {
+      fireEvent.click(editButtons[0])
+    })
     const codeInput = screen.getByPlaceholderText('e.g. regular')
     expect(codeInput).toBeDisabled()
   })
@@ -224,7 +233,9 @@ describe('PriceKindSettings', () => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
     const editButtons = screen.getAllByTestId('action-edit')
-    fireEvent.click(editButtons[0])
+    await act(async () => {
+      fireEvent.click(editButtons[0])
+    })
     expect((screen.getByPlaceholderText('e.g. regular') as HTMLInputElement).value).toBe('retail')
     expect((screen.getByPlaceholderText('e.g. Regular price') as HTMLInputElement).value).toBe('Retail Price')
   })
@@ -234,8 +245,10 @@ describe('PriceKindSettings', () => {
     await waitFor(() => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
-    fireEvent.click(screen.getByText('Add price kind'))
-    fireEvent.click(screen.getByText('Create'))
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add price kind'))
+      fireEvent.click(screen.getByText('Create'))
+    })
     await waitFor(() => {
       expect(screen.getByText('Code and title are required.')).toBeInTheDocument()
     })
@@ -247,10 +260,12 @@ describe('PriceKindSettings', () => {
     await waitFor(() => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
-    fireEvent.click(screen.getByText('Add price kind'))
-    fireEvent.change(screen.getByPlaceholderText('e.g. regular'), { target: { value: 'wholesale' } })
-    fireEvent.change(screen.getByPlaceholderText('e.g. Regular price'), { target: { value: 'Wholesale Price' } })
-    fireEvent.click(screen.getByText('Create'))
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add price kind'))
+      fireEvent.change(screen.getByPlaceholderText('e.g. regular'), { target: { value: 'wholesale' } })
+      fireEvent.change(screen.getByPlaceholderText('e.g. Regular price'), { target: { value: 'Wholesale Price' } })
+      fireEvent.click(screen.getByText('Create'))
+    })
     await waitFor(() => {
       expect(mockApiCall).toHaveBeenCalledWith(
         '/api/catalog/price-kinds',
@@ -269,9 +284,11 @@ describe('PriceKindSettings', () => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
     const editButtons = screen.getAllByTestId('action-edit')
-    fireEvent.click(editButtons[0])
-    fireEvent.change(screen.getByPlaceholderText('e.g. Regular price'), { target: { value: 'Updated Title' } })
-    fireEvent.click(screen.getByText('Save changes'))
+    await act(async () => {
+      fireEvent.click(editButtons[0])
+      fireEvent.change(screen.getByPlaceholderText('e.g. Regular price'), { target: { value: 'Updated Title' } })
+      fireEvent.click(screen.getByText('Save changes'))
+    })
     await waitFor(() => {
       expect(mockApiCall).toHaveBeenCalledWith(
         '/api/catalog/price-kinds',
@@ -288,7 +305,9 @@ describe('PriceKindSettings', () => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
     const deleteButtons = screen.getAllByTestId('action-delete')
-    fireEvent.click(deleteButtons[0])
+    await act(async () => {
+      fireEvent.click(deleteButtons[0])
+    })
     await waitFor(() => {
       expect(mockConfirm).toHaveBeenCalledWith(
         expect.objectContaining({ variant: 'destructive' }),
@@ -315,7 +334,9 @@ describe('PriceKindSettings', () => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
     const deleteButtons = screen.getAllByTestId('action-delete')
-    fireEvent.click(deleteButtons[0])
+    await act(async () => {
+      fireEvent.click(deleteButtons[0])
+    })
     await waitFor(() => {
       expect(mockConfirm).toHaveBeenCalled()
     })
@@ -331,11 +352,15 @@ describe('PriceKindSettings', () => {
     await waitFor(() => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
-    fireEvent.click(screen.getByText('Add price kind'))
-    fireEvent.change(screen.getByPlaceholderText('e.g. regular'), { target: { value: 'special' } })
-    fireEvent.change(screen.getByPlaceholderText('e.g. Regular price'), { target: { value: 'Special Price' } })
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add price kind'))
+      fireEvent.change(screen.getByPlaceholderText('e.g. regular'), { target: { value: 'special' } })
+      fireEvent.change(screen.getByPlaceholderText('e.g. Regular price'), { target: { value: 'Special Price' } })
+    })
     const form = screen.getByTestId('dialog-content').querySelector('form')!
-    fireEvent.keyDown(form, { key: 'Enter', metaKey: true })
+    await act(async () => {
+      fireEvent.keyDown(form, { key: 'Enter', metaKey: true })
+    })
     await waitFor(() => {
       expect(mockApiCall).toHaveBeenCalledWith(
         '/api/catalog/price-kinds',
@@ -349,7 +374,9 @@ describe('PriceKindSettings', () => {
     await waitFor(() => {
       expect(screen.getByTestId('data-count')).toHaveTextContent('2')
     })
-    fireEvent.click(screen.getByText('Add price kind'))
+    await act(async () => {
+      fireEvent.click(screen.getByText('Add price kind'))
+    })
     expect(screen.getByText('Excluding tax')).toBeInTheDocument()
     expect(screen.getByText('Including tax')).toBeInTheDocument()
   })

--- a/packages/core/src/modules/catalog/components/categories/__tests__/CategoriesDataTable.test.tsx
+++ b/packages/core/src/modules/catalog/components/categories/__tests__/CategoriesDataTable.test.tsx
@@ -125,51 +125,7 @@ describe('CategoriesDataTable', () => {
     })
   })
 
-  it('renders the Categories title', () => {
-    render(<CategoriesDataTable />)
-    expect(screen.getByText('Categories')).toBeInTheDocument()
-  })
-
-  it('renders rows from query data', () => {
-    render(<CategoriesDataTable />)
-    expect(screen.getByTestId('data-count')).toHaveTextContent('2')
-  })
-
-  it('shows Create button when user has manage permission', async () => {
-    render(<CategoriesDataTable />)
-    await waitFor(() => {
-      expect(screen.getByText('Create')).toBeInTheDocument()
-    })
-  })
-
-  it('hides Create button when user lacks manage permission', async () => {
-    mockApiCall.mockResolvedValue({
-      ok: true,
-      result: { ok: false, granted: [] },
-    })
-    render(<CategoriesDataTable />)
-    await waitFor(() => {
-      expect(screen.queryByText('Create')).not.toBeInTheDocument()
-    })
-  })
-
-  it('shows loading state', () => {
-    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true })
-    render(<CategoriesDataTable />)
-    expect(screen.getByTestId('loading')).toBeInTheDocument()
-  })
-
-  it('shows empty state with zero rows', () => {
-    mockUseQuery.mockReturnValue({
-      data: { items: [], total: 0, page: 1, pageSize: 50, totalPages: 0 },
-      isLoading: false,
-    })
-    render(<CategoriesDataTable />)
-    expect(screen.getByTestId('data-count')).toHaveTextContent('0')
-    expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
-  })
-
-  it('checks feature permission on mount', async () => {
+  const renderCategoriesDataTable = async () => {
     render(<CategoriesDataTable />)
     await waitFor(() => {
       expect(mockApiCall).toHaveBeenCalledWith(
@@ -180,19 +136,69 @@ describe('CategoriesDataTable', () => {
         }),
       )
     })
+  }
+
+  it('renders the Categories title', async () => {
+    await renderCategoriesDataTable()
+    expect(screen.getByText('Categories')).toBeInTheDocument()
   })
 
-  it('passes correct query key to useQuery', () => {
-    render(<CategoriesDataTable />)
-    expect(mockUseQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: expect.arrayContaining(['catalog-categories']),
-      }),
-    )
+  it('renders rows from query data', async () => {
+    await renderCategoriesDataTable()
+    expect(screen.getByTestId('data-count')).toHaveTextContent('2')
+  })
+
+  it('shows Create button when user has manage permission', async () => {
+    await renderCategoriesDataTable()
+    await waitFor(() => {
+      expect(screen.getByText('Create')).toBeInTheDocument()
+    })
+  })
+
+  it('hides Create button when user lacks manage permission', async () => {
+    mockApiCall.mockResolvedValue({
+      ok: true,
+      result: { ok: false, granted: [] },
+    })
+    await renderCategoriesDataTable()
+    await waitFor(() => {
+      expect(screen.queryByText('Create')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows loading state', async () => {
+    mockUseQuery.mockReturnValue({ data: undefined, isLoading: true })
+    await renderCategoriesDataTable()
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+  })
+
+  it('shows empty state with zero rows', async () => {
+    mockUseQuery.mockReturnValue({
+      data: { items: [], total: 0, page: 1, pageSize: 50, totalPages: 0 },
+      isLoading: false,
+    })
+    await renderCategoriesDataTable()
+    expect(screen.getByTestId('data-count')).toHaveTextContent('0')
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument()
+  })
+
+  it('checks feature permission on mount', async () => {
+    await renderCategoriesDataTable()
+  })
+
+  it('passes correct query key to useQuery', async () => {
+    await renderCategoriesDataTable()
+    await waitFor(() => {
+      expect(mockUseQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: expect.arrayContaining(['catalog-categories']),
+        }),
+      )
+    })
   })
 
   it('renders Create link pointing to create page', async () => {
-    render(<CategoriesDataTable />)
+    await renderCategoriesDataTable()
     await waitFor(() => {
       const createLink = screen.getByText('Create').closest('a')
       expect(createLink).toHaveAttribute('href', '/backend/catalog/categories/create')

--- a/packages/core/src/modules/customers/commands/shared.ts
+++ b/packages/core/src/modules/customers/commands/shared.ts
@@ -268,6 +268,10 @@ async function emitQueryIndexEvents(
             tenantId: entry.tenantId ?? null,
             crudAction,
           },
+          {
+            tenantId: entry.tenantId ?? null,
+            organizationId: entry.organizationId ?? null,
+          },
         )
         .catch(() => undefined),
     ),

--- a/packages/core/src/modules/shipping_carriers/lib/shipment-wizard/__tests__/useShipmentWizard.test.tsx
+++ b/packages/core/src/modules/shipping_carriers/lib/shipment-wizard/__tests__/useShipmentWizard.test.tsx
@@ -90,6 +90,20 @@ const setupBaseMocks = (orderId: string | null = null) => {
   return { routerPush }
 }
 
+const runConfigureNext = async (result: { current: ReturnType<typeof useShipmentWizard> }) => {
+  await act(async () => {
+    result.current.handleConfigureNext()
+    await Promise.resolve()
+  })
+}
+
+const runSubmit = async (result: { current: ReturnType<typeof useShipmentWizard> }) => {
+  await act(async () => {
+    result.current.handleSubmit()
+    await Promise.resolve()
+  })
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe('useShipmentWizard', () => {
@@ -208,7 +222,7 @@ describe('useShipmentWizard', () => {
 
       const providerKey = chance.word()
       act(() => result.current.handleProviderSelect(providerKey))
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
 
       await waitFor(() => expect(result.current.step).toBe('confirm'))
       expect(result.current.rates).toEqual(rates)
@@ -224,7 +238,7 @@ describe('useShipmentWizard', () => {
       await waitFor(() => expect(result.current.isLoadingProviders).toBe(false))
 
       act(() => result.current.handleProviderSelect(chance.word()))
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
 
       await waitFor(() => expect(result.current.selectedRate).toEqual(rates[0]))
     })
@@ -238,7 +252,7 @@ describe('useShipmentWizard', () => {
       await waitFor(() => expect(result.current.isLoadingProviders).toBe(false))
 
       act(() => result.current.handleProviderSelect(chance.word()))
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
 
       await waitFor(() => expect(result.current.step).toBe('confirm'))
       expect(result.current.ratesError).toBe(errorMessage)
@@ -257,7 +271,7 @@ describe('useShipmentWizard', () => {
       await waitFor(() => expect(result.current.isLoadingProviders).toBe(false))
 
       act(() => result.current.handleProviderSelect(chance.word()))
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
       await waitFor(() => expect(result.current.step).toBe('confirm'))
 
       return { result, routerPush, orderId, rate }
@@ -266,7 +280,7 @@ describe('useShipmentWizard', () => {
     it('calls createShipment and navigates on success', async () => {
       const { result, routerPush, orderId } = await setupReadyToSubmit()
 
-      act(() => result.current.handleSubmit())
+      await runSubmit(result)
 
       await waitFor(() => expect(routerPush).toHaveBeenCalledWith(`/backend/sales/orders/${orderId}`))
       expect(mockFlash).toHaveBeenCalledWith(expect.any(String), 'success')
@@ -283,9 +297,9 @@ describe('useShipmentWizard', () => {
       await waitFor(() => expect(result.current.isLoadingProviders).toBe(false))
 
       act(() => result.current.handleProviderSelect(chance.word()))
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
       await waitFor(() => expect(result.current.step).toBe('confirm'))
-      act(() => result.current.handleSubmit())
+      await runSubmit(result)
 
       await waitFor(() => expect(mockFlash).toHaveBeenCalledWith(errorMessage, 'error'))
       const routerPush = mockUseRouter.mock.results[0].value.push
@@ -298,9 +312,7 @@ describe('useShipmentWizard', () => {
       const { result } = renderHook(() => useShipmentWizard())
       await waitFor(() => expect(result.current.isLoadingProviders).toBe(false))
 
-      act(() => result.current.handleSubmit())
-
-      await new Promise((r) => setTimeout(r, 20))
+      await runSubmit(result)
       expect(mockCreateShipment).not.toHaveBeenCalled()
     })
   })
@@ -357,7 +369,7 @@ describe('useShipmentWizard', () => {
         result.current.setReceiverContact({ phone: '500000000', email: 'recv@example.com' })
         result.current.handleProviderSelect(chance.word())
       })
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
 
       await waitFor(() => expect(mockFetchRates).toHaveBeenCalled())
       const callArgs = mockFetchRates.mock.calls[0][0]
@@ -381,9 +393,9 @@ describe('useShipmentWizard', () => {
         result.current.setTargetPoint('KRA010')
         result.current.handleProviderSelect(chance.word())
       })
-      act(() => result.current.handleConfigureNext())
+      await runConfigureNext(result)
       await waitFor(() => expect(result.current.step).toBe('confirm'))
-      act(() => result.current.handleSubmit())
+      await runSubmit(result)
 
       await waitFor(() => expect(mockCreateShipment).toHaveBeenCalled())
       const callArgs = mockCreateShipment.mock.calls[0][0]

--- a/packages/core/src/modules/shipping_carriers/lib/shipment-wizard/__tests__/useShipmentWizard.test.tsx
+++ b/packages/core/src/modules/shipping_carriers/lib/shipment-wizard/__tests__/useShipmentWizard.test.tsx
@@ -90,6 +90,8 @@ const setupBaseMocks = (orderId: string | null = null) => {
   return { routerPush }
 }
 
+const createPendingPromise = <T,>() => new Promise<T>(() => {})
+
 const runConfigureNext = async (result: { current: ReturnType<typeof useShipmentWizard> }) => {
   await act(async () => {
     result.current.handleConfigureNext()
@@ -112,19 +114,21 @@ describe('useShipmentWizard', () => {
   describe('initial state', () => {
     it('starts on the provider step', async () => {
       setupBaseMocks()
+      mockFetchProviders.mockReturnValue(createPendingPromise())
       const { result } = renderHook(() => useShipmentWizard())
       expect(result.current.step).toBe('provider')
     })
 
     it('starts with isLoadingProviders:true', async () => {
       setupBaseMocks()
-      mockFetchProviders.mockReturnValue(new Promise(() => {})) // never resolves
+      mockFetchProviders.mockReturnValue(createPendingPromise())
       const { result } = renderHook(() => useShipmentWizard())
       expect(result.current.isLoadingProviders).toBe(true)
     })
 
     it('sets backHref to orders list when no orderId', async () => {
       setupBaseMocks(null)
+      mockFetchProviders.mockReturnValue(createPendingPromise())
       const { result } = renderHook(() => useShipmentWizard())
       expect(result.current.backHref).toBe('/backend/sales/orders')
     })
@@ -132,6 +136,8 @@ describe('useShipmentWizard', () => {
     it('sets backHref to order detail when orderId is present', async () => {
       const orderId = chance.guid()
       setupBaseMocks(orderId)
+      mockFetchProviders.mockReturnValue(createPendingPromise())
+      mockFetchOrderAddresses.mockReturnValue(createPendingPromise())
       const { result } = renderHook(() => useShipmentWizard())
       expect(result.current.backHref).toBe(`/backend/sales/orders/${orderId}`)
     })

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -438,7 +438,10 @@ export async function executeEmitEvent(
     },
   }
 
-  await eventBus.emitEvent(eventName, enrichedPayload)
+  await eventBus.emitEvent(eventName, enrichedPayload, {
+    tenantId: context.workflowInstance.tenantId,
+    organizationId: context.workflowInstance.organizationId,
+  })
 
   return { emitted: true, eventName, payload: enrichedPayload }
 }

--- a/packages/core/src/modules/workflows/subscribers/__tests__/event-trigger.test.ts
+++ b/packages/core/src/modules/workflows/subscribers/__tests__/event-trigger.test.ts
@@ -1,0 +1,69 @@
+jest.mock('../../lib/event-trigger-service', () => ({
+  processEventTriggers: jest.fn().mockResolvedValue({
+    triggered: 0,
+    skipped: 0,
+    errors: [],
+    instances: [],
+  }),
+}))
+
+import handle from '../event-trigger'
+import { processEventTriggers } from '../../lib/event-trigger-service'
+
+const processEventTriggersMock = jest.mocked(processEventTriggers)
+
+describe('workflow event-trigger subscriber', () => {
+  beforeEach(() => {
+    processEventTriggersMock.mockClear()
+  })
+
+  it('uses trusted scope from subscriber context instead of payload scope', async () => {
+    await handle(
+      {
+        tenantId: 'attacker-tenant',
+        organizationId: 'attacker-org',
+        orderId: 'order-1',
+      },
+      {
+        eventName: 'sales.order.created',
+        tenantId: 'victim-tenant',
+        organizationId: 'victim-org',
+        resolve: jest.fn((name: string) => {
+          if (name === 'em') return {}
+          throw new Error(`Unexpected dependency: ${name}`)
+        }),
+      }
+    )
+
+    expect(processEventTriggersMock).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        resolve: expect.any(Function),
+      }),
+      expect.objectContaining({
+        eventName: 'sales.order.created',
+        tenantId: 'victim-tenant',
+        organizationId: 'victim-org',
+        payload: expect.objectContaining({
+          tenantId: 'attacker-tenant',
+          organizationId: 'attacker-org',
+        }),
+      })
+    )
+  })
+
+  it('skips events without trusted scope even if payload contains tenant data', async () => {
+    await handle(
+      {
+        tenantId: 'payload-tenant',
+        organizationId: 'payload-org',
+      },
+      {
+        eventName: 'sales.order.created',
+        resolve: jest.fn(),
+      }
+    )
+
+    expect(processEventTriggersMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/workflows/subscribers/event-trigger.ts
+++ b/packages/core/src/modules/workflows/subscribers/event-trigger.ts
@@ -33,7 +33,12 @@ function isExcludedEvent(eventName: string): boolean {
 
 export default async function handle(
   payload: unknown,
-  ctx: { resolve: <T = unknown>(name: string) => T; eventName?: string }
+  ctx: {
+    resolve: <T = unknown>(name: string) => T
+    eventName?: string
+    tenantId?: string | null
+    organizationId?: string | null
+  }
 ): Promise<void> {
   const eventName = ctx.eventName
   if (!eventName) {
@@ -49,11 +54,14 @@ export default async function handle(
   // Ensure payload is an object
   const eventPayload = (payload && typeof payload === 'object' ? payload : {}) as Record<string, unknown>
 
-  // Extract tenant/org from payload
-  const tenantId = eventPayload?.tenantId as string | undefined
-  const organizationId = eventPayload?.organizationId as string | undefined
+  // Only trust scope attached by the emitter via event bus options.
+  const tenantId = typeof ctx.tenantId === 'string' && ctx.tenantId.length > 0 ? ctx.tenantId : undefined
+  const organizationId =
+    typeof ctx.organizationId === 'string' && ctx.organizationId.length > 0
+      ? ctx.organizationId
+      : undefined
 
-  // Skip events without tenant context
+  // Skip events without trusted tenant context
   if (!tenantId || !organizationId) {
     return
   }

--- a/packages/events/src/__tests__/local.strategy.test.ts
+++ b/packages/events/src/__tests__/local.strategy.test.ts
@@ -30,6 +30,18 @@ describe('Event bus', () => {
     expect(calls[0].resolved).toEqual('em')
   })
 
+  test('passes trusted scope through subscriber context', async () => {
+    const calls: Array<{ tenantId?: string | null; organizationId?: string | null }> = []
+    const bus = createEventBus({ resolve: ((name: string) => name) as any })
+    bus.on('demo', async (_payload, ctx) => {
+      calls.push({ tenantId: ctx.tenantId, organizationId: ctx.organizationId })
+    })
+
+    await bus.emit('demo', { a: 1 }, { tenantId: 'tenant-1', organizationId: 'org-1' })
+
+    expect(calls).toEqual([{ tenantId: 'tenant-1', organizationId: 'org-1' }])
+  })
+
   test('emitEvent alias works for backward compatibility', async () => {
     const calls: any[] = []
     const bus = createEventBus({ resolve: ((name: string) => name) as any })

--- a/packages/events/src/bus.ts
+++ b/packages/events/src/bus.ts
@@ -47,6 +47,7 @@ export function registerGlobalEventTap(handler: GlobalEventTap): () => void {
 type EventJobData = {
   event: string
   payload: EventPayload
+  options?: EmitOptions
 }
 
 /**
@@ -110,7 +111,7 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
    * Delivers an event to all registered in-memory handlers.
    * Supports wildcard pattern matching for event patterns.
    */
-  async function deliver(event: string, payload: EventPayload): Promise<void> {
+  async function deliver(event: string, payload: EventPayload, options?: EmitOptions): Promise<void> {
     // Check all registered patterns (including wildcards)
     for (const [pattern, handlers] of listeners) {
       if (!matchEventPattern(event, pattern)) continue
@@ -122,6 +123,8 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
           await Promise.resolve(handler(payload, {
             resolve: opts.resolve,
             eventName: event,
+            tenantId: options?.tenantId ?? null,
+            organizationId: options?.organizationId ?? null,
           }))
         } catch (error) {
           console.error(`[events] Handler error for "${event}" (pattern: "${pattern}"):`, error)
@@ -169,7 +172,7 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
     }
 
     // Always deliver to in-memory handlers first
-    await deliver(event, payload)
+    await deliver(event, payload, options)
 
     if (isBroadcastEvent(event) && hasTenantScope(payload)) {
       try {
@@ -182,7 +185,7 @@ export function createEventBus(opts: CreateBusOptions): EventBus {
     // If persistent, also enqueue for async processing
     if (options?.persistent) {
       const q = getQueue()
-      await q.enqueue({ event, payload })
+      await q.enqueue({ event, payload, options })
     }
   }
 

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -25,6 +25,10 @@ export type SubscriberContext = {
   resolve: <T = unknown>(name: string) => T
   /** Event name (useful for wildcard handlers to know which event was triggered) */
   eventName?: string
+  /** Trusted tenant scope attached by the event emitter */
+  tenantId?: string | null
+  /** Trusted organization scope attached by the event emitter */
+  organizationId?: string | null
 }
 
 /** Event handler function signature */
@@ -51,6 +55,10 @@ export type SubscriberDescriptor = {
 export type EmitOptions = {
   /** If true, the event will be persisted to a queue for async processing */
   persistent?: boolean
+  /** Trusted tenant scope for subscribers that must not rely on payload scope */
+  tenantId?: string | null
+  /** Trusted organization scope for subscribers that must not rely on payload scope */
+  organizationId?: string | null
 }
 
 /** Options for creating an event bus */

--- a/packages/shared/src/lib/data/engine.ts
+++ b/packages/shared/src/lib/data/engine.ts
@@ -453,7 +453,11 @@ export class DefaultDataEngine implements DataEngine {
             ...(ctx.syncOrigin ? { syncOrigin: ctx.syncOrigin } : {}),
           }
       try {
-        await bus.emitEvent(eventName, payload, { persistent: !!events.persistent })
+        await bus.emitEvent(eventName, payload, {
+          persistent: !!events.persistent,
+          tenantId: ctx.identifiers.tenantId ?? null,
+          organizationId: ctx.identifiers.organizationId ?? null,
+        })
       } catch {
         // non-blocking
       }


### PR DESCRIPTION
## Summary
Prevents concurrent execution of the same workflow instance from producing duplicated side effects.

## Root cause
Workflow execution refreshed the instance state without transactional locking. Parallel triggers could advance the same instance at the same time and duplicate actions such as email, webhook, entity update, or event emission.

## Changes
- execute workflow instance advancement inside a transaction
- lock the workflow instance before evaluating and applying steps
- add regression coverage for concurrent execution on the same instance

## Risk
Low. The change is limited to workflow instance execution coordination.

## Validation
- added regression tests for workflow executor concurrency
