### PR TITLE
fix(mercato): type and test AI assistant integration fallback (carry-forward #1656)

### DIFF
--- a/apps/mercato/src/__tests__/AiAssistantShellIntegration.failure.test.tsx
+++ b/apps/mercato/src/__tests__/AiAssistantShellIntegration.failure.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { AiAssistantShellIntegration } from '@/components/AiAssistantShellIntegration'
+
+const loadError = new Error('chunk load failed')
+
+jest.mock('@open-mercato/ai-assistant/frontend', () => {
+  throw loadError
+})
+
+describe('AiAssistantShellIntegration (import failure)', () => {
+  let errorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+  })
+
+  it('renders children via a pass-through fallback and logs the failure', async () => {
+    render(
+      <AiAssistantShellIntegration tenantId="tenant-1" organizationId="org-1">
+        <div>AI chat trigger</div>
+      </AiAssistantShellIntegration>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText('AI chat trigger')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByTestId('ai-assistant-provider')).not.toBeInTheDocument()
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to load AI assistant integration',
+      loadError,
+    )
+  })
+})

--- a/apps/mercato/src/components/AiAssistantShellIntegration.tsx
+++ b/apps/mercato/src/components/AiAssistantShellIntegration.tsx
@@ -23,10 +23,15 @@ export function AiAssistantShellIntegration({
 
   React.useEffect(() => {
     let cancelled = false
-    void import('@open-mercato/ai-assistant/frontend').then((module) => {
-      if (cancelled) return
-      setIntegrationComponent(() => module.AiAssistantIntegration)
-    })
+    void import('@open-mercato/ai-assistant/frontend')
+      .then((module) => {
+        if (cancelled) return
+        setIntegrationComponent(() => module.AiAssistantIntegration)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setIntegrationComponent(() => (props) => <>{props.children}</>)
+      })
     return () => {
       cancelled = true
     }

--- a/apps/mercato/src/components/AiAssistantShellIntegration.tsx
+++ b/apps/mercato/src/components/AiAssistantShellIntegration.tsx
@@ -14,6 +14,8 @@ type AiAssistantShellIntegrationProps = {
   children: React.ReactNode
 }
 
+const AiAssistantIntegrationFallback: AiAssistantIntegrationComponent = ({ children }) => <>{children}</>
+
 export function AiAssistantShellIntegration({
   tenantId,
   organizationId,
@@ -28,9 +30,10 @@ export function AiAssistantShellIntegration({
         if (cancelled) return
         setIntegrationComponent(() => module.AiAssistantIntegration)
       })
-      .catch(() => {
+      .catch((error) => {
         if (cancelled) return
-        setIntegrationComponent(() => (props) => <>{props.children}</>)
+        console.error('Failed to load AI assistant integration', error)
+        setIntegrationComponent(() => AiAssistantIntegrationFallback)
       })
     return () => {
       cancelled = true


### PR DESCRIPTION
Supersedes #1656

Credit: original implementation by @tomaioo. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original fork branch (the CLA is still unsigned there, and the fork branch breaks the `prepare` CI job).

## Included work
- Original change from #1656 — guard the dynamic `import('@open-mercato/ai-assistant/frontend')` call with a `.catch` handler so a failed chunk load doesn't surface as an unhandled promise rejection.
- Follow-up fixes applied during re-review:
  - Extract the pass-through fallback into a named `AiAssistantIntegrationFallback` typed against the shared `AiAssistantIntegrationComponent`. This resolves the `TS7006: Parameter 'props' implicitly has an 'any' type` error that was failing the `prepare` CI job on #1656.
  - Log the rejection reason via `console.error` so a real integration failure is observable in production instead of silently swallowed.
  - Add `apps/mercato/src/__tests__/AiAssistantShellIntegration.failure.test.tsx` covering the new failure path: when the dynamic import rejects, the component logs the error and renders children through the pass-through fallback.

## Verification

- `yarn jest src/__tests__/AiAssistantShellIntegration.test.tsx src/__tests__/AiAssistantShellIntegration.failure.test.tsx` — 2/2 test suites passing, 2/2 tests passing.
- `yarn tsc --noEmit -p tsconfig.json` — no `AiAssistantShellIntegration` errors (the remaining errors on this worktree are pre-existing missing-generated-file errors unrelated to this PR).

The branch was re-reviewed after autofix and is intended to be merge-ready.