### PR TITLE
fix(workflows): prevent column truncation on definitions list

### DIFF
--- a/packages/core/src/modules/workflows/backend/definitions/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/page.tsx
@@ -229,6 +229,7 @@ export default function WorkflowDefinitionsListPage() {
       id: 'workflowId',
       header: t('workflows.fields.workflowId'),
       accessorKey: 'workflowId',
+      meta: { truncate: false },
       cell: ({ row }) => (
         <span className="font-mono text-sm">{row.original.workflowId}</span>
       ),
@@ -237,11 +238,12 @@ export default function WorkflowDefinitionsListPage() {
       id: 'workflowName',
       header: t('workflows.fields.workflowName'),
       accessorKey: 'workflowName',
+      meta: { truncate: false },
       cell: ({ row }) => (
         <div>
           <div className="font-medium">{row.original.workflowName}</div>
           {row.original.description && (
-            <div className="text-xs text-gray-500 line-clamp-1">
+            <div className="text-xs text-gray-500">
               {row.original.description}
             </div>
           )}
@@ -257,6 +259,7 @@ export default function WorkflowDefinitionsListPage() {
       id: 'version',
       header: t('workflows.fields.version'),
       accessorKey: 'version',
+      meta: { truncate: false },
       cell: ({ row }) => (
         <Badge variant="secondary" className="font-mono">
           v{row.original.version}


### PR DESCRIPTION
## Summary

The **Workflow ID**, **Workflow Name**, and **Version** columns on `/backend/definitions` were being clipped mid-text because `DataTable` applied default `maxWidth` caps (150/250/150 px) via the shared `TruncatedCell` wrapper, which also forces `whitespace-nowrap`. Even on a 2560px-wide viewport the full workflow IDs and descriptions were hidden behind ellipses.

## Changes

- Set `meta: { truncate: false }` on the three columns in `packages/core/src/modules/workflows/backend/definitions/page.tsx` so they skip the `TruncatedCell` wrapper and size to their content.
- Drop `line-clamp-1` from the description line so the full description renders.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor UI fix, no spec needed)

## Testing

- Manual check with Playwright at 2560×1440: full IDs (`sales_order_approval_v1`, `checkout_simple_v1`, …), full workflow titles, and full descriptions now render without ellipsis.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (n/a)
- [ ] I added or adjusted tests that cover the change. (purely presentational)
- [ ] I added or updated integration tests in `.ai/qa/tests/` (n/a — no behavior change)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (n/a)

### Design System Compliance
- [x] No hardcoded status colors
- [x] No arbitrary text sizes
- [x] Empty state handled for list/data pages
- [x] Loading state handled for async pages
- [x] \`aria-label\` on all icon-only buttons
- [x] Uses existing DS components — no custom replacements

🤖 Generated with [Claude Code](https://claude.com/claude-code)