### PR TITLE
fix(create-app): use `yarn mercato db` commands in codex enforcement rules

### DIFF
--- a/packages/create-app/agentic/codex/enforcement-rules.md
+++ b/packages/create-app/agentic/codex/enforcement-rules.md
@@ -4,9 +4,9 @@
 1. **After editing any entity file** (`src/modules/<id>/entities/*.ts`):
    - STOP immediately before any further action
    - Tell the user: "I modified an entity in module <id>. Should I create a migration?"
-   - If yes: run `yarn db:generate`
+   - If yes: run `yarn mercato db generate`
    - Show the generated migration to the user before applying
-   - Ask for confirmation, then run `yarn db:migrate`
+   - Ask for confirmation, then run `yarn mercato db migrate`
    - Run `yarn generate` after migration is applied
 
 2. **After editing `src/modules.ts`**: immediately run `yarn generate`


### PR DESCRIPTION
## Summary
- Standalone apps scaffolded by `create-app` don't have root `yarn db:generate` / `yarn db:migrate` scripts — those belong to the monorepo. Update the codex enforcement rules to instruct agents to run `yarn mercato db generate` and `yarn mercato db migrate` instead.

## Test plan
- [ ] Scaffold a standalone app via `create-app` and confirm the generated `agentic/codex/enforcement-rules.md` points at commands the standalone app actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)