### PR TITLE
docs(search): make vector auto-indexing opt-in by default

### DIFF
--- a/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
+++ b/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
@@ -1,0 +1,48 @@
+## Overview
+
+- Goal: Disable vector search auto-indexing by default in shipped env examples and document the explicit opt-in path for enabling it.
+- Affected modules/packages: `packages/search`, `packages/core`, `apps/mercato`, `packages/create-app/template`, `apps/docs`.
+- Smallest safe scope: add a preferred `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` environment flag with backward-compatible support for the legacy flag, update env examples to default auto-indexing off, and align all env-focused docs.
+- Non-goals: changing search strategy behavior, removing the legacy env flag, changing embedding provider support, or modifying search UI defaults.
+
+## Risks
+
+- Env-name drift: docs and runtime could diverge if the new alias is not wired everywhere that reads or reports the flag.
+- Backward compatibility: the legacy `DISABLE_VECTOR_SEARCH_AUTOINDEXING` flag must keep working for existing deployments.
+- Docs coverage: env-focused installation/customization pages must all describe the same opt-in steps or operators will get conflicting guidance.
+
+## Implementation Plan
+
+### Phase 1: Plan and BC-safe env support
+
+1. Add the run plan on the task branch.
+2. Introduce `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` as the preferred env name while preserving `DISABLE_VECTOR_SEARCH_AUTOINDEXING` as a supported legacy alias in runtime/config surfaces.
+
+### Phase 2: Default-off examples and docs
+
+1. Update shipped `.env.example` files so vector auto-indexing is disabled by default and the enable path is explicit.
+2. Update env-focused docs pages to explain that vector search remains available when an embedding provider is configured, but auto-indexing is opt-in via `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` or by removing the disable flag.
+
+### Phase 3: Validation and PR delivery
+
+1. Run docs-focused validation and re-read the diff for scope/BC issues.
+2. Commit progress updates, push the branch, open the PR, label it, and post the required summary.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Plan and BC-safe env support
+
+- [ ] 1.1 Add the run plan on the task branch
+- [ ] 1.2 Introduce `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` as the preferred env name while preserving `DISABLE_VECTOR_SEARCH_AUTOINDEXING` as a supported legacy alias in runtime/config surfaces
+
+### Phase 2: Default-off examples and docs
+
+- [ ] 2.1 Update shipped `.env.example` files so vector auto-indexing is disabled by default and the enable path is explicit
+- [ ] 2.2 Update env-focused docs pages to explain that vector search remains available when an embedding provider is configured, but auto-indexing is opt-in via `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` or by removing the disable flag
+
+### Phase 3: Validation and PR delivery
+
+- [ ] 3.1 Run docs-focused validation and re-read the diff for scope/BC issues
+- [ ] 3.2 Commit progress updates, push the branch, open the PR, label it, and post the required summary

--- a/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
+++ b/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
@@ -44,5 +44,5 @@
 
 ### Phase 3: Validation and PR delivery
 
-- [ ] 3.1 Run docs-focused validation and re-read the diff for scope/BC issues
+- [x] 3.1 Run docs-focused validation and re-read the diff for scope/BC issues — 6470d0b98
 - [ ] 3.2 Commit progress updates, push the branch, open the PR, label it, and post the required summary

--- a/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
+++ b/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
@@ -45,4 +45,4 @@
 ### Phase 3: Validation and PR delivery
 
 - [x] 3.1 Run docs-focused validation and re-read the diff for scope/BC issues — 6470d0b98
-- [ ] 3.2 Commit progress updates, push the branch, open the PR, label it, and post the required summary
+- [x] 3.2 Commit progress updates, push the branch, open the PR, label it, and post the required summary — abb800af1

--- a/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
+++ b/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
@@ -35,12 +35,12 @@
 ### Phase 1: Plan and BC-safe env support
 
 - [x] 1.1 Add the run plan on the task branch — 57e7fab22
-- [ ] 1.2 Introduce `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` as the preferred env name while preserving `DISABLE_VECTOR_SEARCH_AUTOINDEXING` as a supported legacy alias in runtime/config surfaces
+- [x] 1.2 Introduce `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` as the preferred env name while preserving `DISABLE_VECTOR_SEARCH_AUTOINDEXING` as a supported legacy alias in runtime/config surfaces — 6470d0b98
 
 ### Phase 2: Default-off examples and docs
 
-- [ ] 2.1 Update shipped `.env.example` files so vector auto-indexing is disabled by default and the enable path is explicit
-- [ ] 2.2 Update env-focused docs pages to explain that vector search remains available when an embedding provider is configured, but auto-indexing is opt-in via `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` or by removing the disable flag
+- [x] 2.1 Update shipped `.env.example` files so vector auto-indexing is disabled by default and the enable path is explicit — 6470d0b98
+- [x] 2.2 Update env-focused docs pages to explain that vector search remains available when an embedding provider is configured, but auto-indexing is opt-in via `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` or by removing the disable flag — 6470d0b98
 
 ### Phase 3: Validation and PR delivery
 

--- a/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
+++ b/.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
@@ -34,7 +34,7 @@
 
 ### Phase 1: Plan and BC-safe env support
 
-- [ ] 1.1 Add the run plan on the task branch
+- [x] 1.1 Add the run plan on the task branch — 57e7fab22
 - [ ] 1.2 Introduce `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` as the preferred env name while preserving `DISABLE_VECTOR_SEARCH_AUTOINDEXING` as a supported legacy alias in runtime/config surfaces
 
 ### Phase 2: Default-off examples and docs

--- a/apps/docs/docs/api/vector.mdx
+++ b/apps/docs/docs/api/vector.mdx
@@ -66,6 +66,8 @@ Each result includes a similarity `score` (higher is better), a primary URL, opt
 
 The `configuredProviders` array lists providers with valid API keys. Use this to populate provider dropdowns in custom UIs.
 
+If `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true`, the API reports auto-indexing as locked off and rejects attempts to re-enable it from the UI or API. The legacy alias `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` is still accepted for existing deployments.
+
 ### Settings payloads
 
 ```bash

--- a/apps/docs/docs/customization/standalone-app.mdx
+++ b/apps/docs/docs/customization/standalone-app.mdx
@@ -311,7 +311,8 @@ The `.env.example` file documents all available variables. Key sections:
 | `JWT_SECRET` | Yes | Secret for signing auth tokens. |
 | `REDIS_URL` | Yes | Redis connection for caching and events. |
 | `MEILISEARCH_HOST` | No | Meilisearch URL for full-text search. |
-| `OPENAI_API_KEY` | No | Required for vector search and AI features. |
+| `OPENAI_API_KEY` | No | Enables OpenAI-backed AI features; pair it with `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` when you want vector auto-indexing. |
+| `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` | No | Defaults to `true` in the example env. Set to `false` or remove it to enable automatic vector indexing. |
 | `CACHE_STRATEGY` | No | `memory`, `sqlite`, `redis`, or `jsonfile`. Defaults to `memory`. |
 | `QUEUE_STRATEGY` | No | `local` or `async`. Use `async` with Redis for production. |
 | `APP_URL` | No | Public URL, used in emails and onboarding. |

--- a/apps/docs/docs/framework/modules/configs.mdx
+++ b/apps/docs/docs/framework/modules/configs.mdx
@@ -46,10 +46,9 @@ Every call automatically resolves the request-scoped `EntityManager` and the con
 ## Default seeding & automation
 
 - `yarn mercato configs restore-defaults` seeds module defaults. The command runs automatically during `mercato init` after database migrations complete.
-- Environment flags can override values. Example: `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` forces the `vector.auto_index_enabled` toggle off and prevents the API/UI from re-enabling it.
+- Environment flags can override values. Example: `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true` forces the `vector.auto_index_enabled` toggle off and prevents the API/UI from re-enabling it. The legacy alias `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` still works for older deployments.
 - Additional defaults can be registered by other modules via `restoreDefaults` (e.g., inside their CLI bootstrap or migrations).
 
 ## Usage example: vector search auto-indexing
 
 The vector module reads `moduleConfigService.getValue('vector', 'auto_index_enabled', { defaultValue: true })` inside its subscribers before running expensive embedding work. A backend settings page at `/backend/vector-search` exposes the toggle through `/api/vector/settings`, so operators can pause real-time indexing without redeploying the app.
-

--- a/apps/docs/docs/installation/devcontainer.mdx
+++ b/apps/docs/docs/installation/devcontainer.mdx
@@ -95,7 +95,10 @@ Create `apps/mercato/.env.local` inside the container (or on the host before ope
 ```env
 OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
+OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false
 ```
+
+Use `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` only if you want automatic vector embedding jobs inside the container. The default example env keeps auto-indexing disabled until you opt in.
 
 ---
 

--- a/apps/docs/docs/installation/docker.mdx
+++ b/apps/docs/docs/installation/docker.mdx
@@ -143,8 +143,11 @@ All variables are pre-configured with sensible defaults in the compose file. Ove
 | `OM_DEV_AUTO_OPEN` | `1` | Set to `0` to disable browser auto-open |
 | `POSTGRES_PASSWORD` | `postgres` | Database password |
 | `JWT_SECRET` | `JWT` | Auth token secret — change for production |
-| `OPENAI_API_KEY` | — | Required for vector search and AI features |
+| `OPENAI_API_KEY` | — | Enables OpenAI-backed AI features; combine it with `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` to turn vector auto-indexing on |
+| `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` | `true` in the shipped example env | Set to `false` or remove it to enable automatic vector indexing |
 | `DEMO_MODE` | `true` | Seeds demo CRM data on first run |
+
+Vector auto-indexing is disabled by default in `apps/mercato/.env.example`. To enable it, configure an embedding provider such as `OPENAI_API_KEY` and set `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` before you start the stack. The legacy alias `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` is still honored for older deployments.
 
 ---
 

--- a/apps/docs/docs/installation/prerequisites.mdx
+++ b/apps/docs/docs/installation/prerequisites.mdx
@@ -71,7 +71,7 @@ The pgvector extension is automatically installed in all databases, enabling vec
 
 ### Embedding Provider API Keys (optional)
 
-Vector search requires at least one embedding provider. Configure the API key(s) for your preferred provider(s):
+Vector search requires at least one embedding provider. The shipped example env keeps vector auto-indexing off by default; enable it with `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` after you choose a provider. Configure the API key(s) for your preferred provider(s):
 
 ```bash
 # OpenAI (default provider)
@@ -89,7 +89,7 @@ AWS_REGION=us-east-1
 OLLAMA_BASE_URL=http://localhost:11434  # Optional, defaults to localhost
 ```
 
-You can configure multiple providers and switch between them in **Backend -> Configuration -> Vector Search**. See the [Vector Search API reference](/api/vector) for details.
+You can configure multiple providers and switch between them in **Backend -> Configuration -> Vector Search**. After adding a provider key, enable automatic vector indexing with `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` if you want real-time embeddings, or leave the default disable flag in place and run manual reindex jobs instead. See the [Vector Search API reference](/api/vector) for details.
 
 Need a refresher on what each environment toggle controls? Review the [System status variables](../framework/operations/system-status#managing-variables) directory for descriptions and defaults before you customize additional flags.
 

--- a/apps/docs/docs/installation/railway.mdx
+++ b/apps/docs/docs/installation/railway.mdx
@@ -43,10 +43,11 @@ After clicking the deploy button, Railway will prompt you to fill in the require
 
 | Variable | Description |
 |----------|-------------|
-| `OPENAI_API_KEY` | Enables AI features (OCR, vector search, AI assistant). |
+| `OPENAI_API_KEY` | Enables OpenAI-backed AI features (OCR, AI assistant, and vector search when auto-indexing is enabled). |
 | `RESEND_API_KEY` | Transactional emails (invitations, password resets). |
 | `RESEND_FROM_EMAIL` | Sender address, e.g. `no-reply@yourdomain.com`. |
 | `DEMO_MODE` | Set to `false` to skip seeding demo CRM data on first boot. Defaults to `true`. |
+| `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` | Keep `true` to leave vector auto-indexing off; set to `false` when you want automatic embedding jobs. |
 
 :::info Railway auto-wires services
 Railway automatically injects `DATABASE_URL`, `REDIS_URL`, and `MEILISEARCH_HOST` / `MEILISEARCH_API_KEY` from the provisioned services. You do not need to set these manually.

--- a/apps/docs/docs/installation/setup.mdx
+++ b/apps/docs/docs/installation/setup.mdx
@@ -471,7 +471,8 @@ Key variables you may want to override:
 | `POSTGRES_USER` | `postgres` | Database username |
 | `POSTGRES_PASSWORD` | `postgres` | Database password |
 | `JWT_SECRET` | `JWT` | Auth token secret |
-| `OPENAI_API_KEY` | — | Required for vector search and AI features |
+| `OPENAI_API_KEY` | — | Enables OpenAI-backed AI features; add it with `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` only when you want vector auto-indexing on |
+| `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` | `true` in the shipped example env | Set to `false` or remove it to enable automatic vector indexing |
 | `DEMO_MODE` | `true` | Seeds demo CRM data on first run |
 
 If you need a different splash port in Docker, set it before startup so the host/container mapping stays aligned:
@@ -568,7 +569,13 @@ MEILISEARCH_MASTER_KEY=meilisearch-dev-key
 
 # AI Features (optional)
 OPENAI_API_KEY=sk-your-openai-key
+
+# Vector search auto-indexing is off by default in the shipped example env.
+# Enable it only when you want real-time embedding jobs:
+OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false
 ```
+
+If you keep `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true` (the default in `apps/mercato/.env.example`), semantic search can still be configured and reindexed manually, but record changes will not enqueue embeddings automatically. The legacy alias `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` still works, but prefer the `OM_` name for new setups.
 
 **Note:** The container hostnames (`postgres`, `redis`, `meilisearch`) match the service names in `docker-compose.fullapp.yml`.
 

--- a/apps/docs/docs/installation/vps.mdx
+++ b/apps/docs/docs/installation/vps.mdx
@@ -74,7 +74,13 @@ MEILISEARCH_MASTER_KEY=your-strong-meilisearch-key
 
 # AI features (optional)
 OPENAI_API_KEY=sk-...
+
+# Vector search auto-indexing is disabled by default in the shipped example env.
+# Enable it explicitly when you want automatic embedding jobs.
+OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false
 ```
+
+If you leave `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true`, vector search can still be configured and reindexed manually. The legacy alias `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` remains supported for existing deployments.
 
 Generate strong secrets:
 

--- a/apps/docs/docs/user-guide/search.mdx
+++ b/apps/docs/docs/user-guide/search.mdx
@@ -53,7 +53,7 @@ docker run -d --name meilisearch \
 
 ### Vector Search (Optional)
 
-Vector search enables semantic understanding of queries. Configure at least one embedding provider:
+Vector search enables semantic understanding of queries. The shipped example env keeps vector auto-indexing disabled by default, so configure at least one embedding provider and then opt in to automatic indexing if you want live embedding updates:
 
 | Provider | Environment Variable |
 |----------|---------------------|
@@ -64,7 +64,7 @@ Vector search enables semantic understanding of queries. Configure at least one 
 | Amazon Bedrock | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
 | Ollama (local) | `OLLAMA_BASE_URL=http://localhost:11434` |
 
-Without a configured provider, semantic search is disabled but other strategies continue working.
+Without a configured provider, semantic search is disabled but other strategies continue working. With a provider configured and `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true`, you can still run manual vector reindex jobs; automatic indexing just stays off.
 
 ### Token Search (Built-in)
 
@@ -87,8 +87,10 @@ Navigate to **Settings > Module Configuration > Search Settings** to manage:
 |----------|--------|
 | `MEILISEARCH_HOST` | Enables Meilisearch (Fuzzy) strategy |
 | `MEILISEARCH_API_KEY` | Authentication key for Meilisearch |
-| `OPENAI_API_KEY` (or other provider key) | Enables Vector (Semantic) strategy |
-| `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` | Disables automatic vector indexing |
+| `OPENAI_API_KEY` (or other provider key) | Configures a vector embedding provider |
+| `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true` | Keeps automatic vector indexing disabled (default in shipped example envs) |
+| `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false` | Enables automatic vector indexing |
+| `DISABLE_VECTOR_SEARCH_AUTOINDEXING=1` | Legacy alias for keeping automatic vector indexing disabled |
 
 ## What Gets Indexed
 

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -238,6 +238,11 @@ TENANT_DATA_ENCRYPTION_KEY=
 # Embedding Provider Configuration (for vector search)
 # ============================================================================
 # Vector search requires ONE embedding provider to be configured.
+# Automatic vector indexing ships disabled by default in this example env.
+# Enable it by setting OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false or removing this line,
+# then trigger a vector reindex from Settings > Search or the CLI.
+OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true
+# Legacy alias still supported: DISABLE_VECTOR_SEARCH_AUTOINDEXING=1
 # OpenAI is the default provider if no explicit configuration is set.
 
 # OpenAI (default embedding provider)

--- a/apps/mercato/src/i18n/de.json
+++ b/apps/mercato/src/i18n/de.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "Version {{version}} wurde installiert. Analytics-Widgets für Admin- und Mitarbeiter-Rollen aktivieren.",
   "upgrades.v042.success": "Analytics-Widgets für Admin- und Mitarbeiter-Rollen aktiviert.",
   "upgrades.versionLabel": "Version {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "Auto-Indexierung ist über DISABLE_VECTOR_SEARCH_AUTOINDEXING deaktiviert.",
+  "vector.api.errors.autoIndexingDisabled": "Die Auto-Indizierung ist über OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING deaktiviert (Legacy-Alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Konfigurationsdienst nicht verfügbar",
   "vector.api.errors.indexFetchFailed": "Vektor-Index-Abruf fehlgeschlagen",
   "vector.api.errors.indexUnavailable": "Vektor-Index nicht verfügbar",

--- a/apps/mercato/src/i18n/en.json
+++ b/apps/mercato/src/i18n/en.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "Version {{version}} has been installed. Enable analytics widgets for admin and employee roles.",
   "upgrades.v042.success": "Analytics widgets enabled for admin and employee roles.",
   "upgrades.versionLabel": "Version {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "Auto-indexing is disabled via DISABLE_VECTOR_SEARCH_AUTOINDEXING.",
+  "vector.api.errors.autoIndexingDisabled": "Auto-indexing is disabled via OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (legacy alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Configuration service unavailable",
   "vector.api.errors.indexFetchFailed": "Vector index fetch failed",
   "vector.api.errors.indexUnavailable": "Vector index unavailable",

--- a/apps/mercato/src/i18n/es.json
+++ b/apps/mercato/src/i18n/es.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "La versión {{version}} se ha instalado. Habilita los widgets de analíticas para los roles admin y empleado.",
   "upgrades.v042.success": "Widgets de analíticas habilitados para admin y empleado.",
   "upgrades.versionLabel": "Versión {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "La indexación automática está deshabilitada mediante DISABLE_VECTOR_SEARCH_AUTOINDEXING.",
+  "vector.api.errors.autoIndexingDisabled": "La indexación automática está deshabilitada mediante OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (alias heredado: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Servicio de configuración no disponible",
   "vector.api.errors.indexFetchFailed": "Error al obtener el índice vectorial",
   "vector.api.errors.indexUnavailable": "Índice vectorial no disponible",

--- a/apps/mercato/src/i18n/pl.json
+++ b/apps/mercato/src/i18n/pl.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "Wersja {{version}} została zainstalowana. Włącz widżety analityczne dla ról admin i pracownik.",
   "upgrades.v042.success": "Widżety analityczne włączone dla ról admin i pracownik.",
   "upgrades.versionLabel": "Wersja {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "Automatyczne indeksowanie jest wyłączone przez DISABLE_VECTOR_SEARCH_AUTOINDEXING.",
+  "vector.api.errors.autoIndexingDisabled": "Automatyczne indeksowanie jest wyłączone przez OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (stary alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Usługa konfiguracji niedostępna",
   "vector.api.errors.indexFetchFailed": "Pobieranie indeksu wektorowego nie powiodło się",
   "vector.api.errors.indexUnavailable": "Indeks wektorowy niedostępny",

--- a/packages/core/src/modules/configs/cli.ts
+++ b/packages/core/src/modules/configs/cli.ts
@@ -259,7 +259,9 @@ async function runStructuralCachePurge(args: ParsedArgs) {
 }
 
 function envDisablesAutoIndexing(): boolean {
-  const raw = process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING
+  const raw =
+    process.env.OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING ??
+    process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING
   if (!raw) return false
   return parseBooleanToken(raw) === true
 }
@@ -296,7 +298,9 @@ const restoreDefaults: ModuleCli = {
       )
       console.log(
         `[configs] Vector auto-indexing default set to ${defaultEnabled ? 'enabled' : 'disabled'}${
-          disabledByEnv ? ' (forced by DISABLE_VECTOR_SEARCH_AUTOINDEXING)' : ''
+          disabledByEnv
+            ? ' (forced by OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING or legacy DISABLE_VECTOR_SEARCH_AUTOINDEXING)'
+            : ''
         }.`,
       )
     } finally {

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -217,6 +217,11 @@ TENANT_DATA_ENCRYPTION_KEY=
 # Embedding Provider Configuration (for vector search)
 # ============================================================================
 # Vector search requires ONE embedding provider to be configured.
+# Automatic vector indexing ships disabled by default in this example env.
+# Enable it by setting OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=false or removing this line,
+# then trigger a vector reindex from Settings > Search or the CLI.
+OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING=true
+# Legacy alias still supported: DISABLE_VECTOR_SEARCH_AUTOINDEXING=1
 # OpenAI is the default provider if no explicit configuration is set.
 
 # OpenAI (default embedding provider)

--- a/packages/create-app/template/src/i18n/de.json
+++ b/packages/create-app/template/src/i18n/de.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "Version {{version}} wurde installiert. Analytics-Widgets für Admin- und Mitarbeiter-Rollen aktivieren.",
   "upgrades.v042.success": "Analytics-Widgets für Admin- und Mitarbeiter-Rollen aktiviert.",
   "upgrades.versionLabel": "Version {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "Auto-Indexierung ist über DISABLE_VECTOR_SEARCH_AUTOINDEXING deaktiviert.",
+  "vector.api.errors.autoIndexingDisabled": "Die Auto-Indizierung ist über OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING deaktiviert (Legacy-Alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Konfigurationsdienst nicht verfügbar",
   "vector.api.errors.indexFetchFailed": "Vektor-Index-Abruf fehlgeschlagen",
   "vector.api.errors.indexUnavailable": "Vektor-Index nicht verfügbar",

--- a/packages/create-app/template/src/i18n/en.json
+++ b/packages/create-app/template/src/i18n/en.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "Version {{version}} has been installed. Enable analytics widgets for admin and employee roles.",
   "upgrades.v042.success": "Analytics widgets enabled for admin and employee roles.",
   "upgrades.versionLabel": "Version {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "Auto-indexing is disabled via DISABLE_VECTOR_SEARCH_AUTOINDEXING.",
+  "vector.api.errors.autoIndexingDisabled": "Auto-indexing is disabled via OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (legacy alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Configuration service unavailable",
   "vector.api.errors.indexFetchFailed": "Vector index fetch failed",
   "vector.api.errors.indexUnavailable": "Vector index unavailable",

--- a/packages/create-app/template/src/i18n/es.json
+++ b/packages/create-app/template/src/i18n/es.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "La versión {{version}} se ha instalado. Habilita los widgets de analíticas para los roles admin y empleado.",
   "upgrades.v042.success": "Widgets de analíticas habilitados para admin y empleado.",
   "upgrades.versionLabel": "Versión {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "La indexación automática está deshabilitada mediante DISABLE_VECTOR_SEARCH_AUTOINDEXING.",
+  "vector.api.errors.autoIndexingDisabled": "La indexación automática está deshabilitada mediante OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (alias heredado: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Servicio de configuración no disponible",
   "vector.api.errors.indexFetchFailed": "Error al obtener el índice vectorial",
   "vector.api.errors.indexUnavailable": "Índice vectorial no disponible",

--- a/packages/create-app/template/src/i18n/pl.json
+++ b/packages/create-app/template/src/i18n/pl.json
@@ -912,7 +912,7 @@
   "upgrades.v042.message": "Wersja {{version}} została zainstalowana. Włącz widżety analityczne dla ról admin i pracownik.",
   "upgrades.v042.success": "Widżety analityczne włączone dla ról admin i pracownik.",
   "upgrades.versionLabel": "Wersja {{version}}",
-  "vector.api.errors.autoIndexingDisabled": "Automatyczne indeksowanie jest wyłączone przez DISABLE_VECTOR_SEARCH_AUTOINDEXING.",
+  "vector.api.errors.autoIndexingDisabled": "Automatyczne indeksowanie jest wyłączone przez OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (stary alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "vector.api.errors.configUnavailable": "Usługa konfiguracji niedostępna",
   "vector.api.errors.indexFetchFailed": "Pobieranie indeksu wektorowego nie powiodło się",
   "vector.api.errors.indexUnavailable": "Indeks wektorowy niedostępny",

--- a/packages/search/src/modules/search/api/embeddings/route.ts
+++ b/packages/search/src/modules/search/api/embeddings/route.ts
@@ -177,7 +177,12 @@ export async function POST(req: Request) {
     if (parsed.data.autoIndexingEnabled !== undefined) {
       if (envDisablesAutoIndexing()) {
         return NextResponse.json(
-          { error: t('search.api.errors.autoIndexingDisabled', 'Auto-indexing is disabled via DISABLE_VECTOR_SEARCH_AUTOINDEXING.') },
+          {
+            error: t(
+              'search.api.errors.autoIndexingDisabled',
+              'Auto-indexing is disabled via OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (legacy alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).',
+            ),
+          },
           { status: 409 },
         )
       }

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -1,5 +1,5 @@
 {
-  "search.api.errors.autoIndexingDisabled": "Automatische Indizierung ist deaktiviert.",
+  "search.api.errors.autoIndexingDisabled": "Die Auto-Indizierung ist über OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING deaktiviert (Legacy-Alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "search.api.errors.configUnavailable": "Konfigurationsdienst nicht verfügbar.",
   "search.api.errors.confirmAllRequired": "Bestätigung ist für alle Einträge erforderlich.",
   "search.api.errors.indexFetchFailed": "Indexdaten konnten nicht abgerufen werden.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "search.api.errors.autoIndexingDisabled": "Auto-indexing is disabled.",
+  "search.api.errors.autoIndexingDisabled": "Auto-indexing is disabled via OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (legacy alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "search.api.errors.configUnavailable": "Configuration service unavailable.",
   "search.api.errors.confirmAllRequired": "Confirmation is required for all items.",
   "search.api.errors.indexFetchFailed": "Failed to fetch index data.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -1,5 +1,5 @@
 {
-  "search.api.errors.autoIndexingDisabled": "La indexación automática está deshabilitada.",
+  "search.api.errors.autoIndexingDisabled": "La indexación automática está deshabilitada mediante OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (alias heredado: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "search.api.errors.configUnavailable": "Servicio de configuración no disponible.",
   "search.api.errors.confirmAllRequired": "Se requiere confirmación para todos los elementos.",
   "search.api.errors.indexFetchFailed": "Error al obtener los datos del índice.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -1,5 +1,5 @@
 {
-  "search.api.errors.autoIndexingDisabled": "Automatyczne indeksowanie jest wyłączone.",
+  "search.api.errors.autoIndexingDisabled": "Automatyczne indeksowanie jest wyłączone przez OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING (stary alias: DISABLE_VECTOR_SEARCH_AUTOINDEXING).",
   "search.api.errors.configUnavailable": "Usługa konfiguracji jest niedostępna.",
   "search.api.errors.confirmAllRequired": "Wymagane jest potwierdzenie dla wszystkich elementów.",
   "search.api.errors.indexFetchFailed": "Nie udało się pobrać danych indeksu.",

--- a/packages/search/src/modules/search/lib/__tests__/auto-indexing.test.ts
+++ b/packages/search/src/modules/search/lib/__tests__/auto-indexing.test.ts
@@ -1,0 +1,44 @@
+import { envDisablesAutoIndexing, resolveAutoIndexingEnabled } from '../auto-indexing'
+
+describe('search auto-indexing env overrides', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env.OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING
+    delete process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('uses the OM_ env name to disable auto-indexing', () => {
+    process.env.OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING = 'true'
+
+    expect(envDisablesAutoIndexing()).toBe(true)
+  })
+
+  it('keeps the legacy env alias working', () => {
+    process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING = '1'
+
+    expect(envDisablesAutoIndexing()).toBe(true)
+  })
+
+  it('prefers the OM_ env name when both aliases are set', () => {
+    process.env.OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING = 'false'
+    process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING = '1'
+
+    expect(envDisablesAutoIndexing()).toBe(false)
+  })
+
+  it('forces auto-indexing off before module config is consulted', async () => {
+    process.env.OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING = 'true'
+    const resolve = jest.fn().mockReturnValue({
+      getValue: jest.fn().mockResolvedValue(true),
+    })
+
+    await expect(resolveAutoIndexingEnabled({ resolve })).resolves.toBe(false)
+    expect(resolve).not.toHaveBeenCalled()
+  })
+})

--- a/packages/search/src/modules/search/lib/auto-indexing.ts
+++ b/packages/search/src/modules/search/lib/auto-indexing.ts
@@ -4,7 +4,9 @@ import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 export const SEARCH_AUTO_INDEX_CONFIG_KEY = 'auto_index_enabled'
 
 export function envDisablesAutoIndexing(): boolean {
-  const raw = process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING
+  const raw =
+    process.env.OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING ??
+    process.env.DISABLE_VECTOR_SEARCH_AUTOINDEXING
   if (!raw) return false
   return parseBooleanToken(raw) === true
 }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md
Status: complete

## Goal
- Disable vector search auto-indexing by default in shipped env examples and document the explicit opt-in path.

## What Changed
- Added `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` as the preferred env flag while preserving the legacy alias.
- Disabled vector auto-indexing by default in shipped `.env.example` files for the app and standalone template.
- Updated env-focused docs and vector-search messaging to explain how to enable automatic indexing explicitly.
- Added a focused unit test covering the new env alias and precedence behavior.

## Tests
- `yarn jest packages/search/src/modules/search/lib/__tests__/auto-indexing.test.ts --runInBand`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

## Backward Compatibility
- No contract surface changes. `DISABLE_VECTOR_SEARCH_AUTOINDEXING` remains supported as a legacy alias while `OM_DISABLE_VECTOR_SEARCH_AUTOINDEXING` becomes the preferred env name for new setups.

## Progress
See [Progress section in the plan](.ai/runs/2026-04-23-disable-vector-search-indexing-by-default.md#progress).
