### PR TITLE
fix(workflows): close edit dialog before awaiting step delete confirm (#1585)

### DIFF
--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -10,6 +10,7 @@ import { Node, Edge, addEdge, Connection, applyNodeChanges, applyEdgeChanges, No
 import { useState, useCallback, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { graphToDefinition, definitionToGraph, validateWorkflowGraph, generateStepId, generateTransitionId, ValidationError } from '../../../lib/graph-utils'
+import { performDeleteEdgeFlow, performDeleteNodeFlow } from '../../../lib/visual-editor-delete-flow'
 import { workflowDefinitionDataSchema } from '../../../data/validators'
 import { Page } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -227,34 +228,28 @@ export default function VisualEditorPage() {
 
   // Delete edge
   const handleDeleteEdge = useCallback(async (edgeId: string) => {
-    const confirmed = await confirm({
-      title: t('workflows.confirm.deleteTransitionTitle'),
-      text: t('workflows.confirm.deleteTransitionText'),
-      variant: 'destructive',
+    await performDeleteEdgeFlow(edgeId, {
+      confirm,
+      t,
+      setShowEdgeDialog,
+      setSelectedEdge,
+      setEdges,
+      notifyDeleted: () => flash('Transition deleted successfully', 'success'),
     })
-    if (!confirmed) return
-    setShowEdgeDialog(false)
-    setSelectedEdge(null)
-    setEdges((eds) => eds.filter((edge) => edge.id !== edgeId))
-    flash('Transition deleted successfully', 'success')
   }, [confirm, t])
 
   // Delete node
   const handleDeleteNode = useCallback(async (nodeId: string) => {
-    const node = nodes.find((n) => n.id === nodeId)
-    const nodeData = node?.data as { stepName?: string; label?: string } | undefined
-    const stepName = nodeData?.stepName || nodeData?.label || nodeId
-    const confirmed = await confirm({
-      title: t('workflows.confirm.deleteStepTitle'),
-      text: t('workflows.confirm.deleteStep', { name: stepName }),
-      variant: 'destructive',
+    await performDeleteNodeFlow(nodeId, {
+      nodes,
+      confirm,
+      t,
+      setShowNodeDialog,
+      setSelectedNode,
+      setNodes,
+      setEdges,
+      notifyDeleted: () => flash('Step deleted successfully', 'success'),
     })
-    if (!confirmed) return
-    setShowNodeDialog(false)
-    setSelectedNode(null)
-    setNodes((nds) => nds.filter((n) => n.id !== nodeId))
-    setEdges((eds) => eds.filter((edge) => edge.source !== nodeId && edge.target !== nodeId))
-    flash('Step deleted successfully', 'success')
   }, [confirm, nodes, t])
 
   // Handle new connections

--- a/packages/core/src/modules/workflows/lib/__tests__/visual-editor-delete-flow.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/visual-editor-delete-flow.test.ts
@@ -1,0 +1,177 @@
+import type { Node, Edge } from '@xyflow/react'
+import { performDeleteEdgeFlow, performDeleteNodeFlow, type ConfirmFn } from '../visual-editor-delete-flow'
+
+describe('performDeleteNodeFlow', () => {
+  const makeNodes = (): Node[] => [
+    { id: 'n1', type: 'automated', position: { x: 0, y: 0 }, data: { stepName: 'Step One' } },
+    { id: 'n2', type: 'automated', position: { x: 0, y: 0 }, data: { stepName: 'Step Two' } },
+  ]
+  const t = (key: string) => key
+  const nopSetEdges = (_u: (eds: Edge[]) => Edge[]) => {}
+
+  it('closes the edit dialog before awaiting the confirm dialog', async () => {
+    const calls: string[] = []
+    const confirm: ConfirmFn = async () => {
+      calls.push('confirm:await')
+      return true
+    }
+    await performDeleteNodeFlow('n1', {
+      nodes: makeNodes(),
+      confirm,
+      t,
+      setShowNodeDialog: (open) => {
+        if (!open) calls.push('setShowNodeDialog:false')
+      },
+      setSelectedNode: (node) => {
+        if (node === null) calls.push('setSelectedNode:null')
+      },
+      setNodes: () => calls.push('setNodes'),
+      setEdges: () => calls.push('setEdges'),
+      notifyDeleted: () => calls.push('notifyDeleted'),
+    })
+
+    const closeIdx = calls.indexOf('setShowNodeDialog:false')
+    const confirmIdx = calls.indexOf('confirm:await')
+    expect(closeIdx).toBeGreaterThanOrEqual(0)
+    expect(confirmIdx).toBeGreaterThanOrEqual(0)
+    expect(closeIdx).toBeLessThan(confirmIdx)
+  })
+
+  it('removes the node and connected edges when confirmed', async () => {
+    let nodesState: Node[] = makeNodes()
+    let edgesState: Edge[] = [
+      { id: 'e1', source: 'n1', target: 'n2' },
+      { id: 'e2', source: 'n2', target: 'n1' },
+      { id: 'e3', source: 'n2', target: 'n2' },
+    ]
+    const notify = jest.fn()
+    const result = await performDeleteNodeFlow('n1', {
+      nodes: nodesState,
+      confirm: async () => true,
+      t,
+      setShowNodeDialog: () => {},
+      setSelectedNode: () => {},
+      setNodes: (updater) => {
+        nodesState = updater(nodesState)
+      },
+      setEdges: (updater) => {
+        edgesState = updater(edgesState)
+      },
+      notifyDeleted: notify,
+    })
+    expect(result).toBe(true)
+    expect(nodesState.map((n) => n.id)).toEqual(['n2'])
+    expect(edgesState.map((e) => e.id)).toEqual(['e3'])
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mutate graph state when cancelled', async () => {
+    let nodesState: Node[] = makeNodes()
+    let edgesState: Edge[] = []
+    const notify = jest.fn()
+    const result = await performDeleteNodeFlow('n1', {
+      nodes: nodesState,
+      confirm: async () => false,
+      t,
+      setShowNodeDialog: () => {},
+      setSelectedNode: () => {},
+      setNodes: (updater) => {
+        nodesState = updater(nodesState)
+      },
+      setEdges: (updater) => {
+        edgesState = updater(edgesState)
+      },
+      notifyDeleted: notify,
+    })
+    expect(result).toBe(false)
+    expect(nodesState.map((n) => n.id)).toEqual(['n1', 'n2'])
+    expect(edgesState).toEqual([])
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it('uses stepName in the confirmation text when available', async () => {
+    const confirm = jest.fn().mockResolvedValue(false)
+    await performDeleteNodeFlow('n1', {
+      nodes: makeNodes(),
+      confirm,
+      t: (key, paramsOrFallback, fallback) => {
+        if (key === 'workflows.confirm.deleteStep') {
+          return `delete:${paramsOrFallback?.name ?? fallback ?? key}`
+        }
+        return key
+      },
+      setShowNodeDialog: () => {},
+      setSelectedNode: () => {},
+      setNodes: nopSetEdges,
+      setEdges: nopSetEdges,
+      notifyDeleted: () => {},
+    })
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'delete:Step One', variant: 'destructive' }),
+    )
+  })
+})
+
+describe('performDeleteEdgeFlow', () => {
+  it('closes the edit dialog before awaiting the confirm dialog', async () => {
+    const calls: string[] = []
+    const confirm: ConfirmFn = async () => {
+      calls.push('confirm:await')
+      return true
+    }
+    await performDeleteEdgeFlow('e1', {
+      confirm,
+      t: (k) => k,
+      setShowEdgeDialog: (open) => {
+        if (!open) calls.push('setShowEdgeDialog:false')
+      },
+      setSelectedEdge: (edge) => {
+        if (edge === null) calls.push('setSelectedEdge:null')
+      },
+      setEdges: () => calls.push('setEdges'),
+      notifyDeleted: () => calls.push('notifyDeleted'),
+    })
+    const closeIdx = calls.indexOf('setShowEdgeDialog:false')
+    const confirmIdx = calls.indexOf('confirm:await')
+    expect(closeIdx).toBeGreaterThanOrEqual(0)
+    expect(confirmIdx).toBeGreaterThanOrEqual(0)
+    expect(closeIdx).toBeLessThan(confirmIdx)
+  })
+
+  it('removes only the target edge when confirmed', async () => {
+    let edgesState: Edge[] = [
+      { id: 'e1', source: 'n1', target: 'n2' },
+      { id: 'e2', source: 'n2', target: 'n3' },
+    ]
+    const notify = jest.fn()
+    const result = await performDeleteEdgeFlow('e1', {
+      confirm: async () => true,
+      t: (k) => k,
+      setShowEdgeDialog: () => {},
+      setSelectedEdge: () => {},
+      setEdges: (updater) => {
+        edgesState = updater(edgesState)
+      },
+      notifyDeleted: notify,
+    })
+    expect(result).toBe(true)
+    expect(edgesState.map((e) => e.id)).toEqual(['e2'])
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not mutate edges when cancelled', async () => {
+    let edgesState: Edge[] = [{ id: 'e1', source: 'n1', target: 'n2' }]
+    const result = await performDeleteEdgeFlow('e1', {
+      confirm: async () => false,
+      t: (k) => k,
+      setShowEdgeDialog: () => {},
+      setSelectedEdge: () => {},
+      setEdges: (updater) => {
+        edgesState = updater(edgesState)
+      },
+      notifyDeleted: () => {},
+    })
+    expect(result).toBe(false)
+    expect(edgesState).toEqual([{ id: 'e1', source: 'n1', target: 'n2' }])
+  })
+})

--- a/packages/core/src/modules/workflows/lib/visual-editor-delete-flow.ts
+++ b/packages/core/src/modules/workflows/lib/visual-editor-delete-flow.ts
@@ -1,0 +1,71 @@
+import type { Node, Edge } from '@xyflow/react'
+
+export type ConfirmFn = (options: {
+  title: string
+  text: string
+  variant?: 'default' | 'destructive'
+}) => Promise<boolean>
+
+export type DeleteNodeDeps = {
+  nodes: Node[]
+  confirm: ConfirmFn
+  t: (key: string, paramsOrFallback?: any, fallback?: any) => string
+  setShowNodeDialog: (open: boolean) => void
+  setSelectedNode: (node: Node | null) => void
+  setNodes: (updater: (nds: Node[]) => Node[]) => void
+  setEdges: (updater: (eds: Edge[]) => Edge[]) => void
+  notifyDeleted: () => void
+}
+
+export type DeleteEdgeDeps = {
+  confirm: ConfirmFn
+  t: (key: string, paramsOrFallback?: any, fallback?: any) => string
+  setShowEdgeDialog: (open: boolean) => void
+  setSelectedEdge: (edge: Edge | null) => void
+  setEdges: (updater: (eds: Edge[]) => Edge[]) => void
+  notifyDeleted: () => void
+}
+
+/**
+ * Runs the step-delete confirmation flow.
+ *
+ * Why: The edit dialog is a Radix modal; the confirm dialog is a native
+ * <dialog> in the browser top layer. If we await confirm() while the edit
+ * modal is still open, Radix's onPointerDownOutside fires on the confirm
+ * click and closes the edit modal mid-interaction, which leaves the
+ * confirm dialog stuck open and requires a second click (issue #1585).
+ *
+ * We therefore close the edit dialog *before* awaiting confirmation so
+ * only one modal is on screen when the user confirms.
+ */
+export async function performDeleteNodeFlow(nodeId: string, deps: DeleteNodeDeps): Promise<boolean> {
+  const node = deps.nodes.find((n) => n.id === nodeId)
+  const nodeData = node?.data as { stepName?: string; label?: string } | undefined
+  const stepName = nodeData?.stepName || nodeData?.label || nodeId
+  deps.setShowNodeDialog(false)
+  deps.setSelectedNode(null)
+  const confirmed = await deps.confirm({
+    title: deps.t('workflows.confirm.deleteStepTitle'),
+    text: deps.t('workflows.confirm.deleteStep', { name: stepName }),
+    variant: 'destructive',
+  })
+  if (!confirmed) return false
+  deps.setNodes((nds) => nds.filter((n) => n.id !== nodeId))
+  deps.setEdges((eds) => eds.filter((edge) => edge.source !== nodeId && edge.target !== nodeId))
+  deps.notifyDeleted()
+  return true
+}
+
+export async function performDeleteEdgeFlow(edgeId: string, deps: DeleteEdgeDeps): Promise<boolean> {
+  deps.setShowEdgeDialog(false)
+  deps.setSelectedEdge(null)
+  const confirmed = await deps.confirm({
+    title: deps.t('workflows.confirm.deleteTransitionTitle'),
+    text: deps.t('workflows.confirm.deleteTransitionText'),
+    variant: 'destructive',
+  })
+  if (!confirmed) return false
+  deps.setEdges((eds) => eds.filter((edge) => edge.id !== edgeId))
+  deps.notifyDeleted()
+  return true
+}


### PR DESCRIPTION
Fixes #1585

## Problem

Deleting a step (or transition) in the Visual Workflow Editor required **two clicks** of the "Confirm" button. After the first click, the Edit Step modal dismissed but the confirmation popup stayed active; only the second click completed the deletion and fired the success toast.

## Root Cause

`handleDeleteNode` / `handleDeleteEdge` in `backend/definitions/visual-editor/page.tsx` awaited `confirm()` **while the Edit Step Radix Dialog was still open**. The confirm dialog is a native `<dialog>` element in the browser top layer — its pointerdown bubbles up to `document`, where Radix's `onPointerDownOutside` fires, calls `onOpenChange(false)`, and closes the outer dialog mid-interaction. That interruption prevents `useConfirmDialog`'s promise from settling on the first click, so the confirm modal stays open until a second click.

PR #1211 hoisted `useConfirmDialog` out of the child dialogs to the page root, which fixed the stale-dialog case but did not remove the nested-modal scenario — hence the regression returned.

## What Changed

- Close the Edit Step / Edit Transition dialog **before** awaiting the confirmation in `handleDeleteNode` / `handleDeleteEdge`. With only one modal on screen, the confirm click resolves normally on the first attempt.
- Extracted the delete flow into `lib/visual-editor-delete-flow.ts` so the ordering invariant can be locked down by tests. `page.tsx` now delegates to `performDeleteNodeFlow` / `performDeleteEdgeFlow`.

## Tests

- New unit suite `lib/__tests__/visual-editor-delete-flow.test.ts` (7 tests):
  - asserts `setShowNodeDialog(false)` / `setShowEdgeDialog(false)` run **before** `confirm()` is awaited (regression for #1585)
  - verifies node removal also drops incident edges when confirmed
  - verifies graph state is untouched and no notification fires when cancelled
  - verifies `stepName` flows into the confirmation text
- `yarn test` (workflows module): 353/353 pass
- `yarn typecheck`: pass
- `yarn i18n:check-sync`: pass
- `yarn build:packages`: pass
- `yarn generate`: pass

Pre-existing sync-akeneo test failure (`Cannot find module '../../../generated/entities.ids.generated.js'`) is unrelated to this change.

## Backward Compatibility

- No contract surface changes. Pure behavior fix inside a backend page component plus a new internal helper module.