### PR TITLE
fix(security): require authentication on /api/docs/openapi and   /api/docs/markdown

### DIFF
--- a/apps/mercato/src/app/api/docs/markdown/__tests__/route.test.ts
+++ b/apps/mercato/src/app/api/docs/markdown/__tests__/route.test.ts
@@ -1,0 +1,64 @@
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromCookies: jest.fn(),
+}))
+
+jest.mock('@/.mercato/generated/modules.generated', () => ({
+  modules: [],
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    t: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/openapi', () => ({
+  buildOpenApiDocument: jest.fn(() => ({
+    openapi: '3.1.0',
+    info: { title: 'Open Mercato API', version: 'test' },
+    paths: { '/api/health': { get: { summary: 'Health' } } },
+  })),
+  sanitizeOpenApiDocument: jest.fn((doc) => doc),
+  generateMarkdownFromOpenApi: jest.fn(() => '# Open Mercato API\n\n## /api/health\n'),
+}))
+
+jest.mock('@open-mercato/shared/lib/version', () => ({
+  APP_VERSION: 'test',
+}))
+
+import { GET } from '../route'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import { buildOpenApiDocument } from '@open-mercato/shared/lib/openapi'
+
+const mockedGetAuth = getAuthFromCookies as jest.MockedFunction<typeof getAuthFromCookies>
+const mockedBuild = buildOpenApiDocument as jest.MockedFunction<typeof buildOpenApiDocument>
+
+describe('GET /api/docs/markdown (native route)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 for anonymous callers (no cookie) and never builds the document', async () => {
+    mockedGetAuth.mockResolvedValue(null)
+    const res = await GET()
+    expect(res.status).toBe(401)
+    expect(res.headers.get('content-type')).toContain('application/json')
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Unauthorized' })
+    expect(mockedBuild).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with markdown for authenticated callers', async () => {
+    mockedGetAuth.mockResolvedValue({
+      userId: 'u-1',
+      tenantId: 't-1',
+      organizationId: 'o-1',
+    } as never)
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/markdown')
+    const body = await res.text()
+    expect(body).toContain('# Open Mercato API')
+    expect(mockedBuild).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mercato/src/app/api/docs/markdown/route.ts
+++ b/apps/mercato/src/app/api/docs/markdown/route.ts
@@ -1,4 +1,5 @@
 import { modules } from '@/.mercato/generated/modules.generated'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
 import { buildOpenApiDocument, generateMarkdownFromOpenApi, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
@@ -15,6 +16,17 @@ function resolveBaseUrl() {
 }
 
 export async function GET() {
+  const auth = await getAuthFromCookies()
+  if (!auth) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      },
+    })
+  }
+
   const { t } = await resolveTranslations()
   const baseUrl = resolveBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {

--- a/apps/mercato/src/app/api/docs/openapi/__tests__/route.test.ts
+++ b/apps/mercato/src/app/api/docs/openapi/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromCookies: jest.fn(),
+}))
+
+jest.mock('@/.mercato/generated/modules.generated', () => ({
+  modules: [],
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    t: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/openapi', () => ({
+  buildOpenApiDocument: jest.fn(() => ({
+    openapi: '3.1.0',
+    info: { title: 'Open Mercato API', version: 'test' },
+    paths: { '/api/health': { get: { summary: 'Health' } } },
+  })),
+  sanitizeOpenApiDocument: jest.fn((doc) => doc),
+}))
+
+jest.mock('@open-mercato/shared/lib/version', () => ({
+  APP_VERSION: 'test',
+}))
+
+import { GET } from '../route'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import { buildOpenApiDocument } from '@open-mercato/shared/lib/openapi'
+
+const mockedGetAuth = getAuthFromCookies as jest.MockedFunction<typeof getAuthFromCookies>
+const mockedBuild = buildOpenApiDocument as jest.MockedFunction<typeof buildOpenApiDocument>
+
+describe('GET /api/docs/openapi (native route)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 for anonymous callers (no cookie) and never builds the document', async () => {
+    mockedGetAuth.mockResolvedValue(null)
+    const res = await GET()
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body).toEqual({ error: 'Unauthorized' })
+    expect(mockedBuild).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 with the generated OpenAPI document for authenticated callers', async () => {
+    mockedGetAuth.mockResolvedValue({
+      userId: 'u-1',
+      tenantId: 't-1',
+      organizationId: 'o-1',
+    } as never)
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { openapi: string; paths: Record<string, unknown> }
+    expect(body.openapi).toBe('3.1.0')
+    expect(Object.keys(body.paths)).toContain('/api/health')
+    expect(mockedBuild).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/mercato/src/app/api/docs/openapi/route.ts
+++ b/apps/mercato/src/app/api/docs/openapi/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { modules } from '@/.mercato/generated/modules.generated'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
 import { buildOpenApiDocument, sanitizeOpenApiDocument } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
@@ -16,6 +17,11 @@ function resolveBaseUrl() {
 }
 
 export async function GET() {
+  const auth = await getAuthFromCookies()
+  if (!auth) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { t } = await resolveTranslations()
   const baseUrl = resolveBaseUrl()
   const rawDoc = buildOpenApiDocument(modules, {


### PR DESCRIPTION
## Summary

  Gates the native Next.js docs routes
  `apps/mercato/src/app/api/docs/openapi/route.ts` and
  `apps/mercato/src/app/api/docs/markdown/route.ts` with `getAuthFromCookies()`. The
  backend wrapper page `/backend/docs` already required auth (`page.meta.ts` declares
  `requireAuth: true`); the underlying JSON/markdown endpoints were the inconsistency,
   not the wrapper.

  ## Vulnerability

  ### Live PoC evidence (dev box, SHA 493a1b799)

  GET /api/docs/openapi   (no cookies)
  → HTTP 200, OpenAPI 3.1 JSON
  → 393 paths total
  → 557 x-require-features annotations
  → Sensitive paths surfaced (sample, openapi paths drop the /api/ prefix):
     • /auth/admin/nav            (admin nav, 1 path)
     • /scheduler/jobs, /scheduler/executions, /scheduler/trigger,
       /scheduler/targets, /scheduler/queue-jobs   (5 admin scheduler paths)
     • /integrations/credentials, /integrations/health,
       /integrations/logs, ...    (7 integrations paths incl. credential ops)

  GET /api/docs/markdown  (no cookies)
  → HTTP 200, full module markdown (same surface, reflowed)

  `sanitizeOpenApiDocument()` only normalizes schemas — it does **not** filter by role
   or strip admin-annotated operations. `buildOpenApiDocument` at
  `packages/shared/src/lib/openapi/generator.ts:1060-1133` emits every route
  unconditionally with its `x-require-features` / `x-require-roles` / `x-require-auth`
   annotations. Result: anonymous attackers get a complete pre-auth reconnaissance map
   (what admin features exist, which roles guard them, what payloads they accept).

  > **Note on PoC selector quirk:** the original PoC predicate searched for
  `/api/auth/admin/` — too narrow. The OpenAPI document strips the `/api/` prefix from
   path keys (it lives in the `servers` block instead), so admin paths appear as
  `/auth/admin/nav` etc. The selector was tightened for the live run; the underlying
  disclosure is unchanged.

  The frontend `/backend/docs` page already requires auth (verified in
  `packages/core/src/modules/api_docs/backend/docs/page.meta.ts:13`). The asymmetry
  was: wrapper page gated, raw JSON/markdown endpoints open.

  ## Fix

  Call `getAuthFromCookies()` at the top of both `GET` handlers; return `401
  {"error":"Unauthorized"}` (JSON content-type for both, even on the markdown route,
  so consumers can parse the error uniformly) when no session is present. The
  expensive `buildOpenApiDocument` call is skipped on the deny path.

  ## Test plan

  - [x] Unit — new
  `apps/mercato/src/app/api/docs/{openapi,markdown}/__tests__/route.test.ts`: 4/4 PASS
   (anon 401 + document not built, authed 200 + correct content-type)
  - [x] Typecheck — 18/18 PASS
  - [x] Integration ephemeral — `--filter shipping_carriers` smoke: **21/21 PASS in
  33.9s** (boot + admin auth pipeline confirmed intact)
  - [x] PoC against patched build — anonymous GET on both routes returns 401 (verified
   locally)

  ## Backward compatibility

  - The api_docs frontend page (`/backend/docs`) consumes both endpoints client-side
  with cookies — unchanged.
  - The AI-assistant Tier-3 HTTP fallback in
  `packages/ai-assistant/src/modules/ai_assistant/lib/api-endpoint-index.ts:211` is
  unaffected in normal operation: it uses Tier-1 (`openapi.generated.json`) and Tier-2
   (in-process module registry) first; the loopback HTTP fallback now returns 401 for
  unauthenticated callers and gracefully falls through to `null`, which is the
  documented fallback behavior.
  - External tooling that previously fetched the public spec for client generation
  must now authenticate. If a public-spec UX is desired, recommend Option 2 from the
  original report (filter the document in `sanitizeOpenApiDocument` per caller role)
  as a follow-up.

  ## Notes for reviewer

  - Considered alternative: filtering operations by role inside
  `sanitizeOpenApiDocument` so anonymous callers see only `x-require-auth: false`
  operations. Chose the simpler gate-the-route approach to stay consistent with
  `/backend/docs` page meta and avoid touching the openapi sanitizer (used by other
  tooling).
  - Markdown route returns `application/json` on the 401 path (not `text/markdown`) —
  explicit choice so curl/scripts get a parseable error body; success path keeps
  `text/markdown`.