### PR TITLE
fix(shared): include env var names in missing API key error

### DIFF
--- a/.ai/specs/2026-04-16-actionable-missing-api-key-error.md
+++ b/.ai/specs/2026-04-16-actionable-missing-api-key-error.md
@@ -1,0 +1,47 @@
+# Actionable Missing API Key Error
+
+- **Date**: 2026-04-16
+- **Status**: Implemented
+- **Module**: `shared` (lib/ai), `inbox_ops` (consumers)
+- **GitHub Issue**: #1433
+
+## TLDR
+
+Include the expected environment variable name(s) in the error thrown when an AI provider API key is missing, so the error is immediately actionable.
+
+## Problem Statement
+
+When the AI provider API key is missing, the error stored in `inbox_emails.processing_error` is:
+
+```
+LLM extraction failed: Missing API key for provider "anthropic"
+```
+
+This does not tell the user which env var to set. Users set the wrong variable and are stuck with no indication of what went wrong.
+
+## Proposed Solution
+
+Add a `requireOpenCodeProviderApiKey` function in `packages/shared/src/lib/ai/opencode-provider.ts` that either returns the API key or throws with an actionable error message including accepted env var names:
+
+```
+Missing API key for provider "anthropic". Set ANTHROPIC_API_KEY or OPENCODE_ANTHROPIC_API_KEY in your .env file.
+```
+
+This covers all three providers:
+- **Anthropic**: `ANTHROPIC_API_KEY` / `OPENCODE_ANTHROPIC_API_KEY`
+- **OpenAI**: `OPENAI_API_KEY` / `OPENCODE_OPENAI_API_KEY`
+- **Google**: `GOOGLE_GENERATIVE_AI_API_KEY` / `OPENCODE_GOOGLE_API_KEY`
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `packages/shared/src/lib/ai/opencode-provider.ts` | Add `requireOpenCodeProviderApiKey` function |
+| `packages/shared/src/lib/ai/__tests__/opencode-provider.test.ts` | Add tests for the new function |
+| `packages/core/src/modules/inbox_ops/lib/llmProvider.ts` | Replace manual null-check with `requireOpenCodeProviderApiKey` |
+| `packages/core/src/modules/inbox_ops/lib/translationProvider.ts` | Replace manual null-check with `requireOpenCodeProviderApiKey` |
+| `packages/core/src/modules/inbox_ops/ai-tools.ts` | Replace manual null-check with `requireOpenCodeProviderApiKey` |
+
+## Changelog
+
+- **2026-04-16**: Initial spec created.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -90,6 +90,7 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [Webhooks](2026-03-23-inbound-webhook-handlers.md) | 2026-03-23 | Inbound Webhook Handlers | Inbound webhook handler architecture and registration |
 | [Build Check](2026-03-25-safe-build-dev-coexistence.md) | 2026-03-25 | Safe Package Verification Build | Isolated `build:check` output so verification builds never touch live `dist/` artifacts |
 | [Not Found](2026-03-23-unified-record-not-found-ui-state.md) | 2026-03-23 | Unified Record Not-Found UI State | Consistent UI state for missing/deleted records |
+| [API Key Error](2026-04-16-actionable-missing-api-key-error.md) | 2026-04-16 | Actionable Missing API Key Error | Include expected env var names in missing AI provider API key error (#1433) |
 
 ### Implemented Specifications
 

--- a/packages/core/src/modules/inbox_ops/ai-tools.ts
+++ b/packages/core/src/modules/inbox_ops/ai-tools.ts
@@ -6,7 +6,7 @@ import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/
 import { hasFeature } from '@open-mercato/shared/security/features'
 import {
   resolveOpenCodeModel,
-  resolveOpenCodeProviderApiKey,
+  requireOpenCodeProviderApiKey,
 } from '@open-mercato/shared/lib/ai/opencode-provider'
 import { InboxProposal, InboxProposalAction, InboxDiscrepancy } from './data/entities'
 import { inboxProposalCategoryEnum } from './data/validators'
@@ -391,10 +391,7 @@ Input text is limited to 10,000 characters for cost control.`,
     requireTenantContext(ctx)
 
     const providerId = resolveExtractionProviderId()
-    const apiKey = resolveOpenCodeProviderApiKey(providerId)
-    if (!apiKey) {
-      throw new Error(`Missing API key for provider "${providerId}"`)
-    }
+    const apiKey = requireOpenCodeProviderApiKey(providerId)
 
     const modelConfig = resolveOpenCodeModel(providerId, {})
     const model = await createStructuredModel(providerId, apiKey, modelConfig.modelId)

--- a/packages/core/src/modules/inbox_ops/lib/__tests__/translationProvider.test.ts
+++ b/packages/core/src/modules/inbox_ops/lib/__tests__/translationProvider.test.ts
@@ -8,7 +8,7 @@ jest.mock('ai', () => ({
 jest.mock('@open-mercato/shared/lib/ai/opencode-provider', () => ({
   resolveFirstConfiguredOpenCodeProvider: jest.fn(() => 'openai'),
   resolveOpenCodeModel: jest.fn(() => ({ modelId: 'gpt-4o', modelWithProvider: 'openai:gpt-4o' })),
-  resolveOpenCodeProviderApiKey: jest.fn(() => 'test-key'),
+  requireOpenCodeProviderApiKey: jest.fn(() => 'test-key'),
   resolveOpenCodeProviderId: jest.fn((id: string) => id || 'openai'),
 }))
 
@@ -84,8 +84,10 @@ describe('translateProposalContent', () => {
   })
 
   it('throws when API key is missing', async () => {
-    const { resolveOpenCodeProviderApiKey } = require('@open-mercato/shared/lib/ai/opencode-provider')
-    resolveOpenCodeProviderApiKey.mockReturnValueOnce(null)
+    const { requireOpenCodeProviderApiKey } = require('@open-mercato/shared/lib/ai/opencode-provider')
+    requireOpenCodeProviderApiKey.mockImplementationOnce(() => {
+      throw new Error('Missing API key for provider "openai". Set OPENAI_API_KEY or OPENCODE_OPENAI_API_KEY in your .env file.')
+    })
 
     await expect(
       translateProposalContent({

--- a/packages/core/src/modules/inbox_ops/lib/llmProvider.ts
+++ b/packages/core/src/modules/inbox_ops/lib/llmProvider.ts
@@ -2,7 +2,7 @@ import { generateObject } from 'ai'
 import {
   resolveFirstConfiguredOpenCodeProvider,
   resolveOpenCodeModel,
-  resolveOpenCodeProviderApiKey,
+  requireOpenCodeProviderApiKey,
   resolveOpenCodeProviderId,
   type OpenCodeProviderId,
 } from '@open-mercato/shared/lib/ai/opencode-provider'
@@ -84,10 +84,7 @@ export async function runExtractionWithConfiguredProvider(input: {
   modelWithProvider: string
 }> {
   const providerId = resolveExtractionProviderId()
-  const apiKey = resolveOpenCodeProviderApiKey(providerId)
-  if (!apiKey) {
-    throw new Error(`Missing API key for provider "${providerId}"`)
-  }
+  const apiKey = requireOpenCodeProviderApiKey(providerId)
 
   const modelConfig = resolveOpenCodeModel(providerId, {
     overrideModel: input.modelOverride,

--- a/packages/core/src/modules/inbox_ops/lib/translationProvider.ts
+++ b/packages/core/src/modules/inbox_ops/lib/translationProvider.ts
@@ -2,7 +2,7 @@ import { generateText } from 'ai'
 import { z } from 'zod'
 import {
   resolveOpenCodeModel,
-  resolveOpenCodeProviderApiKey,
+  requireOpenCodeProviderApiKey,
 } from '@open-mercato/shared/lib/ai/opencode-provider'
 import { createStructuredModel, resolveExtractionProviderId, withTimeout } from './llmProvider'
 
@@ -20,10 +20,7 @@ export async function translateProposalContent(input: {
   targetLocale: string
 }): Promise<{ summary: string; actions: Record<string, string> }> {
   const providerId = resolveExtractionProviderId()
-  const apiKey = resolveOpenCodeProviderApiKey(providerId)
-  if (!apiKey) {
-    throw new Error(`Missing API key for provider "${providerId}"`)
-  }
+  const apiKey = requireOpenCodeProviderApiKey(providerId)
 
   const modelConfig = resolveOpenCodeModel(providerId, {
     overrideModel: process.env.INBOX_OPS_LLM_MODEL,

--- a/packages/shared/src/lib/ai/__tests__/opencode-provider.test.ts
+++ b/packages/shared/src/lib/ai/__tests__/opencode-provider.test.ts
@@ -2,6 +2,7 @@ import {
   resolveOpenCodeProviderId,
   resolveFirstConfiguredOpenCodeProvider,
   resolveOpenCodeModel,
+  requireOpenCodeProviderApiKey,
 } from '../opencode-provider'
 
 describe('opencode provider helpers', () => {
@@ -121,5 +122,40 @@ describe('opencode provider helpers', () => {
       },
     })
     expect(provider).toBe('google')
+  })
+
+  describe('requireOpenCodeProviderApiKey', () => {
+    it('returns the API key when configured', () => {
+      const key = requireOpenCodeProviderApiKey('anthropic', {
+        ANTHROPIC_API_KEY: 'my-key',
+      })
+      expect(key).toBe('my-key')
+    })
+
+    it('returns the fallback OPENCODE_* key when primary is missing', () => {
+      const key = requireOpenCodeProviderApiKey('openai', {
+        OPENAI_API_KEY: '',
+        OPENCODE_OPENAI_API_KEY: 'fallback-key',
+      })
+      expect(key).toBe('fallback-key')
+    })
+
+    it('throws with env var names for anthropic when key is missing', () => {
+      expect(() => requireOpenCodeProviderApiKey('anthropic', {})).toThrow(
+        'Missing API key for provider "anthropic". Set ANTHROPIC_API_KEY or OPENCODE_ANTHROPIC_API_KEY in your .env file.',
+      )
+    })
+
+    it('throws with env var names for openai when key is missing', () => {
+      expect(() => requireOpenCodeProviderApiKey('openai', {})).toThrow(
+        'Missing API key for provider "openai". Set OPENAI_API_KEY or OPENCODE_OPENAI_API_KEY in your .env file.',
+      )
+    })
+
+    it('throws with env var names for google when key is missing', () => {
+      expect(() => requireOpenCodeProviderApiKey('google', {})).toThrow(
+        'Missing API key for provider "google". Set GOOGLE_GENERATIVE_AI_API_KEY or OPENCODE_GOOGLE_API_KEY in your .env file.',
+      )
+    })
   })
 })

--- a/packages/shared/src/lib/ai/opencode-provider.ts
+++ b/packages/shared/src/lib/ai/opencode-provider.ts
@@ -108,6 +108,22 @@ export function resolveOpenCodeProviderApiKey(
   return null
 }
 
+export function requireOpenCodeProviderApiKey(
+  providerId: OpenCodeProviderId,
+  env: EnvLookup = process.env,
+): string {
+  const apiKey = resolveOpenCodeProviderApiKey(providerId, env)
+  if (apiKey) {
+    return apiKey
+  }
+
+  const provider = OPEN_CODE_PROVIDERS[providerId]
+  const envKeysHint = provider.envKeys.join(' or ')
+  throw new Error(
+    `Missing API key for provider "${providerId}". Set ${envKeysHint} in your .env file.`,
+  )
+}
+
 export function getOpenCodeProviderConfiguredEnvKey(
   providerId: OpenCodeProviderId,
   env: EnvLookup = process.env,


### PR DESCRIPTION
## Summary
- Add `requireOpenCodeProviderApiKey()` to `@open-mercato/shared` that throws with actionable env var names (e.g. *"Set ANTHROPIC_API_KEY or OPENCODE_ANTHROPIC_API_KEY in your .env file"*) instead of a generic "Missing API key" message
- Replace duplicated null-check pattern in 3 `inbox_ops` call sites (`llmProvider.ts`, `translationProvider.ts`, `ai-tools.ts`)
- Covers all 3 providers: Anthropic, OpenAI, Google

Closes #1433

## Test plan
- [x] 5 new unit tests for `requireOpenCodeProviderApiKey` (success path, fallback key, error message for each provider)
- [x] Updated `translationProvider.test.ts` mock to match new function
- [x] All 3621 existing tests pass
- [x] Full CI gate verified: build, generate, typecheck, i18n sync, app build

🤖 Generated with [Claude Code](https://claude.com/claude-code)