### PR TITLE
fix(auth): honor redirect query param on login page

### DIFF
--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-026.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-026.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test'
+import { postForm } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  readJsonSafe,
+} from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+/**
+ * TC-AUTH-026: Login redirect query parameter
+ *
+ * Verifies that /login?redirect=<path> redirects to the specified path after
+ * successful authentication, and that external URLs are sanitized to /backend.
+ */
+test.describe('TC-AUTH-026: Login redirect query parameter', () => {
+  test('should redirect to the path specified in redirect query param after login', async ({ page }) => {
+    test.slow()
+    const targetPath = '/backend/users'
+
+    await page.goto(`/login?redirect=${encodeURIComponent(targetPath)}`, { waitUntil: 'domcontentloaded' })
+
+    await page.waitForSelector('form[data-auth-ready="1"]', { state: 'visible', timeout: 5_000 })
+    await page.getByLabel('Email').fill('admin@acme.com')
+    await page.getByLabel('Password').fill('secret')
+    await page.getByLabel('Password').press('Enter')
+
+    await expect(page).toHaveURL(new RegExp(targetPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')), { timeout: 10_000 })
+  })
+
+  test('should default to /backend when no redirect param is provided', async ({ page }) => {
+    test.slow()
+
+    await page.goto('/login', { waitUntil: 'domcontentloaded' })
+
+    await page.waitForSelector('form[data-auth-ready="1"]', { state: 'visible', timeout: 5_000 })
+    await page.getByLabel('Email').fill('admin@acme.com')
+    await page.getByLabel('Password').fill('secret')
+    await page.getByLabel('Password').press('Enter')
+
+    await expect(page).toHaveURL(/\/backend/, { timeout: 10_000 })
+  })
+
+  test('API should return sanitized redirect for external URLs', async ({ request }) => {
+    const response = await postForm(request, '/api/auth/login', {
+      email: 'admin@acme.com',
+      password: 'secret',
+      redirect: 'https://evil.com/steal',
+    })
+    expect(response.ok()).toBe(true)
+    const body = await readJsonSafe<{ redirect?: string }>(response)
+    expect(body?.redirect).toBe('/backend')
+  })
+
+  test('API should honor valid redirect path', async ({ request }) => {
+    const response = await postForm(request, '/api/auth/login', {
+      email: 'admin@acme.com',
+      password: 'secret',
+      redirect: '/backend/users',
+    })
+    expect(response.ok()).toBe(true)
+    const body = await readJsonSafe<{ redirect?: string }>(response)
+    expect(body?.redirect).toBe('/backend/users')
+  })
+})

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -31,6 +31,19 @@ type ParsedLoginForm = {
   remember: boolean
   tenantIdRaw: string
   requiredRoles: string[]
+  redirectTo: string
+}
+
+function sanitizeRedirect(param: string, baseUrl: string): string {
+  if (!param) return '/backend'
+  try {
+    const base = new URL(baseUrl)
+    const resolved = new URL(param, baseUrl)
+    if (resolved.origin === base.origin && resolved.pathname.startsWith('/')) {
+      return resolved.pathname + resolved.search + resolved.hash
+    }
+  } catch {}
+  return '/backend'
 }
 
 function parseRequiredRoles(rawValue: string): string[] {
@@ -55,6 +68,7 @@ async function parseLoginForm(req: Request): Promise<ParsedLoginForm> {
         remember: parseBooleanToken(params.get('remember')) === true,
         tenantIdRaw: String(params.get('tenantId') ?? params.get('tenant') ?? '').trim(),
         requiredRoles: requireRoleRaw ? parseRequiredRoles(requireRoleRaw) : [],
+        redirectTo: String(params.get('redirect') ?? ''),
       }
     }
 
@@ -66,6 +80,7 @@ async function parseLoginForm(req: Request): Promise<ParsedLoginForm> {
       remember: parseBooleanToken(form.get('remember')?.toString()) === true,
       tenantIdRaw: String(form.get('tenantId') ?? form.get('tenant') ?? '').trim(),
       requiredRoles: requireRoleRaw ? parseRequiredRoles(requireRoleRaw) : [],
+      redirectTo: String(form.get('redirect') ?? ''),
     }
   } catch {
     return {
@@ -74,13 +89,14 @@ async function parseLoginForm(req: Request): Promise<ParsedLoginForm> {
       remember: false,
       tenantIdRaw: '',
       requiredRoles: [],
+      redirectTo: '',
     }
   }
 }
 
 export async function POST(req: Request) {
   const { translate } = await resolveTranslations()
-  const { email, password, remember, tenantIdRaw, requiredRoles } = await parseLoginForm(req)
+  const { email, password, remember, tenantIdRaw, requiredRoles, redirectTo } = await parseLoginForm(req)
   // Rate limit — two layers, both checked before validation and DB work
   const { error: rateLimitError, compoundKey: rateLimitCompoundKey } = await checkAuthRateLimit({
     req, ipConfig: loginIpRateLimitConfig, compoundConfig: loginRateLimitConfig, compoundIdentifier: email,
@@ -154,7 +170,7 @@ export async function POST(req: Request) {
   const responseData: { ok: true; token: string; redirect: string; refreshToken?: string } = {
     ok: true,
     token,
-    redirect: '/backend',
+    redirect: sanitizeRedirect(redirectTo, req.url),
   }
   if (remember) {
     const expiresAt = new Date(Date.now() + rememberMeDays * 24 * 60 * 60 * 1000)

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -205,6 +205,8 @@ export default function LoginPage() {
     try {
       const form = new FormData(e.currentTarget)
       if (requiredRoles.length) form.set('requireRole', requiredRoles.join(','))
+      const redirectParam = searchParams.get('redirect')
+      if (redirectParam) form.set('redirect', redirectParam)
       const res = await fetch('/api/auth/login', { method: 'POST', body: form })
       if (res.redirected) {
         clearAllOperations()


### PR DESCRIPTION
## Summary
- The login page ignored the `redirect` query parameter (e.g. `/login?redirect=%2Fbackend%2Fcustoms_clearance`) and always redirected to `/backend` after successful login
- The login frontend now forwards the `redirect` param in the form submission
- The login API reads and sanitizes the redirect (same-origin validation to prevent open redirects) before returning it in the response

## Test plan
- [ ] Visit `/login?redirect=%2Fbackend%2Fcustoms_clearance`, log in, verify redirect to `/backend/customs_clearance`
- [ ] Visit `/login?redirect=%2Fbackend`, log in, verify redirect to `/backend`
- [ ] Visit `/login` (no redirect param), log in, verify redirect to `/backend` (default)
- [ ] Visit `/login?redirect=https%3A%2F%2Fevil.com`, log in, verify redirect to `/backend` (sanitized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)