### PR TITLE
fix(security): add tenant encryption map for inbox_ops module

### DIFF
--- a/packages/core/src/modules/inbox_ops/__tests__/encryption.test.ts
+++ b/packages/core/src/modules/inbox_ops/__tests__/encryption.test.ts
@@ -1,0 +1,65 @@
+import { defaultEncryptionMaps } from '../encryption'
+
+describe('inbox_ops defaultEncryptionMaps', () => {
+  it('encrypts InboxEmail body, subject, thread, and correspondent addresses', () => {
+    const entry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_email')
+    expect(entry).toBeDefined()
+    expect(entry!.fields).toEqual(expect.arrayContaining([
+      { field: 'subject' },
+      { field: 'raw_text' },
+      { field: 'raw_html' },
+      { field: 'cleaned_text' },
+      { field: 'thread_messages' },
+      { field: 'forwarded_by_address' },
+      { field: 'forwarded_by_name' },
+      { field: 'to_address' },
+      { field: 'reply_to' },
+      { field: 'processing_error' },
+    ]))
+  })
+
+  it('encrypts InboxProposal summary, participants, and translations', () => {
+    const entry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_proposal')
+    expect(entry).toBeDefined()
+    expect(entry!.fields).toEqual(expect.arrayContaining([
+      { field: 'summary' },
+      { field: 'participants' },
+      { field: 'translations' },
+    ]))
+  })
+
+  it('encrypts InboxProposalAction description and payload', () => {
+    const entry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_proposal_action')
+    expect(entry).toBeDefined()
+    expect(entry!.fields).toEqual(expect.arrayContaining([
+      { field: 'description' },
+      { field: 'payload' },
+      { field: 'execution_error' },
+    ]))
+  })
+
+  it('encrypts InboxDiscrepancy description, expected/found values', () => {
+    const entry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_discrepancy')
+    expect(entry).toBeDefined()
+    expect(entry!.fields).toEqual(expect.arrayContaining([
+      { field: 'description' },
+      { field: 'expected_value' },
+      { field: 'found_value' },
+    ]))
+  })
+
+  it('leaves lookup-keyed columns plaintext to preserve WHERE/UNIQUE indexes', () => {
+    // These are documented carve-outs — encrypting them requires paired
+    // *_hash columns plus rewriting the inbound-webhook duplicate detector
+    // and settings lookup. Not in scope for the HUNT-SMELL-01 fix.
+    const emailEntry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_email')
+    const emailFieldNames = (emailEntry?.fields ?? []).map((f) => f.field)
+    expect(emailFieldNames).not.toContain('message_id')
+    expect(emailFieldNames).not.toContain('in_reply_to')
+    expect(emailFieldNames).not.toContain('references')
+    expect(emailFieldNames).not.toContain('content_hash')
+
+    const settingsEntry = defaultEncryptionMaps.find((m) => m.entityId === 'inbox_ops:inbox_settings')
+    expect(settingsEntry).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/inbox_ops/encryption.ts
+++ b/packages/core/src/modules/inbox_ops/encryption.ts
@@ -1,0 +1,51 @@
+import type { ModuleEncryptionMap } from '@open-mercato/shared/modules/encryption'
+
+// Message body, extracted business data, and correspondent identities all
+// count as tenant PII. Columns routed through WHERE/ILIKE lookups or UNIQUE
+// indexes (`inbox_settings.inbox_address`, `inbox_emails.message_id`,
+// `in_reply_to`, `references`, `*.metadata`) are intentionally left plaintext
+// for now — encrypting them requires paired `*_hash` columns plus rewriting
+// the inbound-webhook lookups, which is out of scope for this fix.
+export const defaultEncryptionMaps: ModuleEncryptionMap[] = [
+  {
+    entityId: 'inbox_ops:inbox_email',
+    fields: [
+      { field: 'subject' },
+      { field: 'raw_text' },
+      { field: 'raw_html' },
+      { field: 'cleaned_text' },
+      { field: 'thread_messages' },
+      { field: 'forwarded_by_address' },
+      { field: 'forwarded_by_name' },
+      { field: 'to_address' },
+      { field: 'reply_to' },
+      { field: 'processing_error' },
+    ],
+  },
+  {
+    entityId: 'inbox_ops:inbox_proposal',
+    fields: [
+      { field: 'summary' },
+      { field: 'participants' },
+      { field: 'translations' },
+    ],
+  },
+  {
+    entityId: 'inbox_ops:inbox_proposal_action',
+    fields: [
+      { field: 'description' },
+      { field: 'payload' },
+      { field: 'execution_error' },
+    ],
+  },
+  {
+    entityId: 'inbox_ops:inbox_discrepancy',
+    fields: [
+      { field: 'description' },
+      { field: 'expected_value' },
+      { field: 'found_value' },
+    ],
+  },
+]
+
+export default defaultEncryptionMaps


### PR DESCRIPTION
## Description                                                                                                                                  
                                                                                                                                              
  `inbox_ops` calls `findWithDecryption` in 18 sites but ships no `encryption.ts`. `TenantDataEncryptionService` fails open on empty map      
  (`encrypt.skip.no-map`, payload returned unchanged), so under `TENANT_DATA_ENCRYPTION=true` message bodies, subjects, correspondent         
  addresses, proposal summaries and action payloads land plaintext at rest. Medium severity — at-rest only, HTTP surface unchanged.           
                                                            
  ## Fix

  Register the four PII-bearing entities via standard `encryption.ts` auto-discovery:                                                         
   
  | Entity | Encrypted columns |                                                                                                              
  |---|---|                                                 
  | `inbox_ops:inbox_email` | `subject`, `raw_text`, `raw_html`, `cleaned_text`, `thread_messages`, `forwarded_by_address`,                   
  `forwarded_by_name`, `to_address`, `reply_to`, `processing_error` |                                                                         
  | `inbox_ops:inbox_proposal` | `summary`, `participants`, `translations` |
  | `inbox_ops:inbox_proposal_action` | `description`, `payload`, `execution_error` |                                                         
  | `inbox_ops:inbox_discrepancy` | `description`, `expected_value`, `found_value` |                                                          
                                                                                                                                              
  No schema change. Same wiring as `auth` / `customer_accounts` / `sales`.                                                                    
                                                                                                                                              
  ## Carve-outs (phase 2)                                                                                                                     
                                                            
  Left plaintext — would need paired `*_hash` columns + lookup rewrites, out of scope:                                                        
  - `inbox_settings.inbox_address`, `inbox_emails.message_id` / `in_reply_to` / `references` — WHERE / `@Unique` targets
  - `*.metadata` — opaque JSON, risks TC-API-MSG-class regression                                                                             
                                                                                                                                              
  ## Post-deploy action required                                                                                                              
                                                                                                                                              
  Existing tenants keep storing plaintext until the map is seeded per tenant:                                                                 
                                                                                                                                  
  yarn mercato entities seed-encryption --tenant <tenant-uuid>                                                                                                                                            
  New tenants are handled automatically by setupInitialTenant.                                                                                
                                                                                                                                              
  Test plan                                                                                                                                   
                                                            
  - Unit: core test --testPathPatterns=inbox_ops/__tests__/encryption — 5/5 pass (4 positive + 1 negative pinning carve-outs)                 
  - Generator: cli test --testPathPatterns=structural-contracts — 96/96 pass
  - Two-halves ORM PoC: UPDATE is_active=false → 10/12 fields leak marker plaintext; flip back → 12/12 envelope <iv>:<ct>:<tag>:v1, carve-outs
   stay plaintext by design                                                                                                                   
  - Manual: run seed CLI, exercise webhook, SELECT subject FROM inbox_emails ORDER BY created_at DESC LIMIT 1 — base64 envelope, not readable 
                                                                                                                                              
  Follow-up — customizable maps (not in this PR)                                                                                              
                                                                                                                                              
  The map is already DB-backed per tenant, so customization is mechanically possible via UPDATE encryption_maps. Cleaner paths worth a        
  dedicated PR:                                             
                                                                                                                                              
  1. Granular CLI — encryption-map list|add-field|remove-field|diff under mercato entities. Low cost, scriptable.                             
  2. Admin UI at /backend/settings/encryption-maps — per-tenant editor with reset-to-defaults. Highest UX, moderate cost.
  3. Override file — encryption.override.ts in user apps that merges with core defaults. Best for downstream customers, needs boot-time       
  upsert.                                                                                                                                     
                                                                                                                                              
  Happy to split any into a follow-up spec.
