### PR TITLE
fix(business_rules): pin tenant scope on PUT, reject body-supplied te…

### DIFF
--- a/packages/core/src/modules/business_rules/__tests__/update-schemas-mass-assign-scope.test.ts
+++ b/packages/core/src/modules/business_rules/__tests__/update-schemas-mass-assign-scope.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+import {
+  updateRuleSetSchema,
+  updateBusinessRuleSchema,
+  createLocalizedUpdateBusinessRuleSchema,
+} from '@open-mercato/core/modules/business_rules/data/validators'
+
+const validId = '11111111-1111-4111-8111-111111111111'
+const foreignTenant = '22222222-2222-4222-8222-222222222222'
+const foreignOrg = '33333333-3333-4333-8333-333333333333'
+
+const identityTranslator = ((_key: string, fallback?: string) => fallback ?? _key) as any
+
+describe('business_rules update schemas — mass-assign scope', () => {
+  test('updateRuleSetSchema strips tenantId/organizationId/createdBy from body', () => {
+    const result = updateRuleSetSchema.safeParse({
+      id: validId,
+      setName: 'hijacked',
+      tenantId: foreignTenant,
+      organizationId: foreignOrg,
+      createdBy: 'attacker@evil.test',
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).not.toHaveProperty('tenantId')
+    expect(result.data).not.toHaveProperty('organizationId')
+    expect(result.data).not.toHaveProperty('createdBy')
+    expect(result.data.setName).toBe('hijacked')
+  })
+
+  test('updateBusinessRuleSchema strips tenantId/organizationId/createdBy from body', () => {
+    const result = updateBusinessRuleSchema.safeParse({
+      id: validId,
+      ruleName: 'hijacked-rule',
+      tenantId: foreignTenant,
+      organizationId: foreignOrg,
+      createdBy: 'attacker@evil.test',
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).not.toHaveProperty('tenantId')
+    expect(result.data).not.toHaveProperty('organizationId')
+    expect(result.data).not.toHaveProperty('createdBy')
+    expect(result.data.ruleName).toBe('hijacked-rule')
+  })
+
+  test('createLocalizedUpdateBusinessRuleSchema strips tenantId/organizationId/createdBy from body', () => {
+    const schema = createLocalizedUpdateBusinessRuleSchema(identityTranslator)
+    const result = schema.safeParse({
+      id: validId,
+      ruleName: 'hijacked-localized',
+      tenantId: foreignTenant,
+      organizationId: foreignOrg,
+      createdBy: 'attacker@evil.test',
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data).not.toHaveProperty('tenantId')
+    expect(result.data).not.toHaveProperty('organizationId')
+    expect(result.data).not.toHaveProperty('createdBy')
+    expect(result.data.ruleName).toBe('hijacked-localized')
+  })
+})

--- a/packages/core/src/modules/business_rules/api/rules/route.ts
+++ b/packages/core/src/modules/business_rules/api/rules/route.ts
@@ -244,6 +244,9 @@ export async function PUT(req: Request) {
     ...body,
     updatedBy: auth.sub ?? auth.email ?? null,
   }
+  delete (payload as Record<string, unknown>).tenantId
+  delete (payload as Record<string, unknown>).organizationId
+  delete (payload as Record<string, unknown>).createdBy
 
   const { t } = await resolveTranslations()
   const schema = createLocalizedUpdateBusinessRuleSchema(t)

--- a/packages/core/src/modules/business_rules/api/sets/route.ts
+++ b/packages/core/src/modules/business_rules/api/sets/route.ts
@@ -200,6 +200,9 @@ export async function PUT(req: Request) {
     ...body,
     updatedBy: auth.sub ?? auth.email ?? null,
   }
+  delete (payload as Record<string, unknown>).tenantId
+  delete (payload as Record<string, unknown>).organizationId
+  delete (payload as Record<string, unknown>).createdBy
 
   const parsed = updateRuleSetSchema.safeParse(payload)
   if (!parsed.success) {

--- a/packages/core/src/modules/business_rules/data/validators.ts
+++ b/packages/core/src/modules/business_rules/data/validators.ts
@@ -150,9 +150,10 @@ export const createBusinessRuleSchema = z.object({
 
 export type CreateBusinessRuleInput = z.input<typeof createBusinessRuleSchema>
 
-export const updateBusinessRuleSchema = createBusinessRuleSchema.partial().extend({
-  id: uuid,
-})
+export const updateBusinessRuleSchema = createBusinessRuleSchema
+  .omit({ tenantId: true, organizationId: true, createdBy: true })
+  .partial()
+  .extend({ id: uuid })
 
 export type UpdateBusinessRuleInput = z.input<typeof updateBusinessRuleSchema>
 
@@ -169,9 +170,10 @@ export function createLocalizedBusinessRuleSchema(t: TranslatorFn) {
 }
 
 export function createLocalizedUpdateBusinessRuleSchema(t: TranslatorFn) {
-  return createLocalizedBusinessRuleSchema(t).partial().extend({
-    id: uuid,
-  })
+  return createLocalizedBusinessRuleSchema(t)
+    .omit({ tenantId: true, organizationId: true, createdBy: true })
+    .partial()
+    .extend({ id: uuid })
 }
 
 // Query/Filter Schema
@@ -236,9 +238,10 @@ export const createRuleSetSchema = z.object({
 export type CreateRuleSetInput = z.infer<typeof createRuleSetSchema>
 
 // RuleSet Update Schema
-export const updateRuleSetSchema = createRuleSetSchema.partial().extend({
-  id: uuid,
-})
+export const updateRuleSetSchema = createRuleSetSchema
+  .omit({ tenantId: true, organizationId: true, createdBy: true })
+  .partial()
+  .extend({ id: uuid })
 
 export type UpdateRuleSetInput = z.infer<typeof updateRuleSetSchema>
 


### PR DESCRIPTION
## Summary                                                                                              
                                                                                                          
  `PUT /api/business_rules/sets` and `PUT /api/business_rules/rules` accepted                             
  `tenantId`, `organizationId` and `createdBy` from the request body and passed                           
  them to `em.assign(entity, parsed.data)`. The update schemas were declared as                           
  `createXxxSchema.partial().extend({ id })`, which preserved every scope field                           
  from the create schema as optional-writable. A tenant-admin holding the default                         
  `business_rules.manage` / `business_rules.manage_sets` features could therefore                         
  `POST` a record in their own tenant, then `PUT` it with                                                 
  `{ id, tenantId: <victim>, organizationId: <victim-org> }` to migrate the                               
  record into another tenant.                                                                             
                                                                                                          
  For `BusinessRule` the impact is higher than for `RuleSet`: rules are                                   
  executable (`GUARD` / `VALIDATION` / `ACTION` / `ASSIGNMENT`), so a migrated                            
  rule runs live inside the victim tenant's runtime.                                                      
                                                                                                          
  The `POST` handlers were already correct — they spread `auth.*` into the                                
  payload after the body spread, so the `PUT`/`POST` asymmetry is what this PR                            
  closes.                                                                                                 
                  
  ## Changes                                                                                              
                  
  ### Validators — `packages/core/src/modules/business_rules/data/validators.ts`                          
   
  Three update schemas now `.omit` `tenantId`, `organizationId`, and `createdBy`                          
  before `.partial().extend({ id })`:                                                                     
                                                                                                          
  - `updateRuleSetSchema`                                                                                 
  - `updateBusinessRuleSchema` (static, used for OpenAPI docs)                                            
  - `createLocalizedUpdateBusinessRuleSchema(t)` (i18n-aware, used at the route)                          
                                                                                                          
  Both schema variants are fixed in case a future caller switches between them.                           
                                                                                                          
  ### PUT handlers
                                                                                                          
  - `packages/core/src/modules/business_rules/api/sets/route.ts`
  - `packages/core/src/modules/business_rules/api/rules/route.ts`                                         
   
  Both handlers explicitly strip the three fields from the payload before                                 
  `safeParse` as a belt-and-suspenders defence against any future schema
  regression:                                                                                             
                  
  ```ts                                                                                                   
  delete (payload as Record<string, unknown>).tenantId
  delete (payload as Record<string, unknown>).organizationId                                              
  delete (payload as Record<string, unknown>).createdBy
                                                                                                          
  After the schema change parsed.data no longer contains scope fields, so the                             
  existing em.assign(ruleSet, parsed.data) / em.assign(rule, parsed.data) can
  no longer move the record across tenants. Ownership is already enforced by                              
  em.findOne(..., { id, tenantId: auth.tenantId, organizationId: auth.orgId })                            
  (unchanged).
                                                                                                          
  Tests           
                                                                                                          
  packages/core/src/modules/business_rules/__tests__/update-schemas-mass-assign-scope.test.ts             
  — 3 cases asserting that each of the three update schemas drops
  tenantId / organizationId / createdBy from the parsed payload while                                     
  preserving legitimate fields (setName / ruleName).                                                      
                                                                                                          
  yarn workspace @open-mercato/core test — full core test suite green.                                    
                  
  Backward compatibility                                                                                  
                  
  - No database schema / migration changes.                                                               
  - No event ID / API URL / DI registration / feature ID renamed.
  - Update schemas drop tenantId, organizationId, createdBy from their                                    
  parsed shape. Runtime stays compatible (Zod strips unknown keys), so clients                            
  that include these fields continue to receive 200 — the fields are simply                               
  ignored. TypeScript consumers using z.infer<typeof updateXxxSchema> lose                                
  the three fields; they existed only as an attack vector, not as a legitimate                            
  client contract.                                                                                        
  - POST paths untouched — they correctly pin tenantId / organizationId /                                 
  createdBy from auth.*.