### PR TITLE
fix(workflows): use filterIds for org scoping in all GET handlers

### DIFF
--- a/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
@@ -51,12 +51,18 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
     const definition = await em.findOne(WorkflowDefinition, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
       deletedAt: null,
     })
 

--- a/packages/core/src/modules/workflows/api/definitions/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/route.ts
@@ -64,7 +64,13 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
     const { searchParams } = new URL(request.url)
     const enabled = searchParams.get('enabled')
@@ -76,7 +82,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
       deletedAt: null,
     }
 

--- a/packages/core/src/modules/workflows/api/events/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/events/[id]/route.ts
@@ -46,11 +46,17 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -60,7 +66,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const hasPermission = await rbacService.userHasAllFeatures(
       auth.sub,
       ['workflows.instances.view'],
-      { tenantId, organizationId }
+      { tenantId, organizationId: scope?.selectedId ?? auth.orgId }
     )
 
     if (!hasPermission) {
@@ -70,31 +76,16 @@ export async function GET(request: NextRequest, context: RouteContext) {
       )
     }
 
-    // Find the event - first try without org filter to debug
-    const eventAny = await em.findOne(WorkflowEvent, {
-      id: params.id,
-    })
-
     // Find the event with proper filters
     const event = await em.findOne(WorkflowEvent, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!event) {
       return NextResponse.json(
-        {
-          error: 'Workflow event not found',
-          debug: process.env.NODE_ENV === 'development' ? {
-            requestedId: params.id,
-            requestedTenantId: tenantId,
-            requestedOrganizationId: organizationId,
-            eventExists: !!eventAny,
-            eventTenantId: eventAny?.tenantId,
-            eventOrganizationId: eventAny?.organizationId,
-          } : undefined
-        },
+        { error: 'Workflow event not found' },
         { status: 404 }
       )
     }
@@ -103,7 +94,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
     const instance = await em.findOne(WorkflowInstance, {
       id: event.workflowInstanceId,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     // Build response

--- a/packages/core/src/modules/workflows/api/events/route.ts
+++ b/packages/core/src/modules/workflows/api/events/route.ts
@@ -36,11 +36,17 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -50,7 +56,7 @@ export async function GET(request: NextRequest) {
     const hasPermission = await rbacService.userHasAllFeatures(
       auth.sub,
       ['workflows.instances.view'],
-      { tenantId, organizationId }
+      { tenantId, organizationId: scope?.selectedId ?? auth.orgId }
     )
 
     if (!hasPermission) {
@@ -81,7 +87,7 @@ export async function GET(request: NextRequest) {
     // Build where clause
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (eventType) {
@@ -122,7 +128,7 @@ export async function GET(request: NextRequest) {
     const instances = await em.find(WorkflowInstance, {
       id: { $in: instanceIds },
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     const instanceMap = new Map(instances.map(i => [i.id, i]))

--- a/packages/core/src/modules/workflows/api/instances/[id]/events/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/events/route.ts
@@ -45,11 +45,17 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -58,7 +64,7 @@ export async function GET(
     const instance = await em.findOne(WorkflowInstance, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!instance) {
@@ -77,7 +83,7 @@ export async function GET(
     const where: any = {
       workflowInstanceId: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (eventType) {

--- a/packages/core/src/modules/workflows/api/instances/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/[id]/route.ts
@@ -48,11 +48,17 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -60,7 +66,7 @@ export async function GET(
     const instance = await em.findOne(WorkflowInstance, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!instance) {

--- a/packages/core/src/modules/workflows/api/instances/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/route.ts
@@ -46,11 +46,17 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -67,7 +73,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (workflowId) {

--- a/packages/core/src/modules/workflows/api/tasks/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/[id]/route.ts
@@ -43,11 +43,17 @@ export async function GET(
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -55,7 +61,7 @@ export async function GET(
     const task = await em.findOne(UserTask, {
       id: params.id,
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     })
 
     if (!task) {

--- a/packages/core/src/modules/workflows/api/tasks/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/route.ts
@@ -49,11 +49,17 @@ export async function GET(request: NextRequest) {
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
     const tenantId = auth.tenantId
-    const organizationId = scope?.selectedId ?? auth.orgId
+    const organizationIds = (() => {
+      if (scope?.selectedId) return [scope.selectedId]
+      if (Array.isArray(scope?.filterIds) && scope.filterIds.length > 0) return scope.filterIds
+      if (scope?.filterIds === null) return undefined
+      if (auth.orgId) return [auth.orgId]
+      return undefined
+    })()
 
-    if (!tenantId || !organizationId) {
+    if (!tenantId) {
       return NextResponse.json(
-        { error: 'Missing tenant or organization context' },
+        { error: 'Missing tenant context' },
         { status: 400 }
       )
     }
@@ -70,7 +76,7 @@ export async function GET(request: NextRequest) {
     // Build where clause with tenant scoping
     const where: any = {
       tenantId,
-      organizationId,
+      ...(organizationIds ? { organizationId: { $in: organizationIds } } : {}),
     }
 
     if (status) {


### PR DESCRIPTION
## Summary

When "All Organisations" is selected in the navbar org selector, all workflow GET endpoints (definitions, instances, events, tasks) return empty results. The root cause is that `scope.selectedId` is `null` in the "all orgs" case, and the code falls back to `auth.orgId` (a single org), filtering out everything else. This PR switches all workflow GET handlers to use `scope.filterIds` (which is already ACL-scoped) for database queries, matching the pattern used by other modules like dashboards and query_index.

## Changes

- Replace `scope?.selectedId ?? auth.orgId` with a `filterIds`-aware resolution in all 9 workflow GET handler files (definitions, instances, events, tasks — both list and detail endpoints)
- Use `$in` operator for `organizationId` filter to support multiple org IDs
- Update guard clauses from `!tenantId || !organizationId` to `!tenantId` (org can be legitimately absent in "all orgs" mode)
- Remove leftover debug query in `events/[id]/route.ts`
- Write endpoints (POST/PUT/DELETE) are unchanged — they correctly need a concrete single org

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- Verified type-checking passes (`tsc --noEmit`)
- Manual: select "All Organisations" → visit `/backend/definitions` → definitions from all orgs should now appear
- Manual: select a specific org → only that org's definitions should appear

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors — N/A (backend API only)
- [x] No arbitrary text sizes — N/A
- [x] Empty state handled — N/A
- [x] Loading state handled — N/A
- [x] `aria-label` on all icon-only buttons — N/A
- [x] Uses existing DS components — N/A