### PR TITLE
docs(inbox_ops): add local development walkthrough (#1435)

### DIFF
--- a/apps/docs/docs/user-guide/inbox-ops.mdx
+++ b/apps/docs/docs/user-guide/inbox-ops.mdx
@@ -21,6 +21,10 @@ Set up the email-to-ERP agent so your team can forward customer email threads an
 - An AI provider API key (Anthropic, OpenAI, or Google) for email extraction
 - Your Open Mercato instance must be publicly accessible (or use a tunnel like ngrok for development)
 
+:::tip Running on localhost?
+If you are setting this up on your dev machine, jump straight to the [Local Development Setup](#local-development-setup) section — it walks through the full Resend + ngrok flow end to end.
+:::
+
 ## Step 1: Set Up Your Receiving Domain
 
 Resend needs to receive emails on your behalf. Choose one of two options:
@@ -187,6 +191,168 @@ Send a test email to verify everything works end-to-end:
 | Proposal created but no products matched | Your catalog is empty or product names differ | Add products to the catalog; the system does fuzzy matching on names and SKUs |
 | HTTP 429 from webhook | Rate limit exceeded | Default limits: 10/min, 100/hour, 1000/day per inbox address |
 | Same email not processed twice | Deduplication by message ID or content hash | This is intentional — each unique email is only processed once |
+
+## Local Development Setup
+
+This section is a complete, step-by-step walkthrough for running InboxOps on your laptop against a real Resend account using an [ngrok](https://ngrok.com) tunnel to expose the webhook endpoint. Allow about 15–20 minutes for the first-time setup.
+
+### What You Will End Up With
+
+```
+           (forwarded email)
+ [you] ───────────────────────▶ anything@<id>.resend.app
+                                         │
+                               Resend servers (email.received)
+                                         │
+                              (POST /api/inbox_ops/webhook/inbound)
+                                         ▼
+                     https://<slug>.ngrok-free.app
+                                         │   (ngrok tunnel)
+                                         ▼
+                      http://localhost:3000  (your dev server)
+                                         │
+                            extraction worker + proposal
+```
+
+If any link in that chain is broken, the flow fails silently — the [Troubleshooting Local Development](#troubleshooting-local-development) section below maps each failure mode to its fix.
+
+### Step A — Prepare a Resend Account
+
+1. Sign up at [https://resend.com](https://resend.com). The free tier is enough — you do **not** need a verified sending domain for receiving.
+2. After login, go to **API Keys** &rarr; **Create API Key**.
+   - Name it `open-mercato-local`.
+   - Permission: **Full access** (you will need read access on the receiving inbox).
+   - Copy the value (starts with `re_`). You will paste it into `.env` in Step C.
+3. Open the **Domains** page and locate your free managed receiving domain. Resend provisions one automatically and it looks like `eldaaelkia.resend.app`. Copy the full domain — you will reuse it as `INBOX_OPS_DOMAIN`.
+
+:::note Where is my free receiving domain?
+If you do not see a `*.resend.app` entry on the Domains list, go to **Emails &rarr; Receiving** — Resend exposes it there as well. Any address you invent under that domain (for example `ops-84f470a7@eldaaelkia.resend.app`) is a valid receiving inbox.
+:::
+
+### Step B — Start an ngrok Tunnel to Your Dev Server
+
+1. Install ngrok: `brew install ngrok` on macOS, or follow [https://ngrok.com/download](https://ngrok.com/download) for other platforms.
+2. Create a free ngrok account, grab your authtoken from [https://dashboard.ngrok.com/get-started/your-authtoken](https://dashboard.ngrok.com/get-started/your-authtoken), and register it once:
+
+   ```bash
+   ngrok config add-authtoken <your-token>
+   ```
+3. Start your Open Mercato dev server in one terminal:
+
+   ```bash
+   yarn dev
+   ```
+
+   By default it binds to `http://localhost:3000`.
+4. Start the tunnel in a second terminal:
+
+   ```bash
+   ngrok http 3000
+   ```
+
+   ngrok prints a forwarding URL similar to:
+
+   ```
+   Forwarding  https://9e3a-203-0-113-42.ngrok-free.app -> http://localhost:3000
+   ```
+
+   Copy the `https://...ngrok-free.app` URL. You will paste it into Resend in Step D.
+
+:::caution ngrok URLs rotate
+A free ngrok URL changes every time you restart the tunnel. You will need to update the Resend webhook URL (Step D) each time. For a stable URL, claim a reserved domain under **Cloud Edge &rarr; Domains** in the ngrok dashboard and run `ngrok http --domain=<your>.ngrok-free.app 3000`.
+:::
+
+### Step C — Wire Environment Variables
+
+Open `apps/mercato/.env` (or copy from `apps/mercato/.env.example` if it does not exist yet) and set the following block. Uncomment the keys, do not leave the sample `#` prefix:
+
+```env
+# ----- InboxOps (Resend + ngrok local dev) -----
+RESEND_API_KEY=re_your_api_key_from_step_a
+RESEND_WEBHOOK_SIGNING_SECRET=whsec_filled_in_after_step_d
+INBOX_OPS_DOMAIN=eldaaelkia.resend.app
+
+# AI provider — pick one
+OPENCODE_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-api03-...
+# OPENAI_API_KEY=sk-...
+# GOOGLE_GENERATIVE_AI_API_KEY=AI...
+```
+
+Leave `RESEND_WEBHOOK_SIGNING_SECRET` empty for now — Resend will give it to you in Step D, and you will restart the dev server after filling it in.
+
+:::tip Prefer HMAC mode for offline tests?
+If you only need to exercise the webhook without involving Resend (for example in CI or during automated E2E), set `INBOX_OPS_WEBHOOK_SECRET=<any-long-string>` and use `scripts/test-inbox-webhook*.sh` instead. The endpoint accepts either mode as long as at least one secret is configured. See [Developer Testing](#developer-testing).
+:::
+
+### Step D — Register the Webhook in Resend
+
+1. In Resend, open **Webhooks** &rarr; **Add Webhook**.
+2. **Endpoint URL**: paste your ngrok URL with the webhook path appended:
+
+   ```
+   https://9e3a-203-0-113-42.ngrok-free.app/api/inbox_ops/webhook/inbound
+   ```
+3. **Events**: select `email.received`. You can leave other events unchecked for now.
+4. Click **Create**. Resend shows the webhook detail page with a **Signing secret** that starts with `whsec_`.
+5. Copy the signing secret and paste it into your `.env` as `RESEND_WEBHOOK_SIGNING_SECRET`.
+6. **Restart the dev server** (`Ctrl+C`, then `yarn dev` again) so the new secret is picked up.
+
+:::note Screenshots
+If you want visual references while following along, capture the Resend **API Keys**, **Domains** (or **Emails &rarr; Receiving**), and **Webhooks &rarr; Edit Webhook** screens, plus the ngrok terminal output showing the `Forwarding` line. These screens are the only five places where a misconfiguration can happen, and each has a unique visible field (API key prefix, domain value, webhook URL, signing secret, ngrok forwarding URL) that maps 1:1 to the env vars above.
+:::
+
+### Step E — Align the Tenant Inbox Address With Your Domain
+
+Open Mercato generates the tenant's inbox address at tenant setup time using whatever `INBOX_OPS_DOMAIN` was set then. If you changed `INBOX_OPS_DOMAIN` (for example because you used the default `inbox.mercato.local` on first boot), the address stored in `inbox_settings.inbox_address` will still point at the old domain and Resend traffic will never match it.
+
+Check the current address:
+
+```sql
+SELECT id, inbox_address, is_active
+FROM inbox_settings
+WHERE deleted_at IS NULL;
+```
+
+If the domain does not match your `INBOX_OPS_DOMAIN`, update it:
+
+```sql
+UPDATE inbox_settings
+SET inbox_address = REPLACE(inbox_address, 'inbox.mercato.local', 'eldaaelkia.resend.app'),
+    updated_at = NOW()
+WHERE deleted_at IS NULL;
+```
+
+Replace both strings with the values that match your setup. You can also edit it from the admin UI: **Inbox Ops &rarr; Settings** shows the current address, but the domain part is only editable by rewriting the row directly until automatic resync is implemented.
+
+After updating, refresh the admin UI and confirm the inbox address displayed on **Inbox Ops &rarr; Settings** matches `ops-<slug>@<INBOX_OPS_DOMAIN>`.
+
+### Step F — Send a Test Email End to End
+
+1. From any mailbox (Gmail, iCloud, your company inbox) send a plain-text email to the inbox address shown on **Inbox Ops &rarr; Settings**. Use the sample body from [Step 5: Test the Integration](#step-5-test-the-integration) or any realistic customer request.
+2. Watch three places in parallel:
+   - **ngrok terminal** — every webhook delivery shows up as `POST /api/inbox_ops/webhook/inbound 200 OK`. No line here means Resend never sent the webhook (usually a Resend-side config issue).
+   - **Dev server logs** — look for `inbox_ops.webhook.received` and `inbox_ops.extraction.completed`. Errors like `Failed to fetch Resend email` or `Inbox address not found` are logged here.
+   - **Admin UI** — open **Inbox Ops** in the sidebar. Within ~30 seconds of the email arriving, a new proposal row appears.
+3. Open the proposal. You should see extracted actions (contact match, order line items, draft reply). If actions are empty but the email is logged, the LLM ran but did not find anything useful — check the email body and the AI provider configuration.
+
+If nothing lands in the UI, Resend's own **Webhooks &rarr; Logs** tab shows you the HTTP status code it saw when it called your ngrok URL. This is the single most useful debugging signal — see the next section.
+
+### Troubleshooting Local Development
+
+Use this table in addition to the general [Troubleshooting](#troubleshooting) table — the failure modes below are specific to local tunnelled setups.
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Resend webhook log shows **200 OK** but no proposal appears in the UI | The inbox address on the email does not match any `inbox_settings.inbox_address` for an active tenant (silent accept). | Run the SQL from [Step E](#step-e--align-the-tenant-inbox-address-with-your-domain) and confirm the domain matches `INBOX_OPS_DOMAIN`. Then re-forward the email — old deliveries are deduplicated by message ID and will not replay. |
+| Resend webhook log shows repeated **connection refused** or **502** errors | ngrok is not running, or its URL changed and Resend is still calling the old one. | In the ngrok terminal, copy the current `Forwarding` URL and update the Resend webhook endpoint in **Webhooks &rarr; Edit**. Restart ngrok with a reserved domain if this happens often. |
+| Resend webhook log shows **503** with `RESEND_WEBHOOK_SIGNING_SECRET not configured` | The dev server started before you filled in the secret. | Fill `RESEND_WEBHOOK_SIGNING_SECRET` in `.env`, stop `yarn dev` with `Ctrl+C`, then start it again. |
+| Resend webhook log shows **400** with `invalid signature` | Signing secret mismatch — common after recreating the webhook in Resend. | Copy the **current** signing secret from **Webhooks &rarr; Edit &rarr; Signing secret**, replace it in `.env`, and restart the dev server. |
+| Dev server logs `Failed to fetch Resend email` after a 200 webhook | `RESEND_API_KEY` is missing, expired, or lacks permission to read received emails. | Regenerate the key in Resend with full access, paste it into `.env`, and restart. |
+| Dev server logs `Inbox address not found` right after a valid signature | The email was sent to a `@<domain>` that is not the tenant's configured `inbox_address`. | Either send the test email to the address shown on **Inbox Ops &rarr; Settings**, or rewrite `inbox_settings.inbox_address` to match the domain you are actually using. |
+| Email lands but stays stuck at status `received`; no extraction runs | AI provider misconfigured — no `OPENCODE_PROVIDER` or the matching API key is empty. | Set `OPENCODE_PROVIDER` and its API key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_GENERATIVE_AI_API_KEY`), restart, then click **Reprocess** on the proposal. |
+| Forwarding the same email twice does nothing the second time | Deduplication by message ID / content hash is intentional. | Change the email body (even a single character) before re-forwarding, or reprocess the existing proposal from the admin UI. |
+| ngrok shows the request but the dev server logs nothing | Dev server is not bound to `localhost:3000`, or you tunnelled the wrong port. | Confirm the port in the `yarn dev` output and restart `ngrok http <port>` accordingly. |
 
 ## Security
 


### PR DESCRIPTION
Fixes #1435

## Problem
The InboxOps user guide covered production setup but did not walk users through a realistic local development flow. New contributors had to piece together Resend account setup, ngrok tunnelling, env var naming, and the `inbox_settings.inbox_address` refresh procedure from source code and support chats. The "silent 200 OK" failure mode (webhook accepted but inbox address does not match) was especially hard to diagnose without explicit guidance.

## What Changed
Added a new **Local Development Setup** section to `apps/docs/docs/user-guide/inbox-ops.mdx` that walks through the full flow end to end:

- **Step A — Prepare a Resend Account**: sign up, API key creation, and how to locate the free managed receiving domain (`*.resend.app`).
- **Step B — Start an ngrok Tunnel**: install, authtoken registration, `ngrok http 3000`, and a warning about URL rotation on the free tier.
- **Step C — Wire Environment Variables**: exact `.env` block with `RESEND_API_KEY`, `RESEND_WEBHOOK_SIGNING_SECRET`, `INBOX_OPS_DOMAIN`, `OPENCODE_PROVIDER`, and matching AI key.
- **Step D — Register the Webhook in Resend**: endpoint URL, event selection, signing secret handoff, restart reminder.
- **Step E — Align the Tenant Inbox Address With Your Domain**: the manual SQL workaround on `inbox_settings.inbox_address` (until automatic resync is implemented), plus the check query.
- **Step F — Send a Test Email End to End**: what to watch in the ngrok terminal, the dev server logs, and the admin UI.
- **Troubleshooting Local Development**: 8-row table covering the failure modes the issue called out — silent 200 OK from domain mismatch, stale ngrok URL, `503`/`400` signing-secret failures, missing `RESEND_API_KEY`, AI provider not configured, dedup, and wrong local port.

Added a jump tip to the **Prerequisites** section so local-dev readers skip straight to the new section.

No existing sections were removed or renamed; all new cross-links (`#step-5-test-the-integration`, `#troubleshooting`, `#developer-testing`) already existed on the page.

## Screenshots
The issue asked for screenshots from ngrok and Resend "if possible". Actual screenshots require a live Resend account and an interactive ngrok session, so they are not bundled with this PR — instead, each UI-touching step describes the exact field label and value to look for, and a `:::note Screenshots` callout lists the five screens worth capturing in a future follow-up. That keeps the doc useful today without shipping broken image references.

## Tests
- `yarn build` in `apps/docs` completes successfully. The only broken-anchor warning reported by Docusaurus (`/installation/wsl2#connecting-wsl2-to-a-windows-hosted-database`) is pre-existing on `develop` and not related to this change.
- Docs-only change — no unit, integration, i18n, or typecheck surface is touched. No `em.find*` calls added; no contract surface (import path, event ID, API URL, schema, etc.) changed.

## Backward Compatibility
No contract surface changes. Documentation-only addition.