### PR TITLE
fix(ui): hide messages topbar icon when backing module is disabled

### DIFF
--- a/apps/mercato/src/components/BackendHeaderChrome.tsx
+++ b/apps/mercato/src/components/BackendHeaderChrome.tsx
@@ -67,13 +67,13 @@ export function BackendHeaderChrome({
     () => hasFeature(grantedFeatures, 'ai_assistant.view'),
     [grantedFeatures],
   )
-  const showMessages = React.useMemo(
-    () => hasFeature(grantedFeatures, 'messages.view'),
-    [grantedFeatures],
-  )
   const showSearch = React.useMemo(
     () => hasFeature(grantedFeatures, 'search.global'),
     [grantedFeatures],
+  )
+  const showMessages = React.useMemo(
+    () => hasVisibleRoute(payload?.groups, '/backend/messages'),
+    [payload?.groups],
   )
 
   return (

--- a/packages/create-app/template/src/components/BackendHeaderChrome.tsx
+++ b/packages/create-app/template/src/components/BackendHeaderChrome.tsx
@@ -67,13 +67,13 @@ export function BackendHeaderChrome({
     () => hasFeature(grantedFeatures, 'ai_assistant.view'),
     [grantedFeatures],
   )
-  const showMessages = React.useMemo(
-    () => hasFeature(grantedFeatures, 'messages.view'),
-    [grantedFeatures],
-  )
   const showSearch = React.useMemo(
     () => hasFeature(grantedFeatures, 'search.global'),
     [grantedFeatures],
+  )
+  const showMessages = React.useMemo(
+    () => hasVisibleRoute(payload?.groups, '/backend/messages'),
+    [payload?.groups],
   )
 
   return (


### PR DESCRIPTION
## Summary

- Switch the topbar **messages** icon from feature-based (`messages.view`) to nav-visibility-based (`/backend/messages`) gating, matching the existing integrations button pattern.
- **Fixes a bug: `/api/messages` and `/api/messages/unread-count` 404 spam when the `messages` module is disabled in `modules.ts` (the icon kept rendering because `messages.view` was still stored in role rows).**
- Synced in `packages/create-app/template/src/components/BackendHeaderChrome.tsx` per create-app AGENTS.md sync rule.

## Scope note — follow-up needed

The original intent covered topbar items for AI assistant, search, notifications bell, and organization switcher as well. **Those are intentionally NOT changed here** and still use the old feature-based gating. Reason:

- Their admin config pages (`/backend/config/ai-assistant`, `/backend/config/search`, `/backend/config/notifications`) live in `payload.settingsSections`, not `payload.groups`, so `hasVisibleRoute(groups, ...)` can't find them.
- Those config pages also require admin-only features (`ai_assistant.settings.manage`, `search.view`, `notifications.manage`) — so even if we queried `settingsSections`, we'd overgate regular users who have `ai_assistant.view` / `search.global` / `messages.view` but no admin config access.
- The organization switcher has no natural nav entry to gate on.

So: **the "module disabled → hide topbar icon" behavior is only correct for messages here.** For the other four topbar items the same 404-spam class of bug can still occur when their module is removed but roles still carry the feature string. Closing that gap cleanly needs a separate mechanism — either a known-features registry exposed on `BackendChromePayload`, or a "modules installed" list, so the client can distinguish "user lacks the feature" from "the module that declares this feature is gone". Should be addressed in a follow-up PR.

## Test plan

- [x] Baseline: all modules enabled — every topbar icon (messages, AI chat, search, org switcher, notifications, integrations) renders and works as before.
- [x] Disable `messages` in `apps/mercato/src/modules.ts`, run `yarn generate` + `yarn mercato configs cache structural --all-tenants`, restart dev. Verify the mail icon is gone, no `/api/messages/*` requests fire, no 404s in console.
- [x] Feature-removed-but-module-enabled case: keep `messages` enabled, remove `messages.view` from the current user's role — icon disappears because the nav API hides `/backend/messages` when `requireFeatures` isn't satisfied.
- [x] Non-admin user with `messages.view` but no admin config features — mail icon still renders (regression check vs. the overgating bug caught in review).
- [x] `yarn lint`, `yarn typecheck`, and `yarn build:packages` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)