### PR TITLE
fix: dev HMR origins for non-localhost login

### DIFF
--- a/apps/mercato/next.config.ts
+++ b/apps/mercato/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 import fs from "node:fs";
 import path from "node:path";
+import { resolveAllowedDevOrigins } from './src/lib/dev-origins'
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
 const appPackageJsonPath = new URL('./package.json', import.meta.url)
@@ -10,6 +11,7 @@ const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8')) a
 const transpiledWorkspacePackages = Object.keys(appPackageJson.dependencies ?? {}).filter(
   (packageName) => packageName.startsWith('@open-mercato/') && packageName !== '@open-mercato/cli',
 )
+const allowedDevOrigins = isDevelopment ? resolveAllowedDevOrigins() : []
 
 const contentSecurityPolicy = [
   "default-src 'self'",
@@ -40,6 +42,7 @@ const nextConfig: NextConfig = {
     // Monorepo root is two levels up from apps/mercato
     root: path.resolve(process.cwd(), "../.."),
   },
+  allowedDevOrigins: allowedDevOrigins.length > 0 ? allowedDevOrigins : undefined,
   // Externalize packages that are only used in CLI context, not Next.js
   serverExternalPackages: [
     'esbuild',

--- a/apps/mercato/src/__tests__/dev-origins.test.ts
+++ b/apps/mercato/src/__tests__/dev-origins.test.ts
@@ -1,0 +1,17 @@
+import { resolveAllowedDevOrigins } from '../lib/dev-origins'
+
+describe('resolveAllowedDevOrigins', () => {
+  it('extracts hostnames from public app origin envs', () => {
+    expect(
+      resolveAllowedDevOrigins({
+        APP_URL: 'https://preview.example.com/app/',
+        NEXT_PUBLIC_APP_URL: 'https://public.example.com',
+        APP_ALLOWED_ORIGINS: 'https://builder.example.com, https://preview.example.com/app/, invalid, https://public.example.com',
+      }),
+    ).toEqual(['preview.example.com', 'public.example.com', 'builder.example.com'])
+  })
+
+  it('returns an empty list when no valid origins are configured', () => {
+    expect(resolveAllowedDevOrigins({ APP_URL: 'not-a-url', NEXT_PUBLIC_APP_URL: '', APP_ALLOWED_ORIGINS: '  ' })).toEqual([])
+  })
+})

--- a/apps/mercato/src/__tests__/dev-origins.test.ts
+++ b/apps/mercato/src/__tests__/dev-origins.test.ts
@@ -14,4 +14,34 @@ describe('resolveAllowedDevOrigins', () => {
   it('returns an empty list when no valid origins are configured', () => {
     expect(resolveAllowedDevOrigins({ APP_URL: 'not-a-url', NEXT_PUBLIC_APP_URL: '', APP_ALLOWED_ORIGINS: '  ' })).toEqual([])
   })
+
+  it('strips explicit ports so only the hostname is allowlisted', () => {
+    expect(
+      resolveAllowedDevOrigins({
+        APP_URL: 'https://preview.example.com:8443/',
+        NEXT_PUBLIC_APP_URL: 'http://public.example.com:3000',
+        APP_ALLOWED_ORIGINS: '',
+      }),
+    ).toEqual(['preview.example.com', 'public.example.com'])
+  })
+
+  it('lowercases hostnames and dedupes case-insensitive duplicates', () => {
+    expect(
+      resolveAllowedDevOrigins({
+        APP_URL: 'https://Preview.Example.COM/',
+        NEXT_PUBLIC_APP_URL: 'https://preview.example.com',
+        APP_ALLOWED_ORIGINS: '',
+      }),
+    ).toEqual(['preview.example.com'])
+  })
+
+  it('accepts IPv6 literal hosts', () => {
+    expect(
+      resolveAllowedDevOrigins({
+        APP_URL: 'http://[::1]:3000/',
+        NEXT_PUBLIC_APP_URL: '',
+        APP_ALLOWED_ORIGINS: '',
+      }),
+    ).toEqual(['[::1]'])
+  })
 })

--- a/apps/mercato/src/lib/dev-origins.ts
+++ b/apps/mercato/src/lib/dev-origins.ts
@@ -1,0 +1,30 @@
+function readOriginHostname(raw: string | undefined): string | null {
+  const value = raw?.trim()
+  if (!value) return null
+
+  try {
+    return new URL(value).hostname
+  } catch {
+    return null
+  }
+}
+
+function readCsv(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+export function resolveAllowedDevOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
+  const origins = new Set<string>()
+
+  for (const raw of [env.APP_URL, env.NEXT_PUBLIC_APP_URL, ...readCsv(env.APP_ALLOWED_ORIGINS)]) {
+    const hostname = readOriginHostname(raw)
+    if (hostname) {
+      origins.add(hostname)
+    }
+  }
+
+  return Array.from(origins)
+}

--- a/apps/mercato/src/lib/dev-origins.ts
+++ b/apps/mercato/src/lib/dev-origins.ts
@@ -1,3 +1,10 @@
+// This file is mirrored verbatim between:
+//   - apps/mercato/src/lib/dev-origins.ts
+//   - packages/create-app/template/src/lib/dev-origins.ts
+// Scaffolded standalone apps cannot import @open-mercato/*, so the
+// duplication is deliberate. Keep both copies in sync when editing; CI
+// runs `yarn template:sync` to enforce parity.
+
 function readOriginHostname(raw: string | undefined): string | null {
   const value = raw?.trim()
   if (!value) return null

--- a/packages/create-app/src/lib/ready-apps.test.ts
+++ b/packages/create-app/src/lib/ready-apps.test.ts
@@ -225,6 +225,13 @@ test('CLI bare scaffold skips interactive agentic setup with --skip-agentic-setu
     assert.equal(existsSync(join(targetDir, '.cursor')), false)
     assert.equal(existsSync(join(targetDir, '.codex')), false)
     assert.equal(existsSync(join(targetDir, 'src', 'modules', 'example', '__integration__')), false)
+
+    const nextConfig = readFileSync(join(targetDir, 'next.config.ts'), 'utf8')
+    assert.match(nextConfig, /resolveAllowedDevOrigins/)
+
+    const devOriginsHelper = readFileSync(join(targetDir, 'src', 'lib', 'dev-origins.ts'), 'utf8')
+    assert.match(devOriginsHelper, /APP_ALLOWED_ORIGINS/)
+    assert.match(devOriginsHelper, /NEXT_PUBLIC_APP_URL/)
   } finally {
     rmSync(targetRoot, { recursive: true, force: true })
   }

--- a/packages/create-app/template/next.config.ts
+++ b/packages/create-app/template/next.config.ts
@@ -1,6 +1,8 @@
 import type { NextConfig } from "next";
+import { resolveAllowedDevOrigins } from './src/lib/dev-origins'
 
 const isDevelopment = process.env.NODE_ENV !== 'production'
+const allowedDevOrigins = isDevelopment ? resolveAllowedDevOrigins() : []
 
 const nextConfig: NextConfig = {
   distDir: '.mercato/next',
@@ -13,6 +15,7 @@ const nextConfig: NextConfig = {
         }
       : {}),
   },
+  allowedDevOrigins: allowedDevOrigins.length > 0 ? allowedDevOrigins : undefined,
   // Transpile @open-mercato packages that have TypeScript in src/
   // Note: @open-mercato/shared is excluded as it has pre-built dist/ files
   transpilePackages: [

--- a/packages/create-app/template/src/lib/dev-origins.ts
+++ b/packages/create-app/template/src/lib/dev-origins.ts
@@ -1,0 +1,30 @@
+function readOriginHostname(raw: string | undefined): string | null {
+  const value = raw?.trim()
+  if (!value) return null
+
+  try {
+    return new URL(value).hostname
+  } catch {
+    return null
+  }
+}
+
+function readCsv(value: string | undefined): string[] {
+  return (value ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+export function resolveAllowedDevOrigins(env: NodeJS.ProcessEnv = process.env): string[] {
+  const origins = new Set<string>()
+
+  for (const raw of [env.APP_URL, env.NEXT_PUBLIC_APP_URL, ...readCsv(env.APP_ALLOWED_ORIGINS)]) {
+    const hostname = readOriginHostname(raw)
+    if (hostname) {
+      origins.add(hostname)
+    }
+  }
+
+  return Array.from(origins)
+}

--- a/packages/create-app/template/src/lib/dev-origins.ts
+++ b/packages/create-app/template/src/lib/dev-origins.ts
@@ -1,3 +1,10 @@
+// This file is mirrored verbatim between:
+//   - apps/mercato/src/lib/dev-origins.ts
+//   - packages/create-app/template/src/lib/dev-origins.ts
+// Scaffolded standalone apps cannot import @open-mercato/*, so the
+// duplication is deliberate. Keep both copies in sync when editing; CI
+// runs `yarn template:sync` to enforce parity.
+
 function readOriginHostname(raw: string | undefined): string | null {
   const value = raw?.trim()
   if (!value) return null


### PR DESCRIPTION
## Summary
- derive `allowedDevOrigins` from the app's configured public origin envs in development
- keep the logic in a small reusable helper and cover it with a unit test
- verify `/login` on `host.docker.internal` no longer logs the HMR websocket handshake failure when `APP_URL` points at that host

## Verification
- `bunx jest --config jest.config.cjs src/__tests__/dev-origins.test.ts --runInBand`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- manual Playwright repro against `http://host.docker.internal:3002/login` with `APP_URL=http://host.docker.internal:3002`