### PR TITLE
fix(workflows): halt workflow on activity failure by default

### DIFF
--- a/packages/core/src/modules/workflows/components/EdgeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialog.tsx
@@ -51,7 +51,7 @@ export function EdgeEditDialog({ edge, isOpen, onClose, onSave, onDelete }: Edge
   const [transitionName, setTransitionName] = useState('')
   const [trigger, setTrigger] = useState('auto')
   const [priority, setPriority] = useState('100')
-  const [continueOnActivityFailure, setContinueOnActivityFailure] = useState(true)
+  const [continueOnActivityFailure, setContinueOnActivityFailure] = useState(false)
   const [preConditions, setPreConditions] = useState<TransitionCondition[]>([])
   const [postConditions, setPostConditions] = useState<TransitionCondition[]>([])
   const [showAdvanced, setShowAdvanced] = useState(false)
@@ -94,7 +94,7 @@ export function EdgeEditDialog({ edge, isOpen, onClose, onSave, onDelete }: Edge
 
       setTrigger(edgeData?.trigger || 'auto')
       setPriority((edgeData?.priority || 100).toString())
-      setContinueOnActivityFailure(edgeData?.continueOnActivityFailure !== undefined ? edgeData.continueOnActivityFailure : true)
+      setContinueOnActivityFailure(edgeData?.continueOnActivityFailure !== undefined ? edgeData.continueOnActivityFailure : false)
 
       // Handle pre/post conditions - convert from various formats
       const rawPreConditions = edgeData?.preConditions || []

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -211,7 +211,7 @@ export const workflowTransitionSchema = z.object({
   preConditions: z.array(transitionConditionSchema).optional(),
   postConditions: z.array(transitionConditionSchema).optional(),
   activities: z.array(activityDefinitionSchema).optional(), // Activities to execute during transition
-  continueOnActivityFailure: z.boolean().default(true).optional(), // If false, transition fails when any activity fails
+  continueOnActivityFailure: z.boolean().default(false).optional(), // If true, transition continues even when activities fail
   priority: z.number().int().min(0).max(9999).default(0),
 })
 

--- a/packages/core/src/modules/workflows/i18n/de.json
+++ b/packages/core/src/modules/workflows/i18n/de.json
@@ -197,7 +197,7 @@
   "workflows.edgeEditor.confirmDelete": "Möchten Sie diesen Übergang wirklich löschen?",
   "workflows.edgeEditor.confirmRemoveActivity": "Möchten Sie diese Aktivität wirklich entfernen?",
   "workflows.edgeEditor.continueOnActivityFailure": "Bei Aktivitätsfehler fortfahren",
-  "workflows.edgeEditor.continueOnActivityFailureHint": "Wenn deaktiviert, schlägt der Übergang fehl, wenn eine Aktivität fehlschlägt (Standard: aktiviert)",
+  "workflows.edgeEditor.continueOnActivityFailureHint": "Wenn deaktiviert, schlägt der Übergang fehl, wenn eine Aktivität fehlschlägt (Standard: deaktiviert)",
   "workflows.edgeEditor.deleteTransition": "Übergang löschen",
   "workflows.edgeEditor.description": "Übergangseigenschaften, Bedingungen und Aktivitäten konfigurieren",
   "workflows.edgeEditor.entityType": "Entitätstyp",

--- a/packages/core/src/modules/workflows/i18n/en.json
+++ b/packages/core/src/modules/workflows/i18n/en.json
@@ -197,7 +197,7 @@
   "workflows.edgeEditor.confirmDelete": "Are you sure you want to delete this transition?",
   "workflows.edgeEditor.confirmRemoveActivity": "Are you sure you want to remove this activity?",
   "workflows.edgeEditor.continueOnActivityFailure": "Continue on Activity Failure",
-  "workflows.edgeEditor.continueOnActivityFailureHint": "If unchecked, the transition will fail when any activity fails (default: checked)",
+  "workflows.edgeEditor.continueOnActivityFailureHint": "If unchecked, the transition will fail when any activity fails (default: unchecked)",
   "workflows.edgeEditor.deleteTransition": "Delete Transition",
   "workflows.edgeEditor.description": "Configure transition properties, conditions, and activities",
   "workflows.edgeEditor.entityType": "Entity Type",

--- a/packages/core/src/modules/workflows/i18n/es.json
+++ b/packages/core/src/modules/workflows/i18n/es.json
@@ -197,7 +197,7 @@
   "workflows.edgeEditor.confirmDelete": "¿Seguro que quieres eliminar esta transicion?",
   "workflows.edgeEditor.confirmRemoveActivity": "¿Seguro que quieres eliminar esta actividad?",
   "workflows.edgeEditor.continueOnActivityFailure": "Continuar si falla la actividad",
-  "workflows.edgeEditor.continueOnActivityFailureHint": "Si no esta marcado, la transicion fallara cuando alguna actividad falle (predeterminado: marcado)",
+  "workflows.edgeEditor.continueOnActivityFailureHint": "Si no esta marcado, la transicion fallara cuando alguna actividad falle (predeterminado: no marcado)",
   "workflows.edgeEditor.deleteTransition": "Eliminar transicion",
   "workflows.edgeEditor.description": "Configurar propiedades, condiciones y actividades de la transicion",
   "workflows.edgeEditor.entityType": "Tipo de entidad",

--- a/packages/core/src/modules/workflows/i18n/pl.json
+++ b/packages/core/src/modules/workflows/i18n/pl.json
@@ -197,7 +197,7 @@
   "workflows.edgeEditor.confirmDelete": "Czy na pewno chcesz usunąć to przejście?",
   "workflows.edgeEditor.confirmRemoveActivity": "Czy na pewno chcesz usunąć to działanie?",
   "workflows.edgeEditor.continueOnActivityFailure": "Kontynuuj przy Niepowodzeniu Działania",
-  "workflows.edgeEditor.continueOnActivityFailureHint": "Jeśli odznaczone, przejście zakończy się niepowodzeniem, gdy którekolwiek działanie się nie powiedzie (domyślnie: zaznaczone)",
+  "workflows.edgeEditor.continueOnActivityFailureHint": "Jeśli odznaczone, przejście zakończy się niepowodzeniem, gdy którekolwiek działanie się nie powiedzie (domyślnie: odznaczone)",
   "workflows.edgeEditor.deleteTransition": "Usuń Przejście",
   "workflows.edgeEditor.description": "Konfiguruj właściwości przejścia, warunki i działania",
   "workflows.edgeEditor.entityType": "Typ Encji",

--- a/packages/core/src/modules/workflows/lib/__tests__/transition-handler.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/transition-handler.test.ts
@@ -10,12 +10,14 @@ import {
   WorkflowEvent,
 } from '../../data/entities'
 import * as transitionHandler from '../transition-handler'
+import * as activityExecutor from '../activity-executor'
 import * as ruleEvaluator from '../../../business_rules/lib/rule-evaluator'
 import * as ruleEngine from '../../../business_rules/lib/rule-engine'
 
 // Mock dependencies
 jest.mock('../../../business_rules/lib/rule-evaluator')
 jest.mock('../../../business_rules/lib/rule-engine')
+jest.mock('../activity-executor')
 
 describe('Transition Handler (Unit Tests)', () => {
   let mockEm: jest.Mocked<EntityManager>
@@ -749,6 +751,82 @@ describe('Transition Handler (Unit Tests)', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('evaluation error')
       // Note: No event is logged when evaluation fails early
+    })
+  })
+
+  // ============================================================================
+  // Activity Failure / continueOnActivityFailure Tests
+  // ============================================================================
+
+  describe('executeTransition with activity failures', () => {
+    const definitionWithActivities = (continueOnActivityFailure?: boolean) => ({
+      ...mockDefinition,
+      definition: {
+        ...mockDefinition.definition,
+        transitions: [
+          { fromStepId: 'start', toStepId: 'step-1' },
+          {
+            fromStepId: 'step-1',
+            toStepId: 'step-2',
+            activities: [{ activityType: 'SEND_EMAIL', activityName: 'notify', config: {} }],
+            ...(continueOnActivityFailure !== undefined ? { continueOnActivityFailure } : {}),
+          },
+          { fromStepId: 'step-2', toStepId: 'end' },
+        ],
+      },
+    })
+
+    const setupMocks = (def: any) => {
+      mockEm.findOne.mockReset()
+      mockEm.findOne.mockResolvedValue(def)
+      mockEm.create.mockReturnValue({} as any)
+      ;(ruleEngine.executeRules as jest.Mock)
+        .mockResolvedValueOnce({ allowed: true, executedRules: [], totalExecutionTime: 5 })
+        .mockResolvedValueOnce({ allowed: true, executedRules: [], totalExecutionTime: 5 })
+    }
+
+    test('should fail transition when activity fails and continueOnActivityFailure is omitted (default false)', async () => {
+      const def = definitionWithActivities()
+      setupMocks(def)
+      ;(activityExecutor.executeActivities as jest.Mock).mockResolvedValue([
+        { success: false, error: 'Email failed', activityType: 'SEND_EMAIL', activityName: 'notify' },
+      ])
+
+      const result = await transitionHandler.executeTransition(
+        mockEm, mockContainer, mockInstance, 'step-1', 'step-2', { workflowContext: {} }
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Email failed')
+    })
+
+    test('should succeed transition when activity fails but continueOnActivityFailure is true', async () => {
+      const def = definitionWithActivities(true)
+      setupMocks(def)
+      ;(activityExecutor.executeActivities as jest.Mock).mockResolvedValue([
+        { success: false, error: 'Email failed', activityType: 'SEND_EMAIL', activityName: 'notify' },
+      ])
+
+      const result = await transitionHandler.executeTransition(
+        mockEm, mockContainer, mockInstance, 'step-1', 'step-2', { workflowContext: {} }
+      )
+
+      expect(result.success).toBe(true)
+    })
+
+    test('should fail transition when activity fails and continueOnActivityFailure is explicitly false', async () => {
+      const def = definitionWithActivities(false)
+      setupMocks(def)
+      ;(activityExecutor.executeActivities as jest.Mock).mockResolvedValue([
+        { success: false, error: 'Email failed', activityType: 'SEND_EMAIL', activityName: 'notify' },
+      ])
+
+      const result = await transitionHandler.executeTransition(
+        mockEm, mockContainer, mockInstance, 'step-1', 'step-2', { workflowContext: {} }
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Email failed')
     })
   })
 

--- a/packages/core/src/modules/workflows/lib/__tests__/workflow-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/workflow-executor.test.ts
@@ -588,6 +588,60 @@ describe('Workflow Executor (Unit Tests)', () => {
         workflowExecutor.executeWorkflow(mockEm, mockContainer, testInstanceId)
       ).rejects.toThrow('Workflow definition not found')
     })
+
+    test('should return FAILED status when transition fails', async () => {
+      const transitionHandler = jest.requireMock('../transition-handler') as {
+        findValidTransitions: jest.Mock
+        executeTransition: jest.Mock
+      }
+
+      const instance = {
+        id: testInstanceId,
+        definitionId: testDefinitionId,
+        workflowId: 'simple-workflow',
+        version: 1,
+        status: 'RUNNING',
+        currentStepId: 'start',
+        context: {},
+        tenantId: testTenantId,
+        organizationId: testOrgId,
+        startedAt: new Date(),
+        retryCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as WorkflowInstance
+
+      mockEm.findOne.mockImplementation(async (_entity: unknown, where: unknown) => {
+        if ((where as Record<string, unknown>)?.id === testInstanceId) {
+          return instance
+        }
+        if ((where as Record<string, unknown>)?.id === testDefinitionId) {
+          return mockDefinition as WorkflowDefinition
+        }
+        return null
+      })
+
+      transitionHandler.findValidTransitions.mockResolvedValue([
+        {
+          isValid: true,
+          transition: {
+            transitionId: 'start-to-end',
+            fromStepId: 'start',
+            toStepId: 'end',
+            trigger: 'auto',
+          },
+        },
+      ])
+      transitionHandler.executeTransition.mockResolvedValue({
+        success: false,
+        error: 'Activities failed: Email delivery error',
+      })
+
+      const result = await workflowExecutor.executeWorkflow(mockEm, mockContainer, testInstanceId)
+
+      expect(result.status).toBe('FAILED')
+      expect(result.errors).toContain('Activities failed: Email delivery error')
+    })
   })
 
   // ============================================================================

--- a/packages/core/src/modules/workflows/lib/edgeFormTransforms.ts
+++ b/packages/core/src/modules/workflows/lib/edgeFormTransforms.ts
@@ -85,7 +85,7 @@ export function edgeToFormValues(edge: Edge): EdgeFormValues {
     priority: (edgeData?.priority || 100).toString(),
     continueOnActivityFailure: edgeData?.continueOnActivityFailure !== undefined
       ? edgeData.continueOnActivityFailure
-      : true,
+      : false,
     preConditions: normalizeConditions(edgeData?.preConditions || []),
     postConditions: normalizeConditions(edgeData?.postConditions || []),
     activities: edgeData?.activities || [],

--- a/packages/core/src/modules/workflows/lib/graph-utils.ts
+++ b/packages/core/src/modules/workflows/lib/graph-utils.ts
@@ -126,7 +126,7 @@ export function graphToDefinition(
       transition.priority = edgeData.priority
     }
 
-    // Add continueOnActivityFailure if present (default true)
+    // Add continueOnActivityFailure if present (default false)
     if (edgeData?.continueOnActivityFailure !== undefined) {
       transition.continueOnActivityFailure = edgeData.continueOnActivityFailure
     }
@@ -321,7 +321,7 @@ export function definitionToGraph(
         priority: (transition as any).priority !== undefined ? (transition as any).priority : 0,
         continueOnActivityFailure: (transition as any).continueOnActivityFailure !== undefined
           ? (transition as any).continueOnActivityFailure
-          : true,
+          : false,
         preConditions: transition.preConditions || [],
         postConditions: transition.postConditions || [],
         activities: transition.activities || [],

--- a/packages/core/src/modules/workflows/lib/transition-handler.ts
+++ b/packages/core/src/modules/workflows/lib/transition-handler.ts
@@ -414,7 +414,7 @@ export async function executeTransition(
       const failedActivities = results.filter(r => !r.success)
 
       if (failedActivities.length > 0) {
-        const continueOnFailure = transition.continueOnActivityFailure ?? true
+        const continueOnFailure = transition.continueOnActivityFailure ?? false
 
         // Log activity failures
         await logTransitionEvent(em, {

--- a/packages/core/src/modules/workflows/lib/workflow-executor.ts
+++ b/packages/core/src/modules/workflows/lib/workflow-executor.ts
@@ -394,7 +394,7 @@ export async function executeWorkflow(
             errors.push(transitionResult.error || 'Transition failed')
 
             return {
-              status: 'RUNNING',
+              status: 'FAILED',
               currentStep: currentInstance.currentStepId,
               context: currentInstance.context,
               events,


### PR DESCRIPTION
## Summary

The workflow engine continued to the next step when an activity failed, because `continueOnActivityFailure` defaulted to `true` and the executor returned `status: 'RUNNING'` on transition failure. This flips the default to `false` (halt on error) and returns `status: 'FAILED'` when a transition fails. Workflows that need the old behavior must explicitly set `continueOnActivityFailure: true`.

## Changes

- Flip `continueOnActivityFailure` default from `true` to `false` in transition-handler, validator schema, and all UI defaults (EdgeEditDialog, edgeFormTransforms, graph-utils)
- Return `status: 'FAILED'` instead of `'RUNNING'` when `transitionResult.success === false` in workflow-executor
- Update i18n hint text (en, es, pl, de) to reflect new default
- Add 3 unit tests for `continueOnActivityFailure` behavior in transition-handler
- Add 1 unit test for executor FAILED status on transition failure

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- `npx jest --testPathPatterns='workflows' --no-coverage` — 323 tests pass (319 existing + 4 new)
- `npx tsc --noEmit --project packages/core/tsconfig.json` — no errors

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements