### PR TITLE
feat(shared): accept { cause } option in CrudHttpError constructor

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/errors.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/errors.test.ts
@@ -1,0 +1,36 @@
+import { CrudHttpError, isCrudHttpError } from '../errors'
+
+describe('CrudHttpError', () => {
+  it('builds from string body', () => {
+    const err = new CrudHttpError(400, 'Bad thing')
+    expect(err.status).toBe(400)
+    expect(err.body).toEqual({ error: 'Bad thing' })
+    expect(err.message).toBe('Bad thing')
+    expect(isCrudHttpError(err)).toBe(true)
+  })
+
+  it('builds from object body', () => {
+    const err = new CrudHttpError(422, { error: 'nope', field: 'x' })
+    expect(err.body).toEqual({ error: 'nope', field: 'x' })
+    expect(err.message).toBe('nope')
+  })
+
+  it('forwards cause to Error constructor', () => {
+    const upstream = new Error('upstream boom')
+    const err = new CrudHttpError(502, { error: 'Upstream API error' }, { cause: upstream })
+    expect(err.cause).toBe(upstream)
+    expect(err.status).toBe(502)
+    expect(err.body).toEqual({ error: 'Upstream API error' })
+  })
+
+  it('accepts cause with string body', () => {
+    const upstream = new Error('root')
+    const err = new CrudHttpError(500, 'Failed', { cause: upstream })
+    expect(err.cause).toBe(upstream)
+  })
+
+  it('cause defaults to undefined when options omitted', () => {
+    const err = new CrudHttpError(400, 'x')
+    expect(err.cause).toBeUndefined()
+  })
+})

--- a/packages/shared/src/lib/crud/errors.ts
+++ b/packages/shared/src/lib/crud/errors.ts
@@ -7,9 +7,13 @@ export class CrudHttpError extends Error {
   status: number
   body: Record<string, any>
 
-  constructor(status: number, body?: Record<string, any> | string) {
+  constructor(
+    status: number,
+    body?: Record<string, any> | string,
+    options?: { cause?: unknown },
+  ) {
     const normalizedBody = typeof body === 'string' ? { error: body } : body ?? {}
-    super(typeof body === 'string' ? body : normalizedBody.error ?? 'Request failed')
+    super(typeof body === 'string' ? body : normalizedBody.error ?? 'Request failed', options)
     this.status = status
     this.body = normalizedBody
   }


### PR DESCRIPTION
## Summary

- Adds optional third argument `options?: { cause?: unknown }` to `CrudHttpError` and forwards it to `super(message, options)`.
- Lets callers preserve upstream error chains when wrapping provider/service failures at the CRUD boundary: `throw new CrudHttpError(502, { error: '...' }, { cause: err })`.
- Fully backward compatible — existing two-arg call sites are unaffected.

## Why

`CrudHttpError` is the canonical wrap-and-rethrow boundary for API/CRUD handlers, so it's exactly where upstream provider error context tends to be lost. Today callers have to either post-hoc assign `.cause` or use a `withCause()` helper — functional but undiscoverable from the signature. Forwarding `{ cause }` to the base `Error` makes `util.inspect`, Sentry, and New Relic render the full chain.

Closes #1690

## Test plan

- [x] New unit tests in `packages/shared/src/lib/crud/__tests__/errors.test.ts` cover cause forwarding with object body, string body, and default-undefined.
- [x] `yarn jest src/lib/crud/__tests__/errors.test.ts` in `packages/shared` → 5/5 pass.
- [ ] CI lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)