### PR TITLE
fix: missing asterisk

### DIFF
--- a/packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx
+++ b/packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx
@@ -224,10 +224,10 @@ export function scheduledJobFields(
           <div className="space-y-4">
             {targetType === 'queue' && (
               <div className="space-y-1">
-                <label htmlFor="targetQueue" className="block text-sm font-medium">
+                <Label htmlFor="targetQueue">
                   {t('scheduler.form.target_queue', 'Target Queue')}
-                  <span className="text-red-600"> *</span>
-                </label>
+                  <span className="text-destructive"> *</span>
+                </Label>
                 <ComboboxInput
                   value={targetQueue}
                   onChange={(next) => setFormValue && setFormValue('targetQueue', next)}
@@ -239,10 +239,10 @@ export function scheduledJobFields(
             )}
             {targetType === 'command' && (
               <div className="space-y-1">
-                <label htmlFor="targetCommand" className="block text-sm font-medium">
+                <Label htmlFor="targetCommand">
                   {t('scheduler.form.target_command', 'Target Command')}
-                  <span className="text-red-600"> *</span>
-                </label>
+                  <span className="text-destructive"> *</span>
+                </Label>
                 <ComboboxInput
                   value={targetCommand}
                   onChange={(next) => setFormValue && setFormValue('targetCommand', next)}

--- a/packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx
+++ b/packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx
@@ -224,9 +224,10 @@ export function scheduledJobFields(
           <div className="space-y-4">
             {targetType === 'queue' && (
               <div className="space-y-1">
-                <Label htmlFor="targetQueue">
+                <label htmlFor="targetQueue" className="block text-sm font-medium">
                   {t('scheduler.form.target_queue', 'Target Queue')}
-                </Label>
+                  <span className="text-red-600"> *</span>
+                </label>
                 <ComboboxInput
                   value={targetQueue}
                   onChange={(next) => setFormValue && setFormValue('targetQueue', next)}
@@ -238,9 +239,10 @@ export function scheduledJobFields(
             )}
             {targetType === 'command' && (
               <div className="space-y-1">
-                <Label htmlFor="targetCommand">
+                <label htmlFor="targetCommand" className="block text-sm font-medium">
                   {t('scheduler.form.target_command', 'Target Command')}
-                </Label>
+                  <span className="text-red-600"> *</span>
+                </label>
                 <ComboboxInput
                   value={targetCommand}
                   onChange={(next) => setFormValue && setFormValue('targetCommand', next)}


### PR DESCRIPTION
## Summary
The Create Schedule form treats **Target Queue** (when Target Type is Queue) and **Target Command** (when Target Type is Command) as required for submission, but those fields were rendered inside a custom `CrudForm` field with plain labels—so they never received the same red **\*** used for other required fields. Labels now match `CrudForm`’s required styling (`block text-sm font-medium` + `<span className="text-red-600"> *</span>`), and the asterisk only appears for the active target type.

## Changes
- Update `packages/scheduler/src/modules/scheduler/lib/scheduledJobFormConfig.tsx`: replace custom `Label` wrappers for Target Queue / Target Command with the same label + required asterisk pattern as `CrudForm`.
- 
## Specification
**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

## Testing
- `read_lints` on `scheduledJobFormConfig.tsx` (clean).
- Manual: `yarn dev` → `/backend/config/scheduled-jobs/new` → confirm **\*** on **Target Queue** with Target Type **Queue**; switch to **Command** and confirm **\*** on **Target Command** and no queue asterisk.

## Checklist
- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues
Fixes #1588