### PR TITLE
fix(auth): use forwarded headers for redirect URLs behind reverse proxies

### DIFF
--- a/packages/core/src/modules/auth/api/reset.ts
+++ b/packages/core/src/modules/auth/api/reset.ts
@@ -13,6 +13,7 @@ import { z } from 'zod'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 
 const resetRateLimitConfig = readEndpointRateLimitConfig('RESET', {
   points: 3, duration: 60, blockDuration: 60, keyPrefix: 'reset',
@@ -41,8 +42,7 @@ export async function POST(req: Request) {
   const resReq = await auth.requestPasswordReset(parsed.data.email)
   if (!resReq) return NextResponse.json({ ok: true })
   const { user, token } = resReq
-  const url = new URL(req.url)
-  const base = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const base = getAppBaseUrl(req)
   const resetUrl = `${base}/reset/${token}`
 
   const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -7,6 +7,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { refreshSessionRequestSchema } from '@open-mercato/core/modules/auth/data/validators'
 import { checkAuthRateLimit } from '@open-mercato/core/modules/auth/lib/rateLimitCheck'
 import { buildRequestOriginUrl } from '@open-mercato/core/modules/auth/lib/requestRedirect'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { z } from 'zod'
@@ -56,7 +57,7 @@ function clearStaffAuthCookies(response: NextResponse) {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const baseUrl = getAppBaseUrl(req)
   const redirectTo = sanitizeRedirect(url.searchParams.get('redirect'), baseUrl)
   const token = parseCookie(req, 'session_token')
   if (!token) {

--- a/packages/core/src/modules/auth/lib/requestRedirect.ts
+++ b/packages/core/src/modules/auth/lib/requestRedirect.ts
@@ -1,4 +1,6 @@
 export function buildRequestOriginUrl(req: Request, path: string): string {
   const url = new URL(req.url)
-  return new URL(path, `${url.protocol}//${url.host}`).toString()
+  const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || url.host
+  return new URL(path, `${proto}://${host}`).toString()
 }

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -18,6 +18,7 @@ import {
   customerSignupIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
 import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 
 export const metadata: { path?: string } = {}
 
@@ -26,8 +27,7 @@ type OrganizationLookupRow = {
 }
 
 function resolveBaseUrl(req: Request): string {
-  const url = new URL(req.url)
-  return process.env.APP_URL || `${url.protocol}//${url.host}`
+  return getAppBaseUrl(req)
 }
 
 function resolvePortalLoginUrl(baseUrl: string, organizationSlug?: string | null): string {

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -25,7 +26,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ ok: false, error: 'Invalid tenant id.' }, { status: 400 })
   }
 
-  const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const baseUrl = getAppBaseUrl(req)
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
   const service = new OnboardingService(em)

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { SearchIndexer } from '@open-mercato/search'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { onboardingVerifySchema } from '@open-mercato/onboarding/modules/onboarding/data/validators'
 import { OnboardingService } from '@open-mercato/onboarding/modules/onboarding/lib/service'
 import { sendWorkspaceReadyEmail } from '@open-mercato/onboarding/modules/onboarding/lib/ready-email'
@@ -288,7 +289,7 @@ async function runDeferredProvisioning(args: {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+  const baseUrl = getAppBaseUrl(req)
   const token = url.searchParams.get('token') ?? ''
   const parsed = onboardingVerifySchema.safeParse({ token })
   if (!parsed.success) {

--- a/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
+++ b/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 import { loadDictionary } from '@open-mercato/shared/lib/i18n/server'
 import { defaultLocale, locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
 import { createFallbackTranslator } from '@open-mercato/shared/lib/i18n/translate'
@@ -124,8 +125,7 @@ export async function POST(req: Request) {
       throw err
     }
 
-    const url = new URL(req.url)
-    const baseUrl = process.env.APP_URL || `${url.protocol}//${url.host}`
+    const baseUrl = getAppBaseUrl(req)
     const verifyUrl = `${baseUrl}/api/onboarding/onboarding/verify?token=${token}`
 
     const firstName = request.firstName || parsed.data.firstName

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -1,9 +1,15 @@
-export function getAppBaseUrl(req: Request): string {
+function resolveRequestOrigin(req: Request): string {
   const url = new URL(req.url)
+  const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '')
+  const host = req.headers.get('x-forwarded-host') || req.headers.get('host') || url.host
+  return `${proto}://${host}`
+}
+
+export function getAppBaseUrl(req: Request): string {
   return (
     process.env.NEXT_PUBLIC_APP_URL ||
     process.env.APP_URL ||
-    `${url.protocol}//${url.host}`
+    resolveRequestOrigin(req)
   )
 }
 


### PR DESCRIPTION
## Summary

Behind reverse proxies (Cloud Run, nginx), `req.url` resolves to the container's internal address (e.g. `localhost:3000`) instead of the external URL. This PR fixes URL resolution across auth, customer accounts, and onboarding modules to use `X-Forwarded-Host` and `X-Forwarded-Proto` headers when available.

## Changes

- Added `resolveRequestOrigin()` helper to `packages/shared/src/lib/url.ts` that reads `X-Forwarded-Proto` and `X-Forwarded-Host` headers, falling back to `req.url`
- Updated `getAppBaseUrl()` in shared to use the new helper as its fallback
- Fixed `buildRequestOriginUrl()` in `auth/lib/requestRedirect.ts` with the same forwarded-header logic
- Replaced 6 inlined `process.env.APP_URL || protocol//host` patterns with `getAppBaseUrl(req)` across auth, customer_accounts, and onboarding modules

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- Verified no remaining `url.protocol.*url.host` patterns (except `inviteToken.ts` which takes a string, not `Request`, and throws in prod without `APP_URL`)
- Could not run `yarn build:packages` (deps not installed in workspace), but all changes are straightforward import + substitution

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements