### PR TITLE
perf(ui): memoize Tabs context value to prevent consumer re-renders (#1409)

### DIFF
--- a/packages/ui/src/primitives/__tests__/tabs.test.tsx
+++ b/packages/ui/src/primitives/__tests__/tabs.test.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { act, render, fireEvent } from '@testing-library/react'
+import { Tabs, TabsContent, TabsContext, TabsList, TabsTrigger } from '../tabs'
+
+describe('Tabs context provider', () => {
+  it('keeps a stable context value reference across unrelated parent re-renders', () => {
+    const captured: unknown[] = []
+
+    function Capture() {
+      captured.push(React.useContext(TabsContext))
+      return null
+    }
+
+    let bump: () => void = () => {}
+
+    function Host() {
+      const [n, setN] = React.useState(0)
+      bump = () => setN((prev) => prev + 1)
+      return (
+        <Tabs defaultValue="a">
+          <span data-testid="unrelated">{n}</span>
+          <Capture />
+          <TabsList>
+            <TabsTrigger value="a">A</TabsTrigger>
+            <TabsTrigger value="b">B</TabsTrigger>
+          </TabsList>
+          <TabsContent value="a">A content</TabsContent>
+        </Tabs>
+      )
+    }
+
+    render(<Host />)
+    const initial = captured[captured.length - 1]
+
+    act(() => {
+      bump()
+    })
+    act(() => {
+      bump()
+    })
+
+    const afterUnrelated = captured[captured.length - 1]
+    expect(afterUnrelated).toBe(initial)
+  })
+
+  it('produces a new context value reference when the selected tab changes', () => {
+    const captured: unknown[] = []
+
+    function Capture() {
+      captured.push(React.useContext(TabsContext))
+      return null
+    }
+
+    const { getByRole } = render(
+      <Tabs defaultValue="a">
+        <Capture />
+        <TabsList>
+          <TabsTrigger value="a">A</TabsTrigger>
+          <TabsTrigger value="b">B</TabsTrigger>
+        </TabsList>
+        <TabsContent value="a">A content</TabsContent>
+        <TabsContent value="b">B content</TabsContent>
+      </Tabs>,
+    )
+
+    const before = captured[captured.length - 1]
+    fireEvent.click(getByRole('tab', { name: 'B' }))
+    const after = captured[captured.length - 1]
+
+    expect(after).not.toBe(before)
+  })
+})

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -10,9 +10,9 @@ type TabsContextValue = {
   onValueChange: (value: string) => void
 }
 
-const TabsContext = createContext<TabsContextValue | undefined>(undefined)
+export const TabsContext = createContext<TabsContextValue | undefined>(undefined)
 
-function useTabsContext() {
+export function useTabsContext() {
   const context = useContext(TabsContext)
   if (!context) {
     throw new Error('Tabs components must be used within a Tabs provider')
@@ -49,8 +49,13 @@ export function Tabs({
     [isControlled, onValueChange],
   )
 
+  const contextValue = React.useMemo<TabsContextValue>(
+    () => ({ value, onValueChange: handleValueChange }),
+    [value, handleValueChange],
+  )
+
   return (
-    <TabsContext.Provider value={{ value, onValueChange: handleValueChange }}>
+    <TabsContext.Provider value={contextValue}>
       <div className={className}>{children}</div>
     </TabsContext.Provider>
   )


### PR DESCRIPTION
Fixes #1409

## Problem
`Tabs` passed a fresh `{ value, onValueChange }` object to its context provider on every render, so every consumer (tab triggers and, more importantly, `TabsContent` panels containing heavy forms, tables, and charts) re-rendered on every unrelated parent re-render.

## Root Cause
Inline object literal in `packages/ui/src/primitives/tabs.tsx` — `value={{ value, onValueChange: handleValueChange }}` — created a new reference each render, invalidating `React.useContext` equality for all consumers.

## What Changed
- Wrap the provider value in `React.useMemo` keyed on `value` + `handleValueChange`. The reference now changes only when the selected tab changes or the parent passes a new `onValueChange` handler.
- Export `TabsContext` and `useTabsContext` so tests (and anyone building custom triggers/content components) can read the provider directly. Additive only — no breaking change.

## Tests
- `packages/ui/src/primitives/__tests__/tabs.test.tsx`
  - asserts the context reference is stable across unrelated parent re-renders (regression for the fix)
  - asserts the context reference changes when the selected tab changes (guards the `useMemo` deps)
- `yarn workspace @open-mercato/ui test --testPathPatterns=tabs` → 2 passed
- Pre-existing failures in `CustomDataSection` exist on `origin/develop` without this change and are unrelated

## Backward Compatibility
No contract surface changes. Behavior of `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent` is unchanged. New named exports (`TabsContext`, `useTabsContext`) are purely additive.