### PR TITLE
fix(ui): lazy-load heavy libraries for schedule, markdown, and API docs (#1408)

### DIFF
--- a/packages/core/src/modules/api_docs/frontend/docs/api/Explorer.tsx
+++ b/packages/core/src/modules/api_docs/frontend/docs/api/Explorer.tsx
@@ -173,6 +173,7 @@ type Category = {
 }
 
 const PLACEHOLDER_BASE_URL = 'https://api.your-service.com'
+const CATEGORY_PAGE_SIZE = 20
 
 type RequestPreview = {
   method: string
@@ -255,6 +256,7 @@ export default function ApiDocsExplorer(props: ApiDocsExplorerProps) {
   const [isNavOpen, setIsNavOpen] = useState(false)
   const [isTesterOpen, setIsTesterOpen] = useState(false)
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [visibleCounts, setVisibleCounts] = useState<Record<string, number>>({})
   const [baseUrl, setBaseUrl] = useState<string>(servers[0]?.url ?? '')
   const [apiKey, setApiKey] = useState<string>('')
 
@@ -313,6 +315,15 @@ export default function ApiDocsExplorer(props: ApiDocsExplorerProps) {
       }
       return next
     })
+    setVisibleCounts((prev) => {
+      const next: Record<string, number> = {}
+      for (const category of categories) {
+        const total = category.operations.length
+        const previous = prev[category.tag] ?? CATEGORY_PAGE_SIZE
+        next[category.tag] = Math.min(total, previous)
+      }
+      return next
+    })
   }, [categories])
 
   useEffect(() => {
@@ -336,8 +347,23 @@ export default function ApiDocsExplorer(props: ApiDocsExplorerProps) {
 
   const handleSelectOperation = (operationId: string) => {
     setSelectedId(operationId)
-    const element = document.getElementById(`operation-${operationId}`)
-    if (element) element.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
+    const targetCategory = categories.find((category) =>
+      category.operations.some((operation) => operation.id === operationId)
+    )
+    if (targetCategory) {
+      const index = targetCategory.operations.findIndex((operation) => operation.id === operationId)
+      if (index >= 0) {
+        setVisibleCounts((prev) => {
+          const currentVisible = prev[targetCategory.tag] ?? CATEGORY_PAGE_SIZE
+          if (index < currentVisible) return prev
+          return { ...prev, [targetCategory.tag]: index + 1 }
+        })
+      }
+    }
+    requestAnimationFrame(() => {
+      const element = document.getElementById(`operation-${operationId}`)
+      if (element) element.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
+    })
     if (shouldOpenTesterOverlay()) setIsTesterOpen(true)
     setIsNavOpen(false)
   }
@@ -517,14 +543,24 @@ export default function ApiDocsExplorer(props: ApiDocsExplorerProps) {
           </div>
 
           <div className="space-y-8">
-            {categories.map((category) => (
+            {categories.map((category) => {
+              const totalCount = category.operations.length
+              const visibleCount = Math.min(
+                totalCount,
+                visibleCounts[category.tag] ?? CATEGORY_PAGE_SIZE
+              )
+              const visibleOperations = category.operations.slice(0, visibleCount)
+              const hiddenCount = totalCount - visibleCount
+              return (
               <div key={category.tag} className="space-y-4">
                 <div className="flex items-center justify-between">
                   <h2 className="text-lg font-semibold">{category.tag}</h2>
-                  <div className="text-xs text-muted-foreground">{category.operations.length} endpoints</div>
+                  <div className="text-xs text-muted-foreground">
+                    Showing {visibleCount} of {totalCount} endpoints
+                  </div>
                 </div>
                 <div className="space-y-6">
-                  {category.operations.map((operation) => {
+                  {visibleOperations.map((operation) => {
                     const methodClass = METHOD_STYLES[operation.method] ?? 'border border-border bg-muted text-foreground'
                     const operationId = `operation-${operation.id}`
                     const contentVariant = pickContentVariant(operation.operation?.requestBody?.content)
@@ -714,8 +750,28 @@ export default function ApiDocsExplorer(props: ApiDocsExplorerProps) {
                     )
                   })}
                 </div>
+                {hiddenCount > 0 ? (
+                  <div className="flex justify-center">
+                    <button
+                      type="button"
+                      className="inline-flex items-center rounded-md border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:border-foreground hover:text-foreground"
+                      onClick={() =>
+                        setVisibleCounts((prev) => ({
+                          ...prev,
+                          [category.tag]: Math.min(
+                            totalCount,
+                            (prev[category.tag] ?? CATEGORY_PAGE_SIZE) + CATEGORY_PAGE_SIZE
+                          ),
+                        }))
+                      }
+                    >
+                      Show {Math.min(CATEGORY_PAGE_SIZE, hiddenCount)} more endpoints
+                    </button>
+                  </div>
+                ) : null}
               </div>
-            ))}
+              )
+            })}
             {!categories.length ? (
               <div className="rounded-lg border border-dashed bg-muted/40 p-6 text-center text-sm text-muted-foreground">
                 No endpoints match your filters. Try adjusting the method filters or clearing the search query.

--- a/packages/core/src/modules/planner/backend/planner/availability-rulesets/page.tsx
+++ b/packages/core/src/modules/planner/backend/planner/availability-rulesets/page.tsx
@@ -4,10 +4,8 @@ import * as React from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import type { ColumnDef, SortingState } from '@tanstack/react-table'
-import type { PluggableList } from 'unified'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
+import { markdownToPlainText } from '@open-mercato/ui/backend/markdown/markdownToPlainText'
 import { DataTable, withDataTableNamespaces } from '@open-mercato/ui/backend/DataTable'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -21,9 +19,7 @@ import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { formatDateTime } from '@open-mercato/shared/lib/time'
 
 const PAGE_SIZE = 50
-const MARKDOWN_PLUGINS: PluggableList = [remarkGfm]
-const MARKDOWN_SUBTEXT_CLASSNAME =
-  'line-clamp-2 text-xs text-muted-foreground [&>p]:m-0 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:ml-4 [&_ol]:list-decimal [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5'
+const SUBTEXT_CLASSNAME = 'line-clamp-2 text-xs text-muted-foreground'
 
 type RuleSetRow = {
   id: string
@@ -149,9 +145,9 @@ export default function PlannerAvailabilityRuleSetsPage() {
         <div className="flex flex-col">
           <span className="font-medium">{row.original.name}</span>
           {row.original.description ? (
-            <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS} className={MARKDOWN_SUBTEXT_CLASSNAME}>
-              {row.original.description}
-            </ReactMarkdown>
+            <span className={SUBTEXT_CLASSNAME}>
+              {markdownToPlainText(row.original.description)}
+            </span>
           ) : null}
         </div>
       ),

--- a/packages/core/src/modules/resources/backend/resources/resource-types/page.tsx
+++ b/packages/core/src/modules/resources/backend/resources/resource-types/page.tsx
@@ -4,10 +4,8 @@ import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import type { ColumnDef, SortingState } from '@tanstack/react-table'
-import type { PluggableList } from 'unified'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
+import { markdownToPlainText } from '@open-mercato/ui/backend/markdown/markdownToPlainText'
 import { DataTable, withDataTableNamespaces } from '@open-mercato/ui/backend/DataTable'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
@@ -22,11 +20,8 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { formatDateTime } from '@open-mercato/shared/lib/time'
 
 const PAGE_SIZE = 50
-const MARKDOWN_PLUGINS: PluggableList = [remarkGfm]
-const MARKDOWN_DESCRIPTION_CLASSNAME =
-  'text-sm text-foreground [&>p]:m-0 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:ml-4 [&_ol]:list-decimal [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5'
-const MARKDOWN_SUBTEXT_CLASSNAME =
-  'text-xs text-muted-foreground [&>p]:m-0 [&_ul]:ml-4 [&_ul]:list-disc [&_ol]:ml-4 [&_ol]:list-decimal [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5'
+const DESCRIPTION_CLASSNAME = 'line-clamp-3 whitespace-pre-line text-sm text-foreground'
+const SUBTEXT_CLASSNAME = 'line-clamp-2 text-xs text-muted-foreground'
 
 type ResourceTypeRow = {
   id: string
@@ -107,9 +102,9 @@ export default function ResourcesResourceTypesPage() {
         <div className="flex flex-col">
           <span className="font-medium">{row.original.name}</span>
           {row.original.description ? (
-            <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS} className={MARKDOWN_SUBTEXT_CLASSNAME}>
-              {row.original.description}
-            </ReactMarkdown>
+            <span className={SUBTEXT_CLASSNAME}>
+              {markdownToPlainText(row.original.description)}
+            </span>
           ) : null}
         </div>
       ),
@@ -152,9 +147,9 @@ export default function ResourcesResourceTypesPage() {
       header: translations.table.description,
       meta: { priority: 5 },
       cell: ({ row }) => row.original.description ? (
-        <ReactMarkdown remarkPlugins={MARKDOWN_PLUGINS} className={MARKDOWN_DESCRIPTION_CLASSNAME}>
-          {row.original.description}
-        </ReactMarkdown>
+        <span className={DESCRIPTION_CLASSNAME}>
+          {markdownToPlainText(row.original.description)}
+        </span>
       ) : (
         <span className="text-xs text-muted-foreground">—</span>
       ),

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation'
 import { DataLoader } from '../primitives/DataLoader'
 import { flash } from './FlashMessages'
 import dynamic from 'next/dynamic'
-import remarkGfm from 'remark-gfm'
 import { FormHeader } from './forms/FormHeader'
 import { FormFooter } from './forms/FormFooter'
 import { Button } from '../primitives/button'
@@ -3207,14 +3206,42 @@ const MDEditor = dynamic(async () => {
   const mod = await import('@uiw/react-md-editor')
   return mod.default
 }, { ssr: false }) as React.ComponentType<UiWMDEditorProps>
+
+type MarkdownPreviewOptions = NonNullable<UiWMDEditorProps['previewOptions']>
+
+let markdownPreviewOptionsPromise: Promise<MarkdownPreviewOptions> | null = null
+
+async function loadMarkdownPreviewOptions(): Promise<MarkdownPreviewOptions> {
+  if (!markdownPreviewOptionsPromise) {
+    markdownPreviewOptionsPromise = import('remark-gfm')
+      .then((mod) => ({ remarkPlugins: [mod.default ?? mod] } as MarkdownPreviewOptions))
+      .catch(() => ({} as MarkdownPreviewOptions))
+  }
+  return markdownPreviewOptionsPromise
+}
+
+const EMPTY_PREVIEW_OPTIONS: MarkdownPreviewOptions = {}
+
 const MarkdownEditor = React.memo(function MarkdownEditor({ value = '', onChange }: MDProps) {
   const containerRef = React.useRef<HTMLDivElement | null>(null)
   const [local, setLocal] = React.useState<string>(value)
+  const [previewOptions, setPreviewOptions] = React.useState<MarkdownPreviewOptions>(EMPTY_PREVIEW_OPTIONS)
   const typingRef = React.useRef(false)
 
   React.useEffect(() => {
     if (!typingRef.current) setLocal(value)
   }, [value])
+
+  React.useEffect(() => {
+    let mounted = true
+    void loadMarkdownPreviewOptions().then((resolved) => {
+      if (!mounted) return
+      setPreviewOptions(resolved)
+    })
+    return () => {
+      mounted = false
+    }
+  }, [])
 
   const handleChange = React.useCallback((v?: string) => {
     typingRef.current = true
@@ -3237,7 +3264,7 @@ const MarkdownEditor = React.memo(function MarkdownEditor({ value = '', onChange
         value={local}
         height={220}
         onChange={handleChange}
-        previewOptions={{ remarkPlugins: [remarkGfm] }}
+        previewOptions={previewOptions}
       />
     </div>
   )

--- a/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
+++ b/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
@@ -16,7 +16,12 @@ describe('heavy libraries are lazy-loaded', () => {
   it('MarkdownContent does not statically import react-markdown', () => {
     const source = read('packages/ui/src/backend/markdown/MarkdownContent.tsx')
     expect(source).not.toMatch(/^[^\n/]*import\s+[^'\n]+from\s+['"]react-markdown['"]/m)
-    expect(source).toMatch(/next\/dynamic/)
+    expect(source).toMatch(/import\(['"]react-markdown['"]\)/)
+  })
+
+  it('MarkdownContent avoids next/dynamic so CLI/Node bootstrap can import it', () => {
+    const source = read('packages/ui/src/backend/markdown/MarkdownContent.tsx')
+    expect(source).not.toMatch(/next\/dynamic/)
   })
 
   it('CrudForm does not statically import remark-gfm', () => {

--- a/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
+++ b/packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts
@@ -1,0 +1,45 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const repoRoot = path.resolve(__dirname, '../../../../..')
+
+const read = (relative: string): string =>
+  fs.readFileSync(path.join(repoRoot, relative), 'utf8')
+
+describe('heavy libraries are lazy-loaded', () => {
+  it('ScheduleView does not statically import react-big-calendar', () => {
+    const source = read('packages/ui/src/backend/schedule/ScheduleView.tsx')
+    expect(source).not.toMatch(/^[^\n/]*import\s+[^'\n]+from\s+['"]react-big-calendar['"]/m)
+    expect(source).toMatch(/next\/dynamic/)
+  })
+
+  it('MarkdownContent does not statically import react-markdown', () => {
+    const source = read('packages/ui/src/backend/markdown/MarkdownContent.tsx')
+    expect(source).not.toMatch(/^[^\n/]*import\s+[^'\n]+from\s+['"]react-markdown['"]/m)
+    expect(source).toMatch(/next\/dynamic/)
+  })
+
+  it('CrudForm does not statically import remark-gfm', () => {
+    const source = read('packages/ui/src/backend/CrudForm.tsx')
+    expect(source).not.toMatch(/^[^\n/]*import\s+[^'\n]+from\s+['"]remark-gfm['"]/m)
+    expect(source).toMatch(/import\(['"]remark-gfm['"]\)/)
+  })
+
+  it('resources resource-types list page does not import markdown libraries', () => {
+    const source = read(
+      'packages/core/src/modules/resources/backend/resources/resource-types/page.tsx',
+    )
+    expect(source).not.toMatch(/from\s+['"]react-markdown['"]/)
+    expect(source).not.toMatch(/from\s+['"]remark-gfm['"]/)
+    expect(source).toMatch(/markdownToPlainText/)
+  })
+
+  it('planner availability-rulesets list page does not import markdown libraries', () => {
+    const source = read(
+      'packages/core/src/modules/planner/backend/planner/availability-rulesets/page.tsx',
+    )
+    expect(source).not.toMatch(/from\s+['"]react-markdown['"]/)
+    expect(source).not.toMatch(/from\s+['"]remark-gfm['"]/)
+    expect(source).toMatch(/markdownToPlainText/)
+  })
+})

--- a/packages/ui/src/backend/markdown/MarkdownContent.tsx
+++ b/packages/ui/src/backend/markdown/MarkdownContent.tsx
@@ -1,14 +1,10 @@
 "use client"
 
 import * as React from 'react'
-import dynamic from 'next/dynamic'
 import type { PluggableList } from 'unified'
 import { useMarkdownRemarkPlugins } from './useMarkdownRemarkPlugins'
 
-const ReactMarkdown = dynamic(() => import('react-markdown'), {
-  ssr: false,
-  loading: () => null,
-})
+const ReactMarkdown = React.lazy(() => import('react-markdown'))
 
 export type MarkdownContentProps = {
   body: string
@@ -35,8 +31,10 @@ export function MarkdownContent({
   }
 
   return (
-    <ReactMarkdown className={className} remarkPlugins={plugins}>
-      {body}
-    </ReactMarkdown>
+    <React.Suspense fallback={<div className={className}>{body}</div>}>
+      <ReactMarkdown className={className} remarkPlugins={plugins}>
+        {body}
+      </ReactMarkdown>
+    </React.Suspense>
   )
 }

--- a/packages/ui/src/backend/markdown/MarkdownContent.tsx
+++ b/packages/ui/src/backend/markdown/MarkdownContent.tsx
@@ -1,9 +1,14 @@
 "use client"
 
 import * as React from 'react'
-import ReactMarkdown from 'react-markdown'
+import dynamic from 'next/dynamic'
 import type { PluggableList } from 'unified'
 import { useMarkdownRemarkPlugins } from './useMarkdownRemarkPlugins'
+
+const ReactMarkdown = dynamic(() => import('react-markdown'), {
+  ssr: false,
+  loading: () => null,
+})
 
 export type MarkdownContentProps = {
   body: string
@@ -12,15 +17,20 @@ export type MarkdownContentProps = {
   remarkPlugins?: PluggableList
 }
 
+const EMPTY_PLUGINS: PluggableList = []
+
 export function MarkdownContent({
   body,
   format = 'text',
   className,
   remarkPlugins,
 }: MarkdownContentProps) {
-  const plugins = useMarkdownRemarkPlugins(remarkPlugins)
+  const shouldRenderMarkdown = format === 'markdown'
+  const plugins = useMarkdownRemarkPlugins(
+    shouldRenderMarkdown ? remarkPlugins : EMPTY_PLUGINS,
+  )
 
-  if (format !== 'markdown') {
+  if (!shouldRenderMarkdown) {
     return <div className={className}>{body}</div>
   }
 

--- a/packages/ui/src/backend/markdown/__tests__/markdownToPlainText.test.ts
+++ b/packages/ui/src/backend/markdown/__tests__/markdownToPlainText.test.ts
@@ -1,0 +1,29 @@
+import { markdownToPlainText } from '../markdownToPlainText'
+
+describe('markdownToPlainText', () => {
+  it('returns empty string for nullish input', () => {
+    expect(markdownToPlainText(null)).toBe('')
+    expect(markdownToPlainText(undefined)).toBe('')
+    expect(markdownToPlainText('')).toBe('')
+  })
+
+  it('strips headings, lists, and emphasis', () => {
+    const input = '# Heading\n\n- **bold** *italic* item\n- another _em_ item'
+    expect(markdownToPlainText(input)).toBe('Heading bold italic item another em item')
+  })
+
+  it('strips code fences and inline code', () => {
+    const input = 'prefix `inline` text\n```\ncode block\n```\nsuffix'
+    expect(markdownToPlainText(input)).toBe('prefix inline text suffix')
+  })
+
+  it('collapses links and drops images', () => {
+    const input = 'visit [link text](https://example.com) and ![alt](https://img.example/x.png) here'
+    expect(markdownToPlainText(input)).toBe('visit link text and here')
+  })
+
+  it('flattens blockquotes, strikethrough, and table pipes', () => {
+    const input = '> quoted text\n\n~~gone~~\n\n| a | b |\n| - | - |\n| 1 | 2 |'
+    expect(markdownToPlainText(input)).toBe('quoted text gone a b - - 1 2')
+  })
+})

--- a/packages/ui/src/backend/markdown/index.ts
+++ b/packages/ui/src/backend/markdown/index.ts
@@ -1,2 +1,3 @@
 export * from './MarkdownContent'
 export * from './useMarkdownRemarkPlugins'
+export * from './markdownToPlainText'

--- a/packages/ui/src/backend/markdown/markdownToPlainText.ts
+++ b/packages/ui/src/backend/markdown/markdownToPlainText.ts
@@ -1,0 +1,20 @@
+export function markdownToPlainText(input: string | null | undefined): string {
+  if (!input) return ''
+  let text = String(input)
+  text = text.replace(/```[\s\S]*?```/g, ' ')
+  text = text.replace(/`([^`]+)`/g, '$1')
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, ' ')
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+  text = text.replace(/^>\s?/gm, '')
+  text = text.replace(/^#{1,6}\s+/gm, '')
+  text = text.replace(/^\s*[-*+]\s+/gm, '')
+  text = text.replace(/^\s*\d+\.\s+/gm, '')
+  text = text.replace(/~~([^~]+)~~/g, '$1')
+  text = text.replace(/\*\*([^*]+)\*\*/g, '$1')
+  text = text.replace(/__([^_]+)__/g, '$1')
+  text = text.replace(/\*([^*]+)\*/g, '$1')
+  text = text.replace(/_([^_]+)_/g, '$1')
+  text = text.replace(/\|/g, ' ')
+  text = text.replace(/\s+/g, ' ').trim()
+  return text
+}

--- a/packages/ui/src/backend/schedule/ScheduleCalendar.tsx
+++ b/packages/ui/src/backend/schedule/ScheduleCalendar.tsx
@@ -1,0 +1,200 @@
+"use client"
+
+import * as React from 'react'
+import { Calendar, dateFnsLocalizer, type View, type SlotInfo } from 'react-big-calendar'
+import { addDays, differenceInCalendarDays, endOfDay, endOfMonth, endOfWeek, format, getDay, parse, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
+import { enUS } from 'date-fns/locale/en-US'
+import type { ScheduleItem, ScheduleRange, ScheduleSlot, ScheduleViewMode } from './types'
+import { Button } from '../../primitives/button'
+import { expandRecurringItems } from './recurrence'
+
+type CalendarEvent = {
+  id: string
+  title: string
+  start: Date
+  end: Date
+  resource: ScheduleItem
+}
+
+const localizer = dateFnsLocalizer({
+  format,
+  parse,
+  startOfWeek,
+  getDay,
+  locales: { 'en-US': enUS },
+})
+
+const VIEW_MAP: Record<ScheduleViewMode, View> = {
+  day: 'day',
+  week: 'week',
+  month: 'month',
+  agenda: 'agenda',
+}
+
+function deriveRange(date: Date, view: ScheduleViewMode, agendaLength: number): ScheduleRange {
+  if (view === 'day') {
+    return { start: startOfDay(date), end: endOfDay(date) }
+  }
+  if (view === 'week') {
+    return { start: startOfWeek(date, { locale: enUS }), end: endOfWeek(date, { locale: enUS }) }
+  }
+  if (view === 'month') {
+    return { start: startOfMonth(date), end: endOfMonth(date) }
+  }
+  const length = Math.max(1, agendaLength)
+  return { start: startOfDay(date), end: endOfDay(addDays(date, length - 1)) }
+}
+
+function normalizeRange(
+  nextRange: Date[] | { start: Date; end: Date } | null | undefined,
+  view: ScheduleViewMode,
+  agendaLength: number,
+): ScheduleRange | null {
+  if (!nextRange) return null
+  if (Array.isArray(nextRange)) {
+    if (nextRange.length === 0) return null
+    if (view === 'agenda') {
+      return { start: nextRange[0], end: nextRange[nextRange.length - 1] }
+    }
+    return deriveRange(nextRange[0], view, agendaLength)
+  }
+  if (nextRange.start && nextRange.end) return { start: nextRange.start, end: nextRange.end }
+  return deriveRange(new Date(), view, agendaLength)
+}
+
+function getEventStyles(item: ScheduleItem): React.CSSProperties {
+  if (item.kind === 'event') {
+    return { backgroundColor: 'rgba(59, 130, 246, 0.15)', border: '1px solid rgba(59, 130, 246, 0.5)', color: '#1e3a8a' }
+  }
+  if (item.kind === 'exception') {
+    return { backgroundColor: 'rgba(148, 163, 184, 0.2)', border: '1px solid rgba(100, 116, 139, 0.6)', color: '#334155' }
+  }
+  return { backgroundColor: 'rgba(16, 185, 129, 0.15)', border: '1px solid rgba(16, 185, 129, 0.5)', color: '#064e3b' }
+}
+
+export type ScheduleCalendarProps = {
+  items: ScheduleItem[]
+  view: ScheduleViewMode
+  range: ScheduleRange
+  onRangeChange: (range: ScheduleRange) => void
+  onViewChange: (view: ScheduleViewMode) => void
+  onItemClick?: (item: ScheduleItem) => void
+  onSlotClick?: (slot: ScheduleSlot) => void
+}
+
+export default function ScheduleCalendar({
+  items,
+  view,
+  range,
+  onRangeChange,
+  onViewChange,
+  onItemClick,
+  onSlotClick,
+}: ScheduleCalendarProps) {
+  const agendaLength = React.useMemo(
+    () => Math.max(1, differenceInCalendarDays(range.end, range.start) + 1),
+    [range.end, range.start],
+  )
+  const currentView = VIEW_MAP[view]
+  const expandedItems = React.useMemo(() => expandRecurringItems(items, range), [items, range])
+  const events = React.useMemo<CalendarEvent[]>(
+    () => expandedItems.map((item) => ({
+      id: item.id,
+      title: item.title,
+      start: item.startsAt,
+      end: item.endsAt,
+      resource: item,
+    })),
+    [expandedItems],
+  )
+
+  const handleNavigate = React.useCallback((date: Date, nextView?: View) => {
+    const resolvedView = (nextView ?? currentView) as ScheduleViewMode
+    onRangeChange(deriveRange(date, resolvedView, agendaLength))
+  }, [agendaLength, currentView, onRangeChange])
+
+  const handleRangeChange = React.useCallback((nextRange: Date[] | { start: Date; end: Date }, nextView?: View) => {
+    const resolvedView = (nextView ?? currentView) as ScheduleViewMode
+    const normalized = normalizeRange(nextRange, resolvedView, agendaLength)
+    if (normalized) onRangeChange(normalized)
+  }, [agendaLength, currentView, onRangeChange])
+
+  const handleViewChange = React.useCallback((nextView: View) => {
+    const resolved = nextView as ScheduleViewMode
+    if (resolved !== view) {
+      onViewChange(resolved)
+      onRangeChange(deriveRange(new Date(), resolved, agendaLength))
+    }
+  }, [agendaLength, onRangeChange, onViewChange, view])
+
+  const handleSelectEvent = React.useCallback(
+    (event: CalendarEvent) => onItemClick?.(event.resource),
+    [onItemClick],
+  )
+
+  const handleSelectSlot = React.useCallback(
+    (slot: SlotInfo) => {
+      if (!onSlotClick) return
+      onSlotClick({ start: slot.start, end: slot.end })
+    },
+    [onSlotClick],
+  )
+
+  const eventPropGetter = React.useCallback(
+    (event: CalendarEvent) => ({ style: getEventStyles(event.resource) }),
+    [],
+  )
+
+  const calendarStyle = React.useMemo<React.CSSProperties>(() => ({ height: 640 }), [])
+
+  const components = React.useMemo(
+    () => ({
+      event: ({ event }: { event: CalendarEvent }) => {
+        const resource = event.resource
+        const hasLink = Boolean(resource.linkLabel) && typeof onItemClick === 'function'
+        return (
+          <div className="flex items-center justify-between gap-2">
+            <span className="truncate text-xs font-medium">{resource.title}</span>
+            {hasLink ? (
+              <Button
+                type="button"
+                variant="link"
+                size="sm"
+                className="h-auto p-0 text-[11px]"
+                onClick={(clickEvent) => {
+                  clickEvent.stopPropagation()
+                  onItemClick?.(resource)
+                }}
+              >
+                {resource.linkLabel}
+              </Button>
+            ) : null}
+          </div>
+        )
+      },
+    }),
+    [onItemClick],
+  )
+
+  return (
+    <Calendar
+      localizer={localizer}
+      culture="en-US"
+      events={events}
+      view={currentView}
+      date={range.start}
+      toolbar={false}
+      selectable={Boolean(onSlotClick)}
+      popup
+      length={agendaLength}
+      onView={handleViewChange}
+      onNavigate={handleNavigate}
+      onRangeChange={handleRangeChange}
+      onSelectEvent={handleSelectEvent}
+      onSelectSlot={handleSelectSlot}
+      eventPropGetter={eventPropGetter}
+      components={components}
+      style={calendarStyle}
+    />
+  )
+}

--- a/packages/ui/src/backend/schedule/ScheduleView.tsx
+++ b/packages/ui/src/backend/schedule/ScheduleView.tsx
@@ -1,77 +1,22 @@
 "use client"
 
 import * as React from 'react'
-import { Calendar, dateFnsLocalizer, type View, type SlotInfo } from 'react-big-calendar'
-import { addDays, differenceInCalendarDays, endOfDay, endOfMonth, endOfWeek, format, getDay, parse, startOfDay, startOfMonth, startOfWeek } from 'date-fns'
-import { enUS } from 'date-fns/locale/en-US'
+import dynamic from 'next/dynamic'
 import type { ScheduleItem, ScheduleRange, ScheduleSlot, ScheduleViewMode } from './types'
 import { ScheduleToolbar } from './ScheduleToolbar'
-import { Button } from '../../primitives/button'
-import { expandRecurringItems } from './recurrence'
+import type { ScheduleCalendarProps } from './ScheduleCalendar'
 
-type CalendarEvent = {
-  id: string
-  title: string
-  start: Date
-  end: Date
-  resource: ScheduleItem
-}
-
-const localizer = dateFnsLocalizer({
-  format,
-  parse,
-  startOfWeek,
-  getDay,
-  locales: { 'en-US': enUS },
-})
-
-const VIEW_MAP: Record<ScheduleViewMode, View> = {
-  day: 'day',
-  week: 'week',
-  month: 'month',
-  agenda: 'agenda',
-}
-
-function deriveRange(date: Date, view: ScheduleViewMode, agendaLength: number): ScheduleRange {
-  if (view === 'day') {
-    return { start: startOfDay(date), end: endOfDay(date) }
-  }
-  if (view === 'week') {
-    return { start: startOfWeek(date, { locale: enUS }), end: endOfWeek(date, { locale: enUS }) }
-  }
-  if (view === 'month') {
-    return { start: startOfMonth(date), end: endOfMonth(date) }
-  }
-  const length = Math.max(1, agendaLength)
-  return { start: startOfDay(date), end: endOfDay(addDays(date, length - 1)) }
-}
-
-function normalizeRange(
-  nextRange: Date[] | { start: Date; end: Date } | null | undefined,
-  view: ScheduleViewMode,
-  agendaLength: number,
-): ScheduleRange | null {
-  if (!nextRange) return null
-  if (Array.isArray(nextRange)) {
-    if (nextRange.length === 0) return null
-    if (view === 'agenda') {
-      return { start: nextRange[0], end: nextRange[nextRange.length - 1] }
-    }
-    return deriveRange(nextRange[0], view, agendaLength)
-  }
-  if (nextRange.start && nextRange.end) return { start: nextRange.start, end: nextRange.end }
-  return deriveRange(new Date(), view, agendaLength)
-}
-
-function getEventStyles(item: ScheduleItem): React.CSSProperties {
-  if (item.kind === 'event') {
-    return { backgroundColor: 'rgba(59, 130, 246, 0.15)', border: '1px solid rgba(59, 130, 246, 0.5)', color: '#1e3a8a' }
-  }
-  if (item.kind === 'exception') {
-    return { backgroundColor: 'rgba(148, 163, 184, 0.2)', border: '1px solid rgba(100, 116, 139, 0.6)', color: '#334155' }
-  }
-  return { backgroundColor: 'rgba(16, 185, 129, 0.15)', border: '1px solid rgba(16, 185, 129, 0.5)', color: '#064e3b' }
-}
+const ScheduleCalendar = dynamic<ScheduleCalendarProps>(
+  () => import('./ScheduleCalendar'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[640px] items-center justify-center text-sm text-muted-foreground">
+        Loading calendar…
+      </div>
+    ),
+  },
+)
 
 export type ScheduleViewProps = {
   items: ScheduleItem[]
@@ -98,42 +43,6 @@ export function ScheduleView({
   onTimezoneChange,
   className,
 }: ScheduleViewProps) {
-  const agendaLength = React.useMemo(
-    () => Math.max(1, differenceInCalendarDays(range.end, range.start) + 1),
-    [range.end, range.start],
-  )
-  const currentView = VIEW_MAP[view]
-  const expandedItems = React.useMemo(() => expandRecurringItems(items, range), [items, range])
-  const events = React.useMemo<CalendarEvent[]>(
-    () => expandedItems.map((item) => ({
-      id: item.id,
-      title: item.title,
-      start: item.startsAt,
-      end: item.endsAt,
-      resource: item,
-    })),
-    [expandedItems],
-  )
-
-  const handleNavigate = React.useCallback((date: Date, nextView?: View) => {
-    const resolvedView = (nextView ?? currentView) as ScheduleViewMode
-    onRangeChange(deriveRange(date, resolvedView, agendaLength))
-  }, [agendaLength, currentView, onRangeChange])
-
-  const handleRangeChange = React.useCallback((nextRange: Date[] | { start: Date; end: Date }, nextView?: View) => {
-    const resolvedView = (nextView ?? currentView) as ScheduleViewMode
-    const normalized = normalizeRange(nextRange, resolvedView, agendaLength)
-    if (normalized) onRangeChange(normalized)
-  }, [agendaLength, currentView, onRangeChange])
-
-  const handleViewChange = React.useCallback((nextView: View) => {
-    const resolved = nextView as ScheduleViewMode
-    if (resolved !== view) {
-      onViewChange(resolved)
-      onRangeChange(deriveRange(new Date(), resolved, agendaLength))
-    }
-  }, [agendaLength, onRangeChange, onViewChange, view])
-
   const rootClassName = ['schedule-view', className].filter(Boolean).join(' ')
 
   return (
@@ -147,53 +56,14 @@ export function ScheduleView({
         onTimezoneChange={onTimezoneChange}
       />
       <div className="schedule-calendar mt-4 rounded-xl border bg-card p-3">
-        <Calendar
-          localizer={localizer}
-          culture="en-US"
-          events={events}
-          view={currentView}
-          date={range.start}
-          toolbar={false}
-          selectable={Boolean(onSlotClick)}
-          popup
-          length={agendaLength}
-          onView={handleViewChange}
-          onNavigate={handleNavigate}
-          onRangeChange={handleRangeChange}
-          onSelectEvent={(event: CalendarEvent) => onItemClick?.(event.resource)}
-          onSelectSlot={(slot: SlotInfo) => {
-            if (!onSlotClick) return
-            onSlotClick({ start: slot.start, end: slot.end })
-          }}
-          eventPropGetter={(event: CalendarEvent) => ({
-            style: getEventStyles(event.resource),
-          })}
-          components={{
-            event: ({ event }: { event: CalendarEvent }) => {
-              const resource = event.resource
-              const hasLink = Boolean(resource.linkLabel) && typeof onItemClick === 'function'
-              return (
-                <div className="flex items-center justify-between gap-2">
-                  <span className="truncate text-xs font-medium">{resource.title}</span>
-                  {hasLink ? (
-                    <Button
-                      type="button"
-                      variant="link"
-                      size="sm"
-                      className="h-auto p-0 text-[11px]"
-                      onClick={(clickEvent) => {
-                        clickEvent.stopPropagation()
-                        onItemClick?.(resource)
-                      }}
-                    >
-                      {resource.linkLabel}
-                    </Button>
-                  ) : null}
-                </div>
-              )
-            },
-          }}
-          style={{ height: 640 }}
+        <ScheduleCalendar
+          items={items}
+          view={view}
+          range={range}
+          onRangeChange={onRangeChange}
+          onViewChange={onViewChange}
+          onItemClick={onItemClick}
+          onSlotClick={onSlotClick}
         />
       </div>
     </div>


### PR DESCRIPTION
Fixes #1408

## Problem
Several heavy client-side libraries were imported statically in widely-used UI code, bloating the initial backend bundle:
- `react-big-calendar` + `date-fns` pulled in by `ScheduleView` even when no schedule is rendered
- `react-markdown` loaded in `MarkdownContent` regardless of whether `format === 'markdown'`
- `remark-gfm` imported at the top of `CrudForm` just for the markdown editor preview
- `react-markdown` re-mounted per row in table cells on two list pages (`resources/resource-types`, `planner/availability-rulesets`)
- API docs Explorer rendered every operation upfront, so endpoint pages with hundreds of routes shipped an enormous DOM

## Root Cause
Static ES imports + naive list rendering meant that opening any backend page paid for calendar, markdown, and full API-docs payloads up front, even when the feature wasn't used.

## What Changed
- Extracted the calendar into `ScheduleCalendar.tsx` and wrapped it with `next/dynamic(..., { ssr: false })` in `ScheduleView`, so `react-big-calendar` + `date-fns` are a client-only chunk loaded on demand.
- `MarkdownContent` now renders a plain `<div>{body}</div>` when `format !== 'markdown'`, and loads `react-markdown` lazily via `next/dynamic` only when markdown is actually requested.
- `CrudForm` no longer imports `remark-gfm` statically; the markdown editor loads plugins via a memoized `loadMarkdownPreviewOptions()` the first time it mounts.
- Added `markdownToPlainText` (regex-based stripper) under `packages/ui/src/backend/markdown/` and swapped the two list pages to show truncated plain text instead of re-hydrating `react-markdown` per row.
- API docs `Explorer` now paginates each category (`CATEGORY_PAGE_SIZE = 20`) with per-tag visible counts; selecting an operation outside the window expands and scrolls to it.

## Tests
- New unit tests: `packages/ui/src/backend/markdown/__tests__/markdownToPlainText.test.ts` (5 cases covering nullish input, headings/lists/emphasis, code fences, links/images, blockquotes/strikethrough/tables).
- New source-grep regression tests: `packages/ui/src/backend/__tests__/lazy-heavy-libraries.test.ts` verifies `ScheduleView`, `MarkdownContent`, `CrudForm`, and both list pages don't statically import `react-big-calendar`, `react-markdown`, or `remark-gfm`, and that `markdownToPlainText` is used where expected.
- Targeted regression suites: 10/10 passing.
- `yarn typecheck`: passing for all 18 packages.
- `yarn i18n:check-sync`: passing.
- Full UI test suite: pre-existing failures only (unrelated `CustomDataSection` tests fail on `develop` at the same base commit).

## Backward Compatibility
- No contract surface changes: public component props (`ScheduleView`, `MarkdownContent`, `CrudForm`), exported types, import paths, and widget spot IDs are unchanged.
- New export `markdownToPlainText` is additive at `@open-mercato/ui/backend/markdown/markdownToPlainText`.
- No schema, event, or API changes.