### PR TITLE
fix(testing,i18n): restore Jest module resolution and reduce false-positive unused i18n keys

### DIFF
--- a/packages/cache/jest.config.cjs
+++ b/packages/cache/jest.config.cjs
@@ -5,6 +5,10 @@ module.exports = {
   watchman: false,
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@open-mercato/cache/(.*)$': '<rootDir>/src/$1',
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/packages/checkout/jest.config.cjs
+++ b/packages/checkout/jest.config.cjs
@@ -5,6 +5,13 @@ module.exports = {
   watchman: false,
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@open-mercato/checkout/(.*)$': '<rootDir>/src/$1',
+    '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@open-mercato/queue/(.*)$': '<rootDir>/../queue/src/$1',
+    '^@open-mercato/ui/(.*)$': '<rootDir>/../ui/src/$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/packages/gateway-stripe/jest.config.cjs
+++ b/packages/gateway-stripe/jest.config.cjs
@@ -5,6 +5,13 @@ module.exports = {
   watchman: false,
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@open-mercato/gateway-stripe/(.*)$': '<rootDir>/src/$1',
+    '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@open-mercato/queue/(.*)$': '<rootDir>/../queue/src/$1',
+    '^@open-mercato/ui/(.*)$': '<rootDir>/../ui/src/$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/packages/onboarding/jest.config.cjs
+++ b/packages/onboarding/jest.config.cjs
@@ -5,6 +5,14 @@ module.exports = {
   watchman: false,
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@open-mercato/onboarding/(.*)$': '<rootDir>/src/$1',
+    '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@open-mercato/search$': '<rootDir>/../search/src/index',
+    '^@open-mercato/search/(.*)$': '<rootDir>/../search/src/$1',
+    '^@open-mercato/ui/(.*)$': '<rootDir>/../ui/src/$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/packages/sync-akeneo/jest.config.cjs
+++ b/packages/sync-akeneo/jest.config.cjs
@@ -5,6 +5,14 @@ module.exports = {
   watchman: false,
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^#generated/(.*)$': '<rootDir>/../core/generated/$1',
+    '^@open-mercato/sync-akeneo/(.*)$': '<rootDir>/src/$1',
+    '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
+    '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@open-mercato/queue/(.*)$': '<rootDir>/../queue/src/$1',
+    '^@open-mercato/ui/(.*)$': '<rootDir>/../ui/src/$1',
+  },
   transform: {
     '^.+\\.(t|j)sx?$': [
       'ts-jest',

--- a/scripts/__tests__/i18n-scanner.test.mjs
+++ b/scripts/__tests__/i18n-scanner.test.mjs
@@ -1,0 +1,143 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildPrefixIndex, scanText } from '../i18n-scanner.mjs'
+
+test('direct t()/translate() calls are detected', () => {
+  const text = [
+    "const label = t('module.entity.title')",
+    "const fallback = translate('module.entity.subtitle', 'Default')",
+  ].join('\n')
+
+  const { refs, dynamicCount } = scanText(text, new Set([
+    'module.entity.title',
+    'module.entity.subtitle',
+    'module.entity.unused',
+  ]))
+
+  const keys = new Set(refs.map((r) => r.key))
+  assert.ok(keys.has('module.entity.title'))
+  assert.ok(keys.has('module.entity.subtitle'))
+  assert.ok(!keys.has('module.entity.unused'))
+  assert.equal(dynamicCount, 0)
+})
+
+test('direct-call pattern does not match when t/translate is a suffix of a different identifier', () => {
+  // Exercises the lookbehind on pattern 1 in isolation: the surrounding
+  // identifier has no dotted string literal, so nothing should fire.
+  const text = "const ctx = getTranslationContext(arg)"
+  const { refs, dynamicCount } = scanText(text, new Set(['module.entity.title']))
+  assert.deepEqual(refs, [])
+  // The `(arg)` call does not trigger the dynamic counter either — only
+  // t() / translate() invocations are counted.
+  assert.equal(dynamicCount, 0)
+})
+
+test('labelKey / titleKey property references are detected when the value is a known key', () => {
+  const text = [
+    "const item = { labelKey: 'module.entity.label', titleKey: 'module.entity.title' }",
+    "const unrelated = { somethingKey: 'not.a.real.key' }",
+  ].join('\n')
+
+  const { refs } = scanText(text, new Set([
+    'module.entity.label',
+    'module.entity.title',
+  ]))
+
+  // Both patterns 2a (keyPropertyPattern) and 2b (dottedLiteralPattern) can match
+  // the same literal; the unique set of recognized keys is what matters.
+  const keys = new Set(refs.map((r) => r.key))
+  assert.equal(keys.size, 2)
+  assert.ok(keys.has('module.entity.label'))
+  assert.ok(keys.has('module.entity.title'))
+})
+
+test('dotted string literals used as data values are detected when they match a known key', () => {
+  const text = [
+    "const key = condition ? 'auth.login.requireRolesMessage' : 'auth.login.requireRoleMessage'",
+    "const descriptors = ['app.metadata.description']",
+    "const route = 'some/file/path.tsx'",
+  ].join('\n')
+
+  const { refs } = scanText(text, new Set([
+    'auth.login.requireRoleMessage',
+    'auth.login.requireRolesMessage',
+    'app.metadata.description',
+  ]))
+
+  const keys = new Set(refs.map((r) => r.key))
+  assert.equal(keys.size, 3)
+  assert.ok(keys.has('auth.login.requireRoleMessage'))
+  assert.ok(keys.has('auth.login.requireRolesMessage'))
+  assert.ok(keys.has('app.metadata.description'))
+})
+
+test('template-literal prefix expands to every known key under that prefix', () => {
+  const text = [
+    'const label = t(`webhooks.deliveries.status.${row.status}`)',
+    'const also = translate(`scheduler.trigger_type.${type}`, fallback)',
+  ].join('\n')
+
+  const allKeys = new Set([
+    'webhooks.deliveries.status.pending',
+    'webhooks.deliveries.status.delivered',
+    'webhooks.deliveries.status.failed',
+    'scheduler.trigger_type.manual',
+    'scheduler.trigger_type.cron',
+    'unrelated.other.key',
+  ])
+
+  const { refs, dynamicCount } = scanText(text, allKeys)
+  const used = new Set(refs.map((r) => r.key))
+
+  assert.ok(used.has('webhooks.deliveries.status.pending'))
+  assert.ok(used.has('webhooks.deliveries.status.delivered'))
+  assert.ok(used.has('webhooks.deliveries.status.failed'))
+  assert.ok(used.has('scheduler.trigger_type.manual'))
+  assert.ok(used.has('scheduler.trigger_type.cron'))
+  assert.ok(!used.has('unrelated.other.key'))
+  assert.equal(dynamicCount, 2)
+})
+
+test('template-literal prefix also handles suffix after the variable', () => {
+  const text = 'const v = t(`foo.bar.${x}.suffix`)'
+  const allKeys = new Set([
+    'foo.bar.one.suffix',
+    'foo.bar.two.suffix',
+    'foo.bar.one.other',
+    'baz.qux',
+  ])
+
+  const { refs } = scanText(text, allKeys)
+  const used = new Set(refs.map((r) => r.key))
+  assert.ok(used.has('foo.bar.one.suffix'))
+  assert.ok(used.has('foo.bar.two.suffix'))
+  assert.ok(used.has('foo.bar.one.other'))
+  assert.ok(!used.has('baz.qux'))
+})
+
+test('dynamicCount counts variable-passed t() calls without producing false references', () => {
+  const text = [
+    'const key = makeKey()',
+    'const val = t(key)',
+    'const val2 = translate(getLabel())',
+  ].join('\n')
+
+  const { refs, dynamicCount } = scanText(text, new Set(['some.key']))
+  assert.deepEqual(refs, [])
+  assert.equal(dynamicCount, 2)
+})
+
+test('buildPrefixIndex groups keys by every dotted prefix', () => {
+  const index = buildPrefixIndex(new Set([
+    'a.b.c',
+    'a.b.d',
+    'a.e',
+    'x.y',
+  ]))
+
+  assert.deepEqual([...(index.get('a') ?? [])].sort(), ['a.b.c', 'a.b.d', 'a.e'])
+  assert.deepEqual([...(index.get('a.b') ?? [])].sort(), ['a.b.c', 'a.b.d'])
+  assert.deepEqual([...(index.get('x') ?? [])].sort(), ['x.y'])
+  assert.equal(index.has('a.b.c'), false, 'leaf keys have no downstream bucket')
+})

--- a/scripts/i18n-check-usage.ts
+++ b/scripts/i18n-check-usage.ts
@@ -18,6 +18,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { globSync } from 'glob'
+// @ts-expect-error — JS sibling module shared with the node:test suite.
+import { scanText } from './i18n-scanner.mjs'
 
 const __filename_ = typeof __filename !== 'undefined' ? __filename : fileURLToPath(import.meta.url)
 const ROOT = path.resolve(path.dirname(__filename_), '..')
@@ -80,44 +82,15 @@ function scanSourceFiles(allTranslationKeys: Set<string>): { refs: KeyReference[
     absolute: true,
   })
 
-  // Pattern 1: Direct t('key') or translate('key') calls
-  const directCallPattern = /(?<![a-zA-Z_])(?:t|translate)\(\s*(['"])([a-zA-Z0-9_.]+)\1/g
-
-  // Pattern 2: Indirect key properties — labelKey: 'key', titleKey: 'key', descriptionKey: 'key', etc.
-  const keyPropertyPattern = /[a-zA-Z]*[Kk]ey['"]?\s*[:=]\s*(['"])([a-zA-Z0-9_.]+)\1/g
-
-  // Pattern 3: Detect dynamic t() calls for counting
-  const dynamicCallPattern = /(?<![a-zA-Z_])(?:t|translate)\(\s*(?!['"])[a-zA-Z`{]/g
-
   const refs: KeyReference[] = []
   let dynamicCount = 0
 
   for (const filePath of sourceFiles) {
     const content = fs.readFileSync(filePath, 'utf-8')
-    const lines = content.split('\n')
     const relPath = path.relative(ROOT, filePath)
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i]
-
-      // Direct t()/translate() calls
-      for (const match of line.matchAll(directCallPattern)) {
-        refs.push({ key: match[2], file: relPath, line: i + 1 })
-      }
-
-      // Indirect key properties (only count if the value is a known translation key)
-      for (const match of line.matchAll(keyPropertyPattern)) {
-        const candidate = match[2]
-        if (allTranslationKeys.has(candidate)) {
-          refs.push({ key: candidate, file: relPath, line: i + 1 })
-        }
-      }
-
-      // Dynamic calls
-      for (const _ of line.matchAll(dynamicCallPattern)) {
-        dynamicCount++
-      }
-    }
+    const result = scanText(content, allTranslationKeys, { file: relPath })
+    refs.push(...result.refs)
+    dynamicCount += result.dynamicCount
   }
 
   return { refs, dynamicCount }

--- a/scripts/i18n-scanner.mjs
+++ b/scripts/i18n-scanner.mjs
@@ -1,0 +1,91 @@
+/**
+ * Pure helpers for the i18n usage scanner.
+ *
+ * Extracted so `i18n-check-usage.ts` and its unit tests can share the same
+ * detection logic without touching the filesystem.
+ */
+
+// Pattern 1: Direct t('key') / translate('key') calls.
+const DIRECT_CALL_PATTERN = /(?<![a-zA-Z_])(?:t|translate)\(\s*(['"])([a-zA-Z0-9_.]+)\1/g
+
+// Pattern 2a: Indirect key properties — labelKey: 'key', titleKey: 'key', etc.
+const KEY_PROPERTY_PATTERN = /[a-zA-Z]*[Kk]ey['"]?\s*[:=]\s*(['"])([a-zA-Z0-9_.]+)\1/g
+
+// Pattern 2b: Any dotted string literal — catches ternary branches, array/object data,
+// and other indirect passes that are not direct t() calls. Only counted when the
+// literal exactly equals a known translation key.
+const DOTTED_LITERAL_PATTERN = /(['"])([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)+)\1/g
+
+// Pattern 3: Template-literal calls with a static prefix — e.g.
+//   t(`module.entity.status.${row.status}`)
+// The captured prefix is treated as potentially referencing any known key
+// that starts with `${prefix}.`.
+const TEMPLATE_PREFIX_PATTERN = /(?<![a-zA-Z_])(?:t|translate)\(\s*`([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)*)\.\$\{/g
+
+// Pattern 4: Detect dynamic t() calls for counting (variable args, template literals, etc.).
+const DYNAMIC_CALL_PATTERN = /(?<![a-zA-Z_])(?:t|translate)\(\s*(?!['"])[a-zA-Z`{]/g
+
+export function buildPrefixIndex(allTranslationKeys) {
+  const index = new Map()
+  for (const key of allTranslationKeys) {
+    const segments = key.split('.')
+    for (let i = 1; i < segments.length; i++) {
+      const prefix = segments.slice(0, i).join('.')
+      const bucket = index.get(prefix)
+      if (bucket) {
+        bucket.push(key)
+      } else {
+        index.set(prefix, [key])
+      }
+    }
+  }
+  return index
+}
+
+export function scanText(text, allTranslationKeys, { file = '<inline>' } = {}) {
+  const keySet = allTranslationKeys instanceof Set
+    ? allTranslationKeys
+    : new Set(allTranslationKeys)
+  const prefixIndex = buildPrefixIndex(keySet)
+  const lines = text.split('\n')
+  const refs = []
+  let dynamicCount = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const lineNumber = i + 1
+
+    for (const match of line.matchAll(DIRECT_CALL_PATTERN)) {
+      refs.push({ key: match[2], file, line: lineNumber })
+    }
+
+    for (const match of line.matchAll(KEY_PROPERTY_PATTERN)) {
+      const candidate = match[2]
+      if (keySet.has(candidate)) {
+        refs.push({ key: candidate, file, line: lineNumber })
+      }
+    }
+
+    for (const match of line.matchAll(DOTTED_LITERAL_PATTERN)) {
+      const candidate = match[2]
+      if (keySet.has(candidate)) {
+        refs.push({ key: candidate, file, line: lineNumber })
+      }
+    }
+
+    for (const match of line.matchAll(TEMPLATE_PREFIX_PATTERN)) {
+      const prefix = match[1]
+      const expanded = prefixIndex.get(prefix)
+      if (!expanded) continue
+      for (const key of expanded) {
+        refs.push({ key, file, line: lineNumber })
+      }
+    }
+
+    for (const _ of line.matchAll(DYNAMIC_CALL_PATTERN)) {
+      dynamicCount++
+    }
+  }
+
+  return { refs, dynamicCount }
+}


### PR DESCRIPTION
Addresses the two advisory items flagged during PR #1603's validation gate.

## Problem

**Jest module resolution:** Five packages (`cache`, `checkout`, `gateway-stripe`, `onboarding`, `sync-akeneo`) ship with a `jest.config.cjs` missing `moduleNameMapper`. Running their Jest suites fails at test-suite collection with `Cannot find module '@open-mercato/shared/...'` (and transitively `core`, `queue`, `ui`) because Jest can't resolve the TypeScript sources that other packages' configs map explicitly. `yarn test` was silently skipping coverage for them.

**i18n usage scanner:** `scripts/i18n-check-usage.ts` is advisory-only but was reporting ~3,942 "unused" keys. The noise came from three legitimate reference patterns the regex-based scanner missed:
- `` t(`module.entity.status.${row.status}`) `` — template-literal with static prefix.
- `cond ? 'a.key' : 'b.key'` — ternary/array data.
- `['app.metadata.description']` — any plain string literal matching a known key but not passed directly to `t()`.

## What Changed

### Jest configs — 5 packages (`packages/{cache,checkout,gateway-stripe,onboarding,sync-akeneo}/jest.config.cjs`)

Added `moduleNameMapper` tailored to each package's actual cross-package imports, mirroring the pattern used by `packages/events/jest.config.cjs`. `sync-akeneo` additionally maps `#generated/*` to `packages/core/generated/*` because its `catalog-importer` test transitively loads `packages/core/src/modules/attachments/lib/partitions.ts`, which imports via `#generated/entities.ids.generated`.

Result: all 19 workspace test suites now run to completion (previously 5 silently broken):
- `@open-mercato/cache`: 38/38 passing
- `@open-mercato/checkout`: 29/29 passing (includes the React `CustomerFieldsEditor` test)
- `@open-mercato/gateway-stripe`: 8/8 passing
- `@open-mercato/onboarding`: 37/37 passing
- `@open-mercato/sync-akeneo`: 46/46 passing (including the previously-broken `catalog-importer.test.ts`)

### i18n scanner — `scripts/i18n-check-usage.ts` (+ new `scripts/i18n-scanner.mjs`)

- **Pattern 2b (new):** any dotted string literal exactly matching a known translation key counts as a reference. This catches ternary/array/object-data passes that are not direct `t()` calls and are not covered by the existing `*Key:` property pattern.
- **Pattern 3 (new):** `` t(`prefix.${var}`) `` expands `prefix` against a precomputed prefix index so every known key under `prefix.` is treated as used. Previously these were lumped into the skipped dynamic-call count.
- The pure scanner helpers live in `scripts/i18n-scanner.mjs` so they can be unit-tested by `scripts/__tests__/i18n-scanner.test.mjs` (8/8 passing node:test suite).

Unused count drops from **3,942 → 3,238** without introducing any missing-key errors. The script's exit-code contract is unchanged (exit 1 only on missing keys).

## Tests

- `yarn test` → 19/19 workspaces green (5 previously broken, now running).
- `yarn typecheck` → 18/18 green.
- `yarn lint` → no new errors (only pre-existing warnings in `apps/mercato/src/modules/example`).
- `yarn i18n:check-sync` → in sync across all locales.
- `yarn i18n:check-usage` → exit 0; 3,238 unused advisories (down from 3,942); no missing keys.
- `node --test scripts/__tests__/i18n-scanner.test.mjs` → 8/8 green.

## Backward Compatibility

No contract surface changes. Jest configs are build tooling; the scanner is dev tooling. Both retain their public invocation contract. The scanner only adds references to the set of "used" keys — it never flips a previously-used key to unused, so it cannot break CI.

## Test plan
- [ ] Verify `yarn test` completes with 19/19 workspace suites passing on CI.
- [ ] Verify `yarn i18n:check-usage` reports 3,238 unused keys (down from 3,942) and exit 0.
- [ ] Spot-check that no previously-passing test in the 14 unaffected packages regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)