### PR TITLE
fix(auth): prevent repeated /api/auth/profile fetches

### DIFF
--- a/packages/core/src/modules/auth/backend/auth/profile/page.tsx
+++ b/packages/core/src/modules/auth/backend/auth/profile/page.tsx
@@ -67,7 +67,8 @@ export default function AuthProfilePage() {
     }
     load()
     return () => { cancelled = true }
-  }, [t])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- t is only used in error message, must not trigger re-fetch
+  }, [])
 
   const fields = React.useMemo<CrudField[]>(() => [
     { id: 'email', label: t('auth.profile.form.email', 'Email'), type: 'text', required: true },

--- a/packages/core/src/modules/auth/backend/profile/change-password/page.tsx
+++ b/packages/core/src/modules/auth/backend/profile/change-password/page.tsx
@@ -66,7 +66,8 @@ export default function ProfileChangePasswordPage() {
     }
     load()
     return () => { cancelled = true }
-  }, [t])
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- t is only used in error message, must not trigger re-fetch
+  }, [])
 
   const fields = React.useMemo<CrudField[]>(() => [
     { id: 'email', label: t('auth.profile.form.email', 'Email'), type: 'text', required: true },


### PR DESCRIPTION
## Summary
- Remove `t` (translation function) from `useEffect` dependency arrays in both auth profile pages
- `t` from `useT()` gets a new identity on every re-render (e.g. when `I18nProvider` remounts via `AppShell key={path}`), causing the profile data fetch to fire repeatedly
- `t` was only used inside the error handler, not for the fetch itself — safe to omit from deps

## Test plan
- [ ] Open `/backend/auth/profile` or `/backend/profile/change-password` and verify only one `GET /api/auth/profile` request fires
- [ ] Navigate away and back — confirm no duplicate fetches
- [ ] Trigger a profile load error and verify the error message still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)