### PR TITLE
fix(workflows): resolve CALL_API roles from the instance initiator

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/resolve-call-api-role-ids.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/resolve-call-api-role-ids.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @jest-environment node
+ *
+ * Regression tests for resolveCallApiRoleIds — the CALL_API role resolver
+ * must resolve roles from the workflow instance's triggering user
+ * (metadata.initiatedBy) when available, and only fall back to the
+ * definition author for instances with no human initiator. This prevents
+ * privilege escalation where any user with `workflows.instances.create`
+ * could run an admin-authored workflow's CALL_API step with admin roles.
+ */
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+jest.mock('../../data/entities', () => ({
+  WorkflowDefinition: class WorkflowDefinition {},
+}))
+
+jest.mock('../../../auth/data/entities', () => ({
+  User: class User {},
+  UserRole: class UserRole {},
+  Role: class Role {},
+}))
+
+import { resolveCallApiRoleIds } from '../activity-executor'
+import {
+  findOneWithDecryption,
+  findWithDecryption,
+} from '@open-mercato/shared/lib/encryption/find'
+
+const mockFindOne = findOneWithDecryption as jest.Mock
+const mockFindMany = findWithDecryption as jest.Mock
+
+const TENANT_ID = 'tenant-1'
+const ORG_ID = 'org-1'
+const DEFINITION_ID = 'def-1'
+const AUTHOR_ID = 'author-admin'
+const INITIATOR_ID = 'initiator-low-priv'
+
+type FindOneCall = { entity: string; filter: Record<string, unknown> }
+
+function entityName(arg: unknown): string {
+  if (typeof arg === 'function') return arg.name
+  if (arg && typeof arg === 'object' && 'name' in (arg as Record<string, unknown>)) {
+    return String((arg as { name?: string }).name)
+  }
+  return ''
+}
+
+function setupCommonStubs({
+  authorExists = true,
+  initiatorExists = true,
+  authorRoleIds = ['role-admin'],
+  initiatorRoleIds = ['role-low-priv'],
+}: {
+  authorExists?: boolean
+  initiatorExists?: boolean
+  authorRoleIds?: string[]
+  initiatorRoleIds?: string[]
+} = {}) {
+  mockFindOne.mockReset()
+  mockFindMany.mockReset()
+
+  mockFindOne.mockImplementation(async (_em: unknown, Entity: any, filter: Record<string, unknown>) => {
+    const name = entityName(Entity)
+    if (name === 'WorkflowDefinition') {
+      return {
+        id: filter.id,
+        createdBy: AUTHOR_ID,
+        tenantId: filter.tenantId,
+      }
+    }
+    if (name === 'User') {
+      if (filter.id === AUTHOR_ID && authorExists) return { id: AUTHOR_ID }
+      if (filter.id === INITIATOR_ID && initiatorExists) return { id: INITIATOR_ID }
+      return null
+    }
+    return null
+  })
+
+  mockFindMany.mockImplementation(async (_em: unknown, Entity: any, filter: Record<string, unknown>) => {
+    const name = entityName(Entity)
+    if (name === 'UserRole') {
+      const userFilter = filter.user as string | undefined
+      const ids = userFilter === INITIATOR_ID ? initiatorRoleIds : authorRoleIds
+      return ids.map((id) => ({ role: { id } }))
+    }
+    if (name === 'Role') {
+      const idFilter = filter.id as { $in?: string[] } | string | undefined
+      const ids = Array.isArray((idFilter as any)?.$in) ? (idFilter as any).$in : []
+      return ids.map((id: string) => ({ id }))
+    }
+    return []
+  })
+}
+
+function findOneCalls(): FindOneCall[] {
+  return mockFindOne.mock.calls.map((args) => ({
+    entity: entityName(args[1]),
+    filter: args[2] as Record<string, unknown>,
+  }))
+}
+
+describe('resolveCallApiRoleIds', () => {
+  test('uses the initiator\'s roles when metadata.initiatedBy is set, ignoring the author', async () => {
+    setupCommonStubs({
+      authorRoleIds: ['role-admin'],
+      initiatorRoleIds: ['role-low-priv'],
+    })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-1',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: { initiatedBy: INITIATOR_ID },
+    })
+
+    expect(result).toEqual(['role-low-priv'])
+
+    const calls = findOneCalls()
+    const userCalls = calls.filter((c) => c.entity === 'User')
+    expect(userCalls.map((c) => c.filter.id)).toEqual([INITIATOR_ID])
+
+    // Definition lookup is not required when initiator is present.
+    const definitionCalls = calls.filter((c) => c.entity === 'WorkflowDefinition')
+    expect(definitionCalls.length).toBe(0)
+  })
+
+  test('refuses to run when the initiator has no active scoped roles (never falls back to author)', async () => {
+    setupCommonStubs({
+      initiatorRoleIds: [],
+      authorRoleIds: ['role-admin'],
+    })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-2',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: { initiatedBy: INITIATOR_ID },
+    })
+
+    expect(result).toEqual([])
+
+    const calls = findOneCalls()
+    // Author user must not be consulted once initiator was resolved.
+    expect(calls.some((c) => c.entity === 'User' && c.filter.id === AUTHOR_ID)).toBe(false)
+  })
+
+  test('refuses to run when the initiator user does not exist', async () => {
+    setupCommonStubs({ initiatorExists: false })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-3',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: { initiatedBy: INITIATOR_ID },
+    })
+
+    expect(result).toEqual([])
+
+    const calls = findOneCalls()
+    expect(calls.some((c) => c.entity === 'User' && c.filter.id === AUTHOR_ID)).toBe(false)
+  })
+
+  test('falls back to the definition author for event-triggered instances with no initiator', async () => {
+    setupCommonStubs({ authorRoleIds: ['role-admin'] })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-4',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: null,
+    })
+
+    expect(result).toEqual(['role-admin'])
+
+    const calls = findOneCalls()
+    expect(calls.some((c) => c.entity === 'WorkflowDefinition')).toBe(true)
+    expect(calls.some((c) => c.entity === 'User' && c.filter.id === AUTHOR_ID)).toBe(true)
+  })
+
+  test('falls back to the author when metadata exists but initiatedBy is empty', async () => {
+    setupCommonStubs({ authorRoleIds: ['role-admin'] })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-5',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: { initiatedBy: null },
+    })
+
+    expect(result).toEqual(['role-admin'])
+  })
+
+  test('filters soft-deleted workflow definitions (deletedAt: null)', async () => {
+    setupCommonStubs()
+
+    await resolveCallApiRoleIds({}, {
+      id: 'inst-6',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: null,
+    })
+
+    const definitionCall = findOneCalls().find((c) => c.entity === 'WorkflowDefinition')
+    expect(definitionCall).toBeDefined()
+    expect(definitionCall!.filter.deletedAt).toBeNull()
+  })
+
+  test('returns empty array when no definitionId', async () => {
+    setupCommonStubs()
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-7',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: '',
+      metadata: { initiatedBy: INITIATOR_ID },
+    })
+    expect(result).toEqual([])
+  })
+})

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -788,10 +788,13 @@ export async function executeCallApi(
   //   SECURITY.md changelog entry for this fix.
   //
   //   The resolution strategy is:
-  //     1. Use the workflow instance's `createdBy` user (whoever manually
-  //        started the instance), when available.
-  //     2. Fall back to the workflow definition's `createdBy` (author) when
-  //        the instance was started by an event trigger with no user.
+  //     1. Use the workflow instance's `metadata.initiatedBy` user (whoever
+  //        manually started the instance), when available. Only this user's
+  //        current active roles are used — we never fall back to the author
+  //        when the initiator is known, because that would escalate the
+  //        initiator's privileges.
+  //     2. Fall back to the workflow definition's `createdBy` (author) only
+  //        when the instance was started by an event trigger with no user.
   //     3. If no traceable principal exists, the activity refuses to run —
   //        there is no "system" fallback that bypasses RBAC.
   const resolvedRoleIds = await resolveCallApiRoleIds(apiKeyEm, context.workflowInstance)
@@ -885,38 +888,28 @@ export type CallApiInstanceLike = {
   tenantId: string
   organizationId: string
   definitionId: string
+  metadata?: { initiatedBy?: string | null } | null
 }
 
-export async function resolveCallApiRoleIds(
+async function resolveActiveRoleIdsForUser(
   em: any,
-  instance: CallApiInstanceLike
+  userId: string,
+  scope: { tenantId: string; organizationId: string },
 ): Promise<string[]> {
-  if (!instance.definitionId) return []
-
   const { findOneWithDecryption, findWithDecryption } = await import('@open-mercato/shared/lib/encryption/find')
   const { User, UserRole, Role } = await import('../../auth/data/entities')
-  const { WorkflowDefinition } = await import('../data/entities')
 
-  const scope = { tenantId: instance.tenantId, organizationId: instance.organizationId }
-
-  const definition = await findOneWithDecryption(em, WorkflowDefinition, {
-    id: instance.definitionId,
-    tenantId: instance.tenantId,
-  }, {}, scope)
-  const authorUserId = definition?.createdBy
-  if (!authorUserId) return []
-
-  const author = await findOneWithDecryption(em, User, {
-    id: authorUserId,
-    tenantId: instance.tenantId,
+  const user = await findOneWithDecryption(em, User, {
+    id: userId,
+    tenantId: scope.tenantId,
     deletedAt: null,
   }, {}, scope)
-  if (!author) return []
+  if (!user) return []
 
   const userRoles = await findWithDecryption(
     em,
     UserRole,
-    { user: author.id, deletedAt: null },
+    { user: user.id, deletedAt: null },
     { populate: ['role'] },
     scope,
   )
@@ -928,10 +921,45 @@ export async function resolveCallApiRoleIds(
 
   const scopedRoles = await findWithDecryption(em, Role, {
     id: { $in: roleIds },
-    tenantId: instance.tenantId,
+    tenantId: scope.tenantId,
     deletedAt: null,
   }, {}, scope)
   return scopedRoles.map((r: any) => r.id as string)
+}
+
+export async function resolveCallApiRoleIds(
+  em: any,
+  instance: CallApiInstanceLike
+): Promise<string[]> {
+  if (!instance.definitionId) return []
+
+  const { findOneWithDecryption } = await import('@open-mercato/shared/lib/encryption/find')
+  const { WorkflowDefinition } = await import('../data/entities')
+
+  const scope = { tenantId: instance.tenantId, organizationId: instance.organizationId }
+
+  // 1. Prefer the triggering user (whoever manually started this instance).
+  //    WorkflowInstance.metadata.initiatedBy is the canonical record of that
+  //    principal for user-started instances; use their current role set so
+  //    CALL_API never exceeds the initiator's permissions. Refuse if the
+  //    initiator has no active scoped roles — do not fall back to the
+  //    definition author, which would escalate the initiator's privileges.
+  const initiatorUserId = instance.metadata?.initiatedBy ?? null
+  if (initiatorUserId) {
+    return resolveActiveRoleIdsForUser(em, initiatorUserId, scope)
+  }
+
+  // 2. Event-triggered instance with no human initiator: fall back to the
+  //    definition author. Soft-deleted definitions must not mint keys.
+  const definition = await findOneWithDecryption(em, WorkflowDefinition, {
+    id: instance.definitionId,
+    tenantId: instance.tenantId,
+    deletedAt: null,
+  }, {}, scope)
+  const authorUserId = definition?.createdBy
+  if (!authorUserId) return []
+
+  return resolveActiveRoleIdsForUser(em, authorUserId, scope)
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix privilege escalation in the workflow `CALL_API` activity role resolver. `resolveCallApiRoleIds()` in `packages/core/src/modules/workflows/lib/activity-executor.ts` resolved roles from the workflow *definition's* author unconditionally and never read `WorkflowInstance.metadata.initiatedBy`.
- Match the security comment already in the file: prefer the initiator's current active scoped roles, fall back to the definition author only for event-triggered instances with no human initiator, refuse otherwise.
- Also filter soft-deleted `WorkflowDefinition` rows (`deletedAt: null`) so a deleted definition cannot mint keys.
- Add unit tests for the initiator-first, no-escalation-fallback, event-trigger fallback, soft-delete, and empty-initiator branches.

## Threat

Any user with `workflows.instances.create` who started an admin-authored workflow containing a `CALL_API` step executed that request with the admin author's roles — the executor minted the one-time API key via `withOnetimeApiKey` with the author's role set. The inline comment at `activity-executor.ts:780-797` already describes the correct 3-step policy (initiator → author fallback → refuse), but only step 2 was implemented.

## Fix

- Widen `CallApiInstanceLike` so the resolver can read `instance.metadata.initiatedBy`.
- Factor role-for-user resolution into `resolveActiveRoleIdsForUser()` and call it with the initiator first.
- When an initiator is present but has no active scoped roles, return `[]` (callers treat that as "refuse"). Never fall back to the author in that case — doing so would escalate the initiator's privileges.
- Only when no initiator is recorded (event-triggered instance), fall back to the definition author.
- Add `deletedAt: null` to the `WorkflowDefinition` lookup.

## Test plan

- [x] `yarn jest --modulePathIgnorePatterns="/\\.ai/tmp/" --testPathPatterns="resolve-call-api-role-ids"` — 7/7 pass.
- [x] `yarn jest --modulePathIgnorePatterns="/\\.ai/tmp/" --testPathPatterns="activity-executor.test"` — existing 78/78 still pass.
- [x] `tsc --noEmit` on `packages/core` — clean.
- [ ] Manual: low-privileged user triggers a workflow authored by an admin that contains a `CALL_API` step hitting an admin-only endpoint. Expected: refused or returns only the initiator's permissions.
- [ ] Manual: event-triggered workflow run (no human initiator) still executes `CALL_API` using the definition author's roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)