### PR TITLE
security(attachments): reject executable double extensions (#1597)

### DIFF
--- a/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
+++ b/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
@@ -148,6 +148,26 @@ describe('attachments API', () => {
     expect(j.error).toMatch(/not allowed/i)
   })
 
+  it('rejects uploads whose filename has a dangerous double extension like .pdf.exe', async () => {
+    const { POST: upload } = await loadHandlers()
+    const file = new File([new Uint8Array([1, 2, 3])], 'faktura.pdf.exe', { type: 'application/pdf' })
+    const req = new Request('http://x/api/attachments', { method: 'POST', body: fdWith(file, { fieldKey: '' }) as any })
+    const res = await upload(req)
+    expect(res.status).toBe(400)
+    const payload = await res.json()
+    expect(payload.error).toMatch(/executable/i)
+  })
+
+  it('rejects uploads whose final extension is a known executable type', async () => {
+    const { POST: upload } = await loadHandlers()
+    const file = new File([new Uint8Array([1, 2, 3])], 'installer.msi', { type: 'application/octet-stream' })
+    const req = new Request('http://x/api/attachments', { method: 'POST', body: fdWith(file, { fieldKey: '' }) as any })
+    const res = await upload(req)
+    expect(res.status).toBe(400)
+    const payload = await res.json()
+    expect(payload.error).toMatch(/executable/i)
+  })
+
   it('rejects active content uploads even when the client claims a safe image mime type', async () => {
     const { POST: upload } = await loadHandlers()
     const file = new File(

--- a/packages/core/src/modules/attachments/api/route.ts
+++ b/packages/core/src/modules/attachments/api/route.ts
@@ -29,6 +29,7 @@ import { E } from '#generated/entities.ids.generated'
 import { resolveDefaultAttachmentOcrEnabled } from '../lib/ocrConfig'
 import {
   detectAttachmentMimeType,
+  hasDangerousExecutableExtension,
   isActiveContentAttachment,
   sanitizeUploadedFileName,
 } from '../lib/security'
@@ -273,6 +274,11 @@ export async function POST(req: Request) {
         partitionFromField = sanitizePartitionCode(cfg.partitionCode)
       }
     } catch {}
+  }
+  if (hasDangerousExecutableExtension(file.name)) {
+    return NextResponse.json({
+      error: t('attachments.errors.dangerousExecutable', 'Executable file types are not allowed as attachments.'),
+    }, { status: 400 })
   }
   const effectiveMaxBytes = resolveAttachmentMaxBytes(fieldMaxAttachmentSizeMb)
   if (file.size > effectiveMaxBytes) {

--- a/packages/core/src/modules/attachments/i18n/de.json
+++ b/packages/core/src/modules/attachments/i18n/de.json
@@ -1,6 +1,7 @@
 {
   "attachments.customers.storage.nav.group": "Speicher",
   "attachments.errors.activeContentBlocked": "Das Hochladen aktiver Inhalte ist nicht erlaubt.",
+  "attachments.errors.dangerousExecutable": "Ausführbare Dateitypen sind als Anhänge nicht erlaubt.",
   "attachments.errors.maxUploadSize": "Der Anhang überschreitet die maximal zulässige Upload-Größe.",
   "attachments.errors.publicPartitionBlocked": "Öffentliche Speicherpartitionen können für diesen Upload nicht explizit ausgewählt werden.",
   "attachments.errors.quotaExceeded": "Das Speicherlimit für Anhänge dieses Tenants wurde überschritten.",

--- a/packages/core/src/modules/attachments/i18n/en.json
+++ b/packages/core/src/modules/attachments/i18n/en.json
@@ -1,6 +1,7 @@
 {
   "attachments.customers.storage.nav.group": "Storage",
   "attachments.errors.activeContentBlocked": "Active content uploads are not allowed.",
+  "attachments.errors.dangerousExecutable": "Executable file types are not allowed as attachments.",
   "attachments.errors.maxUploadSize": "Attachment exceeds the maximum upload size.",
   "attachments.errors.publicPartitionBlocked": "Public storage partitions cannot be selected explicitly for this upload.",
   "attachments.errors.quotaExceeded": "Attachment storage quota exceeded for this tenant.",

--- a/packages/core/src/modules/attachments/i18n/es.json
+++ b/packages/core/src/modules/attachments/i18n/es.json
@@ -1,6 +1,7 @@
 {
   "attachments.customers.storage.nav.group": "Almacenamiento",
   "attachments.errors.activeContentBlocked": "No se permite la carga de contenido activo.",
+  "attachments.errors.dangerousExecutable": "No se permiten archivos ejecutables como adjuntos.",
   "attachments.errors.maxUploadSize": "El archivo adjunto supera el tamaño máximo de carga permitido.",
   "attachments.errors.publicPartitionBlocked": "No se pueden seleccionar explícitamente particiones de almacenamiento públicas para esta carga.",
   "attachments.errors.quotaExceeded": "Se superó la cuota de almacenamiento de adjuntos para este tenant.",

--- a/packages/core/src/modules/attachments/i18n/pl.json
+++ b/packages/core/src/modules/attachments/i18n/pl.json
@@ -1,6 +1,7 @@
 {
   "attachments.customers.storage.nav.group": "Magazyn",
   "attachments.errors.activeContentBlocked": "Przesyłanie treści aktywnych nie jest dozwolone.",
+  "attachments.errors.dangerousExecutable": "Pliki wykonywalne nie są dozwolone jako załączniki.",
   "attachments.errors.maxUploadSize": "Załącznik przekracza maksymalny dopuszczalny rozmiar przesyłania.",
   "attachments.errors.publicPartitionBlocked": "Nie można jawnie wybrać publicznej partycji do tego przesyłania.",
   "attachments.errors.quotaExceeded": "Przekroczono limit miejsca na załączniki dla tego tenantu.",

--- a/packages/core/src/modules/attachments/lib/__tests__/security.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/security.test.ts
@@ -1,0 +1,53 @@
+/** @jest-environment node */
+import {
+  getAttachmentExtension,
+  hasDangerousExecutableExtension,
+  sanitizeUploadedFileName,
+} from '@open-mercato/core/modules/attachments/lib/security'
+
+describe('hasDangerousExecutableExtension', () => {
+  it('flags files whose final extension is executable', () => {
+    expect(hasDangerousExecutableExtension('malware.exe')).toBe(true)
+    expect(hasDangerousExecutableExtension('script.BAT')).toBe(true)
+    expect(hasDangerousExecutableExtension('setup.msi')).toBe(true)
+    expect(hasDangerousExecutableExtension('macro.vbs')).toBe(true)
+  })
+
+  it('flags double-extension payloads where the final extension is executable', () => {
+    expect(hasDangerousExecutableExtension('faktura.pdf.exe')).toBe(true)
+    expect(hasDangerousExecutableExtension('invoice.PDF.EXE')).toBe(true)
+    expect(hasDangerousExecutableExtension('contract.docx.js')).toBe(true)
+  })
+
+  it('flags files that hide an executable segment before a seemingly safe extension', () => {
+    expect(hasDangerousExecutableExtension('report.exe.pdf')).toBe(true)
+    expect(hasDangerousExecutableExtension('archive.bat.zip')).toBe(true)
+  })
+
+  it('does not flag legitimate filenames', () => {
+    expect(hasDangerousExecutableExtension('doc.pdf')).toBe(false)
+    expect(hasDangerousExecutableExtension('photo.jpeg')).toBe(false)
+    expect(hasDangerousExecutableExtension('report.final.pdf')).toBe(false)
+    expect(hasDangerousExecutableExtension('notes.docx')).toBe(false)
+    expect(hasDangerousExecutableExtension('archive.tar.gz')).toBe(false)
+  })
+
+  it('returns false for empty or extensionless inputs', () => {
+    expect(hasDangerousExecutableExtension('')).toBe(false)
+    expect(hasDangerousExecutableExtension(null)).toBe(false)
+    expect(hasDangerousExecutableExtension(undefined)).toBe(false)
+    expect(hasDangerousExecutableExtension('README')).toBe(false)
+    expect(hasDangerousExecutableExtension('   ')).toBe(false)
+  })
+
+  it('does not rely on MIME type — detection is filename-only', () => {
+    expect(hasDangerousExecutableExtension('faktura.pdf.exe')).toBe(true)
+  })
+
+  it('remains aligned with filename sanitization', () => {
+    const raw = 'faktura.pdf.exe'
+    expect(hasDangerousExecutableExtension(raw)).toBe(true)
+    expect(sanitizeUploadedFileName(raw)).toBe('faktura_pdf.exe')
+    expect(getAttachmentExtension(sanitizeUploadedFileName(raw))).toBe('exe')
+  })
+})

--- a/packages/core/src/modules/attachments/lib/security.ts
+++ b/packages/core/src/modules/attachments/lib/security.ts
@@ -30,6 +30,32 @@ const ACTIVE_CONTENT_MIME_TYPES = new Set([
 
 const ACTIVE_CONTENT_EXTENSIONS = new Set(['htm', 'html', 'svg', 'xhtml', 'xml'])
 
+const DANGEROUS_EXECUTABLE_EXTENSIONS = new Set([
+  'app',
+  'apk',
+  'bat',
+  'cmd',
+  'com',
+  'dll',
+  'exe',
+  'hta',
+  'jar',
+  'js',
+  'jse',
+  'lnk',
+  'msi',
+  'pif',
+  'ps1',
+  'psm1',
+  'reg',
+  'scr',
+  'sh',
+  'vbe',
+  'vbs',
+  'wsf',
+  'wsh',
+])
+
 const SAFE_INLINE_MIME_TYPES = new Set([
   'image/avif',
   'image/bmp',
@@ -44,6 +70,18 @@ export function getAttachmentExtension(fileName: string | null | undefined): str
   const parts = trimmed.split('.').filter(Boolean)
   if (parts.length < 2) return ''
   return parts[parts.length - 1]!.toLowerCase()
+}
+
+export function hasDangerousExecutableExtension(fileName: string | null | undefined): boolean {
+  const trimmed = String(fileName ?? '').trim()
+  if (!trimmed) return false
+  const parts = trimmed.split('.').filter(Boolean)
+  if (parts.length < 2) return false
+  for (let i = 1; i < parts.length; i += 1) {
+    const segment = parts[i]!.toLowerCase()
+    if (DANGEROUS_EXECUTABLE_EXTENSIONS.has(segment)) return true
+  }
+  return false
 }
 
 export function sanitizeUploadedFileName(input: string | null | undefined): string {


### PR DESCRIPTION
Fixes #1597

## Problem
Uploads named like `faktura.pdf.exe` were accepted by the attachments API and stored as-is. A user could later download the file and execute it. The only pre-existing defenses were per-field `acceptExtensions` (only applied when a `CustomFieldDef` configures it) and the active-content (HTML/SVG/XML) blocklist from PR #1442 — neither covers executable payloads.

## Root Cause
`POST /api/attachments` trusted whatever extension the client supplied and did not maintain an executable blocklist. `sanitizeUploadedFileName` preserves the final extension verbatim, so `faktura.pdf.exe` landed on disk as `faktura_pdf.exe`, fully executable on end-user machines.

## What Changed
- Added `hasDangerousExecutableExtension(fileName)` in `packages/core/src/modules/attachments/lib/security.ts`, which scans every dot-separated extension segment (not just the final one) against a blocklist covering the executables listed in the issue plus related Windows/macOS/Android variants (`exe`, `bat`, `cmd`, `com`, `scr`, `pif`, `msi`, `dll`, `sh`, `ps1`, `psm1`, `vbs`, `vbe`, `js`, `jse`, `wsf`, `wsh`, `hta`, `jar`, `app`, `apk`, `reg`, `lnk`).
- Wired the helper into `packages/core/src/modules/attachments/api/route.ts` before the buffer read. Rejected uploads return HTTP 400 with the new `attachments.errors.dangerousExecutable` i18n key. The check runs on the raw client-supplied `file.name` so interior segments like `report.exe.pdf` are caught, not just trailing ones.
- Added translations for en/de/es/pl.

## Tests
- `packages/core/src/modules/attachments/lib/__tests__/security.test.ts` — unit coverage for trailing, interior, case-insensitive, and empty-input paths.
- `packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts` — two HTTP-level cases: `faktura.pdf.exe` and a plain `installer.msi` both return 400 with an "executable" error.
- Ran: targeted Jest (`attachments/(lib/__tests__/security|api/__tests__/attachments.api)`) → 24 passing; full `@open-mercato/core` suite → 2836 passing, 1 pre-existing `InlineEditors` failure on `develop` (unrelated, reproduced on a clean checkout).
- Ran: `yarn i18n:check-sync` (clean), `yarn i18n:check-usage` (new key is referenced), `yarn workspace @open-mercato/core typecheck` (clean), `yarn build:packages` + `yarn generate` (clean).

## Backward Compatibility
- No contract surface changes. Added a new i18n key to every locale (additive) and a new exported helper from `lib/security` (additive). API rejects a class of uploads that were previously insecure — this is the intended behavior change and is documented via the new error key.