### PR TITLE
fix(ci): extend QA Dokploy slots and adapt Docker provider API

### DIFF
--- a/.ai/specs/enterprise/implemented/SPEC-ENT-006-2026-03-01-qa-preview-deployment-dokploy.md
+++ b/.ai/specs/enterprise/implemented/SPEC-ENT-006-2026-03-01-qa-preview-deployment-dokploy.md
@@ -4,9 +4,9 @@
 
 **Key Points:**
 - Two GitHub Actions workflows manage the full QA slot lifecycle: `qa-deploy.yml` (manual deploy) and `qa-stop-on-merge.yml` (automatic stop on PR close).
-- `qa-deploy.yml` builds the preview Docker image, pushes it to GHCR, updates the Dokploy slot via REST API, and optionally labels the PR (`qa:qa1` / `qa:qa2`) and posts a machine-readable marker comment used later for safe slot cleanup.
+- `qa-deploy.yml` builds the preview Docker image, pushes it to GHCR, updates the Dokploy slot via REST API, and optionally labels the PR (`qa:qa1` / `qa:qa2` / `qa:qa3` / `qa:qa4`) and posts a machine-readable marker comment used later for safe slot cleanup.
 - `qa-stop-on-merge.yml` triggers automatically when a labelled PR is closed (merged or abandoned), reads the marker comment to identify the expected image, verifies the slot still runs that image (safety check against concurrent redeployment), and stops the Dokploy application.
-- Each QA slot (`qa1`, `qa2`) maps to a pre-configured long-lived Dokploy application running as a Docker-provider app.
+- Each QA slot (`qa1`, `qa2`, `qa3`, `qa4`) maps to a pre-configured long-lived Dokploy application running as a Docker-provider app.
 
 **Scope:**
 - `.github/workflows/qa-deploy.yml` — manual build-and-deploy workflow
@@ -31,9 +31,9 @@
 
 Open Mercato has no automated QA preview environment. Developers must run the full stack locally or share a single staging server. This spec introduces named QA slot deployments spanning two workflows:
 
-1. **Deploy** (`qa-deploy.yml`): A developer manually triggers the workflow, selects a slot (`qa1`/`qa2`), specifies the branch to build, and optionally associates a PR number. The workflow builds the preview image, pushes it to GHCR, updates the Dokploy application's Docker image via REST API, triggers a redeploy, and — if a PR number was supplied — labels the PR and posts a marker comment encoding the deployed slot and image tag.
+1. **Deploy** (`qa-deploy.yml`): A developer manually triggers the workflow, selects a slot (`qa1`/`qa2`/`qa3`/`qa4`), specifies the branch to build, and optionally associates a PR number. The workflow builds the preview image, pushes it to GHCR, updates the Dokploy application's Docker image via REST API, triggers a redeploy, and — if a PR number was supplied — labels the PR and posts a marker comment encoding the deployed slot and image tag.
 
-2. **Stop on close** (`qa-stop-on-merge.yml`): When a PR that carries a `qa:qa1` or `qa:qa2` label is closed (merged or abandoned), this workflow automatically detects the slot, reads the most recent marker comment to identify the expected image, fetches the current Dokploy application config to verify the image has not since been replaced by another deployment, and stops the slot only if the image matches.
+2. **Stop on close** (`qa-stop-on-merge.yml`): When a PR that carries a `qa:qa1`, `qa:qa2`, `qa:qa3`, or `qa:qa4` label is closed (merged or abandoned), this workflow automatically detects the slot, reads the most recent marker comment to identify the expected image, fetches the current Dokploy application config to verify the image has not since been replaced by another deployment, and stops the slot only if the image matches.
 
 The environment uses an ephemeral PostgreSQL container (docker.sock) and resets on every deployment.
 
@@ -56,7 +56,7 @@ Triggered manually via `workflow_dispatch` with inputs:
 
 | Input | Required | Description |
 |-------|----------|-------------|
-| `slot` | Yes | QA slot to deploy to (`qa1` or `qa2`) |
+| `slot` | Yes | QA slot to deploy to (`qa1`, `qa2`, `qa3`, or `qa4`) |
 | `branch` | Yes | Branch to checkout and build |
 | `pr_number` | No | PR number to label and comment on; omit for slot-only deploys |
 
@@ -64,8 +64,8 @@ Steps:
 1. Checkout the specified branch.
 2. Build `docker/preview/Dockerfile` via `docker/build-push-action` with GHA cache (`type=gha`).
 3. Push image to GHCR as `ghcr.io/<org>/<repo>:<slot>-<sha7>`.
-4. Resolve Dokploy `applicationId` from repository variables (`DOKPLOY_APP_ID_QA1` / `DOKPLOY_APP_ID_QA2`).
-5. Call `POST /api/application.saveDockerProvider` to update the slot's Docker image reference.
+4. Resolve Dokploy `applicationId` from repository variables (`DOKPLOY_APP_ID_QA1` / `DOKPLOY_APP_ID_QA2` / `DOKPLOY_APP_ID_QA3` / `DOKPLOY_APP_ID_QA4`).
+5. Call `POST /api/application.saveDockerProvider` to update the slot's Docker image reference and GHCR pull credentials.
 6. Call `POST /api/application.deploy` to trigger a redeploy.
 7. *(If `pr_number` provided)* Add label `qa:<slot>` to the PR.
 8. *(If `pr_number` provided)* Post a PR comment containing a machine-readable HTML marker: `<!-- dokploy-qa slot=<slot> image=<image_full> -->`, followed by a human-readable deployment summary.
@@ -75,7 +75,7 @@ Steps:
 Triggered automatically on `pull_request` closed events (both merged and abandoned; gate: `action == 'closed'`).
 
 Steps:
-1. List labels on the merged PR; detect `qa:qa1` or `qa:qa2`.
+1. List labels on the merged PR; detect `qa:qa1`, `qa:qa2`, `qa:qa3`, or `qa:qa4`.
 2. Skip silently if no QA label is present.
 3. Resolve Dokploy `applicationId` from repository variables.
 4. Paginate PR comments in reverse order; find the most recent comment containing `<!-- dokploy-qa slot=<slot> image=<image> -->` and extract the expected image tag.
@@ -94,7 +94,7 @@ Steps:
 | Image comparison safety check in stop workflow | A slot may have been redeployed for a different PR since this one last deployed. Comparing the live Dokploy image prevents stopping a slot that another team member is actively using. |
 | `action == 'closed'` gate in stop workflow | Fires on any PR close — merged or abandoned. Ensures slots are reclaimed regardless of how the PR was resolved. |
 | Pre-build image in CI, push to GHCR, then tell Dokploy | Decouples build from deployment. CI has build cache (`type=gha`); Dokploy does not need GitHub App access. Cleaner separation of concerns. |
-| Named slots (`qa1`, `qa2`) instead of per-PR ephemeral URLs | Predictable URLs, predictable resource usage, easier to share with stakeholders. |
+| Named slots (`qa1`, `qa2`, `qa3`, `qa4`) instead of per-PR ephemeral URLs | Predictable URLs, predictable resource usage, easier to share with stakeholders. |
 | `cancel-in-progress: false` concurrency per slot | Queues concurrent deploys to the same slot rather than cancelling in-flight builds; prevents partial deployments. |
 | Standalone `docker/preview/Dockerfile` | Keeps preview tooling (docker-cli, jest config) isolated from the main production `Dockerfile`. |
 
@@ -143,7 +143,7 @@ Developer triggers workflow_dispatch
     ├── Resolve DOKPLOY_APP_ID_QA1 → applicationId
     │
     ├── POST /api/application.saveDockerProvider
-    │       { applicationId, dockerImage: "ghcr.io/...:<tag>" }
+    │       { applicationId, dockerImage: "ghcr.io/...:<tag>", registryUrl: "ghcr.io", username, password }
     │
     ├── POST /api/application.deploy
     │       { applicationId }
@@ -208,6 +208,8 @@ PR #123 closed (carries label "qa:qa1") — merged or abandoned
 |------|----------------|-------|
 | `qa1` | `vars.DOKPLOY_APP_ID_QA1` | `qa:qa1` |
 | `qa2` | `vars.DOKPLOY_APP_ID_QA2` | `qa:qa2` |
+| `qa3` | `vars.DOKPLOY_APP_ID_QA3` | `qa:qa3` |
+| `qa4` | `vars.DOKPLOY_APP_ID_QA4` | `qa:qa4` |
 
 ---
 
@@ -223,7 +225,13 @@ No new database entities. Deployment state is encoded in PR comments (marker for
 
 **`POST /api/application.saveDockerProvider`** — update slot image
 ```json
-{ "applicationId": "<string>", "dockerImage": "ghcr.io/<org>/<repo>:<tag>" }
+{
+  "applicationId": "<string>",
+  "dockerImage": "ghcr.io/<org>/<repo>:<tag>",
+  "registryUrl": "ghcr.io",
+  "username": "<ghcr-username>",
+  "password": "<ghcr-token>"
+}
 ```
 
 **`POST /api/application.deploy`** — trigger redeploy
@@ -263,6 +271,8 @@ The stop workflow scans comments in reverse chronological order and uses the **m
 |--------|-------------|
 | `DOKPLOY_URL` | Base URL of the Dokploy server (e.g. `https://dokploy.example.com`) |
 | `DOKPLOY_API_KEY` | Dokploy API key with deploy + stop permissions |
+| `GHCR_USERNAME` | GitHub username Dokploy uses when authenticating to GHCR |
+| `GHCR_TOKEN` | GHCR token Dokploy uses to pull the private QA image (`read:packages` required) |
 
 ### GitHub Repository Variables
 
@@ -270,6 +280,8 @@ The stop workflow scans comments in reverse chronological order and uses the **m
 |----------|-------------|
 | `DOKPLOY_APP_ID_QA1` | Dokploy `applicationId` for the `qa1` slot |
 | `DOKPLOY_APP_ID_QA2` | Dokploy `applicationId` for the `qa2` slot |
+| `DOKPLOY_APP_ID_QA3` | Dokploy `applicationId` for the `qa3` slot |
+| `DOKPLOY_APP_ID_QA4` | Dokploy `applicationId` for the `qa4` slot |
 
 ### GitHub Actions Permissions
 
@@ -370,11 +382,11 @@ permissions:
 
 2. **Create `.github/workflows/qa-stop-on-merge.yml`** with:
    - Trigger: `pull_request` `closed`, gate: `action == 'closed'` (fires on merge and abandon)
-   - Steps: detect `qa:qa1`/`qa:qa2` label → resolve app ID → find marker comment → fetch current Dokploy image → compare → stop if match
+   - Steps: detect `qa:qa1`/`qa:qa2`/`qa:qa3`/`qa:qa4` label → resolve app ID → find marker comment → fetch current Dokploy image → compare → stop if match
 
-3. **Add required secrets** to the GitHub repository: `DOKPLOY_URL`, `DOKPLOY_API_KEY`.
+3. **Add required secrets** to the GitHub repository: `DOKPLOY_URL`, `DOKPLOY_API_KEY`, `GHCR_USERNAME`, `GHCR_TOKEN`.
 
-4. **Add required variables** to the GitHub repository: `DOKPLOY_APP_ID_QA1`, `DOKPLOY_APP_ID_QA2`.
+4. **Add required variables** to the GitHub repository: `DOKPLOY_APP_ID_QA1`, `DOKPLOY_APP_ID_QA2`, `DOKPLOY_APP_ID_QA3`, `DOKPLOY_APP_ID_QA4`.
 
 #### File Manifest
 
@@ -393,7 +405,7 @@ permissions:
 
 #### Steps
 
-1. **Create a new Application** in Dokploy for each slot (`qa1`, `qa2`):
+1. **Create a new Application** in Dokploy for each slot (`qa1`, `qa2`, `qa3`, `qa4`):
    - Name: `open-mercato-qa1`
    - Source type: Docker
    - Docker image: any valid placeholder; the workflow overwrites it on first run
@@ -405,7 +417,7 @@ permissions:
 
 3. **Set environment variables** from the Configuration table above via Application → Environment.
 
-4. **Copy the `applicationId`** from Dokploy (Application → Settings → General) and set it as `DOKPLOY_APP_ID_QA1` / `DOKPLOY_APP_ID_QA2` in GitHub repository variables.
+4. **Copy the `applicationId`** from Dokploy (Application → Settings → General) and set it as `DOKPLOY_APP_ID_QA1` / `DOKPLOY_APP_ID_QA2` / `DOKPLOY_APP_ID_QA3` / `DOKPLOY_APP_ID_QA4` in GitHub repository variables.
 
 5. **Configure domain** for each slot (e.g. `qa1.openmercato.com`) in Dokploy → Domains. Requires a DNS A record pointing to the Dokploy server IP.
 

--- a/.github/QA-DEPLOYMENT.md
+++ b/.github/QA-DEPLOYMENT.md
@@ -9,7 +9,7 @@ This guide explains how to deploy a branch to a QA environment and what to expec
 There are two ways to get a QA environment:
 
 1. **Dynamic preview deployments** — automatic, per-PR environments for core contributors (described below).
-2. **Slot-based deployments** — manual, shared `qa1`/`qa2` environments available to anyone (described further down).
+2. **Slot-based deployments** — manual, shared `qa1`/`qa2`/`qa3`/`qa4` environments available to anyone (described further down).
 
 ---
 
@@ -45,12 +45,14 @@ The URL is posted as a comment on the PR once the environment is ready.
 
 ## Slot-Based Deployments
 
-There are two named QA slots: **qa1** and **qa2**. Each slot is a long-lived environment with a fixed URL. A slot runs one deployment at a time — deploying to a slot replaces whatever was there before.
+There are four named QA slots: **qa1**, **qa2**, **qa3**, and **qa4**. Each slot is a long-lived environment with a fixed URL. A slot runs one deployment at a time — deploying to a slot replaces whatever was there before.
 
 | Slot | URL |
 |------|-----|
 | qa1 | https://qa1.openmercato.com/backend |
 | qa2 | https://qa2.openmercato.com/backend |
+| qa3 | https://qa3.openmercato.com/backend |
+| qa4 | https://qa4.openmercato.com/backend |
 
 Each deployment spins up a **fresh database** seeded with demo data. There is no persistent state between deployments.
 
@@ -65,7 +67,7 @@ Each deployment spins up a **fresh database** seeded with demo data. There is no
 
    | Field | Required | What to enter |
    |-------|----------|---------------|
-   | **QA slot** | Yes | `qa1` or `qa2` |
+   | **QA slot** | Yes | `qa1`, `qa2`, `qa3`, or `qa4` |
    | **Branch** | Yes | The branch name you want to test (e.g. `feat/my-feature`) |
    | **PR number** | No | The PR number associated with this branch (e.g. `123`). If provided, the workflow will label the PR and post a comment with the deployment details. |
 
@@ -121,13 +123,13 @@ Do not use a QA slot to store test data you need to keep — it will be gone on 
 
 When a PR that was deployed to a slot is **closed** (merged or abandoned), a workflow runs automatically to stop the slot:
 
-1. It detects the `qa:qa1` or `qa:qa2` label on the closed PR.
+1. It detects the `qa:qa1`, `qa:qa2`, `qa:qa3`, or `qa:qa4` label on the closed PR.
 2. It checks whether the slot is still running the image that was deployed for this PR.
 3. If yes — it stops the slot.
 4. If the slot has since been redeployed for a different PR — it skips the stop to avoid interrupting an active session.
 
 **The slot is not stopped automatically if:**
-- The PR was not associated with a deployment (no PR number was entered when triggering the workflow, so no `qa:qa1`/`qa:qa2` label was added).
+- The PR was not associated with a deployment (no PR number was entered when triggering the workflow, so no `qa:qa1`/`qa:qa2`/`qa:qa3`/`qa:qa4` label was added).
 
 In that case, contact a developer or DevOps to stop the slot manually.
 
@@ -202,4 +204,4 @@ For detailed deployment logs, ask a developer with Dokploy access.
 | Workflow succeeds but URL does not load after 20 min | Startup error inside the container | Ask a developer to check Dokploy logs |
 | "Slot queued" — workflow does not start immediately | Another deployment to the same slot is in progress | Wait for the current run to finish; yours starts automatically |
 | URL loads stale content after deployment | Browser cache | Hard-refresh (`Cmd+Shift+R` / `Ctrl+Shift+R`) or open in a private window |
-| PR has no `qa:qa1` label after deployment | PR number was not entered when triggering | The slot is deployed but not linked to the PR; auto-stop on merge will not fire |
+| PR has no `qa:qa*` label after deployment | PR number was not entered when triggering | The slot is deployed but not linked to the PR; auto-stop on merge will not fire |

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -10,6 +10,8 @@ on:
         options:
           - qa1
           - qa2
+          - qa3
+          - qa4
 
       branch:
         description: "Branch to build and deploy"
@@ -110,14 +112,24 @@ jobs:
 
           SLOT="${{ steps.meta.outputs.slot }}"
 
-          if [[ "$SLOT" == "qa1" ]]; then
-            APP_ID="${{ vars.DOKPLOY_APP_ID_QA1 }}"
-          elif [[ "$SLOT" == "qa2" ]]; then
-            APP_ID="${{ vars.DOKPLOY_APP_ID_QA2 }}"
-          else
-            echo "Unknown slot: $SLOT"
-            exit 1
-          fi
+          case "$SLOT" in
+            qa1)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA1 }}"
+              ;;
+            qa2)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA2 }}"
+              ;;
+            qa3)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA3 }}"
+              ;;
+            qa4)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA4 }}"
+              ;;
+            *)
+              echo "Unknown slot: $SLOT"
+              exit 1
+              ;;
+          esac
 
           if [[ -z "$APP_ID" ]]; then
             echo "Missing Dokploy app id for $SLOT"
@@ -133,8 +145,15 @@ jobs:
           DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
           APP_ID: ${{ steps.app.outputs.application_id }}
           DOCKER_IMAGE: ${{ steps.meta.outputs.image_full }}
+          GHCR_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
         run: |
           set -euo pipefail
+
+          if [[ -z "$GHCR_USERNAME" || -z "$GHCR_TOKEN" ]]; then
+            echo "Missing GHCR_USERNAME or GHCR_TOKEN secret"
+            exit 1
+          fi
 
           curl -fsS -X POST "${DOKPLOY_URL}/api/application.saveDockerProvider" \
             -H "x-api-key: ${DOKPLOY_API_KEY}" \
@@ -142,7 +161,16 @@ jobs:
             -d "$(jq -n \
               --arg applicationId "$APP_ID" \
               --arg dockerImage "$DOCKER_IMAGE" \
-              '{applicationId: $applicationId, dockerImage: $dockerImage}')"
+              --arg registryUrl "ghcr.io" \
+              --arg username "$GHCR_USERNAME" \
+              --arg password "$GHCR_TOKEN" \
+              '{
+                applicationId: $applicationId,
+                dockerImage: $dockerImage,
+                registryUrl: $registryUrl,
+                username: $username,
+                password: $password
+              }')"
 
       - name: Trigger Dokploy deploy
         shell: bash

--- a/.github/workflows/qa-stop-on-merge.yml
+++ b/.github/workflows/qa-stop-on-merge.yml
@@ -35,12 +35,14 @@ jobs:
             let slot = "";
             if (names.includes("qa:qa1")) slot = "qa1";
             if (names.includes("qa:qa2")) slot = "qa2";
+            if (names.includes("qa:qa3")) slot = "qa3";
+            if (names.includes("qa:qa4")) slot = "qa4";
 
             core.setOutput("slot", slot);
 
       - name: Skip if no QA label
         if: ${{ steps.slot.outputs.slot == '' }}
-        run: echo "No qa:qa1/qa:qa2 label -> nothing to stop."
+        run: echo "No qa:qa1/qa:qa2/qa:qa3/qa:qa4 label -> nothing to stop."
 
       - name: Resolve Dokploy applicationId
         if: ${{ steps.slot.outputs.slot != '' }}
@@ -48,11 +50,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${{ steps.slot.outputs.slot }}" == "qa1" ]]; then
-            APP_ID="${{ vars.DOKPLOY_APP_ID_QA1 }}"
-          else
-            APP_ID="${{ vars.DOKPLOY_APP_ID_QA2 }}"
-          fi
+          case "${{ steps.slot.outputs.slot }}" in
+            qa1)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA1 }}"
+              ;;
+            qa2)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA2 }}"
+              ;;
+            qa3)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA3 }}"
+              ;;
+            qa4)
+              APP_ID="${{ vars.DOKPLOY_APP_ID_QA4 }}"
+              ;;
+            *)
+              echo "Unknown slot: ${{ steps.slot.outputs.slot }}" >&2
+              exit 1
+              ;;
+          esac
 
           if [[ -z "$APP_ID" ]]; then
             echo "Missing Dokploy app id for slot=${{ steps.slot.outputs.slot }}" >&2


### PR DESCRIPTION
## Summary

This PR updates the QA Dokploy deployment workflows to match the new Dokploy API contract introduced by the Dokploy version bump, and extends slot support from `qa1`/`qa2` to `qa1`/`qa2`/`qa3`/`qa4`.

`application.saveDockerProvider` no longer accepts just `applicationId` and `dockerImage` for our use case. The workflow now also sends the registry connection details required by Dokploy to pull the image from GHCR.

## Changes

- update `.github/workflows/qa-deploy.yml`
- send `registryUrl`, `username`, and `password` in the `application.saveDockerProvider` payload
- read both `GHCR_USERNAME` and `GHCR_TOKEN` from GitHub secrets
- add a fail-fast check when GHCR credentials are missing
- extend manual QA slot support to `qa3` and `qa4`
- resolve Dokploy app IDs for:
  - `DOKPLOY_APP_ID_QA1`
  - `DOKPLOY_APP_ID_QA2`
  - `DOKPLOY_APP_ID_QA3`
  - `DOKPLOY_APP_ID_QA4`
- update `.github/workflows/qa-stop-on-merge.yml` so cleanup works for `qa3` and `qa4` labels too
- update the Dokploy QA deployment docs/spec to reflect the new API contract and slot configuration

## Why

After the Dokploy version bump, the Docker provider API contract changed. Without passing GHCR credentials in the save call, Dokploy cannot reliably persist the full Docker provider configuration needed to deploy private GHCR images.

At the same time, we need two more reusable QA slots, so the workflow routing and cleanup logic now support four Dokploy application IDs instead of two.

## Required repo configuration

This change expects these GitHub secrets to exist:

- `DOKPLOY_URL`
- `DOKPLOY_API_KEY`
- `GHCR_USERNAME`
- `GHCR_TOKEN`

And these GitHub variables:

- `DOKPLOY_APP_ID_QA1`
- `DOKPLOY_APP_ID_QA2`
- `DOKPLOY_APP_ID_QA3`
- `DOKPLOY_APP_ID_QA4`

## Verification

- validated `.github/workflows/qa-deploy.yml` parses as YAML
- validated `.github/workflows/qa-stop-on-merge.yml` parses as YAML
- reviewed the workflow, docs, and spec changes for slot/config consistency

## Risk

Low. The change is scoped to the QA deployment workflows and their documentation/spec, with no application runtime code affected.
