### PR TITLE
fix(messages): prevent duplicate sends from composer (#1631)

### DIFF
--- a/packages/core/jest.setup.ts
+++ b/packages/core/jest.setup.ts
@@ -26,6 +26,12 @@ class MockResponse {
   async text() {
     return this.body
   }
+
+  clone() {
+    const cloned = new MockResponse(this.body, { status: this.status })
+    cloned.headers = new Map(this.headers)
+    return cloned
+  }
 }
 
 if (typeof globalThis.Response === 'undefined') {

--- a/packages/ui/jest.setup.ts
+++ b/packages/ui/jest.setup.ts
@@ -22,6 +22,12 @@ class MockResponse {
   async text() {
     return this.body
   }
+
+  clone() {
+    const cloned = new MockResponse(this.body, { status: this.status })
+    cloned.headers = new Map(this.headers)
+    return cloned
+  }
 }
 
 if (typeof globalThis.Response === 'undefined') {

--- a/packages/ui/src/backend/messages/__tests__/MessageComposer.test.tsx
+++ b/packages/ui/src/backend/messages/__tests__/MessageComposer.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react'
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { MessageComposer } from '../MessageComposer'
 import { apiCall } from '../../utils/apiCall'
@@ -119,6 +119,107 @@ describe('MessageComposer draft flow', () => {
     const payload = JSON.parse(composeRequest?.[1]?.body ?? '{}') as Record<string, unknown>
     expect(payload.isDraft).toBe(true)
     expect(flash).toHaveBeenCalledWith('Draft saved.', 'success')
+  })
+
+  it('keeps the send action disabled after a successful compose submit until the composer resets', async () => {
+    let resolveMessagePost!: (value: {
+      ok: boolean
+      status: number
+      result: { id: string }
+      response: { status: number }
+    }) => void
+
+    ;(apiCall as jest.Mock).mockImplementation((url: string, options?: { method?: string, body?: string }) => {
+      if (url.startsWith('/api/messages/types')) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          result: {
+            items: [{
+              type: 'default',
+              module: 'messages',
+              labelKey: 'messages.types.default',
+              icon: 'mail',
+              allowReply: true,
+              allowForward: true,
+            }],
+          },
+          response: { status: 200 },
+        })
+      }
+
+      if (url === '/api/messages' && options?.method === 'POST') {
+        return new Promise((resolve) => {
+          resolveMessagePost = resolve
+        })
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        result: { items: [] },
+        response: { status: 200 },
+      })
+    })
+
+    renderWithProviders(
+      <MessageComposer
+        inline
+        variant="compose"
+        defaultValues={{
+          recipients: ['11111111-1111-4111-8111-111111111111'],
+          subject: 'Send lock test',
+          body: 'Send lock body',
+        }}
+      />,
+      { dict: {} },
+    )
+
+    await waitFor(() => {
+      expect((apiCall as jest.Mock).mock.calls.some((call) => call[0] === '/api/messages/types')).toBe(true)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    const sendButton = await screen.findByRole('button', { name: /^send$/i })
+    fireEvent.click(sendButton)
+
+    await waitFor(() => {
+      const messagePostCalls = (apiCall as jest.Mock).mock.calls.filter(
+        (call) => call[0] === '/api/messages' && call[1]?.method === 'POST',
+      )
+      expect(messagePostCalls).toHaveLength(1)
+    })
+
+    await waitFor(() => {
+      expect(sendButton).toBeDisabled()
+    })
+
+    await act(async () => {
+      resolveMessagePost({
+        ok: true,
+        status: 201,
+        result: { id: 'message-1' },
+        response: { status: 201 },
+      })
+    })
+
+    await waitFor(() => {
+      expect(flash).toHaveBeenCalledWith('Message sent.', 'success')
+    })
+
+    expect(sendButton).toBeDisabled()
+
+    fireEvent.click(sendButton)
+
+    await waitFor(() => {
+      const messagePostCalls = (apiCall as jest.Mock).mock.calls.filter(
+        (call) => call[0] === '/api/messages' && call[1]?.method === 'POST',
+      )
+      expect(messagePostCalls).toHaveLength(1)
+    })
   })
 
   it('cancels dialog composer without saving draft', async () => {

--- a/packages/ui/src/backend/messages/useMessageCompose.ts
+++ b/packages/ui/src/backend/messages/useMessageCompose.ts
@@ -164,6 +164,8 @@ export function useMessageCompose({
   // because `keyboard.type` characters appeared to "type nowhere" — they were
   // typed correctly, then immediately wiped by the next effect run.
   const isOpenRef = React.useRef(false)
+  const wasOpenRef = React.useRef(false)
+  const submitLockReleaseRef = React.useRef<(() => void) | null>(null)
 
   const messageTypesQuery = useQuery({
     queryKey: ['messages', 'types'],
@@ -288,6 +290,28 @@ export function useMessageCompose({
     normalizedRequiredActionMode,
     requiredActionConfig?.defaultActionType,
   ])
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      submitLockReleaseRef.current?.()
+      submitLockReleaseRef.current = null
+      wasOpenRef.current = false
+      return
+    }
+
+    const justOpened = isOpen && !wasOpenRef.current
+    wasOpenRef.current = isOpen
+    if (!justOpened) return
+    submitLockReleaseRef.current?.()
+    submitLockReleaseRef.current = null
+    setSubmitting(false)
+    setSubmitMode('send')
+  }, [isOpen])
+
+  React.useEffect(() => () => {
+    submitLockReleaseRef.current?.()
+    submitLockReleaseRef.current = null
+  }, [])
 
   React.useEffect(() => {
     if (!isOpen) return
@@ -513,6 +537,8 @@ export function useMessageCompose({
 
     setSubmitMode(isComposeDraftSubmit ? 'draft' : 'send')
     setSubmitting(true)
+    let keepSubmitLock = false
+    let shouldReturnFalse = false
 
     try {
       let nextAttachmentIds = attachmentIds
@@ -525,44 +551,60 @@ export function useMessageCompose({
             : t('messages.errors.loadAttachmentOptionsFailed', 'Failed to load attachments.')
           setSubmitError(message)
           flash(message, 'error')
-          return false
+          shouldReturnFalse = true
         }
       }
 
-      const { endpoint, payload } = operation.buildRequest({ attachmentIds: nextAttachmentIds })
+      if (!shouldReturnFalse) {
+        const { endpoint, payload } = operation.buildRequest({ attachmentIds: nextAttachmentIds })
 
-      const call = await apiCall<{ id?: string }>(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
+        const call = await apiCall<{ id?: string }>(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
 
-      if (!call.ok) {
-        const message = toErrorMessage(call.result) ?? t('messages.errors.sendFailed', 'Failed to send message.')
-        setSubmitError(message)
-        flash(message, 'error')
-        return false
+        if (!call.ok) {
+          const message = toErrorMessage(call.result) ?? t('messages.errors.sendFailed', 'Failed to send message.')
+          setSubmitError(message)
+          flash(message, 'error')
+          shouldReturnFalse = true
+        } else {
+          flash(operation.successMessage, 'success')
+          keepSubmitLock = true
+
+          onSuccess?.({ id: call.result?.id })
+
+          if (!inline) {
+            onOpenChange?.(false)
+          }
+        }
       }
-
-      flash(operation.successMessage, 'success')
-
-      onSuccess?.({ id: call.result?.id })
-
-      if (!inline) {
-        onOpenChange?.(false)
-      }
-      return true
     } catch (error) {
       const message = error instanceof Error
         ? error.message
         : t('messages.errors.sendFailed', 'Failed to send message.')
       setSubmitError(message)
       flash(message, 'error')
-      return false
+      shouldReturnFalse = true
     } finally {
-      setSubmitting(false)
+      if (!keepSubmitLock) {
+        setSubmitting(false)
+      }
       setSubmitMode('send')
     }
+
+    if (shouldReturnFalse) {
+      return false
+    }
+
+    if (keepSubmitLock) {
+      return await new Promise<boolean>((resolve) => {
+        submitLockReleaseRef.current = () => resolve(true)
+      })
+    }
+
+    return true
   }, [
     attachmentIds,
     composeDraftOperation,


### PR DESCRIPTION
Fixes #1631

## Problem
- Sending a message from the composer could briefly re-enable the Send action before navigation completed.
- A fast second click could submit the same message again, which manifested as duplicate inbox entries and doubled notification counts for recipients.

## Root Cause
- The composer-level submit lock reset as soon as the request resolved, while the form-level submit flow was still mounted during the navigation window.

## What Changed
- Keep the composer submit lock active after a successful send until the composer closes or reopens.
- Added a regression test that proves a second click cannot fire another POST after a successful send.
- Merged latest `develop` (2c29774b5) so the branch is up-to-date.
- Cherry-picked the JEST_WORKER_ID `isTestEnv` fix so lazy-loaded markdown/editor stubs activate reliably in Jest even when the shell inherits `NODE_ENV=development`, unblocking the `@open-mercato/ui` and `@open-mercato/core` suites flagged in the prior review.
- Added `MockResponse.clone()` to the Jest setup in `packages/ui` and `packages/core` so 403 flows in `CustomDataSection`/relation fallbacks execute the real `ForbiddenError` path instead of crashing on a missing method.
- Added the missing `sales.shipments.fully_returned` and `sales.shipments.payment_completed` keys to all four locales (en/pl/es/de) that PR #1624 introduced but did not sync.

## Tests
- `yarn test` — all 19 workspaces green (core 3090 tests, ui 304 tests, cli 806 tests, etc.).
- `yarn typecheck` — clean.
- `yarn i18n:check-sync` — all 4 locales in sync.
- `yarn i18n:check-usage` — 0 missing keys.
- `yarn build:packages` — clean.
- `yarn build:app` — clean under `NODE_ENV=production` (pre-existing Next.js 15 prerender on `/_not-found`/`/_global-error` misfires only when the shell inherits `NODE_ENV=development`; unrelated to this change).

## Backward Compatibility
- No contract surface changes.