### PR TITLE
fix: pg lock hopping connections

### DIFF
--- a/packages/create-app/template/scripts/dev-splash.html
+++ b/packages/create-app/template/scripts/dev-splash.html
@@ -355,34 +355,14 @@
         padding: 16px 18px;
         border-radius: 18px;
         border: 1px solid var(--panel-border);
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
-        box-shadow: 0 28px 80px rgba(0, 0, 0, 0.38);
-        width: min(760px, calc(100vw - 40px));
-        max-height: min(82vh, 720px);
-        overflow: auto;
+        background: var(--surface);
       }
-      .git-repo-overlay {
-        position: fixed;
-        inset: 0;
-        z-index: 40;
-        display: grid;
-        place-items: center;
-        padding: 20px;
-        background: rgba(9, 9, 11, 0.72);
-        backdrop-filter: blur(16px);
-      }
-      .git-repo-overlay[hidden] {
+      .git-repo-shell[hidden] {
         display: none;
       }
       .git-repo-header {
         display: grid;
         gap: 6px;
-      }
-      .git-repo-frame {
-        display: flex;
-        align-items: flex-start;
-        justify-content: space-between;
-        gap: 16px;
       }
       .git-repo-heading {
         font-size: 12px;
@@ -390,20 +370,6 @@
         letter-spacing: 0.11em;
         text-transform: uppercase;
         color: var(--muted);
-      }
-      .git-repo-close {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 42px;
-        min-width: 42px;
-        height: 42px;
-        border-radius: 999px;
-        border: 1px solid var(--panel-border);
-        background: rgba(255, 255, 255, 0.06);
-        color: var(--text);
-        font: inherit;
-        cursor: pointer;
       }
       .git-repo-message {
         color: var(--text);
@@ -548,13 +514,6 @@
         opacity: 0.55;
         pointer-events: none;
       }
-      .button:disabled {
-        opacity: 0.7;
-        cursor: not-allowed;
-      }
-      .git-repo-launcher {
-        min-width: min(280px, 100%);
-      }
       .terminal-hint {
         display: inline-flex;
         align-items: center;
@@ -685,9 +644,6 @@
         .actions {
           align-items: stretch;
         }
-        .git-repo-launcher {
-          width: 100%;
-        }
         .coding-shell,
         .coding-menu,
         .coding-summary {
@@ -702,12 +658,6 @@
           max-width: none;
           width: 100%;
           margin-top: 10px;
-        }
-        .git-repo-frame {
-          flex-direction: column;
-        }
-        .git-repo-close {
-          align-self: flex-end;
         }
       }
     </style>
@@ -760,9 +710,36 @@
             </details>
             <div class="coding-status" id="coding-status" hidden></div>
           </div>
-          <button class="button secondary git-repo-launcher" id="git-repo-launcher" type="button" hidden>🐙 GitHub repository</button>
           <div class="terminal-hint" id="terminal-hint">🖥 Keep terminal visible</div>
         </div>
+        <section class="git-repo-shell" id="git-repo-shell" hidden>
+          <div class="git-repo-header">
+            <div class="git-repo-heading" id="git-repo-heading">GitHub repository</div>
+            <div class="git-repo-message" id="git-repo-message"></div>
+          </div>
+          <div class="git-repo-grid" id="git-repo-grid" hidden>
+            <label class="git-repo-field" id="git-repo-owner-field" hidden>
+              <span class="git-repo-label" id="git-repo-owner-label">Owner</span>
+              <select class="git-repo-select" id="git-repo-owner"></select>
+            </label>
+            <label class="git-repo-field">
+              <span class="git-repo-label" id="git-repo-name-label">Repository</span>
+              <input class="git-repo-input" id="git-repo-name" type="text" autocomplete="off" />
+            </label>
+            <label class="git-repo-field">
+              <span class="git-repo-label" id="git-repo-visibility-label">Visibility</span>
+              <select class="git-repo-select" id="git-repo-visibility">
+                <option value="private">Private</option>
+                <option value="public">Public</option>
+              </select>
+            </label>
+          </div>
+          <div class="git-repo-actions">
+            <button class="button secondary" id="git-repo-action" type="button" hidden></button>
+            <a class="button secondary" id="git-repo-link" href="#" hidden target="_blank" rel="noreferrer">Open GitHub repository</a>
+          </div>
+          <div class="git-repo-secondary" id="git-repo-secondary" hidden></div>
+        </section>
         <section class="failure-box" id="failure-box" hidden>
           <div class="failure-heading" id="failure-heading">Recent failure output</div>
           <div class="failure-command" id="failure-command"></div>
@@ -770,39 +747,6 @@
         </section>
       </aside>
     </main>
-    <div class="git-repo-overlay" id="git-repo-overlay" hidden>
-      <section class="git-repo-shell" id="git-repo-shell" role="dialog" aria-modal="true" aria-labelledby="git-repo-heading">
-        <div class="git-repo-frame">
-          <div class="git-repo-header">
-            <div class="git-repo-heading" id="git-repo-heading">GitHub repository</div>
-            <div class="git-repo-message" id="git-repo-message"></div>
-          </div>
-          <button class="git-repo-close" id="git-repo-close" type="button" aria-label="Close GitHub repository">✕</button>
-        </div>
-        <div class="git-repo-grid" id="git-repo-grid" hidden>
-          <label class="git-repo-field" id="git-repo-owner-field" hidden>
-            <span class="git-repo-label" id="git-repo-owner-label">Owner</span>
-            <select class="git-repo-select" id="git-repo-owner"></select>
-          </label>
-          <label class="git-repo-field">
-            <span class="git-repo-label" id="git-repo-name-label">Repository</span>
-            <input class="git-repo-input" id="git-repo-name" type="text" autocomplete="off" />
-          </label>
-          <label class="git-repo-field">
-            <span class="git-repo-label" id="git-repo-visibility-label">Visibility</span>
-            <select class="git-repo-select" id="git-repo-visibility">
-              <option value="private">Private</option>
-              <option value="public">Public</option>
-            </select>
-          </label>
-        </div>
-        <div class="git-repo-actions">
-          <button class="button primary" id="git-repo-action" type="button" hidden></button>
-          <a class="button secondary" id="git-repo-link" href="#" hidden target="_blank" rel="noreferrer">Open GitHub repository</a>
-        </div>
-        <div class="git-repo-secondary" id="git-repo-secondary" hidden></div>
-      </section>
-    </div>
     <script>
       const splashBootstrap = __SPLASH_BOOTSTRAP__
       const modeLine = document.getElementById('mode-line')
@@ -823,9 +767,7 @@
       const codingSummary = document.getElementById('coding-summary')
       const codingMenuPanel = document.getElementById('coding-menu-panel')
       const codingStatus = document.getElementById('coding-status')
-      const gitRepoLauncher = document.getElementById('git-repo-launcher')
-      const gitRepoOverlay = document.getElementById('git-repo-overlay')
-      const gitRepoClose = document.getElementById('git-repo-close')
+      const gitRepoShell = document.getElementById('git-repo-shell')
       const gitRepoHeading = document.getElementById('git-repo-heading')
       const gitRepoMessage = document.getElementById('git-repo-message')
       const gitRepoGrid = document.getElementById('git-repo-grid')
@@ -858,7 +800,6 @@
       const activitySeenAt = new Map()
       let codingActionInFlight = false
       let gitRepoActionInFlight = false
-      let gitRepoModalOpen = false
       let codingMenuLayoutRaf = 0
       const translations = {
         en: {
@@ -884,19 +825,18 @@
           modeSetup: 'Project setup flow',
           codingButtonLabel: '🤖 Start coding with AI',
           codingNoTools: 'No supported coding tools were detected on this machine.',
-          gitRepoLauncher: '🐙 GitHub repository',
           gitRepoHeading: 'GitHub repository',
           gitRepoOwner: 'Owner',
           gitRepoName: 'Repository',
           gitRepoVisibility: 'Visibility',
           gitRepoVisibilityPrivate: 'Private',
           gitRepoVisibilityPublic: 'Public',
-          gitRepoCreate: '✨ Create new GitHub repository',
-          gitRepoPublish: '🚀 Publish to GitHub',
-          gitRepoBusyAuth: '🔐 Authenticating with GitHub…',
-          gitRepoBusyLocal: '🧱 Preparing local repository…',
-          gitRepoBusyRemote: '☁️ Publishing to GitHub…',
-          gitRepoOpen: '🔗 Open GitHub repository',
+          gitRepoCreate: 'Create new GitHub repository',
+          gitRepoPublish: 'Publish to GitHub',
+          gitRepoBusyAuth: 'Authenticating with GitHub…',
+          gitRepoBusyLocal: 'Preparing local repository…',
+          gitRepoBusyRemote: 'Publishing to GitHub…',
+          gitRepoOpen: 'Open GitHub repository',
           gitRepoRestartHint: 'Install GitHub CLI, then restart `yarn dev`.',
         },
         pl: {
@@ -922,19 +862,18 @@
           modeSetup: 'Tryb konfiguracji projektu',
           codingButtonLabel: '🤖 Zacznij kodowac z AI',
           codingNoTools: 'Na tej maszynie nie wykryto obslugiwanych narzedzi do kodowania.',
-          gitRepoLauncher: '🐙 Repozytorium GitHub',
           gitRepoHeading: 'Repozytorium GitHub',
           gitRepoOwner: 'Wlasciciel',
           gitRepoName: 'Repozytorium',
           gitRepoVisibility: 'Widocznosc',
           gitRepoVisibilityPrivate: 'Prywatne',
           gitRepoVisibilityPublic: 'Publiczne',
-          gitRepoCreate: '✨ Utworz nowe repozytorium GitHub',
-          gitRepoPublish: '🚀 Opublikuj na GitHub',
-          gitRepoBusyAuth: '🔐 Trwa uwierzytelnianie w GitHub…',
-          gitRepoBusyLocal: '🧱 Przygotowywanie lokalnego repozytorium…',
-          gitRepoBusyRemote: '☁️ Publikowanie na GitHub…',
-          gitRepoOpen: '🔗 Otworz repozytorium GitHub',
+          gitRepoCreate: 'Utworz nowe repozytorium GitHub',
+          gitRepoPublish: 'Opublikuj na GitHub',
+          gitRepoBusyAuth: 'Trwa uwierzytelnianie w GitHub…',
+          gitRepoBusyLocal: 'Przygotowywanie lokalnego repozytorium…',
+          gitRepoBusyRemote: 'Publikowanie na GitHub…',
+          gitRepoOpen: 'Otworz repozytorium GitHub',
           gitRepoRestartHint: 'Zainstaluj GitHub CLI, a potem uruchom ponownie `yarn dev`.',
         },
         es: {
@@ -960,19 +899,18 @@
           modeSetup: 'Flujo de configuración del proyecto',
           codingButtonLabel: '🤖 Empezar a programar con IA',
           codingNoTools: 'No se detectaron herramientas de programacion compatibles en esta maquina.',
-          gitRepoLauncher: '🐙 Repositorio de GitHub',
           gitRepoHeading: 'Repositorio de GitHub',
           gitRepoOwner: 'Propietario',
           gitRepoName: 'Repositorio',
           gitRepoVisibility: 'Visibilidad',
           gitRepoVisibilityPrivate: 'Privado',
           gitRepoVisibilityPublic: 'Publico',
-          gitRepoCreate: '✨ Crear nuevo repositorio de GitHub',
-          gitRepoPublish: '🚀 Publicar en GitHub',
-          gitRepoBusyAuth: '🔐 Autenticando con GitHub…',
-          gitRepoBusyLocal: '🧱 Preparando el repositorio local…',
-          gitRepoBusyRemote: '☁️ Publicando en GitHub…',
-          gitRepoOpen: '🔗 Abrir repositorio de GitHub',
+          gitRepoCreate: 'Crear nuevo repositorio de GitHub',
+          gitRepoPublish: 'Publicar en GitHub',
+          gitRepoBusyAuth: 'Autenticando con GitHub…',
+          gitRepoBusyLocal: 'Preparando el repositorio local…',
+          gitRepoBusyRemote: 'Publicando en GitHub…',
+          gitRepoOpen: 'Abrir repositorio de GitHub',
           gitRepoRestartHint: 'Instala GitHub CLI y luego reinicia `yarn dev`.',
         },
         de: {
@@ -998,19 +936,18 @@
           modeSetup: 'Projekt-Setup-Ablauf',
           codingButtonLabel: '🤖 Mit KI programmieren',
           codingNoTools: 'Auf diesem Rechner wurden keine unterstuetzten Coding-Tools erkannt.',
-          gitRepoLauncher: '🐙 GitHub-Repository',
           gitRepoHeading: 'GitHub-Repository',
           gitRepoOwner: 'Besitzer',
           gitRepoName: 'Repository',
           gitRepoVisibility: 'Sichtbarkeit',
           gitRepoVisibilityPrivate: 'Privat',
           gitRepoVisibilityPublic: 'Oeffentlich',
-          gitRepoCreate: '✨ Neues GitHub-Repository erstellen',
-          gitRepoPublish: '🚀 Auf GitHub veroeffentlichen',
-          gitRepoBusyAuth: '🔐 GitHub-Anmeldung wird gestartet…',
-          gitRepoBusyLocal: '🧱 Lokales Repository wird vorbereitet…',
-          gitRepoBusyRemote: '☁️ Auf GitHub wird veroeffentlicht…',
-          gitRepoOpen: '🔗 GitHub-Repository oeffnen',
+          gitRepoCreate: 'Neues GitHub-Repository erstellen',
+          gitRepoPublish: 'Auf GitHub veroeffentlichen',
+          gitRepoBusyAuth: 'GitHub-Anmeldung wird gestartet…',
+          gitRepoBusyLocal: 'Lokales Repository wird vorbereitet…',
+          gitRepoBusyRemote: 'Auf GitHub wird veroeffentlicht…',
+          gitRepoOpen: 'GitHub-Repository oeffnen',
           gitRepoRestartHint: 'Installiere GitHub CLI und starte dann `yarn dev` neu.',
         },
       }
@@ -1030,8 +967,6 @@
           'Preparing dev environment…': 'Przygotowywanie środowiska developerskiego…',
           'Waiting for app package manifest…': 'Oczekiwanie na manifest pakietów aplikacji…',
           'Waiting for queue worker startup…': 'Oczekiwanie na start workerów kolejki…',
-          'This GitHub repository already exists. Open it below.': 'To repozytorium GitHub juz istnieje. Otworz je ponizej.',
-          'This project is already connected to GitHub.': 'Ten projekt jest juz polaczony z GitHub.',
           'pending': 'oczekiwanie',
           'scheduler · polling engine': 'scheduler · silnik odpytywania',
         },
@@ -1050,8 +985,6 @@
           'Preparing dev environment…': 'Preparando el entorno de desarrollo…',
           'Waiting for app package manifest…': 'Esperando el manifiesto de paquetes de la aplicación…',
           'Waiting for queue worker startup…': 'Esperando el arranque de los workers de cola…',
-          'This GitHub repository already exists. Open it below.': 'Este repositorio de GitHub ya existe. Abrelo abajo.',
-          'This project is already connected to GitHub.': 'Este proyecto ya esta conectado a GitHub.',
           'pending': 'pendiente',
           'scheduler · polling engine': 'scheduler · motor de sondeo',
         },
@@ -1070,8 +1003,6 @@
           'Preparing dev environment…': 'Entwicklungsumgebung wird vorbereitet…',
           'Waiting for app package manifest…': 'Warte auf das Paketmanifest der App…',
           'Waiting for queue worker startup…': 'Warte auf den Start der Queue-Worker…',
-          'This GitHub repository already exists. Open it below.': 'Dieses GitHub-Repository existiert bereits. Oeffne es unten.',
-          'This project is already connected to GitHub.': 'Dieses Projekt ist bereits mit GitHub verbunden.',
           'pending': 'ausstehend',
           'scheduler · polling engine': 'scheduler · Polling-Engine',
         },
@@ -1097,27 +1028,6 @@
       document.addEventListener('click', (event) => {
         if (!codingMenu.contains(event.target)) {
           codingMenu.open = false
-        }
-      })
-      gitRepoLauncher.addEventListener('click', () => {
-        if (gitRepoLauncher.disabled || gitRepoLauncher.getAttribute('aria-disabled') === 'true') {
-          return
-        }
-        setGitRepoModalOpen(true)
-      })
-      gitRepoClose.addEventListener('click', () => {
-        if (!gitRepoActionInFlight) {
-          setGitRepoModalOpen(false)
-        }
-      })
-      gitRepoOverlay.addEventListener('click', (event) => {
-        if (event.target === gitRepoOverlay && !gitRepoActionInFlight) {
-          setGitRepoModalOpen(false)
-        }
-      })
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && gitRepoModalOpen && !gitRepoActionInFlight) {
-          setGitRepoModalOpen(false)
         }
       })
       codingMenu.addEventListener('toggle', () => {
@@ -1217,15 +1127,8 @@
         terminalHint.textContent = t('terminalHint')
         localeToggle.textContent = '🌐 ' + getLocaleLabel(currentLocale)
         themeToggle.textContent = currentTheme === 'dark' ? t('themeDark') : t('themeLight')
-        gitRepoLauncher.textContent = t('gitRepoLauncher')
         renderCodingFlow(lastState)
         renderGitRepoFlow(lastState)
-      }
-
-      function setGitRepoModalOpen(open) {
-        gitRepoModalOpen = open === true
-        gitRepoOverlay.hidden = !gitRepoModalOpen
-        document.body.style.overflow = gitRepoModalOpen ? 'hidden' : ''
       }
 
       function formatActivityTimestamp(value) {
@@ -1448,7 +1351,6 @@
         if (gitRepoFlow?.ghStatus !== 'available') return
 
         gitRepoActionInFlight = true
-        setGitRepoModalOpen(true)
         renderGitRepoFlow(lastState)
 
         try {
@@ -1513,20 +1415,8 @@
         const ready = state?.ready === true
         const enabled = gitRepoFlow?.enabled === true && splashBootstrap?.gitRepoFlow?.enabled === true
 
-        gitRepoLauncher.hidden = !enabled
-        gitRepoLauncher.disabled = !ready
-        gitRepoLauncher.setAttribute('aria-disabled', ready ? 'false' : 'true')
-        if (gitRepoLauncher.hidden) {
-          setGitRepoModalOpen(false)
-          gitRepoGrid.hidden = true
-          gitRepoAction.hidden = true
-          gitRepoLink.hidden = true
-          gitRepoSecondary.hidden = true
-          return
-        }
-
-        if (!ready) {
-          setGitRepoModalOpen(false)
+        gitRepoShell.hidden = !enabled || !ready
+        if (gitRepoShell.hidden) {
           gitRepoGrid.hidden = true
           gitRepoAction.hidden = true
           gitRepoLink.hidden = true
@@ -1557,12 +1447,11 @@
           || gitRepoFlow?.remoteRepoExists === true
           || gitRepoFlow?.actionState === 'done'
         )
-        const repositoryResolved = canOpenRepository
-          || gitRepoFlow?.remoteRepoExists === true
-          || gitRepoFlow?.repoState === 'github_remote'
         const showForm = gitRepoFlow?.ghStatus === 'available'
-          && !repositoryResolved
+          && gitRepoFlow?.repoState !== 'github_remote'
           && gitRepoFlow?.repoState !== 'other_remote'
+          && gitRepoFlow?.remoteRepoExists !== true
+          && !canOpenRepository
 
         gitRepoGrid.hidden = !showForm
         gitRepoOwnerField.hidden = !showOwnerField
@@ -1588,8 +1477,7 @@
           || gitRepoFlow?.actionState === 'authenticating'
           || gitRepoFlow?.actionState === 'creating_local_repo'
           || gitRepoFlow?.actionState === 'creating_remote_repo'
-        const canStart = !repositoryResolved
-          && showForm
+        const canStart = showForm
           && gitRepoFlow?.ghStatus === 'available'
           && (gitRepoFlow?.repoState === 'missing' || gitRepoFlow?.repoState === 'local_only')
 
@@ -1604,13 +1492,11 @@
         gitRepoVisibility.disabled = busy || !showForm
         gitRepoOwner.disabled = busy || !showOwnerField
 
-        gitRepoLink.hidden = !canOpenRepository
+        gitRepoLink.hidden = false
         gitRepoLink.textContent = t('gitRepoOpen')
         gitRepoLink.href = canOpenRepository ? gitRepoFlow.repoUrl : '#'
         gitRepoLink.setAttribute('aria-disabled', canOpenRepository ? 'false' : 'true')
         gitRepoLink.tabIndex = canOpenRepository ? 0 : -1
-        gitRepoClose.disabled = busy
-        gitRepoOverlay.hidden = !gitRepoModalOpen
       }
 
       function escapeHtml(value) {

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -75,5 +75,17 @@ describe('LocalLockStrategy', () => {
       expect(result).toEqual({ acquired: false })
       expect(fn).not.toHaveBeenCalled()
     })
+
+    it('should rethrow callback errors after acquiring lock', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      const fnError = new Error('Callback failed')
+      const fn = jest.fn(async () => {
+        throw fnError
+      })
+
+      await expect(strategy.runWithLock('test-key', fn)).rejects.toThrow(fnError)
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -5,6 +5,8 @@ describe('LocalLockStrategy', () => {
   let strategy: LocalLockStrategy
   let mockEm: any
   let mockConnection: any
+  let mockForkedEm: any
+  let transactionalImpl: any
   let emFactory: () => any
 
   beforeEach(() => {
@@ -12,8 +14,16 @@ describe('LocalLockStrategy', () => {
       execute: jest.fn() as any,
     }
 
-    mockEm = {
+    transactionalImpl = jest.fn(async (fn: any) => fn(mockForkedEm))
+
+    mockForkedEm = {
       getConnection: jest.fn(() => mockConnection) as any,
+    }
+
+    mockEm = {
+      fork: jest.fn(() => ({
+        transactional: transactionalImpl,
+      })) as any,
     }
 
     emFactory = jest.fn(() => mockEm) as any
@@ -21,327 +31,49 @@ describe('LocalLockStrategy', () => {
     strategy = new LocalLockStrategy(emFactory)
   })
 
-  describe('tryLock', () => {
-    it('should acquire lock successfully', async () => {
+  describe('runWithLock', () => {
+    it('should acquire lock and execute fn', async () => {
       ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
 
-      const result = await strategy.tryLock('test-key')
+      const fn = jest.fn(async () => 'ok')
+      const result = await strategy.runWithLock('test-key', fn)
 
-      expect(result).toBe(true)
+      expect(result).toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
       expect(mockConnection.execute).toHaveBeenCalledWith(
-        'SELECT pg_try_advisory_lock(?) as acquired',
-        expect.any(Array)
+        'SELECT pg_try_advisory_xact_lock(?) as acquired',
+        expect.any(Array),
       )
     })
 
-    it('should fail to acquire lock if already locked', async () => {
+    it('should skip fn if lock not acquired', async () => {
       ;(mockConnection.execute as any).mockResolvedValue([{ acquired: false }])
 
-      const result = await strategy.tryLock('test-key')
+      const fn = jest.fn(async () => 'ok')
+      const result = await strategy.runWithLock('test-key', fn)
 
-      expect(result).toBe(false)
-    })
-
-    it('should use different hashes for different keys', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      await strategy.tryLock('key1')
-      const call1 = (mockConnection.execute as any).mock.calls[0]
-
-      await strategy.tryLock('key2')
-      const call2 = (mockConnection.execute as any).mock.calls[1]
-
-      // The hash values (second parameter) should be different
-      expect(call1[1][0]).not.toBe(call2[1][0])
-    })
-
-    it('should use same hash for same key', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      await strategy.tryLock('same-key')
-      const call1 = (mockConnection.execute as any).mock.calls[0]
-
-      await strategy.tryLock('same-key')
-      const call2 = (mockConnection.execute as any).mock.calls[1]
-
-      // The hash values should be identical
-      expect(call1[1][0]).toBe(call2[1][0])
-    })
-
-    it('should handle database errors gracefully', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('Database connection failed'))
-
-      const result = await strategy.tryLock('test-key')
-
-      expect(result).toBe(false)
+      expect(result).toEqual({ acquired: false })
+      expect(fn).not.toHaveBeenCalled()
     })
 
     it('should handle empty result array', async () => {
       ;(mockConnection.execute as any).mockResolvedValue([])
 
-      const result = await strategy.tryLock('test-key')
+      const fn = jest.fn(async () => 'ok')
+      const result = await strategy.runWithLock('test-key', fn)
 
-      expect(result).toBe(false)
-    })
-
-    it('should handle null acquired value', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: null }])
-
-      const result = await strategy.tryLock('test-key')
-
-      expect(result).toBe(false)
-    })
-
-    it('should handle undefined acquired value', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: undefined }])
-
-      const result = await strategy.tryLock('test-key')
-
-      expect(result).toBe(false)
-    })
-
-    it('should convert hash to positive integer', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      await strategy.tryLock('test-key')
-
-      const call = (mockConnection.execute as any).mock.calls[0]
-      const hash = call[1][0]
-
-      // Hash should be a positive number
-      expect(typeof hash).toBe('number')
-      expect(hash).toBeGreaterThanOrEqual(0)
-    })
-  })
-
-  describe('unlock', () => {
-    it('should release lock successfully', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue(undefined)
-
-      await strategy.unlock('test-key')
-
-      expect(mockConnection.execute).toHaveBeenCalledWith(
-        'SELECT pg_advisory_unlock(?)',
-        expect.any(Array)
-      )
-    })
-
-    it('should use same hash as tryLock for same key', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      await strategy.tryLock('test-key')
-      const lockCall = (mockConnection.execute as any).mock.calls[0]
-      const lockHash = lockCall[1][0]
-
-      await strategy.unlock('test-key')
-      const unlockCall = (mockConnection.execute as any).mock.calls[1]
-      const unlockHash = unlockCall[1][0]
-
-      expect(lockHash).toBe(unlockHash)
+      expect(result).toEqual({ acquired: false })
+      expect(fn).not.toHaveBeenCalled()
     })
 
     it('should handle database errors gracefully', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('Database error'))
+      ;(mockConnection.execute as any).mockRejectedValue(new Error('Database connection failed'))
 
-      // Should not throw
-      await expect(strategy.unlock('test-key')).resolves.not.toThrow()
-    })
+      const fn = jest.fn(async () => 'ok')
+      const result = await strategy.runWithLock('test-key', fn)
 
-    it('should handle network timeout', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('Connection timeout'))
-
-      await expect(strategy.unlock('test-key')).resolves.not.toThrow()
-    })
-
-    it('should work even if lock was never acquired', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue(undefined)
-
-      // Unlocking a never-acquired lock should not error
-      await expect(strategy.unlock('never-locked-key')).resolves.not.toThrow()
-    })
-  })
-
-  describe('hash function', () => {
-    it('should produce consistent hashes for same input', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      await strategy.tryLock('consistent-key')
-      const call1 = (mockConnection.execute as any).mock.calls[0]
-
-      await strategy.tryLock('consistent-key')
-      const call2 = (mockConnection.execute as any).mock.calls[1]
-
-      expect(call1[1][0]).toBe(call2[1][0])
-    })
-
-    it('should produce different hashes for different inputs', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      const keys = ['key1', 'key2', 'key3', 'a', 'aa', 'aaa']
-      const hashes = new Set<number>()
-
-      for (const key of keys) {
-        await strategy.tryLock(key)
-        const call = (mockConnection.execute as any).mock.calls[(mockConnection.execute as any).mock.calls.length - 1]
-        hashes.add(call[1][0])
-      }
-
-      // All hashes should be unique
-      expect(hashes.size).toBe(keys.length)
-    })
-
-    it('should handle empty string', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      await strategy.tryLock('')
-      const call = (mockConnection.execute as any).mock.calls[0]
-
-      expect(call[1][0]).toBe(0) // Empty string should hash to 0
-    })
-
-    it('should handle long strings', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      const longKey = 'a'.repeat(1000)
-      await strategy.tryLock(longKey)
-
-      const call = (mockConnection.execute as any).mock.calls[0]
-      const hash = call[1][0]
-
-      expect(typeof hash).toBe('number')
-      expect(hash).toBeGreaterThanOrEqual(0)
-    })
-
-    it('should handle special characters', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      const specialKeys = [
-        'key-with-dashes',
-        'key_with_underscores',
-        'key.with.dots',
-        'key:with:colons',
-        'key/with/slashes',
-        'key@with@ats',
-        'key#with#hashes',
-        'key$with$dollars',
-      ]
-
-      const hashes = new Set<number>()
-
-      for (const key of specialKeys) {
-        await strategy.tryLock(key)
-        const call = (mockConnection.execute as any).mock.calls[(mockConnection.execute as any).mock.calls.length - 1]
-        hashes.add(call[1][0])
-      }
-
-      // All should produce valid hashes
-      expect(hashes.size).toBe(specialKeys.length)
-    })
-
-    it('should handle unicode characters', async () => {
-      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
-
-      const unicodeKeys = ['café', '日本語', '🎉', 'Ñoño']
-
-      for (const key of unicodeKeys) {
-        await strategy.tryLock(key)
-        const call = (mockConnection.execute as any).mock.calls[(mockConnection.execute as any).mock.calls.length - 1]
-        const hash = call[1][0]
-
-        expect(typeof hash).toBe('number')
-        expect(hash).toBeGreaterThanOrEqual(0)
-      }
-    })
-  })
-
-  describe('integration scenarios', () => {
-    it('should support lock-execute-unlock pattern', async () => {
-      ;(mockConnection.execute as any)
-        .mockResolvedValueOnce([{ acquired: true }])  // tryLock succeeds
-        .mockResolvedValueOnce(undefined)              // unlock succeeds
-
-      const locked = await strategy.tryLock('resource-id')
-      expect(locked).toBe(true)
-
-      // ... do work ...
-
-      await strategy.unlock('resource-id')
-      
-      expect(mockConnection.execute).toHaveBeenCalledTimes(2)
-    })
-
-    it('should handle concurrent lock attempts', async () => {
-      ;(mockConnection.execute as any)
-        .mockResolvedValueOnce([{ acquired: true }])  // First attempt succeeds
-        .mockResolvedValueOnce([{ acquired: false }]) // Second attempt fails
-
-      const lock1 = await strategy.tryLock('shared-resource')
-      const lock2 = await strategy.tryLock('shared-resource')
-
-      expect(lock1).toBe(true)
-      expect(lock2).toBe(false)
-    })
-
-    it('should allow locking after unlock', async () => {
-      ;(mockConnection.execute as any)
-        .mockResolvedValueOnce([{ acquired: true }])  // First lock
-        .mockResolvedValueOnce(undefined)              // Unlock
-        .mockResolvedValueOnce([{ acquired: true }])  // Second lock
-
-      const lock1 = await strategy.tryLock('resource')
-      expect(lock1).toBe(true)
-
-      await strategy.unlock('resource')
-
-      const lock2 = await strategy.tryLock('resource')
-      expect(lock2).toBe(true)
-    })
-
-    it('should handle multiple resources independently', async () => {
-      ;(mockConnection.execute as any)
-        .mockResolvedValueOnce([{ acquired: true }])  // Lock resource1
-        .mockResolvedValueOnce([{ acquired: true }])  // Lock resource2
-        .mockResolvedValueOnce(undefined)              // Unlock resource1
-        .mockResolvedValueOnce(undefined)              // Unlock resource2
-
-      const lock1 = await strategy.tryLock('resource1')
-      const lock2 = await strategy.tryLock('resource2')
-
-      expect(lock1).toBe(true)
-      expect(lock2).toBe(true)
-
-      await strategy.unlock('resource1')
-      await strategy.unlock('resource2')
-
-      expect(mockConnection.execute).toHaveBeenCalledTimes(4)
-    })
-  })
-
-  describe('error handling', () => {
-    it('should not throw on tryLock error', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('SQL error'))
-
-      await expect(strategy.tryLock('test')).resolves.not.toThrow()
-    })
-
-    it('should not throw on unlock error', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('SQL error'))
-
-      await expect(strategy.unlock('test')).resolves.not.toThrow()
-    })
-
-    it('should handle connection pool exhaustion', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('Connection pool exhausted'))
-
-      const result = await strategy.tryLock('test')
-
-      expect(result).toBe(false)
-    })
-
-    it('should handle transaction errors', async () => {
-      ;(mockConnection.execute as any).mockRejectedValue(new Error('Transaction aborted'))
-
-      await expect(strategy.unlock('test')).resolves.not.toThrow()
+      expect(result).toEqual({ acquired: false })
+      expect(fn).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -16,6 +16,7 @@ export class LocalLockStrategy {
   async runWithLock<T>(key: string, fn: () => Promise<T>): Promise<{ acquired: boolean; result?: T }> {
     const em = this.em().fork()
     const hash = this.hashString(key)
+    let lockAcquired = false
 
     try {
       return await em.transactional(async (txEm) => {
@@ -26,12 +27,17 @@ export class LocalLockStrategy {
 
         const acquired = result[0]?.acquired === true
         if (!acquired) return { acquired: false }
+        lockAcquired = true
 
         const fnResult = await fn()
         return { acquired: true, result: fnResult }
       })
     } catch (error) {
-      console.error('[scheduler:local] Failed to run with lock:', error)
+      if (lockAcquired) {
+        throw error
+      }
+
+      console.error('[scheduler:local] Failed to acquire lock:', error)
       return { acquired: false }
     }
   }

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -7,39 +7,32 @@ export class LocalLockStrategy {
   constructor(private em: () => EntityManager) {}
 
   /**
-   * Try to acquire a lock using PostgreSQL advisory locks
+   * Execute a function under a PostgreSQL advisory lock.
+   *
+   * IMPORTANT: Uses transaction-scoped advisory locks (`pg_try_advisory_xact_lock`)
+   * to avoid connection pool/session mismatch issues. The lock is automatically
+   * released when the transaction ends.
    */
-  async tryLock(key: string): Promise<boolean> {
-    const em = this.em()
+  async runWithLock<T>(key: string, fn: () => Promise<T>): Promise<{ acquired: boolean; result?: T }> {
+    const em = this.em().fork()
     const hash = this.hashString(key)
-    
-    try {
-      // Use MikroORM's execute with proper parameter binding
-      const result = await em.getConnection().execute<{ acquired: boolean }[]>(
-        `SELECT pg_try_advisory_lock(?) as acquired`,
-        [hash]
-      )
-      return result[0]?.acquired === true
-    } catch (error) {
-      console.error('[scheduler:local] Failed to acquire lock:', error)
-      return false
-    }
-  }
 
-  /**
-   * Release a lock
-   */
-  async unlock(key: string): Promise<void> {
-    const em = this.em()
-    const hash = this.hashString(key)
-    
     try {
-      await em.getConnection().execute(
-        `SELECT pg_advisory_unlock(?)`,
-        [hash]
-      )
+      return await em.transactional(async (txEm) => {
+        const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
+          `SELECT pg_try_advisory_xact_lock(?) as acquired`,
+          [hash],
+        )
+
+        const acquired = result[0]?.acquired === true
+        if (!acquired) return { acquired: false }
+
+        const fnResult = await fn()
+        return { acquired: true, result: fnResult }
+      })
     } catch (error) {
-      console.error('[scheduler:local] Failed to release lock:', error)
+      console.error('[scheduler:local] Failed to run with lock:', error)
+      return { acquired: false }
     }
   }
 

--- a/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
@@ -17,8 +17,7 @@ jest.mock('@open-mercato/shared/modules/events', () => ({
 // Mock LocalLockStrategy
 jest.mock('../../lib/localLockStrategy', () => ({
   LocalLockStrategy: jest.fn().mockImplementation(() => ({
-    tryLock: jest.fn(),
-    unlock: jest.fn(),
+    runWithLock: jest.fn(),
   })),
 }))
 
@@ -37,7 +36,7 @@ describe('LocalSchedulerService', () => {
   let mockQueue: jest.Mocked<Queue>
   let mockQueueFactory: jest.Mock
   let mockRbacService: { tenantHasFeature: jest.Mock }
-  let mockLockStrategy: { tryLock: jest.Mock; unlock: jest.Mock }
+  let mockLockStrategy: { runWithLock: jest.Mock }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -196,8 +195,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
@@ -257,7 +258,7 @@ describe('LocalSchedulerService', () => {
       const schedule = createSchedule()
 
       mockForkedEm.find.mockResolvedValue([schedule])
-      mockLockStrategy.tryLock.mockResolvedValue(false)
+      mockLockStrategy.runWithLock.mockResolvedValue({ acquired: false })
 
       const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
 
@@ -276,8 +277,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       await service.start()
@@ -300,8 +303,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockCommandBusInstance.execute.mockResolvedValue({ success: true })
 
       await service.start()
@@ -322,8 +327,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       await service.start()
@@ -343,8 +350,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       await service.start()
@@ -364,8 +373,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockRejectedValue(error)
 
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
@@ -390,8 +401,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue(freshSchedule)
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       await service.start()
@@ -401,21 +414,23 @@ describe('LocalSchedulerService', () => {
       expect(mockForkedEm.flush).toHaveBeenCalled()
     })
 
-    it('should always release lock', async () => {
+    it('should execute inside lock wrapper', async () => {
       const schedule = createSchedule()
       const error = new Error('Execution failed')
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockRejectedValue(error)
 
       jest.spyOn(console, 'error').mockImplementation()
 
       await service.start()
 
-      expect(mockLockStrategy.unlock).toHaveBeenCalledWith('schedule:test-1')
+      expect(mockLockStrategy.runWithLock).toHaveBeenCalledWith('schedule:test-1', expect.any(Function))
     })
 
     it('should check feature flag if required', async () => {
@@ -427,8 +442,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockRbacService.tenantHasFeature.mockResolvedValue(true)
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
@@ -452,8 +469,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockRbacService.tenantHasFeature.mockResolvedValue(false)
 
       const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
@@ -483,8 +502,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       await service.start()
@@ -500,8 +521,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue(freshSchedule)
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockRejectedValue(error)
 
       jest.spyOn(console, 'error').mockImplementation()
@@ -517,8 +540,10 @@ describe('LocalSchedulerService', () => {
       })
 
       mockForkedEm.find.mockResolvedValue([schedule])
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
 
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
 
@@ -542,8 +567,10 @@ describe('LocalSchedulerService', () => {
       })
 
       mockForkedEm.find.mockResolvedValue([schedule])
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
 
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
 
@@ -566,8 +593,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockQueue.enqueue.mockResolvedValue(undefined as any)
 
       await service.start()
@@ -592,8 +621,10 @@ describe('LocalSchedulerService', () => {
 
       mockForkedEm.find.mockResolvedValue([schedule])
       mockForkedEm.findOne.mockResolvedValue({ ...schedule })
-      mockLockStrategy.tryLock.mockResolvedValue(true)
-      mockLockStrategy.unlock.mockResolvedValue(undefined as any)
+      mockLockStrategy.runWithLock.mockImplementation(async (_key: string, fn: () => Promise<unknown>) => {
+        await fn()
+        return { acquired: true }
+      })
       mockCommandBusInstance.execute.mockResolvedValue({ success: true })
 
       await service.start()

--- a/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
@@ -134,15 +134,7 @@ export class LocalSchedulerService {
   private async executeSchedule(schedule: ScheduledJob): Promise<void> {
     const lockKey = `schedule:${schedule.id}`
 
-    // Try to acquire lock to prevent duplicate execution
-    const acquired = await this.lockStrategy.tryLock(lockKey)
-    
-    if (!acquired) {
-      console.log(`[scheduler:local] Schedule ${schedule.name} is already locked, skipping`)
-      return
-    }
-
-    try {
+    const { acquired } = await this.lockStrategy.runWithLock(lockKey, async () => {
       console.log(`[scheduler:local] Executing schedule: ${schedule.name} (${schedule.id})`)
 
       // Emit started event
@@ -238,9 +230,11 @@ export class LocalSchedulerService {
         // Still update next run time even on failure
         await this.updateNextRun(schedule)
       }
-    } finally {
-      // Always release the lock
-      await this.lockStrategy.unlock(lockKey)
+    })
+
+    if (!acquired) {
+      console.log(`[scheduler:local] Schedule ${schedule.name} is already locked, skipping`)
+      return
     }
   }
 


### PR DESCRIPTION
## Summary
LocalLockStrategy used session-scoped PostgreSQL advisory locks, but acquired and released them on different pooled connections, causing locks to never be released and permanently blocking subsequent local scheduler runs. Switched to transaction-scoped advisory locks so release is automatic and pool-safe.

## Changes
Updated LocalLockStrategy to use pg_try_advisory_xact_lock and expose runWithLock() (no manual unlock()).
Updated LocalSchedulerService to execute schedule logic inside runWithLock() and skip when not acquired.
Updated unit tests for the new lock API and behavior.

## Specification
Does a spec exist for this feature/module?
[ ] Yes
[ ] No (created a new spec)
[x] N/A (minor change, no spec needed)

## Testing
yarn test --filter @open-mercato/scheduler

## Checklist
[x] This pull request targets develop.
[x] I have read and accept the Open Mercato Contributor License Agreement (see docs/cla.md).
[x] I updated documentation, locales, or generators if the change requires it.
[x] I added or adjusted tests that cover the change.
[x] I added or updated integration tests in .ai/qa/tests/ (or documented why integration coverage is not required).
[x] I created or updated the spec in .ai/specs/ with a changelog entry (if applicable).

## Linked issues
Fixes #1154
