### PR TITLE
Dedupe inbound replays without message id

### DIFF
--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-003.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-003.spec.ts
@@ -5,6 +5,7 @@ const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
 test.describe('TC-WEBHOOK-003: Inbound webhook receiver', () => {
   test('should accept valid inbound webhooks, mark duplicates, and reject invalid endpoints or signatures', async ({ request }) => {
     const messageId = `msg-${Date.now()}`;
+    const replayTimestamp = String(Math.floor(Date.now() / 1000));
     const payload = {
       type: 'mock.inbound.received',
       timestamp: new Date().toISOString(),
@@ -19,7 +20,7 @@ test.describe('TC-WEBHOOK-003: Inbound webhook receiver', () => {
         'content-type': 'application/json',
         'x-mock-webhook-signature': 'valid',
         'webhook-id': messageId,
-        'webhook-timestamp': String(Math.floor(Date.now() / 1000)),
+        'webhook-timestamp': replayTimestamp,
         'webhook-signature': 'v1,mock',
       },
       data: JSON.stringify(payload),
@@ -33,13 +34,39 @@ test.describe('TC-WEBHOOK-003: Inbound webhook receiver', () => {
         'content-type': 'application/json',
         'x-mock-webhook-signature': 'valid',
         'webhook-id': messageId,
-        'webhook-timestamp': String(Math.floor(Date.now() / 1000)),
+        'webhook-timestamp': replayTimestamp,
         'webhook-signature': 'v1,mock',
       },
       data: JSON.stringify(payload),
     });
     expect(duplicateResponse.status()).toBe(200);
     await expect(duplicateResponse.json()).resolves.toEqual({ ok: true, duplicate: true });
+
+    const replayWithoutMessageIdResponse = await request.fetch(`${BASE_URL}/api/webhooks/inbound/mock_inbound`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-mock-webhook-signature': 'valid',
+        'webhook-timestamp': replayTimestamp,
+        'webhook-signature': 'v1,mock',
+      },
+      data: JSON.stringify(payload),
+    });
+    expect(replayWithoutMessageIdResponse.status()).toBe(200);
+    await expect(replayWithoutMessageIdResponse.json()).resolves.toEqual({ ok: true });
+
+    const replayWithoutMessageIdDuplicateResponse = await request.fetch(`${BASE_URL}/api/webhooks/inbound/mock_inbound`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-mock-webhook-signature': 'valid',
+        'webhook-timestamp': replayTimestamp,
+        'webhook-signature': 'v1,mock',
+      },
+      data: JSON.stringify(payload),
+    });
+    expect(replayWithoutMessageIdDuplicateResponse.status()).toBe(200);
+    await expect(replayWithoutMessageIdDuplicateResponse.json()).resolves.toEqual({ ok: true, duplicate: true });
 
     const invalidSignatureResponse = await request.fetch(`${BASE_URL}/api/webhooks/inbound/mock_inbound`, {
       method: 'POST',

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+import { resolveInboundReceiptMessageId } from '../route'
+
+describe('resolveInboundReceiptMessageId', () => {
+  it('prefers explicit webhook ids when present', () => {
+    expect(
+      resolveInboundReceiptMessageId({
+        endpointId: 'mock_inbound',
+        providerKey: 'mock',
+        headers: {
+          'webhook-id': 'msg-123',
+          'webhook-timestamp': '1700000000',
+        },
+        body: '{"ok":true}',
+      })
+    ).toBe('msg-123')
+  })
+
+  it('derives a stable fallback id from provider, endpoint, timestamp, and body', () => {
+    const first = resolveInboundReceiptMessageId({
+      endpointId: 'mock_inbound',
+      providerKey: 'mock',
+      headers: {
+        'webhook-timestamp': '1700000000',
+      },
+      body: '{"ok":true}',
+    })
+
+    const second = resolveInboundReceiptMessageId({
+      endpointId: 'mock_inbound',
+      providerKey: 'mock',
+      headers: {
+        'webhook-timestamp': '1700000000',
+      },
+      body: '{"ok":true}',
+    })
+
+    expect(first).toBe(second)
+    expect(first).toMatch(/^derived:1700000000:/)
+  })
+
+  it('changes when timestamp changes', () => {
+    const first = resolveInboundReceiptMessageId({
+      endpointId: 'mock_inbound',
+      providerKey: 'mock',
+      headers: {
+        'webhook-timestamp': '1700000000',
+      },
+      body: '{"ok":true}',
+    })
+
+    const second = resolveInboundReceiptMessageId({
+      endpointId: 'mock_inbound',
+      providerKey: 'mock',
+      headers: {
+        'webhook-timestamp': '1700000001',
+      },
+      body: '{"ok":true}',
+    })
+
+    expect(first).not.toBe(second)
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { createHash } from 'node:crypto'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
@@ -74,25 +75,28 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     }
   }
 
-  const messageId = headers['webhook-id'] ?? headers['svix-id'] ?? null
-  if (messageId) {
-    try {
-      em.persist(em.create(WebhookInboundReceiptEntity, {
-        endpointId: params.endpointId,
-        messageId,
-        providerKey: adapter.providerKey,
-        eventType: verified.eventType,
-        tenantId: verified.tenantId ?? null,
-        organizationId: verified.organizationId ?? null,
-        createdAt: new Date(),
-      }))
-      await em.flush()
-    } catch (error) {
-      if (isUniqueViolation(error)) {
-        return json({ ok: true, duplicate: true })
-      }
-      throw error
+  const messageId = resolveInboundReceiptMessageId({
+    endpointId: params.endpointId,
+    providerKey: adapter.providerKey,
+    headers,
+    body,
+  })
+  try {
+    em.persist(em.create(WebhookInboundReceiptEntity, {
+      endpointId: params.endpointId,
+      messageId,
+      providerKey: adapter.providerKey,
+      eventType: verified.eventType,
+      tenantId: verified.tenantId ?? null,
+      organizationId: verified.organizationId ?? null,
+      createdAt: new Date(),
+    }))
+    await em.flush()
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      return json({ ok: true, duplicate: true })
     }
+    throw error
   }
 
   await emitWebhooksEvent('webhooks.inbound.received', {
@@ -141,4 +145,49 @@ function isUniqueViolation(error: unknown): boolean {
   if (maybeError.code === '23505') return true
   if (!maybeError.cause || typeof maybeError.cause !== 'object') return false
   return (maybeError.cause as { code?: string }).code === '23505'
+}
+
+type ResolveInboundReceiptMessageIdInput = {
+  endpointId: string
+  providerKey: string
+  headers: Record<string, string>
+  body: string
+}
+
+export function resolveInboundReceiptMessageId(
+  input: ResolveInboundReceiptMessageIdInput
+): string {
+  const explicitMessageId = input.headers['webhook-id'] ?? input.headers['svix-id'] ?? null
+  if (typeof explicitMessageId === 'string' && explicitMessageId.trim().length > 0) {
+    return explicitMessageId.trim()
+  }
+
+  const timestamp =
+    input.headers['webhook-timestamp'] ??
+    input.headers['svix-timestamp'] ??
+    null
+
+  if (typeof timestamp === 'string' && timestamp.trim().length > 0) {
+    const digest = createHash('sha256')
+      .update(input.providerKey)
+      .update(':')
+      .update(input.endpointId)
+      .update(':')
+      .update(timestamp.trim())
+      .update(':')
+      .update(input.body)
+      .digest('hex')
+
+    return `derived:${timestamp.trim()}:${digest}`
+  }
+
+  const digest = createHash('sha256')
+    .update(input.providerKey)
+    .update(':')
+    .update(input.endpointId)
+    .update(':')
+    .update(input.body)
+    .digest('hex')
+
+  return `derived:no-timestamp:${digest}`
 }


### PR DESCRIPTION
## Summary
Prevents replayable inbound webhook deliveries when provider message-id headers are missing.

## Root cause
Inbound webhook dedup stored receipts only when `webhook-id` / `svix-id` was present. A valid signed payload replayed without those headers bypassed dedup and was processed repeatedly within the allowed signature tolerance window.

## Changes
- always derive a stable receipt identifier for inbound webhook deliveries
- use provider header ID when available
- fall back to a deterministic hash based on endpoint/provider/timestamp/body when the header is missing
- add regression coverage for replay attempts without message-id headers

## Risk
Low. The change is scoped to inbound webhook receipt deduplication.

## Validation
- added unit coverage for fallback message-id generation
- extended webhook integration coverage for replay protection
