### PR TITLE
feat(workflows): UI-driven e2e tests + trigger cache invalidation

### DIFF
--- a/packages/core/src/modules/workflows/__integration__/TC-WF-006.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-006.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { deleteWorkflowDefinitionIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/workflowsFixtures'
+
+async function fillText(page: Page, locator: ReturnType<Page['locator']>, value: string): Promise<void> {
+  await locator.fill('')
+  await locator.fill(value)
+}
+
+async function findDefinitionIdByWorkflowId(
+  request: Parameters<typeof apiRequest>[0],
+  token: string,
+  workflowId: string,
+): Promise<string | null> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/workflows/definitions?workflowId=${encodeURIComponent(workflowId)}&limit=1`,
+    { token },
+  ).catch(() => null)
+  if (!res || res.status() !== 200) return null
+  const body = await res.json().catch(() => null)
+  return body?.data?.[0]?.id ?? null
+}
+
+/**
+ * TC-WF-006: Create and delete a workflow definition entirely through the admin UI.
+ *
+ * Verifies the Create form (CrudForm with StepsEditor + TransitionsEditor) actually
+ * produces a persisted definition, that the new entry surfaces on the list page,
+ * and that the row-action delete flow + confirm dialog removes it.
+ *
+ * Every asserted interaction goes through the browser — API calls only run in the
+ * finally block as a safety net if a UI step throws before the UI-level delete.
+ */
+test.describe('TC-WF-006: Create and delete workflow definition via UI', () => {
+  test('creates a definition through the form and deletes it via row actions', async ({ page, request }) => {
+    const timestamp = Date.now()
+    const workflowId = `qa-wf-006-${timestamp}`
+    const workflowName = `QA TC-WF-006 ${timestamp}`
+    let token: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      await login(page, 'admin')
+      await page.goto('/backend/definitions')
+      await expect(page.getByRole('heading', { name: /workflow definitions/i })).toBeVisible()
+
+      // Open the Create form via the list page button
+      await page.getByRole('link', { name: /^create workflow$/i }).click()
+      await expect(page).toHaveURL(/\/backend\/definitions\/create/)
+
+      // Basic fields
+      await fillText(page, page.getByPlaceholder('checkout_workflow'), workflowId)
+      await fillText(page, page.getByPlaceholder('Enter a descriptive workflow name'), workflowName)
+
+      // Steps: add START and END
+      const addStepBtn = page.getByRole('button', { name: /^add step$/i })
+      await addStepBtn.click()
+      await fillText(page, page.locator('#step-0-id'), 'start')
+      await fillText(page, page.locator('#step-0-name'), 'Start')
+      await page.locator('#step-0-type').selectOption('START')
+
+      await addStepBtn.click()
+      await fillText(page, page.locator('#step-1-id'), 'end')
+      await fillText(page, page.locator('#step-1-name'), 'End')
+      await page.locator('#step-1-type').selectOption('END')
+
+      // Transition: start → end
+      await page.getByRole('button', { name: /^add transition$/i }).click()
+      await fillText(page, page.locator('#transition-0-id'), 'start-to-end')
+      await fillText(page, page.locator('#transition-0-name'), 'Auto advance')
+      await page.locator('#transition-0-from').selectOption('start')
+      await page.locator('#transition-0-to').selectOption('end')
+
+      // Submit (two identical buttons — header + footer; click the first)
+      await page.getByRole('button', { name: /^create workflow$/i }).first().click()
+
+      // Back to list — entry should be visible
+      await expect(page).toHaveURL(/\/backend\/definitions(\?|$|\/)/, { timeout: 15_000 })
+      await expect(page.getByRole('heading', { name: /workflow definitions/i })).toBeVisible()
+
+      const searchBox = page.getByPlaceholder(/search/i).first()
+      if (await searchBox.isVisible().catch(() => false)) {
+        await fillText(page, searchBox, workflowId)
+        // Filter bar submits on Enter or via Apply button; both work in this repo
+        await searchBox.press('Enter').catch(() => undefined)
+      }
+
+      const row = page.getByRole('row').filter({ hasText: workflowId })
+      await expect(row).toBeVisible({ timeout: 10_000 })
+
+      // Delete via row action menu → confirm dialog.
+      // RowActions opens on pointerenter AND toggles on click, so hovering is the
+      // stable way to open the menu without the click flipping it back closed.
+      await row.getByRole('button', { name: /open actions/i }).hover()
+      await page.getByRole('menuitem', { name: /^delete$/i }).click()
+
+      const deleteDialog = page.getByRole('dialog', { name: /delete workflow/i })
+      await expect(deleteDialog).toBeVisible()
+      await deleteDialog.getByRole('button', { name: /^delete$/i }).click()
+
+      // Row should disappear. The flash toast may be transient, so assert on row removal instead.
+      await expect(page.getByRole('row').filter({ hasText: workflowId })).toHaveCount(0, { timeout: 10_000 })
+    } finally {
+      if (token) {
+        const leftoverId = await findDefinitionIdByWorkflowId(request, token, workflowId)
+        await deleteWorkflowDefinitionIfExists(request, token, leftoverId)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-007.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-007.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect, type Page } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { deleteWorkflowDefinitionIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/workflowsFixtures'
+
+async function fillText(page: Page, locator: ReturnType<Page['locator']>, value: string): Promise<void> {
+  await locator.fill('')
+  await locator.fill(value)
+}
+
+async function findDefinitionIdByWorkflowId(
+  request: Parameters<typeof apiRequest>[0],
+  token: string,
+  workflowId: string,
+): Promise<string | null> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/workflows/definitions?workflowId=${encodeURIComponent(workflowId)}&limit=1`,
+    { token },
+  ).catch(() => null)
+  if (!res || res.status() !== 200) return null
+  const body = await res.json().catch(() => null)
+  return body?.data?.[0]?.id ?? null
+}
+
+async function createMinimalDefinitionViaUi(
+  page: Page,
+  workflowId: string,
+  workflowName: string,
+): Promise<void> {
+  await page.goto('/backend/definitions/create')
+  await expect(page).toHaveURL(/\/backend\/definitions\/create/)
+
+  await fillText(page, page.getByPlaceholder('checkout_workflow'), workflowId)
+  await fillText(page, page.getByPlaceholder('Enter a descriptive workflow name'), workflowName)
+
+  const addStepBtn = page.getByRole('button', { name: /^add step$/i })
+  await addStepBtn.click()
+  await fillText(page, page.locator('#step-0-id'), 'start')
+  await fillText(page, page.locator('#step-0-name'), 'Start')
+  await page.locator('#step-0-type').selectOption('START')
+
+  await addStepBtn.click()
+  await fillText(page, page.locator('#step-1-id'), 'end')
+  await fillText(page, page.locator('#step-1-name'), 'End')
+  await page.locator('#step-1-type').selectOption('END')
+
+  await page.getByRole('button', { name: /^add transition$/i }).click()
+  await fillText(page, page.locator('#transition-0-id'), 'start-to-end')
+  await fillText(page, page.locator('#transition-0-name'), 'Auto advance')
+  await page.locator('#transition-0-from').selectOption('start')
+  await page.locator('#transition-0-to').selectOption('end')
+
+  await page.getByRole('button', { name: /^create workflow$/i }).first().click()
+  await expect(page).toHaveURL(/\/backend\/definitions(\?|$|\/)/, { timeout: 15_000 })
+}
+
+/**
+ * TC-WF-007: Open a UI-created workflow in the visual editor and verify React Flow
+ * renders the START/END nodes and the connecting edge.
+ *
+ * Entirely UI-driven: the definition is created via the Create form (not the API),
+ * then opened in /backend/definitions/visual-editor. React Flow nodes are located
+ * via ReactFlow's default `.react-flow__node` / `.react-flow__edge` class hooks.
+ */
+test.describe('TC-WF-007: Visual editor renders a UI-created workflow', () => {
+  test('loads START/END nodes and their transition in the graph', async ({ page, request }) => {
+    const timestamp = Date.now()
+    const workflowId = `qa-wf-007-${timestamp}`
+    const workflowName = `QA TC-WF-007 ${timestamp}`
+    let token: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      await login(page, 'admin')
+      await createMinimalDefinitionViaUi(page, workflowId, workflowName)
+
+      // Navigate via the visual editor row action instead of URL-typing — more UI-real.
+      const searchBox = page.getByPlaceholder(/search/i).first()
+      if (await searchBox.isVisible().catch(() => false)) {
+        await fillText(page, searchBox, workflowId)
+        await searchBox.press('Enter').catch(() => undefined)
+      }
+
+      const row = page.getByRole('row').filter({ hasText: workflowId })
+      await expect(row).toBeVisible({ timeout: 10_000 })
+      await row.getByRole('button', { name: /open actions/i }).hover()
+      await page.getByRole('menuitem', { name: /edit visually/i }).click()
+
+      await expect(page).toHaveURL(/\/backend\/definitions\/visual-editor\?id=/, { timeout: 15_000 })
+
+      // React Flow renders nodes with `.react-flow__node` and edges with `.react-flow__edge`.
+      const nodes = page.locator('.react-flow__node')
+      await expect(nodes).toHaveCount(2, { timeout: 15_000 })
+
+      // Each node card shows its label — verify START and END are both present.
+      await expect(nodes.filter({ hasText: 'Start' })).toHaveCount(1)
+      await expect(nodes.filter({ hasText: 'End' })).toHaveCount(1)
+
+      // One edge (start → end).
+      await expect(page.locator('.react-flow__edge')).toHaveCount(1, { timeout: 10_000 })
+
+      // Workflow metadata pane reflects what we created.
+      await expect(page.locator(`input[value="${workflowId}"]`).first()).toBeVisible()
+      await expect(page.locator(`input[value="${workflowName}"]`).first()).toBeVisible()
+    } finally {
+      if (token) {
+        const leftoverId = await findDefinitionIdByWorkflowId(request, token, workflowId)
+        await deleteWorkflowDefinitionIfExists(request, token, leftoverId)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-008.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-008.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect, type Page } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+import { getAuthToken, apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import {
+  deleteWorkflowDefinitionIfExists,
+  cancelWorkflowInstanceIfExists,
+} from '@open-mercato/core/modules/core/__integration__/helpers/workflowsFixtures'
+
+async function fillText(page: Page, locator: ReturnType<Page['locator']>, value: string): Promise<void> {
+  await locator.fill('')
+  await locator.fill(value)
+}
+
+async function findDefinitionIdByWorkflowId(
+  request: Parameters<typeof apiRequest>[0],
+  token: string,
+  workflowId: string,
+): Promise<string | null> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/workflows/definitions?workflowId=${encodeURIComponent(workflowId)}&limit=1`,
+    { token },
+  ).catch(() => null)
+  if (!res || res.status() !== 200) return null
+  const body = await res.json().catch(() => null)
+  return body?.data?.[0]?.id ?? null
+}
+
+async function findInstanceIdByWorkflowId(
+  request: Parameters<typeof apiRequest>[0],
+  token: string,
+  workflowId: string,
+): Promise<string | null> {
+  const res = await apiRequest(
+    request,
+    'GET',
+    `/api/workflows/instances?workflowId=${encodeURIComponent(workflowId)}&limit=1`,
+    { token },
+  ).catch(() => null)
+  if (!res || res.status() !== 200) return null
+  const body = await res.json().catch(() => null)
+  return body?.data?.[0]?.id ?? null
+}
+
+async function createMinimalDefinitionViaUi(
+  page: Page,
+  workflowId: string,
+  workflowName: string,
+): Promise<void> {
+  await page.goto('/backend/definitions/create')
+  await expect(page).toHaveURL(/\/backend\/definitions\/create/)
+
+  await fillText(page, page.getByPlaceholder('checkout_workflow'), workflowId)
+  await fillText(page, page.getByPlaceholder('Enter a descriptive workflow name'), workflowName)
+
+  const addStepBtn = page.getByRole('button', { name: /^add step$/i })
+  await addStepBtn.click()
+  await fillText(page, page.locator('#step-0-id'), 'start')
+  await fillText(page, page.locator('#step-0-name'), 'Start')
+  await page.locator('#step-0-type').selectOption('START')
+
+  await addStepBtn.click()
+  await fillText(page, page.locator('#step-1-id'), 'end')
+  await fillText(page, page.locator('#step-1-name'), 'End')
+  await page.locator('#step-1-type').selectOption('END')
+
+  await page.getByRole('button', { name: /^add transition$/i }).click()
+  await fillText(page, page.locator('#transition-0-id'), 'start-to-end')
+  await fillText(page, page.locator('#transition-0-name'), 'Auto advance')
+  await page.locator('#transition-0-from').selectOption('start')
+  await page.locator('#transition-0-to').selectOption('end')
+
+  await page.getByRole('button', { name: /^create workflow$/i }).first().click()
+  await expect(page).toHaveURL(/\/backend\/definitions(\?|$|\/)/, { timeout: 15_000 })
+}
+
+async function openDefinitionDetailViaRowAction(page: Page, workflowId: string): Promise<void> {
+  const searchBox = page.getByPlaceholder(/search/i).first()
+  if (await searchBox.isVisible().catch(() => false)) {
+    await fillText(page, searchBox, workflowId)
+    await searchBox.press('Enter').catch(() => undefined)
+  }
+
+  const row = page.getByRole('row').filter({ hasText: workflowId })
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.getByRole('button', { name: /open actions/i }).hover()
+  await page.getByRole('menuitem', { name: /^edit$/i }).first().click()
+  await expect(page).toHaveURL(/\/backend\/definitions\/[0-9a-f-]{36}/i, { timeout: 15_000 })
+}
+
+async function addEventTriggerViaUi(page: Page, triggerName: string, eventPattern: string): Promise<void> {
+  await page.getByRole('button', { name: /^add trigger$/i }).click()
+
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+
+  await fillText(page, dialog.locator('#trigger-name'), triggerName)
+  const patternInput = dialog.getByPlaceholder('sales.orders.updated')
+  await fillText(page, patternInput, eventPattern)
+  // EventPatternInput only commits via blur/Enter; press Tab to trigger confirmSelection
+  await patternInput.press('Tab')
+
+  await expect(dialog.getByRole('button', { name: /^create$/i })).toBeEnabled({ timeout: 5_000 })
+  await dialog.getByRole('button', { name: /^create$/i }).click()
+  await expect(dialog).toBeHidden({ timeout: 5_000 })
+
+  // Trigger card now lists the pattern inline
+  await expect(page.getByText(eventPattern, { exact: true }).first()).toBeVisible()
+}
+
+/**
+ * TC-WF-008: End-to-end workflow execution fully driven from the admin UI.
+ *
+ * The admin UI does not expose a direct "Start Instance" button, so we route the
+ * execution path through an event trigger (`customers.person.created`) — which is
+ * still the most UI-real way to exercise a workflow end-to-end:
+ *   1. Create a START → END definition via the Create form
+ *   2. Open it via the list row action
+ *   3. Add a `customers.person.created` trigger through the triggers dialog
+ *   4. Submit the edit form to persist the trigger
+ *   5. Create a Person via the CRM UI — this fires `customers.person.created`
+ *   6. Navigate to `/backend/instances`, filter by our workflowId, and assert that
+ *      the auto-started instance appears and reaches a terminal state.
+ */
+test.describe('TC-WF-008: Event-triggered workflow runs end-to-end via UI', () => {
+  test('creates a triggered workflow, fires the event through CRM UI, and sees the instance execute', async ({
+    page,
+    request,
+  }) => {
+    // UI walkthrough + async trigger evaluation + instance completion polling
+    // easily exceeds the 20s default.
+    test.setTimeout(150_000)
+    const timestamp = Date.now()
+    const workflowId = `qa-wf-008-${timestamp}`
+    const workflowName = `QA TC-WF-008 ${timestamp}`
+    const triggerName = `QA Person Created Trigger ${timestamp}`
+    const firstName = `QA${timestamp}`
+    const lastName = 'WF008'
+    let token: string | null = null
+
+    try {
+      token = await getAuthToken(request, 'admin')
+
+      await login(page, 'admin')
+      await createMinimalDefinitionViaUi(page, workflowId, workflowName)
+      await openDefinitionDetailViaRowAction(page, workflowId)
+
+      await addEventTriggerViaUi(page, triggerName, 'customers.person.created')
+
+      // Persist the trigger by submitting the definition edit form
+      await page.getByRole('button', { name: /^update workflow$/i }).first().click()
+      await expect(page).toHaveURL(/\/backend\/definitions(\?|$|\/)/, { timeout: 15_000 })
+
+      // Create a person via the CRM UI → fires customers.person.created → trigger runs
+      await page.goto('/backend/customers/people/create')
+      await expect(page).toHaveURL(/\/backend\/customers\/people\/create/)
+
+      await page.locator('form').getByRole('textbox').first().fill(firstName)
+      await page.locator('form').getByRole('textbox').nth(1).fill(lastName)
+      await page.getByPlaceholder('name@example.com').fill(`qa.wf008.${timestamp}@example.com`)
+
+      await page.getByRole('button', { name: /create person/i }).first().click()
+      await expect(page).toHaveURL(/\/backend\/customers\/people-v2\/[0-9a-f-]{36}$/i, { timeout: 15_000 })
+
+      // Capture the newly created person's entity id from the URL so we can
+      // later prove the workflow instance we observe was triggered by THIS
+      // specific person creation (not a stray prior instance).
+      const personIdMatch = page.url().match(/\/backend\/customers\/people-v2\/([0-9a-f-]{36})/i)
+      const personEntityId = personIdMatch?.[1]
+      expect(personEntityId).toBeTruthy()
+
+      // Look for the auto-started instance and wait for it to reach COMPLETED.
+      // Trigger evaluation is async (subscriber → queue), so poll the instances
+      // list until the row appears AND its status cell reads "Completed". The
+      // list renders status as title-case i18n ("Completed"); the detail page
+      // also contains COMPLETED uppercase inside hidden React Flow nodes,
+      // so asserting on the list row is more robust.
+      const instanceRow = page.getByRole('row').filter({ hasText: workflowId }).first()
+      await expect(async () => {
+        await page.goto('/backend/instances')
+        await expect(instanceRow).toBeVisible({ timeout: 2_000 })
+        await expect(instanceRow).toContainText('Completed', { timeout: 2_000 })
+      }).toPass({ timeout: 60_000, intervals: [1_000, 2_000, 3_000] })
+
+      await instanceRow.getByRole('link').first().click()
+      await expect(page).toHaveURL(/\/backend\/instances\/[0-9a-f-]{36}/i, { timeout: 10_000 })
+
+      // Prove causation: the event-trigger service spreads the event payload
+      // into the instance context, so the `customers.person.created` payload's
+      // `entityId` is rendered in the Context JSON panel on the instance page.
+      // Matching on that id ties this completed instance to our specific
+      // person creation rather than any concurrent run.
+      await expect(page.getByText(personEntityId!, { exact: false }).first())
+        .toBeVisible({ timeout: 10_000 })
+    } finally {
+      if (token) {
+        const instanceId = await findInstanceIdByWorkflowId(request, token, workflowId)
+        await cancelWorkflowInstanceIfExists(request, token, instanceId)
+
+        const leftoverId = await findDefinitionIdByWorkflowId(request, token, workflowId)
+        await deleteWorkflowDefinitionIfExists(request, token, leftoverId)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
@@ -19,6 +19,7 @@ import {
   type UpdateWorkflowDefinitionApiInput,
 } from '../../../data/validators'
 import { serializeWorkflowDefinition } from '../serialize'
+import { invalidateTriggerCache } from '../../../lib/event-trigger-service'
 
 export const metadata = {
   requireAuth: true,
@@ -178,6 +179,10 @@ export async function PUT(
 
     await em.flush()
 
+    // Embedded triggers may have changed; invalidate the in-memory cache so
+    // the wildcard event subscriber reloads them on the next event.
+    if (tenantId) invalidateTriggerCache(tenantId, organizationId ?? undefined)
+
     return NextResponse.json({
       data: serializeWorkflowDefinition(definition),
       message: 'Workflow definition updated successfully',
@@ -268,6 +273,8 @@ export async function DELETE(
     definition.updatedAt = new Date()
 
     await em.flush()
+
+    if (tenantId) invalidateTriggerCache(tenantId, organizationId ?? undefined)
 
     return NextResponse.json({
       message: 'Workflow definition deleted successfully',

--- a/packages/core/src/modules/workflows/api/definitions/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/route.ts
@@ -18,6 +18,7 @@ import {
   type CreateWorkflowDefinitionApiInput,
 } from '../../data/validators'
 import { serializeWorkflowDefinition } from './serialize'
+import { invalidateTriggerCache } from '../../lib/event-trigger-service'
 
 export const metadata = {
   requireAuth: true,
@@ -208,6 +209,11 @@ export async function POST(request: NextRequest) {
     })
 
     await em.persist(definition).flush()
+
+    // Newly-created embedded triggers must be visible to the wildcard event
+    // subscriber immediately; invalidate the in-memory trigger cache so the
+    // next event reload picks up this definition.
+    if (tenantId) invalidateTriggerCache(tenantId, organizationId ?? undefined)
 
     return NextResponse.json(
       {


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Adds three real browser-driven Playwright specs for the workflows admin UI (create/delete definition, visual editor rendering, full event-trigger → auto-started instance → COMPLETED). Also fixes a trigger-cache bug discovered while stabilising the specs: fresh/edited definitions weren't triggering until the 5-minute per-tenant cache TTL expired because `invalidateTriggerCache` was never called.

**Why I'd like this merged:** I want this UI-level safety net green on `develop` so I can safely continue with follow-up workflows work without regressing the admin UI — specifically the WAIT activity/step type (#1472) and code-based workflow definitions (#1444).

## Changes

- `packages/core/src/modules/workflows/__integration__/TC-WF-006.spec.ts` — UI-driven create + delete of a workflow definition (form → list row action).
- `packages/core/src/modules/workflows/__integration__/TC-WF-007.spec.ts` — Visual editor renders a UI-created START→END workflow with its transition.
- `packages/core/src/modules/workflows/__integration__/TC-WF-008.spec.ts` — Event-trigger end-to-end: create definition + `customers.person.created` trigger through the triggers dialog, create a Person in the CRM UI to fire the event, wait for the auto-started instance row to reach `Completed`, and verify the instance Context panel contains the created person's entity id (proves causation).
- `packages/core/src/modules/workflows/api/definitions/route.ts` — invalidate trigger cache after `POST` create.
- `packages/core/src/modules/workflows/api/definitions/[id]/route.ts` — invalidate trigger cache after `PUT` update and `DELETE` soft-delete.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (test additions + targeted bug fix, no spec change needed)

**Spec file path:**
N/A

## Testing

- `yarn test:integration:ephemeral packages/core/src/modules/workflows/__integration__/TC-WF-006.spec.ts` — pass
- `yarn test:integration:ephemeral packages/core/src/modules/workflows/__integration__/TC-WF-007.spec.ts` — pass
- `yarn test:integration:ephemeral packages/core/src/modules/workflows/__integration__/TC-WF-008.spec.ts` — pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance

N/A — no UI component changes; only new test specs and a server-side cache invalidation.

## Linked issues

Related follow-up work I'd like to build on top of a green `develop`:
- #1472 — feat(workflows): implement WAIT activity type
- #1444 — feat(workflows): code-only workflow definitions