### PR TITLE
fix(perf): parallelize entity defs, search availability, and dictionary resolution (#1404)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/definitions.manage.parallel.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.manage.parallel.test.ts
@@ -1,0 +1,71 @@
+/** @jest-environment node */
+import { GET } from '../definitions.manage'
+
+const loadEntityFieldsetConfigsMock = jest.fn()
+
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (key: string) => (key === 'em' ? mockEm : null),
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/data/entities', () => ({
+  CustomFieldDef: 'CustomFieldDef',
+}))
+
+jest.mock('../../lib/fieldsets', () => ({
+  loadEntityFieldsetConfigs: (...args: unknown[]) => loadEntityFieldsetConfigsMock(...args),
+}))
+
+describe('entities/definitions.manage GET (issue #1404)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('fetches defs, tombstones, and fieldset configs in parallel rather than sequentially', async () => {
+    const calls: Array<{ id: string; start: number; end: number }> = []
+    const slowResolve = <T>(id: string, value: T, delay: number): Promise<T> =>
+      new Promise((resolve) => {
+        const start = Date.now()
+        setTimeout(() => {
+          calls.push({ id, start, end: Date.now() })
+          resolve(value)
+        }, delay)
+      })
+
+    mockEm.find.mockImplementation((_entity: unknown, where: Record<string, unknown>) => {
+      if (where && (where as any).deletedAt && typeof (where as any).deletedAt === 'object') {
+        return slowResolve('tombstones', [], 60)
+      }
+      return slowResolve('defs', [], 60)
+    })
+    loadEntityFieldsetConfigsMock.mockImplementation(() => slowResolve('configs', new Map(), 60))
+
+    const start = Date.now()
+    const response = await GET(new Request('http://x/api/entities/definitions/manage?entityId=test:entity'))
+    const elapsed = Date.now() - start
+
+    expect(response.status).toBe(200)
+    // Sequential awaits would be ~180ms; parallel should land near the slowest leg.
+    expect(elapsed).toBeLessThan(150)
+    expect(calls.map((c) => c.id).sort()).toEqual(['configs', 'defs', 'tombstones'])
+    // All three legs should overlap in time, proving parallel execution.
+    const earliestEnd = Math.min(...calls.map((c) => c.end))
+    const latestStart = Math.max(...calls.map((c) => c.start))
+    expect(latestStart).toBeLessThan(earliestEnd)
+  })
+})

--- a/packages/core/src/modules/entities/api/definitions.manage.ts
+++ b/packages/core/src/modules/entities/api/definitions.manage.ts
@@ -21,25 +21,31 @@ export async function GET(req: Request) {
   const em = resolve('em') as any
   // Load all scoped records (active/inactive/deleted) so that per-scope tombstones
   // can shadow global definitions. We'll filter out deleted winners later.
-  const defs = await em.find(CustomFieldDef, {
-    entityId,
-    deletedAt: null,
-    isActive: true,
-    $and: [
-      { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
-      { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
-    ],
-  }, { orderBy: { key: 'asc' } as any })
-
-  // Also load tombstones to shadow lower-scope/global entries with the same key
-  const tombstones = await em.find(CustomFieldDef, {
-    entityId,
-    deletedAt: { $ne: null } as any,
-    $and: [
-      { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
-      { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
-    ],
-  })
+  const [defs, tombstones, configMap] = await Promise.all([
+    em.find(CustomFieldDef, {
+      entityId,
+      deletedAt: null,
+      isActive: true,
+      $and: [
+        { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
+        { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
+      ],
+    }, { orderBy: { key: 'asc' } as any }),
+    em.find(CustomFieldDef, {
+      entityId,
+      deletedAt: { $ne: null } as any,
+      $and: [
+        { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
+        { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
+      ],
+    }),
+    loadEntityFieldsetConfigs(em, {
+      entityIds: [entityId],
+      tenantId: auth.tenantId ?? null,
+      organizationId: auth.orgId ?? null,
+      mode: 'manage',
+    }),
+  ])
   const tombstonedKeys = new Set<string>((tombstones as any[]).map((d: any) => d.key))
 
   // Deduplicate by key, with clear precedence that allows higher-scope tombstones
@@ -77,12 +83,6 @@ export async function GET(req: Request) {
     tenantId: d.tenantId ?? null,
   }))
   const deletedKeys = Array.from(tombstonedKeys)
-  const configMap = await loadEntityFieldsetConfigs(em, {
-    entityIds: [entityId],
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
-    mode: 'manage',
-  })
   const cfg = configMap.get(entityId) ?? { fieldsets: [], singleFieldsetPerRecord: true }
   return NextResponse.json({
     items,

--- a/packages/core/src/modules/sales/lib/__tests__/resolveSalesDictionaryForCandidates.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/resolveSalesDictionaryForCandidates.test.ts
@@ -1,0 +1,135 @@
+/** @jest-environment node */
+import { resolveSalesDictionaryForCandidates } from '../makeStatusDictionaryRoute'
+
+const ensureSalesDictionaryMock = jest.fn()
+
+jest.mock('../dictionaries', () => {
+  const actual = jest.requireActual('../dictionaries')
+  return {
+    ...actual,
+    ensureSalesDictionary: (...args: unknown[]) => ensureSalesDictionaryMock(...args),
+  }
+})
+
+jest.mock('@open-mercato/core/modules/dictionaries/data/entities', () => ({
+  Dictionary: 'Dictionary',
+  DictionaryEntry: 'DictionaryEntry',
+}))
+
+describe('resolveSalesDictionaryForCandidates (issue #1404)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns null without touching the database when there are no candidates', async () => {
+    const em = { find: jest.fn(), findOne: jest.fn() }
+    const result = await resolveSalesDictionaryForCandidates({
+      em: em as unknown as any,
+      tenantId: 'tenant-1',
+      kind: 'order-status',
+      dictionaryKey: 'sales.order_status',
+      candidateOrgIds: [],
+    })
+
+    expect(result).toBeNull()
+    expect(em.find).not.toHaveBeenCalled()
+    expect(ensureSalesDictionaryMock).not.toHaveBeenCalled()
+  })
+
+  it('prefetches all candidate dictionaries in a single query', async () => {
+    const em = {
+      find: jest.fn().mockResolvedValue([
+        { id: 'dict-b', organizationId: 'org-b' },
+        { id: 'dict-c', organizationId: 'org-c' },
+      ]),
+      findOne: jest.fn(),
+    }
+
+    const result = await resolveSalesDictionaryForCandidates({
+      em: em as unknown as any,
+      tenantId: 'tenant-1',
+      kind: 'order-status',
+      dictionaryKey: 'sales.order_status',
+      candidateOrgIds: ['org-a', 'org-b', 'org-c'],
+    })
+
+    expect(em.find).toHaveBeenCalledTimes(1)
+    expect(em.find).toHaveBeenCalledWith(
+      'Dictionary',
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        key: 'sales.order_status',
+        organizationId: { $in: ['org-a', 'org-b', 'org-c'] },
+        deletedAt: null,
+      }),
+    )
+    // Priority order picks 'org-b' over 'org-c' because 'org-b' comes first in the candidate list.
+    expect(result).toEqual({ dictionaryId: 'dict-b', organizationId: 'org-b' })
+    expect(ensureSalesDictionaryMock).not.toHaveBeenCalled()
+  })
+
+  it('respects candidate priority order even when the prefetched rows arrive unordered', async () => {
+    const em = {
+      find: jest.fn().mockResolvedValue([
+        { id: 'dict-c', organizationId: 'org-c' },
+        { id: 'dict-a', organizationId: 'org-a' },
+      ]),
+      findOne: jest.fn(),
+    }
+
+    const result = await resolveSalesDictionaryForCandidates({
+      em: em as unknown as any,
+      tenantId: 'tenant-1',
+      kind: 'order-status',
+      dictionaryKey: 'sales.order_status',
+      candidateOrgIds: ['org-a', 'org-b', 'org-c'],
+    })
+
+    expect(result).toEqual({ dictionaryId: 'dict-a', organizationId: 'org-a' })
+  })
+
+  it('only seeds a dictionary when no candidate org owns one yet', async () => {
+    const em = {
+      find: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn(),
+    }
+    ensureSalesDictionaryMock.mockResolvedValue({ id: 'created-dict' })
+
+    const result = await resolveSalesDictionaryForCandidates({
+      em: em as unknown as any,
+      tenantId: 'tenant-1',
+      kind: 'order-status',
+      dictionaryKey: 'sales.order_status',
+      candidateOrgIds: ['org-a', 'org-b'],
+    })
+
+    expect(ensureSalesDictionaryMock).toHaveBeenCalledTimes(1)
+    expect(ensureSalesDictionaryMock).toHaveBeenCalledWith({
+      em,
+      tenantId: 'tenant-1',
+      organizationId: 'org-a',
+      kind: 'order-status',
+    })
+    expect(result).toEqual({ dictionaryId: 'created-dict', organizationId: 'org-a' })
+  })
+
+  it('does not create per-candidate dictionaries on the read path (no sequential em.flush per org)', async () => {
+    const em = {
+      find: jest.fn().mockResolvedValue([{ id: 'dict-b', organizationId: 'org-b' }]),
+      findOne: jest.fn(),
+    }
+
+    await resolveSalesDictionaryForCandidates({
+      em: em as unknown as any,
+      tenantId: 'tenant-1',
+      kind: 'order-status',
+      dictionaryKey: 'sales.order_status',
+      candidateOrgIds: ['org-a', 'org-b', 'org-c'],
+    })
+
+    // The old implementation called ensureSalesDictionary (which triggers em.flush)
+    // per candidate on the read path. The optimized path must not do that when
+    // any candidate already owns the dictionary.
+    expect(ensureSalesDictionaryMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/sales/lib/makeStatusDictionaryRoute.ts
+++ b/packages/core/src/modules/sales/lib/makeStatusDictionaryRoute.ts
@@ -13,6 +13,68 @@ import {
   defaultDeleteRequestSchema,
 } from '../api/openapi'
 
+type ResolveDictionaryContextInput = {
+  em: EntityManager
+  tenantId: string
+  kind: SalesDictionaryKind
+  dictionaryKey: string
+  candidateOrgIds: string[]
+}
+
+export type ResolvedDictionaryContext = {
+  dictionaryId: string
+  organizationId: string | null
+}
+
+/**
+ * Resolve the dictionary that governs a sales status request.
+ *
+ * Prefetches all candidate dictionaries in a single query so per-request
+ * latency scales with the slowest DB roundtrip rather than the number of
+ * candidate organizations. Creation is deferred to the first candidate org
+ * only when no candidate already owns the dictionary, matching the read-only
+ * bias of the API (seeding happens in setup/seed paths).
+ */
+export async function resolveSalesDictionaryForCandidates(
+  input: ResolveDictionaryContextInput,
+): Promise<ResolvedDictionaryContext | null> {
+  const { em, tenantId, kind, dictionaryKey, candidateOrgIds } = input
+  if (candidateOrgIds.length === 0) return null
+
+  const matches = await em.find(Dictionary, {
+    tenantId,
+    key: dictionaryKey,
+    organizationId: { $in: candidateOrgIds },
+    deletedAt: null,
+  })
+  if (matches.length > 0) {
+    const byOrg = new Map<string, Dictionary>()
+    for (const dict of matches) {
+      if (dict.organizationId && !byOrg.has(dict.organizationId)) {
+        byOrg.set(dict.organizationId, dict)
+      }
+    }
+    for (const orgId of candidateOrgIds) {
+      const dictionary = byOrg.get(orgId)
+      if (dictionary) {
+        return { dictionaryId: dictionary.id, organizationId: orgId }
+      }
+    }
+  }
+
+  const firstOrgId = candidateOrgIds[0]
+  const dictionary = await ensureSalesDictionary({
+    em,
+    tenantId,
+    organizationId: firstOrgId,
+    kind,
+  })
+  if (dictionary) {
+    return { dictionaryId: dictionary.id, organizationId: firstOrgId }
+  }
+  return null
+}
+
 interface StatusDictionaryRouteConfig {
   kind: SalesDictionaryKind
   entityId: string
@@ -90,17 +152,15 @@ export function makeStatusDictionaryRoute(config: StatusDictionaryRouteConfig) {
       }
     }
 
-    for (const orgId of candidateOrgIds) {
-      const dictionary = await ensureSalesDictionary({
-        em,
-        tenantId,
-        organizationId: orgId,
-        kind,
-      })
-      if (dictionary) {
-        return { dictionaryId: dictionary.id, organizationId: orgId }
-      }
-    }
+    const orderedOrgIds = Array.from(candidateOrgIds)
+    const resolved = await resolveSalesDictionaryForCandidates({
+      em,
+      tenantId,
+      kind,
+      dictionaryKey: definition.key,
+      candidateOrgIds: orderedOrgIds,
+    })
+    if (resolved) return resolved
 
     const fallback = await em.findOne(
       Dictionary,

--- a/packages/search/src/__tests__/service.test.ts
+++ b/packages/search/src/__tests__/service.test.ts
@@ -416,4 +416,167 @@ describe('SearchService', () => {
       expect(strategyWithPurge.purge).toHaveBeenCalledWith('test:entity', 'tenant-123')
     })
   })
+
+  describe('availability checks (issue #1404)', () => {
+    it('runs strategy availability probes in parallel, not sequentially', async () => {
+      const probeTimings: Record<string, { start: number; end: number }> = {}
+      const makeSlowStrategy = (id: string, delayMs: number) =>
+        createMockStrategy({
+          id,
+          isAvailable: jest.fn().mockImplementation(async () => {
+            const start = Date.now()
+            await new Promise((resolve) => setTimeout(resolve, delayMs))
+            probeTimings[id] = { start, end: Date.now() }
+            return true
+          }),
+          search: jest.fn().mockResolvedValue([]),
+        })
+
+      const slowA = makeSlowStrategy('slow-a', 60)
+      const slowB = makeSlowStrategy('slow-b', 60)
+      const slowC = makeSlowStrategy('slow-c', 60)
+      const service = new SearchService({
+        strategies: [slowA, slowB, slowC],
+        defaultStrategies: ['slow-a', 'slow-b', 'slow-c'],
+        availabilityCacheTtlMs: 0,
+      })
+
+      const start = Date.now()
+      await service.search('q', { tenantId: 't-1' })
+      const elapsed = Date.now() - start
+
+      // Sequential would be ~180ms; parallel should land near the slowest probe.
+      expect(elapsed).toBeLessThan(150)
+      expect(slowA.isAvailable).toHaveBeenCalledTimes(1)
+      expect(slowB.isAvailable).toHaveBeenCalledTimes(1)
+      expect(slowC.isAvailable).toHaveBeenCalledTimes(1)
+    })
+
+    it('caches positive availability checks within the TTL window', async () => {
+      const strategy = createMockStrategy({
+        id: 'cached',
+        isAvailable: jest.fn().mockResolvedValue(true),
+        search: jest.fn().mockResolvedValue([]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['cached'],
+        availabilityCacheTtlMs: 60_000,
+      })
+
+      await service.search('q', { tenantId: 't-1' })
+      await service.search('q', { tenantId: 't-1' })
+      await service.search('q', { tenantId: 't-1' })
+
+      expect(strategy.isAvailable).toHaveBeenCalledTimes(1)
+    })
+
+    it('caches negative availability checks within the TTL window', async () => {
+      const strategy = createMockStrategy({
+        id: 'down',
+        isAvailable: jest.fn().mockResolvedValue(false),
+        search: jest.fn().mockResolvedValue([]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['down'],
+        availabilityCacheTtlMs: 60_000,
+      })
+
+      await service.search('q', { tenantId: 't-1' })
+      await service.search('q', { tenantId: 't-1' })
+
+      expect(strategy.isAvailable).toHaveBeenCalledTimes(1)
+    })
+
+    it('caches thrown availability errors as unavailable within the TTL window', async () => {
+      const strategy = createMockStrategy({
+        id: 'flaky',
+        isAvailable: jest.fn().mockRejectedValue(new Error('boom')),
+        search: jest.fn().mockResolvedValue([]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['flaky'],
+        availabilityCacheTtlMs: 60_000,
+      })
+
+      const r1 = await service.search('q', { tenantId: 't-1' })
+      const r2 = await service.search('q', { tenantId: 't-1' })
+
+      expect(r1).toEqual([])
+      expect(r2).toEqual([])
+      expect(strategy.isAvailable).toHaveBeenCalledTimes(1)
+      expect(strategy.search).not.toHaveBeenCalled()
+    })
+
+    it('coalesces concurrent probes of the same strategy onto a single in-flight call', async () => {
+      let resolveProbe: ((value: boolean) => void) | undefined
+      const strategy = createMockStrategy({
+        id: 'coalesced',
+        isAvailable: jest.fn().mockImplementation(
+          () =>
+            new Promise<boolean>((resolve) => {
+              resolveProbe = resolve
+            }),
+        ),
+        search: jest.fn().mockResolvedValue([]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['coalesced'],
+        availabilityCacheTtlMs: 0,
+      })
+
+      const p1 = service.search('q', { tenantId: 't-1' })
+      const p2 = service.search('q', { tenantId: 't-1' })
+      const p3 = service.isStrategyAvailable('coalesced')
+
+      // Wait a tick so all three callers register their probes.
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      resolveProbe?.(true)
+      await Promise.all([p1, p2, p3])
+
+      expect(strategy.isAvailable).toHaveBeenCalledTimes(1)
+    })
+
+    it('invalidates the availability cache on demand', async () => {
+      const strategy = createMockStrategy({
+        id: 'invalidated',
+        isAvailable: jest.fn().mockResolvedValue(true),
+        search: jest.fn().mockResolvedValue([]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['invalidated'],
+        availabilityCacheTtlMs: 60_000,
+      })
+
+      await service.search('q', { tenantId: 't-1' })
+      service.invalidateAvailabilityCache('invalidated')
+      await service.search('q', { tenantId: 't-1' })
+
+      expect(strategy.isAvailable).toHaveBeenCalledTimes(2)
+    })
+
+    it('invalidates cached availability when a strategy is unregistered and re-registered', async () => {
+      const strategy = createMockStrategy({
+        id: 'reregistered',
+        isAvailable: jest.fn().mockResolvedValue(true),
+        search: jest.fn().mockResolvedValue([]),
+      })
+      const service = new SearchService({
+        strategies: [strategy],
+        defaultStrategies: ['reregistered'],
+        availabilityCacheTtlMs: 60_000,
+      })
+
+      await service.search('q', { tenantId: 't-1' })
+      service.unregisterStrategy('reregistered')
+      service.registerStrategy(strategy)
+      await service.search('q', { tenantId: 't-1' })
+
+      expect(strategy.isAvailable).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/packages/search/src/service.ts
+++ b/packages/search/src/service.ts
@@ -20,6 +20,13 @@ const DEFAULT_MERGE_CONFIG: ResultMergeConfig = {
 }
 
 /**
+ * Cache TTL for strategy availability checks.
+ * Short window so connectivity changes (Meilisearch up/down) propagate quickly,
+ * long enough to skip per-request RTT to remote backends on hot paths.
+ */
+const STRATEGY_AVAILABILITY_CACHE_TTL_MS = 2_000
+
+/**
  * SearchService orchestrates multiple search strategies, executing searches in parallel
  * and merging results using the RRF algorithm.
  *
@@ -49,6 +56,9 @@ export class SearchService {
   private readonly fallbackStrategy: SearchStrategyId | undefined
   private readonly mergeConfig: ResultMergeConfig
   private readonly presenterEnricher?: PresenterEnricherFn
+  private readonly availabilityCache = new Map<SearchStrategyId, { value: boolean; expiresAt: number }>()
+  private readonly availabilityInflight = new Map<SearchStrategyId, Promise<boolean>>()
+  private readonly availabilityCacheTtlMs: number
 
   constructor(options: SearchServiceOptions = {}) {
     this.strategies = new Map()
@@ -59,6 +69,7 @@ export class SearchService {
     this.fallbackStrategy = options.fallbackStrategy
     this.mergeConfig = options.mergeConfig ?? DEFAULT_MERGE_CONFIG
     this.presenterEnricher = options.presenterEnricher
+    this.availabilityCacheTtlMs = options.availabilityCacheTtlMs ?? STRATEGY_AVAILABILITY_CACHE_TTL_MS
   }
 
   /**
@@ -291,6 +302,8 @@ export class SearchService {
    */
   registerStrategy(strategy: SearchStrategy): void {
     this.strategies.set(strategy.id, strategy)
+    this.availabilityCache.delete(strategy.id)
+    this.availabilityInflight.delete(strategy.id)
   }
 
   /**
@@ -300,6 +313,23 @@ export class SearchService {
    */
   unregisterStrategy(strategyId: SearchStrategyId): void {
     this.strategies.delete(strategyId)
+    this.availabilityCache.delete(strategyId)
+    this.availabilityInflight.delete(strategyId)
+  }
+
+  /**
+   * Invalidate the strategy availability cache.
+   * Call after manual reconnects or env changes when callers must observe the
+   * current backend state immediately rather than waiting for TTL expiry.
+   */
+  invalidateAvailabilityCache(strategyId?: SearchStrategyId): void {
+    if (strategyId) {
+      this.availabilityCache.delete(strategyId)
+      this.availabilityInflight.delete(strategyId)
+      return
+    }
+    this.availabilityCache.clear()
+    this.availabilityInflight.clear()
   }
 
   /**
@@ -334,32 +364,71 @@ export class SearchService {
   async isStrategyAvailable(strategyId: SearchStrategyId): Promise<boolean> {
     const strategy = this.strategies.get(strategyId)
     if (!strategy) return false
-    return strategy.isAvailable()
+    return this.checkStrategyAvailability(strategy)
+  }
+
+  /**
+   * Resolve a strategy's availability via the short-lived TTL cache.
+   * Coalesces concurrent callers onto a single in-flight probe to avoid
+   * thundering-herd on remote backends.
+   */
+  private async checkStrategyAvailability(strategy: SearchStrategy): Promise<boolean> {
+    const now = Date.now()
+    const cached = this.availabilityCache.get(strategy.id)
+    if (cached && cached.expiresAt > now) return cached.value
+
+    const inflight = this.availabilityInflight.get(strategy.id)
+    if (inflight) return inflight
+
+    const probe = (async () => {
+      try {
+        const value = await strategy.isAvailable()
+        this.availabilityCache.set(strategy.id, {
+          value,
+          expiresAt: Date.now() + this.availabilityCacheTtlMs,
+        })
+        return value
+      } catch {
+        this.availabilityCache.set(strategy.id, {
+          value: false,
+          expiresAt: Date.now() + this.availabilityCacheTtlMs,
+        })
+        return false
+      } finally {
+        this.availabilityInflight.delete(strategy.id)
+      }
+    })()
+    this.availabilityInflight.set(strategy.id, probe)
+    return probe
   }
 
   /**
    * Get available strategies from the requested list.
    * Filters out strategies that are not registered or not available.
+   * Probes run in parallel and reuse a short-lived per-strategy availability
+   * cache, so hot paths pay the max latency of the slowest probe (or zero
+   * when cached) instead of the sum of all probes.
    */
   private async getAvailableStrategies(ids?: SearchStrategyId[]): Promise<SearchStrategy[]> {
     const targetIds = ids ?? Array.from(this.strategies.keys())
-    const available: SearchStrategy[] = []
-
+    const candidates: SearchStrategy[] = []
     for (const id of targetIds) {
       const strategy = this.strategies.get(id)
-      if (strategy) {
-        try {
-          const isAvailable = await strategy.isAvailable()
-          if (isAvailable) {
-            available.push(strategy)
-          }
-        } catch {
-          // Strategy availability check failed, skip it
-        }
+      if (strategy) candidates.push(strategy)
+    }
+
+    const probes = await Promise.allSettled(
+      candidates.map((strategy) => this.checkStrategyAvailability(strategy)),
+    )
+
+    const available: SearchStrategy[] = []
+    for (let i = 0; i < probes.length; i++) {
+      const probe = probes[i]
+      if (probe.status === 'fulfilled' && probe.value) {
+        available.push(candidates[i])
       }
     }
 
-    // Sort by priority (higher priority first)
     return available.sort((a, b) => b.priority - a.priority)
   }
 

--- a/packages/shared/src/modules/search.ts
+++ b/packages/shared/src/modules/search.ts
@@ -192,6 +192,8 @@ export type SearchServiceOptions = {
   mergeConfig?: ResultMergeConfig
   /** Callback to enrich results with presenter data from database */
   presenterEnricher?: PresenterEnricherFn
+  /** TTL (ms) for the per-strategy availability cache. Defaults to 2_000. */
+  availabilityCacheTtlMs?: number
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes #1404

## Problem
Three hot paths issued sequential awaits and/or redundant backend roundtrips:
- `entities/definitions.manage` GET awaited `defs`, `tombstones`, and `fieldset configs` one after another (~3× the slowest leg).
- `SearchService.getAvailableStrategies` probed each strategy sequentially in a `for…of` and re-probed on every call (no caching).
- Sales status dictionary resolution walked candidate orgs one at a time and invoked `ensureSalesDictionary` (which triggers `em.flush()`) on the read path.

## Root Cause
Sequential `await` where the awaited calls are independent, plus a read-path seed that issued one DB query per candidate organization.

## What Changed
- `packages/core/src/modules/entities/api/definitions.manage.ts`: fetch `defs`, `tombstones`, and `loadEntityFieldsetConfigs` in a single `Promise.all`.
- `packages/search/src/service.ts`: probe strategies with `Promise.allSettled`, add a TTL-gated availability cache (2s default), coalesce concurrent probes, invalidate on `(un)registerStrategy`, expose `invalidateAvailabilityCache()` helper.
- `packages/shared/src/modules/search.ts`: add optional `availabilityCacheTtlMs` to `SearchServiceOptions` (additive contract change).
- `packages/core/src/modules/sales/lib/makeStatusDictionaryRoute.ts`: extract `resolveSalesDictionaryForCandidates` that prefetches all candidate dictionaries in a single `em.find` with `\$in`, respects candidate priority order, and only falls back to `ensureSalesDictionary` for the first candidate when none already owns one.

## Tests
- `packages/search/src/__tests__/service.test.ts`: added 7 tests — parallelism (3× 60ms → <150ms), positive/negative TTL caching, thrown-error caching, in-flight coalescing, explicit invalidation, re-register invalidation.
- `packages/core/src/modules/entities/api/__tests__/definitions.manage.parallel.test.ts`: new — asserts the three legs overlap in time (timestamp-based) and total elapsed < 150ms.
- `packages/core/src/modules/sales/lib/__tests__/resolveSalesDictionaryForCandidates.test.ts`: new — empty candidates short-circuit without DB, single batched query, priority order honored when rows arrive unordered, seed only when no candidate owns the dictionary, no per-candidate `ensureSalesDictionary` on the read path.

## Backward Compatibility
- No contract surface removed. `SearchServiceOptions` gained one optional field (`availabilityCacheTtlMs`) — purely additive.
- No API response, event ID, widget spot, ACL feature, DI name, or database column changed.