### PR TITLE
fix(workflows): SSRF-guard CALL_WEBHOOK activity

### DIFF
--- a/packages/core/src/modules/workflows/AGENTS.md
+++ b/packages/core/src/modules/workflows/AGENTS.md
@@ -66,11 +66,17 @@ Definition → startWorkflow() → Instance → executeWorkflow() loop
 |---------------|-------------|
 | `SEND_EMAIL` | Send templated email via mail service |
 | `CALL_API` | Call an internal API endpoint |
-| `CALL_WEBHOOK` | Call an external HTTP endpoint |
+| `CALL_WEBHOOK` | Call an external HTTP endpoint (SSRF-guarded via `@open-mercato/shared/lib/url-safety`; `redirect: 'manual'`, 3xx rejected) |
 | `UPDATE_ENTITY` | Mutate an entity via the command bus |
 | `EMIT_EVENT` | Emit a domain event to the event bus |
 | `EXECUTE_FUNCTION` | Run a registered custom function |
 | `WAIT` | Delay execution for a configured duration |
+
+## Environment
+
+| Variable | Effect | Default |
+|----------|--------|---------|
+| `OM_WORKFLOWS_ALLOW_PRIVATE_URLS` | When `1`/`true`/`yes`, bypasses the SSRF guard in `CALL_WEBHOOK` so workflow authors can hit `localhost`, RFC1918, and `.internal` targets. For dev only — MUST remain unset in production. | unset (guard enforced) |
 
 ## DI Services
 

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -134,6 +134,17 @@ export const callApiConfigSchema = z.object({
   timeout: z.number().int().positive().optional(),
 })
 
+// CALL_WEBHOOK activity configuration
+// URL shape is validated here; network-level SSRF guard runs at execution time
+// via @open-mercato/shared/lib/url-safety (assertSafeOutboundUrl).
+export const callWebhookConfigSchema = z.object({
+  url: z.string().min(1, 'Webhook URL is required'),
+  method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']).default('POST'),
+  headers: z.record(z.string(), z.string()).optional(),
+  body: z.any().optional(),
+})
+export type CallWebhookConfig = z.infer<typeof callWebhookConfigSchema>
+
 // Retry policy
 export const retryPolicySchema = z.object({
   maxAttempts: z.number().int().min(1).max(10),

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -425,6 +425,22 @@ describe('Activity Executor (Unit Tests)', () => {
   // ============================================================================
 
   describe('CALL_WEBHOOK activity', () => {
+    const originalAllowPrivate = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+
+    beforeAll(() => {
+      // Bypass DNS lookup for public host tests below; SSRF guard behavior
+      // is exercised in its own describe block with injected lookupHost.
+      process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = '1'
+    })
+
+    afterAll(() => {
+      if (originalAllowPrivate === undefined) {
+        delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+      } else {
+        process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = originalAllowPrivate
+      }
+    })
+
     test('should execute CALL_WEBHOOK activity successfully', async () => {
       ;(global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
@@ -547,7 +563,138 @@ describe('Activity Executor (Unit Tests)', () => {
       )
 
       expect(result.success).toBe(false)
-      expect(result.error).toContain('requires "url"')
+      expect(result.error).toContain('config invalid')
+    })
+  })
+
+  // ============================================================================
+  // CALL_WEBHOOK SSRF guard tests
+  // ============================================================================
+
+  describe('CALL_WEBHOOK SSRF guard', () => {
+    const makeFetchMock = () =>
+      jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ ok: true }),
+      }) as unknown as typeof fetch
+
+    test('rejects loopback IPv4 literal without calling fetch', async () => {
+      const fetchImpl = makeFetchMock()
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'http://127.0.0.1:8080/test', method: 'POST' },
+          mockContext,
+          { fetchImpl, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/unsafe URL.*private_ip_literal/)
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    test('rejects AWS metadata endpoint 169.254.169.254', async () => {
+      const fetchImpl = makeFetchMock()
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'http://169.254.169.254/latest/meta-data/', method: 'GET' },
+          mockContext,
+          { fetchImpl, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/unsafe URL.*private_ip_literal/)
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    test('rejects localhost hostname', async () => {
+      const fetchImpl = makeFetchMock()
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'http://localhost:3000/admin' },
+          mockContext,
+          { fetchImpl, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/unsafe URL.*blocked_hostname/)
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    test('rejects URLs with embedded credentials', async () => {
+      const fetchImpl = makeFetchMock()
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'https://user:pass@example.test/hook' },
+          mockContext,
+          { fetchImpl, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/unsafe URL.*credentials_in_url/)
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    test('rejects file:// scheme', async () => {
+      const fetchImpl = makeFetchMock()
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'file:///etc/passwd' },
+          mockContext,
+          { fetchImpl, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/unsafe URL.*forbidden_protocol/)
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    test('rejects hostnames that DNS-resolve to private IPs (rebinding guard)', async () => {
+      const fetchImpl = makeFetchMock()
+      const lookupHost = jest.fn(async () => [{ address: '10.0.0.5', family: 4 }])
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'https://rebind.evil.example/steal' },
+          mockContext,
+          { fetchImpl, lookupHost, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/unsafe URL.*private_ip_resolved/)
+      expect(fetchImpl).not.toHaveBeenCalled()
+    })
+
+    test('rejects 3xx redirects instead of following them', async () => {
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 302,
+        statusText: 'Found',
+        headers: new Headers({ location: 'http://127.0.0.1:8080/steal' }),
+      }) as unknown as typeof fetch
+      const lookupHost = jest.fn(async () => [{ address: '93.184.216.34', family: 4 }])
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { url: 'https://good.example/hook' },
+          mockContext,
+          { fetchImpl, lookupHost, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/refused to follow redirect 302/)
+    })
+
+    test('passes public host with safe DNS mock and sets redirect:"manual"', async () => {
+      const fetchImpl = makeFetchMock()
+      const lookupHost = jest.fn(async () => [{ address: '93.184.216.34', family: 4 }])
+      const result = await activityExecutor.executeCallWebhook(
+        { url: 'https://good.example/hook', method: 'POST', body: { ok: 1 } },
+        mockContext,
+        { fetchImpl, lookupHost, allowPrivate: false },
+      )
+      expect(result.status).toBe(200)
+      expect(fetchImpl).toHaveBeenCalledTimes(1)
+      const callArgs = (fetchImpl as unknown as jest.Mock).mock.calls[0][1]
+      expect(callArgs.redirect).toBe('manual')
+    })
+
+    test('rejects config without url via zod schema before touching fetch', async () => {
+      const fetchImpl = makeFetchMock()
+      await expect(
+        activityExecutor.executeCallWebhook(
+          { body: {} } as any,
+          mockContext,
+          { fetchImpl, allowPrivate: false },
+        ),
+      ).rejects.toThrow(/config invalid/)
+      expect(fetchImpl).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -15,8 +15,21 @@ import type { AwilixContainer } from 'awilix'
 import { WorkflowInstance } from '../data/entities'
 import { createQueue, Queue } from '@open-mercato/queue'
 import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
+import {
+  assertSafeOutboundUrl,
+  UnsafeOutboundUrlError,
+  type HostLookup,
+} from '@open-mercato/shared/lib/url-safety'
+import { callWebhookConfigSchema } from '../data/validators'
 import { WorkflowActivityJob, WORKFLOW_ACTIVITIES_QUEUE_NAME } from './activity-queue-types'
 import { logWorkflowEvent } from './event-logger'
+
+function isAllowPrivateWorkflowWebhookUrlsEnabled(): boolean {
+  const raw = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+  if (!raw) return false
+  const normalized = raw.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes'
+}
 
 // ============================================================================
 // Types and Interfaces
@@ -598,27 +611,67 @@ async function resolveDictionaryEntryId(
 /**
  * CALL_WEBHOOK activity handler
  *
- * Makes HTTP request to external URL
+ * Makes HTTP request to an external URL. Applies shared SSRF guard
+ * (protocol / credentials / blocked host / private IP literal / DNS rebinding)
+ * before issuing the request and rejects any 3xx redirect rather than following.
  */
-export async function executeCallWebhook(
-  config: any,
-  context: ActivityContext
-): Promise<any> {
-  const { url, method = 'POST', headers = {}, body } = config
+export type CallWebhookDeps = {
+  lookupHost?: HostLookup
+  allowPrivate?: boolean
+  fetchImpl?: typeof fetch
+}
 
-  if (!url) {
-    throw new Error('CALL_WEBHOOK requires "url" field')
+export async function executeCallWebhook(
+  config: unknown,
+  context: ActivityContext,
+  deps: CallWebhookDeps = {}
+): Promise<any> {
+  const parsed = callWebhookConfigSchema.safeParse(config)
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `${issue.path.join('.') || 'config'}: ${issue.message}`)
+      .join('; ')
+    throw new Error(`CALL_WEBHOOK config invalid: ${issues}`)
+  }
+  const { url, method, headers: rawHeaders, body } = parsed.data
+  const headers = rawHeaders ?? {}
+
+  const allowPrivate = deps.allowPrivate ?? isAllowPrivateWorkflowWebhookUrlsEnabled()
+
+  try {
+    await assertSafeOutboundUrl(url, {
+      subject: 'Workflow webhook URL',
+      allowPrivate,
+      lookupHost: deps.lookupHost,
+    })
+  } catch (error) {
+    if (error instanceof UnsafeOutboundUrlError) {
+      throw new Error(
+        `CALL_WEBHOOK rejected unsafe URL (reason=${error.reason}): ${error.message}`
+      )
+    }
+    throw error
   }
 
-  // Make HTTP request
-  const response = await fetch(url, {
+  const fetchImpl = deps.fetchImpl ?? fetch
+  const response = await fetchImpl(url, {
     method,
     headers: {
       'Content-Type': 'application/json',
       ...headers,
     },
-    body: body ? JSON.stringify(body) : undefined,
+    body: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
+    redirect: 'manual',
   })
+
+  if (response.status >= 300 && response.status < 400) {
+    const location = response.headers.get('location')
+    throw new Error(
+      `CALL_WEBHOOK refused to follow redirect ${response.status} to ${
+        location ?? '(no Location header)'
+      }`
+    )
+  }
 
   // Parse response
   let result: any

--- a/packages/shared/src/lib/__tests__/url-safety.test.ts
+++ b/packages/shared/src/lib/__tests__/url-safety.test.ts
@@ -1,0 +1,176 @@
+import {
+  assertSafeOutboundUrl,
+  assertStaticallySafeOutboundUrl,
+  parseOutboundUrl,
+  UnsafeOutboundUrlError,
+} from '../url-safety'
+
+describe('url-safety — parseOutboundUrl', () => {
+  it('accepts plain http and https URLs', () => {
+    expect(parseOutboundUrl('https://example.test/hook').hostname).toBe('example.test')
+    expect(parseOutboundUrl('http://api.example.com:8080/in').hostname).toBe('api.example.com')
+  })
+
+  it('rejects non-http(s) protocols', () => {
+    expect(() => parseOutboundUrl('ftp://example.test/hook')).toThrow(UnsafeOutboundUrlError)
+    expect(() => parseOutboundUrl('file:///etc/passwd')).toThrow(UnsafeOutboundUrlError)
+    expect(() => parseOutboundUrl('gopher://example.test/')).toThrow(UnsafeOutboundUrlError)
+  })
+
+  it('rejects embedded basic-auth credentials', () => {
+    expect(() => parseOutboundUrl('https://user:pass@example.test/hook')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+  })
+
+  it('rejects garbage', () => {
+    expect(() => parseOutboundUrl('not-a-url')).toThrow(UnsafeOutboundUrlError)
+    expect(() => parseOutboundUrl('')).toThrow(UnsafeOutboundUrlError)
+  })
+
+  it('emits reason field for pattern matching', () => {
+    try {
+      parseOutboundUrl('ftp://example.test/')
+      throw new Error('expected throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsafeOutboundUrlError)
+      expect((error as UnsafeOutboundUrlError).reason).toBe('forbidden_protocol')
+    }
+  })
+
+  it('respects custom errorFactory (subclass support)', () => {
+    class CustomErr extends UnsafeOutboundUrlError {
+      constructor(reason: any, message: string) {
+        super(reason, message)
+        this.name = 'CustomErr'
+      }
+    }
+    expect(() =>
+      parseOutboundUrl('ftp://example.test/', {
+        errorFactory: (reason, message) => new CustomErr(reason, message),
+      }),
+    ).toThrow(CustomErr)
+  })
+})
+
+describe('url-safety — assertStaticallySafeOutboundUrl', () => {
+  it('accepts plain public hostnames', () => {
+    expect(() => assertStaticallySafeOutboundUrl('https://api.stripe.com/v1/webhook')).not.toThrow()
+  })
+
+  it('rejects private IPv4 literals', () => {
+    expect(() => assertStaticallySafeOutboundUrl('http://127.0.0.1:8080/x')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+    expect(() => assertStaticallySafeOutboundUrl('http://169.254.169.254/')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+    expect(() => assertStaticallySafeOutboundUrl('http://10.0.0.5/admin')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+    expect(() => assertStaticallySafeOutboundUrl('http://192.168.1.1/')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+  })
+
+  it('rejects IPv6 loopback literal', () => {
+    expect(() => assertStaticallySafeOutboundUrl('http://[::1]/')).toThrow(UnsafeOutboundUrlError)
+    expect(() => assertStaticallySafeOutboundUrl('http://[fc00::1]/')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+  })
+
+  it('rejects well-known blocked hostnames', () => {
+    expect(() => assertStaticallySafeOutboundUrl('http://localhost/')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+    expect(() => assertStaticallySafeOutboundUrl('http://metadata.google.internal/')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+    expect(() => assertStaticallySafeOutboundUrl('http://foo.local/')).toThrow(
+      UnsafeOutboundUrlError,
+    )
+  })
+
+  it('bypasses private host checks when allowPrivate=true', () => {
+    expect(() =>
+      assertStaticallySafeOutboundUrl('http://localhost:3000/dev', { allowPrivate: true }),
+    ).not.toThrow()
+    expect(() =>
+      assertStaticallySafeOutboundUrl('http://10.0.0.5/dev', { allowPrivate: true }),
+    ).not.toThrow()
+  })
+
+  it('still rejects invalid protocols when allowPrivate=true', () => {
+    expect(() =>
+      assertStaticallySafeOutboundUrl('file:///etc/passwd', { allowPrivate: true }),
+    ).toThrow(UnsafeOutboundUrlError)
+  })
+})
+
+describe('url-safety — assertSafeOutboundUrl (DNS rebinding guard)', () => {
+  it('rejects hostnames that resolve to private IPs', async () => {
+    const lookupHost = async () => [{ address: '10.0.0.5', family: 4 }]
+    await expect(
+      assertSafeOutboundUrl('https://rebind.evil.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+  })
+
+  it('rejects AWS metadata even if only one resolved address is private', async () => {
+    const lookupHost = async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ]
+    await expect(
+      assertSafeOutboundUrl('https://mixed.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+  })
+
+  it('accepts hostnames that resolve to public IPs', async () => {
+    const lookupHost = async () => [{ address: '93.184.216.34', family: 4 }]
+    await expect(
+      assertSafeOutboundUrl('https://good.example/', { lookupHost, allowPrivate: false }),
+    ).resolves.toBeUndefined()
+  })
+
+  it('rejects hostnames whose DNS lookup fails', async () => {
+    const lookupHost = async () => {
+      throw new Error('ENOTFOUND')
+    }
+    await expect(
+      assertSafeOutboundUrl('https://broken.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'dns_resolution_failed' })
+  })
+
+  it('rejects hostnames whose DNS lookup returns nothing', async () => {
+    const lookupHost = async () => []
+    await expect(
+      assertSafeOutboundUrl('https://empty.example/', { lookupHost, allowPrivate: false }),
+    ).rejects.toMatchObject({ reason: 'dns_resolution_empty' })
+  })
+
+  it('short-circuits direct private IP literal without DNS lookup', async () => {
+    const lookupHost = jest.fn(async () => [{ address: '93.184.216.34', family: 4 }])
+    await expect(
+      assertSafeOutboundUrl('http://169.254.169.254/latest/meta-data/', {
+        lookupHost,
+        allowPrivate: false,
+      }),
+    ).rejects.toMatchObject({ reason: 'private_ip_literal' })
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('bypasses checks when allowPrivate=true', async () => {
+    const lookupHost = jest.fn()
+    await expect(
+      assertSafeOutboundUrl('http://127.0.0.1:8080/dev', { lookupHost, allowPrivate: true }),
+    ).resolves.toBeUndefined()
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('still rejects invalid protocols when allowPrivate=true', async () => {
+    await expect(
+      assertSafeOutboundUrl('file:///etc/passwd', { allowPrivate: true }),
+    ).rejects.toMatchObject({ reason: 'forbidden_protocol' })
+  })
+})

--- a/packages/shared/src/lib/url-safety.ts
+++ b/packages/shared/src/lib/url-safety.ts
@@ -1,0 +1,163 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
+import { isBlockedHostname, isPrivateIpAddress } from './network'
+
+export type UrlSafetyReason =
+  | 'invalid_url'
+  | 'forbidden_protocol'
+  | 'credentials_in_url'
+  | 'missing_host'
+  | 'blocked_hostname'
+  | 'private_ip_literal'
+  | 'private_ip_resolved'
+  | 'dns_resolution_failed'
+  | 'dns_resolution_empty'
+
+export class UnsafeOutboundUrlError extends Error {
+  public readonly reason: UrlSafetyReason
+
+  constructor(reason: UrlSafetyReason, message?: string) {
+    super(message ?? `Outbound URL rejected: ${reason}`)
+    this.name = 'UnsafeOutboundUrlError'
+    this.reason = reason
+  }
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+
+export type ParsedOutboundUrl = {
+  url: URL
+  hostname: string
+}
+
+export type UrlSafetyErrorFactory = (reason: UrlSafetyReason, message: string) => Error
+
+const defaultErrorFactory: UrlSafetyErrorFactory = (reason, message) =>
+  new UnsafeOutboundUrlError(reason, message)
+
+export type ParseOutboundUrlOptions = {
+  errorFactory?: UrlSafetyErrorFactory
+  subject?: string
+}
+
+export function parseOutboundUrl(
+  rawUrl: string,
+  options: ParseOutboundUrlOptions = {},
+): ParsedOutboundUrl {
+  const subject = options.subject ?? 'URL'
+  const factory = options.errorFactory ?? defaultErrorFactory
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw factory('invalid_url', `${subject} is not a valid URL`)
+  }
+  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
+    throw factory(
+      'forbidden_protocol',
+      `${subject} protocol "${url.protocol.replace(':', '')}" is not allowed; use http or https`,
+    )
+  }
+  if (url.username || url.password) {
+    throw factory('credentials_in_url', `${subject} must not embed basic-auth credentials`)
+  }
+  let hostname = url.hostname.trim().toLowerCase()
+  if (!hostname) {
+    throw factory('missing_host', `${subject} must include a hostname`)
+  }
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1)
+  }
+  return { url, hostname }
+}
+
+export type HostLookup = (
+  hostname: string,
+) => Promise<ReadonlyArray<{ address: string; family: number }>>
+
+export type AssertStaticUrlOptions = ParseOutboundUrlOptions & {
+  allowPrivate?: boolean
+}
+
+export function assertStaticallySafeOutboundUrl(
+  rawUrl: string,
+  options: AssertStaticUrlOptions = {},
+): void {
+  const subject = options.subject ?? 'URL'
+  const factory = options.errorFactory ?? defaultErrorFactory
+  const { hostname } = parseOutboundUrl(rawUrl, options)
+  if (options.allowPrivate) return
+
+  if (isBlockedHostname(hostname)) {
+    throw factory('blocked_hostname', `${subject} host "${hostname}" is not allowed`)
+  }
+  if (isIP(hostname) && isPrivateIpAddress(hostname)) {
+    throw factory(
+      'private_ip_literal',
+      `${subject} host "${hostname}" resolves to a private or reserved IP range`,
+    )
+  }
+}
+
+export type AssertSafeOutboundUrlOptions = AssertStaticUrlOptions & {
+  lookupHost?: HostLookup
+}
+
+export async function assertSafeOutboundUrl(
+  rawUrl: string,
+  options: AssertSafeOutboundUrlOptions = {},
+): Promise<void> {
+  const subject = options.subject ?? 'URL'
+  const factory = options.errorFactory ?? defaultErrorFactory
+  const { hostname } = parseOutboundUrl(rawUrl, options)
+  if (options.allowPrivate) return
+
+  if (isBlockedHostname(hostname)) {
+    throw factory('blocked_hostname', `${subject} host "${hostname}" is not allowed`)
+  }
+
+  if (isIP(hostname)) {
+    if (isPrivateIpAddress(hostname)) {
+      throw factory(
+        'private_ip_literal',
+        `${subject} host "${hostname}" resolves to a private or reserved IP range`,
+      )
+    }
+    return
+  }
+
+  const resolver: HostLookup =
+    options.lookupHost ??
+    (async (host) => {
+      const records = await lookup(host, { all: true, verbatim: true })
+      return records
+    })
+
+  let addresses: ReadonlyArray<{ address: string; family: number }>
+  try {
+    addresses = await resolver(hostname)
+  } catch (error) {
+    throw factory(
+      'dns_resolution_failed',
+      `${subject} host "${hostname}" could not be resolved: ${
+        error instanceof Error ? error.message : 'lookup failed'
+      }`,
+    )
+  }
+
+  if (!addresses || addresses.length === 0) {
+    throw factory(
+      'dns_resolution_empty',
+      `${subject} host "${hostname}" has no DNS A/AAAA records`,
+    )
+  }
+
+  for (const record of addresses) {
+    if (isPrivateIpAddress(record.address)) {
+      throw factory(
+        'private_ip_resolved',
+        `${subject} host "${hostname}" resolves to a private or reserved IP address (${record.address})`,
+      )
+    }
+  }
+}

--- a/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
@@ -1,12 +1,18 @@
-import { lookup } from 'node:dns/promises'
-import { isIP } from 'node:net'
 import {
-  isBlockedHostname,
-  isPrivateIpAddress,
-} from '@open-mercato/shared/lib/network'
+  assertSafeOutboundUrl,
+  assertStaticallySafeOutboundUrl,
+  parseOutboundUrl,
+  type HostLookup,
+  type UrlSafetyReason,
+} from '@open-mercato/shared/lib/url-safety'
 
 export { isPrivateIpAddress } from '@open-mercato/shared/lib/network'
 
+const SUBJECT = 'Webhook URL'
+
+// Kept as a standalone Error subclass (not extending UnsafeOutboundUrlError) so that
+// `reason: string` stays compatible with pre-refactor consumers. See
+// BACKWARD_COMPATIBILITY.md §2 (Type Definitions): required field types MUST NOT be narrowed.
 export class UnsafeWebhookUrlError extends Error {
   public readonly reason: string
 
@@ -17,7 +23,8 @@ export class UnsafeWebhookUrlError extends Error {
   }
 }
 
-const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+const webhookErrorFactory = (reason: UrlSafetyReason, message: string) =>
+  new UnsafeWebhookUrlError(reason, message)
 
 type ParsedWebhookUrl = {
   url: URL
@@ -25,32 +32,7 @@ type ParsedWebhookUrl = {
 }
 
 export function parseWebhookUrl(rawUrl: string): ParsedWebhookUrl {
-  let url: URL
-  try {
-    url = new URL(rawUrl)
-  } catch {
-    throw new UnsafeWebhookUrlError('invalid_url', 'Webhook URL is not a valid URL')
-  }
-  if (!ALLOWED_PROTOCOLS.has(url.protocol)) {
-    throw new UnsafeWebhookUrlError(
-      'forbidden_protocol',
-      `Webhook URL protocol "${url.protocol.replace(':', '')}" is not allowed; use http or https`,
-    )
-  }
-  if (url.username || url.password) {
-    throw new UnsafeWebhookUrlError(
-      'credentials_in_url',
-      'Webhook URL must not embed basic-auth credentials',
-    )
-  }
-  let hostname = url.hostname.trim().toLowerCase()
-  if (!hostname) {
-    throw new UnsafeWebhookUrlError('missing_host', 'Webhook URL must include a hostname')
-  }
-  if (hostname.startsWith('[') && hostname.endsWith(']')) {
-    hostname = hostname.slice(1, -1)
-  }
-  return { url, hostname }
+  return parseOutboundUrl(rawUrl, { errorFactory: webhookErrorFactory, subject: SUBJECT })
 }
 
 export type AssertStaticWebhookUrlDeps = {
@@ -61,23 +43,12 @@ export function assertStaticallySafeWebhookUrl(
   rawUrl: string,
   deps: AssertStaticWebhookUrlDeps = {},
 ): void {
-  const { hostname } = parseWebhookUrl(rawUrl)
   const allowPrivate = deps.allowPrivate ?? isAllowPrivateWebhookUrlsEnabled()
-  if (allowPrivate) return
-
-  if (isBlockedHostname(hostname)) {
-    throw new UnsafeWebhookUrlError(
-      'blocked_hostname',
-      `Webhook URL host "${hostname}" is not allowed`,
-    )
-  }
-  const family = isIP(hostname)
-  if (family && isPrivateIpAddress(hostname)) {
-    throw new UnsafeWebhookUrlError(
-      'private_ip_literal',
-      `Webhook URL host "${hostname}" resolves to a private or reserved IP range`,
-    )
-  }
+  assertStaticallySafeOutboundUrl(rawUrl, {
+    errorFactory: webhookErrorFactory,
+    subject: SUBJECT,
+    allowPrivate,
+  })
 }
 
 export function isAllowPrivateWebhookUrlsEnabled(): boolean {
@@ -88,7 +59,7 @@ export function isAllowPrivateWebhookUrlsEnabled(): boolean {
 }
 
 export type AssertSafeWebhookDeliveryDeps = {
-  lookupHost?: (hostname: string) => Promise<ReadonlyArray<{ address: string; family: number }>>
+  lookupHost?: HostLookup
   allowPrivate?: boolean
 }
 
@@ -96,55 +67,11 @@ export async function assertSafeWebhookDeliveryUrl(
   rawUrl: string,
   deps: AssertSafeWebhookDeliveryDeps = {},
 ): Promise<void> {
-  const { hostname } = parseWebhookUrl(rawUrl)
   const allowPrivate = deps.allowPrivate ?? isAllowPrivateWebhookUrlsEnabled()
-  if (allowPrivate) return
-
-  if (isBlockedHostname(hostname)) {
-    throw new UnsafeWebhookUrlError(
-      'blocked_hostname',
-      `Webhook URL host "${hostname}" is not allowed`,
-    )
-  }
-
-  if (isIP(hostname)) {
-    if (isPrivateIpAddress(hostname)) {
-      throw new UnsafeWebhookUrlError(
-        'private_ip_literal',
-        `Webhook URL host "${hostname}" resolves to a private or reserved IP range`,
-      )
-    }
-    return
-  }
-
-  const resolver = deps.lookupHost ?? (async (host: string) => {
-    const records = await lookup(host, { all: true, verbatim: true })
-    return records
+  await assertSafeOutboundUrl(rawUrl, {
+    errorFactory: webhookErrorFactory,
+    subject: SUBJECT,
+    allowPrivate,
+    lookupHost: deps.lookupHost,
   })
-
-  let addresses: ReadonlyArray<{ address: string; family: number }>
-  try {
-    addresses = await resolver(hostname)
-  } catch (error) {
-    throw new UnsafeWebhookUrlError(
-      'dns_resolution_failed',
-      `Webhook URL host "${hostname}" could not be resolved: ${error instanceof Error ? error.message : 'lookup failed'}`,
-    )
-  }
-
-  if (!addresses || addresses.length === 0) {
-    throw new UnsafeWebhookUrlError(
-      'dns_resolution_empty',
-      `Webhook URL host "${hostname}" has no DNS A/AAAA records`,
-    )
-  }
-
-  for (const record of addresses) {
-    if (isPrivateIpAddress(record.address)) {
-      throw new UnsafeWebhookUrlError(
-        'private_ip_resolved',
-        `Webhook URL host "${hostname}" resolves to a private or reserved IP address (${record.address})`,
-      )
-    }
-  }
 }


### PR DESCRIPTION
 ## Summary
                                                                                     
  Workflow authors with `workflows.definitions.edit` could coerce the server
  to `fetch()` arbitrary URLs via the `CALL_WEBHOOK` activity — including            
  loopback, RFC1918 private ranges, and cloud metadata endpoints                     
  (`169.254.169.254`). The sibling `CALL_API` in the same file already
  enforced an `APP_URL` host check; `CALL_WEBHOOK` had nothing. Response             
  bodies flowed back into workflow context readable by the author, so a              
  successful probe of IMDS would hand platform-scoped AWS keys to any                
  tenant admin.                                                                      
                                                                                     
  This change adds an end-to-end SSRF guard while keeping the activity               
  external-capable.                                         
                                                                                     
  ## Changes                                                
                                                                                     
  - **New shared helper** `@open-mercato/shared/lib/url-safety` with                 
    `UnsafeOutboundUrlError`, `parseOutboundUrl`,
    `assertStaticallySafeOutboundUrl`, and async `assertSafeOutboundUrl`             
    (protocol / credentials / blocked-host / private-IP literal / DNS                
    rebinding). The helper exposes an `errorFactory` hook so callers can             
    throw provider-specific error subclasses without re-implementing the             
    logic.                                                                           
  - **Webhooks refactor** — `@open-mercato/webhooks` `url-safety.ts` now             
    delegates to the shared helper. `UnsafeWebhookUrlError` remains a                
    standalone `Error` subclass with `readonly reason: string` to preserve
    the existing public API (BC-safe per `BACKWARD_COMPATIBILITY.md` §2).            
  - **Validator** — new `callWebhookConfigSchema` in                                 
    `packages/core/src/modules/workflows/data/validators.ts` enforces the            
    `CALL_WEBHOOK` config shape (`url`, `method`, optional                           
    `headers`/`body`) before any network work.                                       
  - **Hardened executor** — `executeCallWebhook`:                                    
    - zod-validates config (runtime-safe on `unknown` input),                        
    - calls `assertSafeOutboundUrl` with subject `"Workflow webhook URL"`,           
    - sets `redirect: 'manual'` and rejects every `3xx` with a clear error           
      (no more silent follow to attacker-controlled hops),                           
    - accepts injectable `deps: { lookupHost, fetchImpl, allowPrivate }` for         
      tests,                                                                         
    - honors a new `OM_WORKFLOWS_ALLOW_PRIVATE_URLS` dev bypass env flag             
      (mirrors the existing webhook flag; documented in workflows                    
      `AGENTS.md`).                                         
  - **Docs** — workflows `AGENTS.md` gains an `## Environment` section and           
    a short note on the `CALL_WEBHOOK` guard in the Activity Types table.            
                                                                                     
  ## Architectural note                                                              
                                                                                     
  `@open-mercato/core` **cannot** depend on `@open-mercato/webhooks`                 
  (webhooks already depends on core). Shared outbound-URL safety is the              
  reusable substrate — any new integration provider or sync adapter that             
  calls `fetch(userUrl)` should go through `assertSafeOutboundUrl` rather            
  than rolling its own checks.                                                       
                                                                                     
  ## Backward compatibility                                                          
                                                            
  - `UnsafeWebhookUrlError.reason` stays typed `string` (not narrowed to             
    the union) so existing external callsites — if any — continue to
    compile.                                                                         
  - Webhook `url-safety` public API (`parseWebhookUrl`,     
    `assertStaticallySafeWebhookUrl`, `assertSafeWebhookDeliveryUrl`,                
    `isPrivateIpAddress`, `isAllowPrivateWebhookUrlsEnabled`) is unchanged.          
  - `activityDefinitionSchema.config` remains permissive; the tight schema           
    applies only to `CALL_WEBHOOK` at execution time.                                
                                                                                     
  ## Tests                                                                           
                                                                                     
  - `@open-mercato/shared` — **20 new** tests for the helper (parse, static          
    check, DNS rebinding, allowPrivate bypass).
  - `@open-mercato/webhooks` — **51/51** existing `url-safety` tests still           
    pass (BC confirmed).                                                             
  - `@open-mercato/core` workflows — **9 new** `CALL_WEBHOOK SSRF guard`             
    tests covering: loopback IPv4, IMDS, `localhost`, embedded credentials,          
    `file://`, DNS rebinding to private, 3xx rejection, public-host                  
    pass-through (with `redirect: 'manual'` asserted), missing-url zod               
    rejection. Existing CALL_WEBHOOK happy-path tests updated to set the             
    dev-bypass flag so they stay network-independent.                                
  - Full workflows suite: **345/345** green.                                         
  - `tsc --noEmit` exit 0 on `@open-mercato/shared`, `@open-mercato/webhooks`,       
    `@open-mercato/core`.                             