### PR TITLE
fix(customers,sales): link seeded deals to pipeline + prevent doc number increment on type switch

### DIFF
--- a/packages/core/src/modules/customers/cli.ts
+++ b/packages/core/src/modules/customers/cli.ts
@@ -1550,10 +1550,21 @@ async function seedCustomerExamples(
     }
   }
 
+  // Load default pipeline and build a value→stageId lookup so deals appear in the pipeline view
+  const defaultPipeline = await em.findOne(CustomerPipeline, { tenantId, organizationId, isDefault: true })
+  const pipelineStages = defaultPipeline
+    ? await em.find(CustomerPipelineStage, { pipelineId: defaultPipeline.id }, { orderBy: { order: 'ASC' } })
+    : []
+  const stageValueToId = new Map<string, string>()
+  for (let i = 0; i < pipelineStages.length && i < PIPELINE_STAGE_DEFAULTS.length; i++) {
+    stageValueToId.set(PIPELINE_STAGE_DEFAULTS[i].value, pipelineStages[i].id)
+  }
+
   for (const company of CUSTOMER_EXAMPLES) {
     const companyEntity = companyEntities.get(company.slug)
     if (!companyEntity) continue
     for (const dealInfo of company.deals ?? []) {
+      const resolvedStageId = dealInfo.pipelineStage ? stageValueToId.get(dealInfo.pipelineStage) ?? null : null
       const deal = em.create(CustomerDeal, {
         organizationId,
         tenantId,
@@ -1561,6 +1572,8 @@ async function seedCustomerExamples(
         description: dealInfo.description ?? null,
         status: dealInfo.status,
         pipelineStage: dealInfo.pipelineStage ?? null,
+        pipelineId: resolvedStageId ? defaultPipeline!.id : null,
+        pipelineStageId: resolvedStageId,
         valueAmount: toAmount(dealInfo.valueAmount),
         valueCurrency:
           dealInfo.valueCurrency ?? (typeof dealInfo.valueAmount === 'number' ? 'USD' : null),

--- a/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
@@ -744,8 +744,7 @@ export function SalesDocumentForm({ onCreated, isSubmitting = false, initialKind
 
     React.useEffect(() => {
       const current = typeof value === 'string' ? value.trim() : ''
-      const wasAuto = autoValueRef.current && current === autoValueRef.current
-      if (!current.length || (wasAuto && lastKindRef.current && lastKindRef.current !== kind)) {
+      if (!current.length && !lastKindRef.current) {
         void requestNumber()
       } else {
         lastKindRef.current = kind


### PR DESCRIPTION
## Summary

Two bug fixes found while testing the demo environment:

- **Seeded deals missing pipeline links** — demo deals had the denormalized `pipelineStage` string but no `pipelineId`/`pipelineStageId` FK references, so they never appeared in the Sales Pipeline kanban view
- **Document number counter incrementing on type switch** — switching between Quote/Order tabs in the create document form triggered auto-generation of a new document number, consuming database sequence numbers without user intent

## Changes

- `packages/core/src/modules/customers/cli.ts` — load default pipeline and resolve stage IDs when seeding example deals, setting `pipelineId` and `pipelineStageId` on each deal
- `packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx` — restrict `useEffect` auto-generation to initial mount only (empty field + no prior kind); explicit Generate button still works as before

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fixes in existing seed logic and UI component

## Testing

- Built packages with `yarn build:packages` — no errors
- Verified seeded deals appear in the pipeline view after re-init
- Verified switching quote/order tabs no longer triggers document number API calls

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

## Linked issues

N/A — discovered during manual testing of demo environment.