### PR TITLE
fix(catalog): scope bulk-delete cache invalidation to worker tenant

### DIFF
--- a/packages/core/src/modules/catalog/lib/__tests__/bulkDelete.test.ts
+++ b/packages/core/src/modules/catalog/lib/__tests__/bulkDelete.test.ts
@@ -13,6 +13,7 @@ jest.mock('@open-mercato/shared/lib/redis/connection', () => ({
 }))
 
 import type { AwilixContainer } from 'awilix'
+import { getCurrentCacheTenant } from '@open-mercato/cache'
 import { deleteCatalogProductsWithProgress } from '../bulkDelete'
 
 describe('deleteCatalogProductsWithProgress', () => {
@@ -104,5 +105,41 @@ describe('deleteCatalogProductsWithProgress', () => {
         userId: 'user-1',
       },
     )
+  })
+
+  it('invokes cache invalidation inside the correct cache tenant scope so tag deletes match stored entries', async () => {
+    const execute = jest.fn().mockResolvedValue({ result: { productId: 'prod-1' } })
+    const startJob = jest.fn().mockResolvedValue(undefined)
+    const updateProgress = jest.fn().mockResolvedValue(undefined)
+    const completeJob = jest.fn().mockResolvedValue(undefined)
+
+    const container = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'commandBus') return { execute }
+        if (name === 'progressService') {
+          return { startJob, updateProgress, completeJob }
+        }
+        return undefined
+      }),
+    } as unknown as AwilixContainer
+
+    const observedTenants: Array<string | null> = []
+    mockInvalidateCrudCache.mockImplementation(async () => {
+      observedTenants.push(getCurrentCacheTenant())
+    })
+
+    await deleteCatalogProductsWithProgress({
+      container,
+      progressJobId: 'job-2',
+      ids: ['prod-1'],
+      scope: {
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    })
+
+    expect(mockInvalidateCrudCache).toHaveBeenCalledTimes(1)
+    expect(observedTenants).toEqual(['tenant-1'])
   })
 })

--- a/packages/core/src/modules/catalog/lib/bulkDelete.ts
+++ b/packages/core/src/modules/catalog/lib/bulkDelete.ts
@@ -1,6 +1,7 @@
 import type { AwilixContainer } from 'awilix'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
+import { runWithCacheTenant } from '@open-mercato/cache'
 import { createModuleQueue, type Queue } from '@open-mercato/queue'
 import type { ProgressService, ProgressServiceContext } from '../../progress/lib/progressService'
 
@@ -101,20 +102,22 @@ export async function deleteCatalogProductsWithProgress(params: {
   }
 
   const summary: CatalogProductBulkDeleteSummary = { affectedCount }
-  for (const id of deletedIds) {
-    await invalidateCrudCache(
-      container,
-      'catalog.product',
-      {
-        id,
-        organizationId: scope.organizationId,
-        tenantId: scope.tenantId,
-      },
-      scope.tenantId,
-      'bulk-delete:catalog.products',
-      BULK_DELETE_CACHE_ALIASES,
-    )
-  }
+  await runWithCacheTenant(scope.tenantId, async () => {
+    for (const id of deletedIds) {
+      await invalidateCrudCache(
+        container,
+        'catalog.product',
+        {
+          id,
+          organizationId: scope.organizationId,
+          tenantId: scope.tenantId,
+        },
+        scope.tenantId,
+        'bulk-delete:catalog.products',
+        BULK_DELETE_CACHE_ALIASES,
+      )
+    }
+  })
   await progressService.completeJob(progressJobId, { resultSummary: summary }, progressContext)
 
   return summary


### PR DESCRIPTION
<!-- Checking the CLA box below confirms you accept the terms in docs/cla.md. -->

## Summary

The catalog bulk-delete worker invalidated CRUD cache tags from outside any `runWithCacheTenant` context, so the tenant-aware cache service prefixed the delete with `tenant:global:` while the LIST endpoint had stored entries under `tenant:<tenantId>:`. The prefixes never matched, `deleteByTags` removed nothing, and users kept seeing deleted products in the list (and in the edit form, which only errored on Save). This PR wraps the post-delete invalidation loop with `runWithCacheTenant(scope.tenantId, …)` so the worker's tag deletes line up with the tags the HTTP request stored.

## Changes

- `packages/core/src/modules/catalog/lib/bulkDelete.ts` — import `runWithCacheTenant` from `@open-mercato/cache` and wrap the `invalidateCrudCache` loop in `deleteCatalogProductsWithProgress` with the worker's tenant scope.
- `packages/core/src/modules/catalog/lib/__tests__/bulkDelete.test.ts` — add a regression test that records `getCurrentCacheTenant()` at invalidation time and asserts it equals the scope tenant.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
_Not applicable — bug fix in existing catalog bulk-delete flow._

## Testing

- `cd packages/core && npx jest --config jest.config.cjs src/modules/catalog/lib/__tests__/bulkDelete.test.ts` — 2/2 pass (new regression case included; verified red on `develop` before the fix).
- Manual runtime check with `ENABLE_CRUD_API_CACHE=true`: warm list cache at `/backend/catalog/products`, bulk-delete ≥2 rows, confirm the list no longer returns stale items and the edit page 404s instead of failing on Save.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. _(No docs/locales/generators impacted — worker-internal fix.)_
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). _(Regression is covered by a unit test that pins the tenant cache scope at the exact call site; an integration test would need the full Redis/queue harness with `ENABLE_CRUD_API_CACHE=true` just to re-observe the same invariant.)_
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). _(N/A — no spec for this flow.)_

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI changes
- [x] No arbitrary text sizes — N/A, no UI changes
- [x] Empty state handled for list/data pages — N/A, no UI changes
- [x] Loading state handled for async pages — N/A, no UI changes
- [x] `aria-label` on all icon-only buttons — N/A, no UI changes
- [x] Uses existing DS components — N/A, no UI changes

## Linked issues

Fixes #1677.