### PR TITLE
fix(security): revoke customer sessions on self-service password change

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/portal/__tests__/password-change.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/__tests__/password-change.route.test.ts
@@ -1,0 +1,126 @@
+/** @jest-environment node */
+
+const mockGetCustomerAuth = jest.fn()
+const mockFindById = jest.fn()
+const mockVerifyPassword = jest.fn()
+const mockUpdatePassword = jest.fn()
+const mockRevokeAllUserSessions = jest.fn()
+
+const customerUserService = {
+  findById: mockFindById,
+  verifyPassword: mockVerifyPassword,
+  updatePassword: mockUpdatePassword,
+}
+
+const customerSessionService = {
+  revokeAllUserSessions: mockRevokeAllUserSessions,
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'customerUserService') return customerUserService
+    if (token === 'customerSessionService') return customerSessionService
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
+  getCustomerAuthFromRequest: jest.fn((req: Request) => mockGetCustomerAuth(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+import { POST } from '@open-mercato/core/modules/customer_accounts/api/portal/password-change'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const userId = '22222222-2222-4222-8222-222222222222'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/customer_accounts/portal/password-change', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('portal /api/customer_accounts/portal/password-change — session revocation on self-service password change', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetCustomerAuth.mockResolvedValue({ sub: userId, tenantId })
+    mockFindById.mockResolvedValue({ id: userId, email: 'user@example.com' })
+    mockVerifyPassword.mockResolvedValue(true)
+    mockUpdatePassword.mockResolvedValue(undefined)
+    mockRevokeAllUserSessions.mockResolvedValue(undefined)
+  })
+
+  it('revokes all existing sessions after a successful password change', async () => {
+    const res = await POST(
+      makeRequest({ currentPassword: 'old-correct-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledWith(userId)
+  })
+
+  it('revokes sessions AFTER updatePassword, never before (ordering invariant)', async () => {
+    await POST(
+      makeRequest({ currentPassword: 'old-correct-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    const updateOrder = mockUpdatePassword.mock.invocationCallOrder[0]
+    const revokeOrder = mockRevokeAllUserSessions.mock.invocationCallOrder[0]
+    expect(updateOrder).toBeLessThan(revokeOrder)
+  })
+
+  it('does NOT revoke sessions when the current password is incorrect', async () => {
+    mockVerifyPassword.mockResolvedValue(false)
+
+    const res = await POST(
+      makeRequest({ currentPassword: 'wrong', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockUpdatePassword).not.toHaveBeenCalled()
+    expect(mockRevokeAllUserSessions).not.toHaveBeenCalled()
+  })
+
+  it('does NOT revoke sessions when the caller is not authenticated', async () => {
+    mockGetCustomerAuth.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({ currentPassword: 'any-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(res.status).toBe(401)
+    expect(mockUpdatePassword).not.toHaveBeenCalled()
+    expect(mockRevokeAllUserSessions).not.toHaveBeenCalled()
+  })
+
+  it('does NOT revoke sessions when the authenticated user cannot be found', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({ currentPassword: 'any-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(res.status).toBe(404)
+    expect(mockUpdatePassword).not.toHaveBeenCalled()
+    expect(mockRevokeAllUserSessions).not.toHaveBeenCalled()
+  })
+
+  it('does NOT revoke sessions when the request body fails validation', async () => {
+    const res = await POST(
+      makeRequest({ currentPassword: 'short', newPassword: 'x' }),
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockUpdatePassword).not.toHaveBeenCalled()
+    expect(mockRevokeAllUserSessions).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/portal/password-change.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/password-change.ts
@@ -4,6 +4,7 @@ import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib
 import { getCustomerAuthFromRequest } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { CustomerUserService } from '@open-mercato/core/modules/customer_accounts/services/customerUserService'
+import { CustomerSessionService } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 import { passwordChangeSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
@@ -28,6 +29,7 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   const customerUserService = container.resolve('customerUserService') as CustomerUserService
+  const customerSessionService = container.resolve('customerSessionService') as CustomerSessionService
 
   const user = await customerUserService.findById(auth.sub, auth.tenantId)
   if (!user) {
@@ -41,6 +43,9 @@ export async function POST(req: Request) {
 
   await customerUserService.updatePassword(user, parsed.data.newPassword)
 
+  // Revoke all existing sessions for security
+  await customerSessionService.revokeAllUserSessions(user.id)
+
   return NextResponse.json({ ok: true })
 }
 
@@ -49,7 +54,7 @@ const errorSchema = z.object({ ok: z.literal(false), error: z.string() })
 
 const methodDoc: OpenApiMethodDoc = {
   summary: 'Change customer password',
-  description: 'Changes the authenticated customer user password after verifying the current password.',
+  description: 'Changes the authenticated customer user password after verifying the current password. Revokes all existing sessions.',
   tags: ['Customer Portal'],
   requestBody: { schema: passwordChangeSchema },
   responses: [{ status: 200, description: 'Password changed', schema: successSchema }],


### PR DESCRIPTION
## Summary                                                                                                      
                                                               
  Customer portal self-service password change (`POST /api/customer_accounts/portal/password-change`) calls       
  `customerUserService.updatePassword` but never revokes the caller's existing sessions. A JWT or refresh token an
   attacker obtained before the rotation stays valid for up to the refresh-token TTL (30 days) — even after the   
  victim proactively changes their password to remediate.      

  This closes the last gap in the customer/staff session-invalidation series:                                     
  - #888 — staff sessions on password change/reset ✅
  - #1223 — customer sessions on admin-initiated reset ✅                                                         
  - **this PR** — customer sessions on self-service change ✅                                                     
                                                                                                                  
  ## Threat model                                                                                                 
                                                               
  1. Attacker obtains a valid customer JWT or refresh token (credential stuffing on a reused password, device     
  theft, XSS on a shared origin, or phishing of the session cookie).
  2. The victim notices suspicious activity and changes their password via the portal profile.                    
  3. **Pre-fix:** the attacker's session continues to work because neither the JWT (checked only against          
  `sessionsRevokedAt`) nor the refresh-token row is invalidated by `updatePassword`.                              
  4. **Post-fix:** the handler writes `sessions_revoked_at` via                                                   
  `customerSessionService.revokeAllUserSessions(user.id)` — JWT validation at `lib/customerAuth.ts:71` then       
  rejects the stale token, and the refresh row is marked revoked.
                                                                                                                  
  ## Root cause                                                

  Every other mutation path on customer sessions already revokes:                                                 
  - `api/password/reset-confirm.ts:50` — password reset confirm
  - `api/admin/users/[id]/reset-password.ts` — admin-initiated reset (#1223)                                      
  - `api/admin/users/[id].ts` — admin user update                                                                 
  - `api/portal/users/[id].ts:52` — admin-delete via portal                                                       
                                                                                                                  
  Self-service change was the only divergent path. The `sessions_revoked_at` column and its consumer in           
  `lib/customerAuth.ts` already existed — only the writer was unwired on this route.                              
                                                                                                                  
  ## Fix                                                       

  `customerUserService.updatePassword(...)`, matching the pattern in `reset-confirm.ts`. OpenAPI description      
  updated to declare the revocation behaviour.                                                              
                                                                                                                  
  ## Regression test                                           
                    
  New `__tests__/password-change.route.test.ts` pins 6 invariants:
                                                                                                                  
  1. `revokeAllUserSessions` called exactly once with `user.id` on the happy path
  2. `revokeAllUserSessions` runs **after** `updatePassword` (ordering check via `mock.invocationCallOrder`) —    
  pre-revoke ordering would race against the password write and leave a window open                           
  3–6. `revokeAllUserSessions` is **not** called when the endpoint short-circuits on: wrong current password,     
  missing auth, missing user, or validation failure                                                          
                                                                                                                  
  ## Validation                                                
                                                                                                                  
  - ✅ Targeted Jest: **6/6** (`cd packages/core && yarn test --testPathPatterns="password-change.route.test"`)
  - ✅ `i18n:check-sync`: all 4 locales in sync                                                                   
  - ✅ Typecheck core: baseline-equivalent — pre-existing `kysely` / `@mikro-orm/decorators/legacy` drift on
  `develop` is identical with and without this change                                                             
  - ✅ Full build: [fill in after `yarn build` completes]                                                         
                                                                                                                  
  ## Labels suggestion                                                                                            
                                                                                                                  
  `security` · `needs-qa`