### PR TITLE
fix(messages): refresh inbox cache on unread events (#1634)

### DIFF
--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetails.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetails.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook } from '@testing-library/react'
+import { useMessageDetails } from '../useMessageDetails'
+
+const mockInvalidateQueries = jest.fn()
+const mockUseAppEvent = jest.fn()
+const mockRouterPush = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}))
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 'scope-1',
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useAppEvent', () => ({
+  useAppEvent: (...args: unknown[]) => mockUseAppEvent(...args),
+}))
+
+jest.mock('../useMessageDetailsQueries', () => ({
+  useMessageDetailsQueries: () => ({
+    detailQuery: { refetch: jest.fn() },
+    detail: null,
+    isLoadingDetail: false,
+    loadErrorMessage: 'load error',
+    attachmentsQuery: { isLoading: false },
+    attachments: [],
+    refreshDetailWithoutAutoMarkRead: jest.fn(),
+    listItemComponentKey: null,
+    contentComponentKey: null,
+    actionsComponentKey: null,
+  }),
+}))
+
+jest.mock('../useMessageDetailsActions', () => ({
+  useMessageDetailsActions: () => ({
+    updatingState: false,
+    executingActionId: null,
+    pendingActionConfirmation: null,
+    deleteConfirmationOpen: false,
+    activeConversationAction: null,
+    setEditOpen: jest.fn(),
+    setDeleteConfirmationOpen: jest.fn(),
+    handleDelete: jest.fn(),
+    handleDeleteDialogKeyDown: jest.fn(),
+    handleExecuteAction: jest.fn(),
+    handleExecuteActionById: jest.fn(),
+    handleConfirmPendingAction: jest.fn(),
+    handleActionConfirmDialogKeyDown: jest.fn(),
+    archiveConversation: jest.fn(),
+    markConversationUnread: jest.fn(),
+    deleteConversation: jest.fn(),
+    setPendingActionConfirmation: jest.fn(),
+  }),
+}))
+
+jest.mock('../useMessageDetailsConversation', () => ({
+  useMessageDetailsConversation: () => ({
+    conversationItems: [],
+    forcedExpandedItemId: null,
+    isConversationItemExpanded: jest.fn(),
+    toggleConversationItem: jest.fn(),
+    buildConversationListItemMessage: jest.fn(),
+    contentProps: {},
+    messageActions: [],
+    objectActionsByObjectId: {},
+    contentComponentKey: null,
+  }),
+}))
+
+describe('useMessageDetails', () => {
+  beforeEach(() => {
+    mockInvalidateQueries.mockReset()
+    mockUseAppEvent.mockReset()
+    mockRouterPush.mockReset()
+  })
+
+  it('invalidates the message list cache when a message event arrives', () => {
+    renderHook(() => useMessageDetails('message-1'))
+
+    const messageEventRegistration = mockUseAppEvent.mock.calls.find(
+      ([eventName]) => eventName === 'messages.message.*',
+    )
+
+    expect(messageEventRegistration).toBeTruthy()
+
+    const [, handler] = messageEventRegistration as [
+      string,
+      (event: { payload?: Record<string, unknown> }) => void,
+    ]
+
+    act(() => {
+      handler({ payload: { messageId: 'message-2' } })
+    })
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['messages', 'list'] })
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['messages', 'detail', 'message-1'] })
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({ queryKey: ['messages', 'detail', 'message-2'] })
+  })
+})

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetails.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetails.ts
@@ -23,8 +23,9 @@ export function useMessageDetails(id: string) {
     queryClient,
   })
 
-  const invalidateDetailQueries = React.useCallback(
+  const invalidateMessageQueries = React.useCallback(
     (payload: Record<string, unknown>) => {
+      void queryClient.invalidateQueries({ queryKey: ['messages', 'list'] })
       void queryClient.invalidateQueries({ queryKey: ['messages', 'detail', id] })
       const messageId = typeof payload.messageId === 'string' ? payload.messageId : null
       if (messageId && messageId !== id) {
@@ -37,9 +38,9 @@ export function useMessageDetails(id: string) {
   useAppEvent(
     'messages.message.*',
     (evt) => {
-      invalidateDetailQueries((evt.payload ?? {}) as Record<string, unknown>)
+      invalidateMessageQueries((evt.payload ?? {}) as Record<string, unknown>)
     },
-    [invalidateDetailQueries],
+    [invalidateMessageQueries],
   )
 
   useAppEvent(


### PR DESCRIPTION
Fixes #1634

## Problem
- Marking a message as unread showed a success toast, but the inbox list could keep showing the stale read state when the list page was not mounted.

## Root Cause
- The message detail page only invalidated detail queries on `messages.message.*` events, so the inbox list cache was not refreshed after a read-state change.

## What Changed
- Invalidated the `messages` list cache from the shared message-event handler in `useMessageDetails`.
- Added a regression test that proves `messages.message.marked_unread` invalidates both the list cache and the detail cache.

## Tests
- `yarn workspace @open-mercato/core test --runInBand packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetails.test.tsx`
- `yarn workspace @open-mercato/core typecheck`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn build:app`
- `yarn test` blocked by an unrelated existing failure in `@open-mercato/events` (`events.worker.test.ts` parallelism assertion)

## Backward Compatibility
- No contract surface changes.