### PR TITLE
Fix/security customer signup tenant binding

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -809,3 +809,13 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: When a feature adds a new app-level env var required for local, test, or non-production behavior, update both `apps/mercato/.env.example` and `packages/create-app/template/.env.example` in the same change. If standalone CI/bootstrap scripts synthesize `.env`, set the same var there explicitly too.
 
 **Applies to**: `apps/mercato/.env.example`, `packages/create-app/template/.env.example`, create-app smoke/parity scripts, and any new env-backed local/testing security feature.
+
+## Keep raw SQL out of API route handlers
+
+**Context**: The customer portal signup route (`packages/core/src/modules/customer_accounts/api/signup.ts`) inlined a tenant-bound organization lookup as a raw `em.getConnection().execute(...)` call. The SQL was only a handful of lines, but it put persistence knowledge into a route file and made regression tests reach into route internals to pin the `WHERE id = ? AND tenant_id = ?` predicate.
+
+**Problem**: Raw SQL in route handlers blurs the layering between HTTP plumbing and persistence. It is easy to drift: the same SQL gets copy-pasted into other routes, each copy is re-audited separately, and security-critical predicates (tenant binding, soft-delete filters) can silently diverge between callers. API routes should read as orchestration — parse, validate, authorize, delegate, respond — not as SQL authors.
+
+**Rule**: API route handlers must not contain raw SQL. Extract DB reads/writes into a named helper in the module's `lib/` (for simple lookups) or a service in `services/` (for stateful or multi-step logic), and import the helper from the route. The helper is the single place where the predicate is defined, audited, and regression-tested. MikroORM entity calls (`findOneWithDecryption`, repository methods) are acceptable in routes when they are single-liner lookups by stable primary keys; anything with a custom `WHERE`, `JOIN`, or raw `execute(...)` belongs in a helper.
+
+**Applies to**: All API route files under `packages/**/api/**` and `apps/**/api/**`. When moving existing inline SQL out of a route, keep the regression test pointed at the helper source so the predicate stays pinned even after the relocation.

--- a/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment node
+ *
+ * Source-level regression guards for the cross-tenant signup+login chain.
+ * Fails the moment someone drops the tenant-bound organization lookup in signup
+ * or removes the emailVerifiedAt gate from login.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const MODULE_ROOT = resolve(__dirname, '..')
+
+function readSource(relPath: string): string {
+  return readFileSync(resolve(MODULE_ROOT, relPath), 'utf8')
+}
+
+describe('customer_accounts signup — organization lookup must bind tenantId', () => {
+  const source = readSource('api/signup.ts')
+
+  test('organization lookup SQL filters by tenant_id as well as id', () => {
+    const lookupSqlPattern = /FROM\s+organizations\s+WHERE\s+id\s*=\s*\?\s+AND\s+tenant_id\s*=\s*\?/i
+    expect(source).toMatch(lookupSqlPattern)
+  })
+
+  test('organization lookup passes both organizationId and tenantId as parameters', () => {
+    const paramsPattern = /\[\s*organizationId\s*,\s*tenantId\s*\]/
+    expect(source).toMatch(paramsPattern)
+  })
+
+  test('mismatched pair no longer slips through — legacy id-only lookup removed', () => {
+    const legacyPattern = /FROM\s+organizations\s+WHERE\s+id\s*=\s*\?\s+AND\s+deleted_at\s+IS\s+NULL\s+LIMIT\s+1/i
+    expect(source).not.toMatch(legacyPattern)
+  })
+})
+
+describe('customer_accounts login — emailVerifiedAt gate blocks unverified accounts', () => {
+  const source = readSource('api/login.ts')
+
+  test('login rejects users whose emailVerifiedAt is falsy', () => {
+    const gatePattern = /if\s*\(\s*!\s*user\.emailVerifiedAt\s*\)/
+    expect(source).toMatch(gatePattern)
+  })
+
+  test('login emits login.failed with email_not_verified reason for telemetry', () => {
+    const emitPattern = /reason:\s*['"]email_not_verified['"]/
+    expect(source).toMatch(emitPattern)
+  })
+
+  test('login verification gate runs after verifyPassword so we do not disclose existence', () => {
+    const passwordIdx = source.indexOf('passwordValid')
+    const gateIdx = source.search(/if\s*\(\s*!\s*user\.emailVerifiedAt\s*\)/)
+    const sessionIdx = source.indexOf('createSession')
+    expect(passwordIdx).toBeGreaterThan(-1)
+    expect(gateIdx).toBeGreaterThan(-1)
+    expect(sessionIdx).toBeGreaterThan(-1)
+    expect(gateIdx).toBeGreaterThan(passwordIdx)
+    expect(gateIdx).toBeLessThan(sessionIdx)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
@@ -15,21 +15,28 @@ function readSource(relPath: string): string {
 }
 
 describe('customer_accounts signup — organization lookup must bind tenantId', () => {
-  const source = readSource('api/signup.ts')
+  const signupSource = readSource('api/signup.ts')
+  const helperSource = readSource('lib/organizationLookup.ts')
 
-  test('organization lookup SQL filters by tenant_id as well as id', () => {
-    const lookupSqlPattern = /FROM\s+organizations\s+WHERE\s+id\s*=\s*\?\s+AND\s+tenant_id\s*=\s*\?/i
-    expect(source).toMatch(lookupSqlPattern)
+  test('signup delegates the lookup to the shared helper (no raw SQL in the route)', () => {
+    expect(signupSource).toMatch(/findOrganizationInTenant\s*\(\s*em\s*,\s*organizationId\s*,\s*tenantId\s*\)/)
+    expect(signupSource).not.toMatch(/FROM\s+organizations\s+WHERE/i)
   })
 
-  test('organization lookup passes both organizationId and tenantId as parameters', () => {
+  test('helper lookup SQL filters by tenant_id as well as id', () => {
+    const lookupSqlPattern = /FROM\s+organizations\s+WHERE\s+id\s*=\s*\?\s+AND\s+tenant_id\s*=\s*\?/i
+    expect(helperSource).toMatch(lookupSqlPattern)
+  })
+
+  test('helper passes both organizationId and tenantId as parameters in order', () => {
     const paramsPattern = /\[\s*organizationId\s*,\s*tenantId\s*\]/
-    expect(source).toMatch(paramsPattern)
+    expect(helperSource).toMatch(paramsPattern)
   })
 
   test('mismatched pair no longer slips through — legacy id-only lookup removed', () => {
     const legacyPattern = /FROM\s+organizations\s+WHERE\s+id\s*=\s*\?\s+AND\s+deleted_at\s+IS\s+NULL\s+LIMIT\s+1/i
-    expect(source).not.toMatch(legacyPattern)
+    expect(signupSource).not.toMatch(legacyPattern)
+    expect(helperSource).not.toMatch(legacyPattern)
   })
 })
 

--- a/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
@@ -63,3 +63,12 @@ describe('customer_accounts login — emailVerifiedAt gate blocks unverified acc
     expect(source).not.toMatch(/Please verify your email/i)
   })
 })
+
+describe('customer_accounts admin create — admin-vouched users are marked verified', () => {
+  const source = readSource('api/admin/users.ts')
+
+  test('admin createUser path stamps emailVerifiedAt so the login gate does not block admin-created accounts', () => {
+    const stampPattern = /customerUserService\.createUser\([\s\S]*?\)\s*(?:\r?\n)\s*user\.emailVerifiedAt\s*=\s*new Date\(\)/
+    expect(source).toMatch(stampPattern)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts
@@ -56,4 +56,10 @@ describe('customer_accounts login — emailVerifiedAt gate blocks unverified acc
     expect(gateIdx).toBeGreaterThan(passwordIdx)
     expect(gateIdx).toBeLessThan(sessionIdx)
   })
+
+  test('unverified-email response body reuses generic invalid-credentials copy (no enumeration oracle)', () => {
+    const gateBlockPattern = /if\s*\(\s*!\s*user\.emailVerifiedAt\s*\)\s*\{[\s\S]*?NextResponse\.json\(\s*\{\s*ok:\s*false,\s*error:\s*['"]Invalid email or password['"]\s*\}/
+    expect(source).toMatch(gateBlockPattern)
+    expect(source).not.toMatch(/Please verify your email/i)
+  })
 })

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -175,6 +175,7 @@ export async function POST(req: Request) {
     parsed.data.displayName,
     { tenantId: auth.tenantId!, organizationId: auth.orgId! },
   )
+  user.emailVerifiedAt = new Date()
   em.persist(user)
   await em.flush()
 

--- a/packages/core/src/modules/customer_accounts/api/login.ts
+++ b/packages/core/src/modules/customer_accounts/api/login.ts
@@ -71,6 +71,18 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'Invalid email or password' }, { status: 401 })
   }
 
+  if (!user.emailVerifiedAt) {
+    void emitCustomerAccountsEvent('customer_accounts.login.failed', {
+      email,
+      reason: 'email_not_verified',
+      tenantId,
+    }).catch(() => undefined)
+    return NextResponse.json(
+      { ok: false, error: 'Please verify your email address before signing in.' },
+      { status: 401 },
+    )
+  }
+
   await customerUserService.resetFailedAttempts(user)
   await customerUserService.updateLastLoginAt(user)
 

--- a/packages/core/src/modules/customer_accounts/api/login.ts
+++ b/packages/core/src/modules/customer_accounts/api/login.ts
@@ -77,10 +77,7 @@ export async function POST(req: Request) {
       reason: 'email_not_verified',
       tenantId,
     }).catch(() => undefined)
-    return NextResponse.json(
-      { ok: false, error: 'Please verify your email address before signing in.' },
-      { status: 401 },
-    )
+    return NextResponse.json({ ok: false, error: 'Invalid email or password' }, { status: 401 })
   }
 
   await customerUserService.resetFailedAttempts(user)

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -18,13 +18,10 @@ import {
   customerSignupIpRateLimitConfig,
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
 import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
+import { findOrganizationInTenant } from '@open-mercato/core/modules/customer_accounts/lib/organizationLookup'
 import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
-
-type OrganizationLookupRow = {
-  slug?: string | null
-}
 
 function resolveBaseUrl(req: Request): string {
   return getAppBaseUrl(req)
@@ -77,10 +74,7 @@ export async function POST(req: Request) {
   const { translate } = await resolveTranslations()
   const baseUrl = resolveBaseUrl(req)
 
-  const [orgRow] = await em.getConnection().execute<OrganizationLookupRow[]>(
-    `SELECT slug FROM organizations WHERE id = ? AND tenant_id = ? AND deleted_at IS NULL LIMIT 1`,
-    [organizationId, tenantId],
-  )
+  const orgRow = await findOrganizationInTenant(em, organizationId, tenantId)
   if (!orgRow) {
     return NextResponse.json({ ok: false, error: 'Registration could not be completed' }, { status: 400 })
   }

--- a/packages/core/src/modules/customer_accounts/api/signup.ts
+++ b/packages/core/src/modules/customer_accounts/api/signup.ts
@@ -78,8 +78,8 @@ export async function POST(req: Request) {
   const baseUrl = resolveBaseUrl(req)
 
   const [orgRow] = await em.getConnection().execute<OrganizationLookupRow[]>(
-    `SELECT slug FROM organizations WHERE id = ? AND deleted_at IS NULL LIMIT 1`,
-    [organizationId],
+    `SELECT slug FROM organizations WHERE id = ? AND tenant_id = ? AND deleted_at IS NULL LIMIT 1`,
+    [organizationId, tenantId],
   )
   if (!orgRow) {
     return NextResponse.json({ ok: false, error: 'Registration could not be completed' }, { status: 400 })

--- a/packages/core/src/modules/customer_accounts/lib/organizationLookup.ts
+++ b/packages/core/src/modules/customer_accounts/lib/organizationLookup.ts
@@ -1,0 +1,20 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+export type OrganizationLookupRow = {
+  slug?: string | null
+}
+
+// Tenant-bound organization lookup. The (id, tenant_id) pair MUST match
+// together so a mismatched body-supplied pair cannot cross-tenant a write.
+// See .ai/lessons.md → "Keep raw SQL out of API route handlers".
+export async function findOrganizationInTenant(
+  em: EntityManager,
+  organizationId: string,
+  tenantId: string,
+): Promise<OrganizationLookupRow | null> {
+  const rows = await em.getConnection().execute<OrganizationLookupRow[]>(
+    `SELECT slug FROM organizations WHERE id = ? AND tenant_id = ? AND deleted_at IS NULL LIMIT 1`,
+    [organizationId, tenantId],
+  )
+  return rows[0] ?? null
+}


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Two coupled gaps in the customer portal auth flow, plus a follow-up to keep the admin-vouched user creation path compatible with the new login gate:</p>
<ol>
<li><code>POST /api/customer_accounts/signup</code> accepted <code>tenantId</code> and <code>organizationId</code> in the body and looked up the organization by <code>id</code> alone. A mismatched pair <code>(tenantId = A, organizationId = B-org)</code> silently resolved: the lookup found <code>B-org</code>, then <code>customerUserService.createUser</code> wrote the <code>CustomerUser</code> under <code>tenantId = A</code> with that row's <code>organizationId = B-org</code>. Cross-scoped writes followed every subsequent read for the row.</li>
<li><code>POST /api/customer_accounts/login</code> never consulted <code>user.emailVerifiedAt</code>. Combined with (1), an anonymous attacker who signed up with an attacker-chosen password could immediately log in against any known victim tenant's <code>isDefault</code> customer role and pick up its <code>portal.*</code> features, without any access to the email inbox.</li>
</ol>
<p>This PR closes both paths as an MVP hotfix. A proper fix (moving <code>tenantId</code>/<code>organizationId</code> out of the signup body into a slug-in-URL segment or a signed portal-bootstrap token) is tracked as a follow-up spec — see the "Follow-up" section below.</p>
<h2>Changes</h2>
<h3>1. Signup — <code>packages/core/src/modules/customer_accounts/api/signup.ts</code></h3>
<p>Organization lookup now binds to the pair:</p>
<pre><code class="language-sql">SELECT slug FROM organizations
 WHERE id = ? AND tenant_id = ? AND deleted_at IS NULL
 LIMIT 1
</code></pre>
<p>Parameters: <code>[organizationId, tenantId]</code>. Mismatched pairs return the same opaque <code>400 { error: 'Registration could not be completed' }</code> as before — no new enumeration oracle.</p>
<h3>2. Login — <code>packages/core/src/modules/customer_accounts/api/login.ts</code></h3>
<p>After a successful <code>verifyPassword</code>, before <code>resetFailedAttempts</code>, the handler gates on <code>user.emailVerifiedAt</code>:</p>
<pre><code class="language-ts">if (!user.emailVerifiedAt) {
  void emitCustomerAccountsEvent('customer_accounts.login.failed', {
    email,
    reason: 'email_not_verified',
    tenantId,
  }).catch(() =&gt; undefined)
  return NextResponse.json({ ok: false, error: 'Invalid email or password' }, { status: 401 })
}
</code></pre>
<p>Two points worth flagging for the reviewer:</p>
<ul>
<li>The gate reuses the generic <code>"Invalid email or password"</code> copy from the password-failure branch. A distinct copy (e.g. <code>"Please verify your email address before signing in"</code>) would have created a three-way enumeration oracle: verified / pending-verification / absent distinguishable to a credential-stuffing caller. Telemetry is preserved server-side via the <code>customer_accounts.login.failed</code> event with <code>reason: 'email_not_verified'</code>.</li>
<li>Gate ordering is <code>password-check → verification-gate → createSession</code>. Running the gate before <code>verifyPassword</code> would leak existence for any pending-verification email without requiring the correct password.</li>
</ul>
<h3>3. Admin create — <code>packages/core/src/modules/customer_accounts/api/admin/users.ts</code></h3>
<p>Admin-provisioned customer accounts are implicitly verified — a staff admin with <code>customer_accounts.users.manage</code> is the out-of-band trust anchor, and the flow never issues an email verification link. After <code>createUser</code>, the handler now stamps <code>emailVerifiedAt</code> so the new login gate does not lock out accounts that were never meant to go through the portal verification email:</p>
<pre><code class="language-ts">const user = await customerUserService.createUser(...)
user.emailVerifiedAt = new Date()
em.persist(user)
await em.flush()
</code></pre>
<p>This mirrors the existing treatment in <code>customerInvitationService.ts:83</code> (<code>// Invitation implicitly verifies email</code>) and the demo seed in <code>setup.ts:193</code>. The service-level factory <code>customerUserService.createUser</code> stays unverified by default — the decision is deliberately made at each caller.</p>
<p>Creation paths enumerated and verified:</p>

Path | Stamps emailVerifiedAt?
-- | --
api/signup.ts self-signup | No — user must click verification link
api/admin/users.ts admin POST | Yes (this PR)
services/customerInvitationService.ts invitation accept | Yes (pre-existing)
setup.ts demo seed | Yes (pre-existing)
services/customerUserService.ts factory | No — caller's decision


<h2>Tests</h2>
<p><code>packages/core/src/modules/customer_accounts/__tests__/signup-login-tenant-binding.test.ts</code> — source-level regex guards (8 cases):</p>
<p><strong>Signup (3):</strong></p>
<ul>
<li>SQL lookup pattern pins <code>FROM organizations WHERE id = ? AND tenant_id = ?</code>.</li>
<li>Parameter tuple pins <code>[organizationId, tenantId]</code>.</li>
<li>Legacy id-only lookup is no longer present.</li>
</ul>
<p><strong>Login (4):</strong></p>
<ul>
<li>Gate <code>if (!user.emailVerifiedAt)</code> is present.</li>
<li>Event emit carries <code>reason: 'email_not_verified'</code>.</li>
<li>Ordering: <code>passwordValid</code> source index &lt; gate index &lt; <code>createSession</code> index.</li>
<li>Gate branch body reuses the generic <code>"Invalid email or password"</code> copy AND the banned <code>"Please verify your email"</code> phrase is absent from the whole file — protects against a well-meaning future edit re-introducing the oracle.</li>
</ul>
<p><strong>Admin create (1):</strong></p>
<ul>
<li><code>createUser(...)</code> must be immediately followed by <code>user.emailVerifiedAt = new Date()</code> (only whitespace between the two tokens) — protects against a future edit that adds logic between the create and the stamp and accidentally short-circuits the verification.</li>
</ul>
<p><strong>Verification:</strong></p>
<ul>
<li><code>yarn workspace @open-mercato/core test</code> — core unit suite green (91/91 in <code>customer_accounts</code>, 2921/2921 overall).</li>
<li><code>yarn test:integration --grep 'TC-AUTH-02[3456]'</code> — TC-AUTH-023 / 024 / 025 / 026 all pass. Before the admin-create stamp the gate would 401 every admin-provisioned account and those four scenarios failed.</li>
</ul>
<h2>Backward compatibility</h2>
<ul>
<li>
<p>No database schema / migration changes.</p>
</li>
<li>
<p>No event ID / API URL / DI registration / feature ID renamed.</p>
</li>
<li>
<p><code>POST /api/customer_accounts/signup</code> contract unchanged — body shape is the same; only the server-side lookup predicate is tightened. Clients sending a consistent <code>(tenantId, organizationId)</code> pair are unaffected. Clients sending a mismatched pair (which was never a legitimate contract — the row went into the wrong tenant) now receive the same generic 400 they would have received for a non-existent organization.</p>
</li>
<li>
<p><code>POST /api/customer_accounts/login</code> behavior change: accounts with <code>emailVerifiedAt = null</code> can no longer log in. This is the intended fix for the E-01 chain.</p>
</li>
<li>
<p>Legacy accounts — any <code>CustomerUser</code> created before this PR shipped via either <code>api/signup.ts</code> (that never completed the verification email) or <code>api/admin/users.ts</code> (that did not stamp <code>emailVerifiedAt</code>) will be rejected by the login gate. If such accounts exist in production, run the backfill:</p>
<pre><code class="language-sql">UPDATE customer_users
   SET email_verified_at = COALESCE(email_verified_at, created_at)
 WHERE email_verified_at IS NULL
   AND created_at &lt; '&lt;flow-ship-date&gt;';
</code></pre>
</li>
<li>
<p>Adjust the cutoff to match the date this PR merges. The backfill covers both admin-provisioned and self-signed legacy rows. Self-signed rows that should have completed email verification but never did still get activated by this one-off backfill — that is a pragmatic trade-off; re-requiring verification for pre-existing active users would mass-lock out real customers. Going forward, new self-signed rows must complete verification.</p>
</li>
</ul>
<h2>Follow-up</h2>
<ul>
<li>Proper fix for the signup body-scope issue: move <code>tenantId</code> / <code>organizationId</code> out of <code>signupSchema</code> body and derive them from either a <code>/&lt;organization-slug&gt;/portal/signup</code> URL segment (validated against <code>organizations.slug</code> + the org's <code>tenant_id</code>) or a short-TTL signed portal-bootstrap token issued on the portal landing GET. Dedicated spec.</li>
<li>Timing-oracle angles on signup / password-reset (~70–160 ms bcrypt differential, ~8–25 ms DB <code>persistAndFlush</code> differential) are orthogonal and not addressed here.</li>
</ul></body></html>