### PR TITLE
fix: bug: Delivery Log missing retry action in "Actions" column (#1068)

### DIFF
--- a/packages/webhooks/src/modules/webhooks/api/webhook-deliveries/[id]/retry/route.ts
+++ b/packages/webhooks/src/modules/webhooks/api/webhook-deliveries/[id]/retry/route.ts
@@ -63,6 +63,7 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
   delivery.status = 'pending'
   delivery.nextRetryAt = null
   delivery.errorMessage = null
+  delivery.attemptNumber = 0
   await em.flush()
 
   await enqueueWebhookDelivery({


### PR DESCRIPTION
## Automated fix for #1068

Fixes #1068

> This PR was opened by [cezar](https://github.com/comerito/cezar) autofix. It is a **draft** — a human reviewer must verify correctness before it merges.

### Root cause
Retry functionality works but deliveries get stuck in 'pending' status

The retry button appears correctly in row actions for failed/expired deliveries, but when clicked, deliveries get stuck in 'pending' status. The retry API endpoint properly sets status to 'pending' and calls enqueueWebhookDelivery() to schedule the job, but there appears to be an issue with either the queue processing or job execution that prevents the delivery from progressing beyond 'pending' status. The UI properly refreshes but shows the delivery permanently stuck in pending state.

### Approach
Fixed retry functionality by resetting delivery.attemptNumber to 0 when retrying a failed webhook delivery. The root cause was that retried deliveries kept their original attempt count, causing them to be immediately marked as expired when processed since they already exceeded maxAttempts.

### Files changed
- `packages/webhooks/src/modules/webhooks/api/webhook-deliveries/[id]/retry/route.ts`

### Verification
Commands run by the fixer:
- `node -e "..." (syntax validation)`
- `grep -n "retriesRemaining.*attemptNumber" (verified root cause location)`

### Review (automated)
**Verdict:** `pass`

Fix correctly resets attemptNumber to 0 when retrying a failed delivery, addressing the root cause where retried deliveries were immediately marked as expired due to already-exhausted attempt counts. The change is minimal, focused, and directly targets the identified problem.

Issues raised:
_(no issues raised)_

### Remaining concerns
- Full integration tests could not be run due to missing dependencies - the fix addresses the identified root cause but should be tested in a complete environment with actual webhook deliveries
