### PR TITLE
docs(skills): reassign authors on review and fix handoffs

### DIFF
--- a/.ai/runs/2026-04-22-skill-author-handoff-reassignment.md
+++ b/.ai/runs/2026-04-22-skill-author-handoff-reassignment.md
@@ -39,10 +39,12 @@ Update the GitHub automation skills so PRs that receive `changes-requested` are 
 
 ### Phase 1: Review Handoff Rules
 
-- [x] 1.1 Update `auto-review-pr` handoff rules and comment templates
-- [x] 1.2 Update `auto-fix-github` handoff rules and comment templates
+- [x] 1.1 Update `auto-review-pr` handoff rules and comment templates — ca98c4969
+- [x] 1.2 Update `auto-fix-github` handoff rules and comment templates — ca98c4969
 
 ### Phase 2: Validation And Delivery
 
-- [x] 2.1 Re-read the updated skills for consistency
-- [ ] 2.2 Open a dedicated PR against `develop`
+- [x] 2.1 Re-read the updated skills for consistency — ca98c4969
+- [x] 2.2 Open a dedicated PR against `develop`
+
+Opened PR: `#1644` https://github.com/open-mercato/open-mercato/pull/1644

--- a/.ai/runs/2026-04-22-skill-author-handoff-reassignment.md
+++ b/.ai/runs/2026-04-22-skill-author-handoff-reassignment.md
@@ -1,0 +1,48 @@
+# Skill Author Handoff Reassignment
+
+## Goal
+
+Update the GitHub automation skills so PRs that receive `changes-requested` are handed back to the PR author, and issues that have just been fixed are handed back to the issue author, with explicit handoff comments.
+
+## Scope
+
+- Update `.ai/skills/auto-review-pr/SKILL.md`
+- Update `.ai/skills/auto-fix-github/SKILL.md`
+- Keep the change limited to skill instructions and comment templates
+
+## Non-goals
+
+- No product code changes
+- No workflow changes outside the affected auto-skills
+- No label policy changes beyond the new author-handoff behavior
+
+## Implementation Plan
+
+### Phase 1: Review Handoff Rules
+
+1. Update `auto-review-pr` so every `changes-requested` outcome reassigns the PR to the original author and posts a clear handoff comment for the next action.
+2. Update `auto-fix-github` so a fixed issue is reassigned to the issue author and gets a verification handoff comment after the fix PR is opened.
+
+### Phase 2: Validation And Delivery
+
+1. Re-read the updated skills for consistency with existing lock, label, and carry-forward rules.
+2. Open a dedicated PR against `develop` containing only the skill updates.
+
+## Risks
+
+- `auto-review-pr` already has carry-forward logic for fork PRs, so the new reassignment wording must not conflict with the replacement-PR flow.
+- `auto-fix-github` currently treats the current user as the long-term owner of the issue, so the new handoff must be explicit enough to avoid ambiguity about who verifies the fix next.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Review Handoff Rules
+
+- [ ] 1.1 Update `auto-review-pr` handoff rules and comment templates
+- [ ] 1.2 Update `auto-fix-github` handoff rules and comment templates
+
+### Phase 2: Validation And Delivery
+
+- [ ] 2.1 Re-read the updated skills for consistency
+- [ ] 2.2 Open a dedicated PR against `develop`

--- a/.ai/runs/2026-04-22-skill-author-handoff-reassignment.md
+++ b/.ai/runs/2026-04-22-skill-author-handoff-reassignment.md
@@ -39,10 +39,10 @@ Update the GitHub automation skills so PRs that receive `changes-requested` are 
 
 ### Phase 1: Review Handoff Rules
 
-- [ ] 1.1 Update `auto-review-pr` handoff rules and comment templates
-- [ ] 1.2 Update `auto-fix-github` handoff rules and comment templates
+- [x] 1.1 Update `auto-review-pr` handoff rules and comment templates
+- [x] 1.2 Update `auto-fix-github` handoff rules and comment templates
 
 ### Phase 2: Validation And Delivery
 
-- [ ] 2.1 Re-read the updated skills for consistency
+- [x] 2.1 Re-read the updated skills for consistency
 - [ ] 2.2 Open a dedicated PR against `develop`

--- a/.ai/skills/auto-fix-github/SKILL.md
+++ b/.ai/skills/auto-fix-github/SKILL.md
@@ -343,6 +343,28 @@ Suggested label comments:
 - `review`: `Label set to \`review\` because the fix PR is ready for code review.`
 - `skip-qa`: `Label set to \`skip-qa\` because this change is low-risk and does not need manual QA.`
 
+#### Author handoff on the fixed issue
+
+Once the fix PR exists, hand the issue back to the original issue author for verification, unless the author is the current fixer, a bot account, or otherwise unavailable.
+
+Suggested flow:
+
+```bash
+ISSUE_AUTHOR=$(gh issue view {issueId} --repo {owner}/{repo} --json author --jq '.author.login')
+
+if [ -n "$ISSUE_AUTHOR" ] && [ "$ISSUE_AUTHOR" != "$CURRENT_USER" ] && [ -n "${PR_URL:-}" ]; then
+  gh issue edit {issueId} --repo {owner}/{repo} --remove-assignee "$CURRENT_USER"
+  gh issue edit {issueId} --repo {owner}/{repo} --add-assignee "$ISSUE_AUTHOR"
+  gh issue comment {issueId} --repo {owner}/{repo} --body "Thanks @${ISSUE_AUTHOR} — a fix PR is ready for this issue: ${PR_URL}. Reassigning the issue to you for recheck/verification of the proposed fix."
+fi
+```
+
+Rules:
+
+- Do this only after a concrete fix PR exists, or when you are explicitly handing the issue back after confirming the fix landed elsewhere.
+- If the author cannot be assigned (bot/deleted account/permission issue), keep the current assignee and still leave the verification handoff comment.
+- Keep this handoff comment separate from the lock-release comment so the timeline clearly shows both the human handoff and the automation completion.
+
 #### Release the in-progress lock on the issue
 
 Always run this as a finally-block — even if the PR open failed or the run was aborted earlier:
@@ -354,7 +376,8 @@ gh issue comment {issueId} --repo {owner}/{repo} --body "🤖 \`auto-fix-github\
 
 Rules:
 
-- Keep the issue assignee as the current user — it shows who owns the resulting PR
+- Once a fix PR is opened, the issue assignee should already be handed back to the original issue author before the lock is released
+- If no fix PR exists or the author cannot be reassigned, keep the current assignee and explain the fallback in the handoff/completion comments
 - Remove the `in-progress` label so other auto-skills can act on the issue (e.g., a follow-up reviewer)
 - Post a completion comment that links the PR (or notes the abort) so the timeline stays auditable
 
@@ -389,5 +412,6 @@ If you stopped because a fix already exists, report the existing PR or commit in
 - New PRs opened by this skill must start in the `review` pipeline state
 - Add `skip-qa` only for clearly low-risk non-customer-facing fixes; otherwise leave QA routing to the author/reviewer
 - When this skill adds PR labels, it must also add a short PR comment explaining why
+- After opening the fix PR, always hand the issue back to the original author with an explicit reassignment/comment handoff when possible
 - Always clean up any temporary worktree created by the current run
 - Branches opened by this skill must use `fix/` for corrective work or `feat/` for enhancement work; never `codex/`

--- a/.ai/skills/auto-review-pr/SKILL.md
+++ b/.ai/skills/auto-review-pr/SKILL.md
@@ -365,6 +365,28 @@ Suggested label comments:
 - `blocked`: `Label set to \`blocked\` because progress depends on an external blocker.`
 - `do-not-merge`: `Label set to \`do-not-merge\` because this PR should not merge yet.`
 
+#### Author handoff on `changes-requested`
+
+When the verdict is `changes-requested`, reassign the PR back to the original PR author after the review and pipeline label are posted, unless the author is the current reviewer, a bot account, or otherwise unavailable.
+
+Suggested flow:
+
+```bash
+PR_AUTHOR=$(gh pr view {prNumber} --json author --jq '.author.login')
+
+if [ -n "$PR_AUTHOR" ] && [ "$PR_AUTHOR" != "$CURRENT_USER" ]; then
+  gh pr edit {prNumber} --remove-assignee "$CURRENT_USER"
+  gh pr edit {prNumber} --add-assignee "$PR_AUTHOR"
+  gh pr comment {prNumber} --body "Thanks @${PR_AUTHOR} — review found actionable items, so I’m handing this PR back to you for the next pass. When the updates are pushed, re-request review and the automation can pick it up from the latest head."
+fi
+```
+
+Rules:
+
+- Do this for every `changes-requested` outcome, including early exits for conflicts, failing required checks, or duplicate/already-merged work.
+- If the author cannot be assigned (bot/deleted account/permission issue), keep the current assignee and leave the same handoff comment without the reassignment claim.
+- The handoff comment is separate from the short pipeline-label comment; keep both.
+
 ### 9. Autonomous autofix flow
 
 After posting a `changes_requested` review, **immediately proceed to fix all actionable findings** without asking the user. The auto-review-pr skill must be fully autonomous — it reviews, fixes, re-reviews, and iterates until the PR is merge-ready or a truly critical blocker remains.
@@ -455,6 +477,7 @@ Replacement PR requirements:
 - Credit the original PR author explicitly
 - State that the new PR carries forward the original work plus the requested fixes
 - Mention that the branch was re-reviewed after autofix and is intended to be merge-ready
+- Reassign the replacement PR to the original PR author when possible, and leave a handoff comment inviting them to do the next recheck from the carried-forward branch
 
 Suggested replacement PR body:
 
@@ -466,6 +489,12 @@ Credit: original implementation by @{originalAuthor}. This follow-up PR carries 
 ## Included work
 - Original changes from #{prNumber}
 - Follow-up fixes applied during re-review
+```
+
+Suggested replacement PR handoff comment:
+
+```markdown
+Thanks @{originalAuthor} — this replacement PR carries your original work forward with the requested fixes applied. Reassigning it to you so you can do the next recheck from the merge-ready branch.
 ```
 
 Suggested original PR closing comment:
@@ -488,7 +517,8 @@ gh pr comment {prNumber} --body "🤖 \`auto-review-pr\` completed: ${VERDICT}. 
 
 Rules:
 
-- Keep the assignee — it shows the human who is responsible for next steps
+- For `changes-requested` outcomes, the assignee should already be handed back to the original PR author before the lock is released
+- For approved outcomes, keep the current assignee unless a later handoff explicitly changed it
 - Remove the `in-progress` label
 - Post a completion comment with the verdict (`APPROVED` or `CHANGES REQUESTED`) and a short summary
 - If autofix mode ran, mention how many fix iterations completed
@@ -532,6 +562,7 @@ If a critical blocker remains that requires human judgment, the summary must des
 - The review body must contain the full structured report
 - Always add the chosen pipeline label and remove every other pipeline label
 - Always add a short PR comment explaining why the chosen pipeline label was applied
+- Always hand `changes-requested` PRs back to the original author with an explicit reassignment/comment handoff when possible
 - Approved PRs with `needs-qa` and without `skip-qa` must land in `qa`, not `merge-queue`
 - Approved PRs without a QA requirement must land in `merge-queue`
 - When a review starts on an unlabeled PR, apply `review` before continuing


### PR DESCRIPTION
## Summary
- update `auto-review-pr` so `changes-requested` handoffs reassign the PR to the original author and leave a clear next-step comment
- update `auto-fix-github` so fixed issues are handed back to the original issue author for verification with an explicit comment
- keep the change scoped to skill documentation and execution guidance only

## Validation
- re-read the updated skill instructions for consistency with existing claim, lock-release, and carry-forward rules
- no code/tests run; docs-only skill update

Tracking plan: `.ai/runs/2026-04-22-skill-author-handoff-reassignment.md`
Status: complete
