### PR TITLE
fix(cli): auto-copy .env.example when .env is missing in dev

### DIFF
--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -194,6 +194,13 @@ async function ensureEnvLoaded() {
 
     // Load .env from app directory if it exists
     const envPath = path.join(appDir, '.env')
+    if (!fs.existsSync(envPath) && process.env.NODE_ENV !== 'production') {
+      const examplePath = path.join(appDir, '.env.example')
+      if (fs.existsSync(examplePath)) {
+        fs.copyFileSync(examplePath, envPath)
+        console.log(`📋 Copied .env.example → .env (edit ${envPath} to customize)`)
+      }
+    }
     if (fs.existsSync(envPath)) {
       const dotenv = await import('dotenv')
       dotenv.config({ path: envPath, quiet: quietDotenv })


### PR DESCRIPTION
## Summary

Running `yarn dev:greenfield` in a fresh clone/workspace fails at step 4/5 with "DATABASE_URL is not set" because no `.env` file exists. This auto-copies `.env.example` → `.env` in non-production environments so greenfield just works out of the box.

## Changes

- In `ensureEnvLoaded()`, auto-copy `.env.example` to `.env` when `.env` is missing and `NODE_ENV !== 'production'`
- Logs a one-liner so the user knows the copy happened

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing

- `yarn build:packages` passes
- Verified the logic only triggers when `.env` is absent and `NODE_ENV` is not `production`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

N/A