### PR TITLE
fix(security): atomic password change + audit event for customer_accounts

### DIFF
--- a/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
+++ b/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
@@ -156,8 +156,8 @@ None — no `--skill-url` passed. Guidance derived from root `AGENTS.md` (PR wor
 
 ### Phase 6: Full validation gate + PR
 
-- [ ] 6.1 Run full validation gate
-- [ ] 6.2 Self code-review + BC self-review
-- [ ] 6.3 Open PR with labels
-- [ ] 6.4 Run auto-review-pr autofix loop
+- [x] 6.1 Run full validation gate — passed (cf6d3886f)
+- [x] 6.2 Self code-review + BC self-review — cf6d3886f
+- [x] 6.3 Open PR with labels — PR #1692
+- [x] 6.4 Run auto-review-pr autofix loop — 13927fc0b (M-1 reset-confirm 404→400, L-1 admin fallback cleanup)
 - [ ] 6.5 Post summary comment, flip Status to complete

--- a/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
+++ b/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
@@ -143,16 +143,16 @@ None — no `--skill-url` passed. Guidance derived from root `AGENTS.md` (PR wor
 
 ### Phase 4: Wire reset-confirm.ts
 
-- [ ] 4.1 Look up user to obtain organizationId
-- [ ] 4.2 Wrap mutations in em.transactional
-- [ ] 4.3 Emit event with changedBy: 'reset'
-- [ ] 4.4 Add reset-confirm.route.test.ts
+- [x] 4.1 Look up user to obtain organizationId — 7c2f0d275
+- [x] 4.2 Wrap mutations in em.transactional — 7c2f0d275
+- [x] 4.3 Emit event with changedBy: 'reset' — 7c2f0d275
+- [x] 4.4 Add reset-confirm.route.test.ts — 7c2f0d275
 
 ### Phase 5: Wire admin reset-password.ts
 
-- [ ] 5.1 Wrap mutations in em.transactional
-- [ ] 5.2 Emit password.changed alongside existing password.reset
-- [ ] 5.3 Add reset-password.route.test.ts
+- [x] 5.1 Wrap mutations in em.transactional — f378b534c
+- [x] 5.2 Emit password.changed alongside existing password.reset — f378b534c
+- [x] 5.3 Add reset-password.route.test.ts — f378b534c
 
 ### Phase 6: Full validation gate + PR
 

--- a/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
+++ b/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
@@ -1,0 +1,163 @@
+# Atomic Password Change + Audit Event — Execution Plan
+
+**Date:** 2026-04-24
+**Slug:** `atomic-password-change-and-audit-event`
+**Branch:** `fix/atomic-password-change-and-audit-event`
+**Motivated by:** Follow-up review observations from PR #1686 (`fix(security): revoke customer sessions on self-service password change`).
+
+## Goal
+
+Two related hardening improvements to customer password-change handlers:
+
+1. **Transactional atomicity** — wrap `customerUserService.updatePassword(...)` + `customerSessionService.revokeAllUserSessions(...)` in a single MikroORM transaction so a revoke failure rolls back the password write. Today, if revoke fails after the password is persisted, sessions linger.
+2. **Audit event emission** — declare a new typed event `customer_accounts.password.changed` in the `customer_accounts` module's `events.ts` and emit it from all three password-change handlers **after** the transaction commits (so rollback does not emit).
+
+## Scope
+
+### In-scope files
+
+- `packages/core/src/modules/customer_accounts/events.ts` — declare `customer_accounts.password.changed`.
+- `packages/core/src/modules/customer_accounts/services/customerUserService.ts` — accept optional `EntityManager` param for `updatePassword`.
+- `packages/core/src/modules/customer_accounts/services/customerSessionService.ts` — accept optional `EntityManager` param for `revokeAllUserSessions`.
+- `packages/core/src/modules/customer_accounts/api/portal/password-change.ts` — wrap in transaction, emit event.
+- `packages/core/src/modules/customer_accounts/api/password/reset-confirm.ts` — wrap in transaction, emit event.
+- `packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts` — wrap in transaction, keep existing `password.reset` event, additionally emit `password.changed`.
+- `packages/core/src/modules/customer_accounts/api/portal/__tests__/password-change.route.test.ts` — extend with new invariants.
+- `packages/core/src/modules/customer_accounts/api/password/__tests__/reset-confirm.route.test.ts` — new test file.
+- `packages/core/src/modules/customer_accounts/api/admin/users/[id]/__tests__/reset-password.route.test.ts` — new test file.
+
+### Non-goals
+
+- No subscriber for the new event (declaration + emission only).
+- No DB schema changes.
+- No changes to other handlers that call `updatePassword` or `revokeAllUserSessions`.
+- No UI changes.
+- No refactor of existing `password.reset` event (admin route continues emitting it for BC).
+
+## Event payload shape
+
+```ts
+'customer_accounts.password.changed': {
+  userId: string,
+  tenantId: string,
+  organizationId: string | null,
+  changedBy: 'self' | 'admin' | 'reset',
+  changedById: string | null,
+  at: string  // ISO8601
+}
+```
+
+- `self` → portal self-service (`password-change.ts`)
+- `reset` → magic-link reset confirm (`reset-confirm.ts`)
+- `admin` → admin-initiated reset (`admin/users/[id]/reset-password.ts`)
+- `changedById`: admin actor id when `changedBy === 'admin'`; `null` otherwise.
+
+## Transaction pattern
+
+Services currently hold a reference to the scoped `em`. MikroORM v7 `em.transactional(cb)` forks the em internally; operations on the outer em are NOT in the transaction. To avoid invasive DI restructuring, add an **optional** `em?: EntityManager` parameter to the two mutating service methods. Inside a handler, resolve services from the container (preserves existing test mocks), then:
+
+```ts
+const em = container.resolve('em') as EntityManager
+await em.transactional(async (trx) => {
+  await customerUserService.updatePassword(user, newPassword, trx)
+  await customerSessionService.revokeAllUserSessions(user.id, trx)
+})
+// Emit event AFTER the transaction commits; a rollback must not emit.
+await emitCustomerAccountsEvent('customer_accounts.password.changed', { ... })
+```
+
+Short-circuit checks (missing auth, invalid body, wrong current password, user not found) stay OUTSIDE the transaction.
+
+## External References
+
+None — no `--skill-url` passed. Guidance derived from root `AGENTS.md` (PR workflow, conventional commits, full gate) and `packages/core/AGENTS.md` (events, transactions, BC).
+
+## Risks
+
+- **BC on service signatures:** Adding a trailing optional param to `updatePassword` / `revokeAllUserSessions` is additive. Per `BACKWARD_COMPATIBILITY.md` category #3 ("Function signatures" — STABLE, new optional params OK), this is permitted.
+- **Event-emission TypeScript compile:** `emitCustomerAccountsEvent` is typed off the `as const` array. Adding a new entry is additive.
+- **Admin route emits two events:** `customer_accounts.password.reset` (existing, keep for BC) + `customer_accounts.password.changed` (new). Any existing subscribers on `.reset` are unaffected.
+- **Reset-confirm handler currently does not look up the user object** — only has `{ userId, tenantId }` from the token. We need `organizationId` for the new event, so the handler will do a single `customerUserService.findById(userId, tenantId)` after token verification. This is a tiny extra query and not a contract change.
+
+## Implementation Plan
+
+### Phase 1: Declare the audit event
+
+- 1.1 Add `customer_accounts.password.changed` to the events array in `events.ts` with `label: 'Customer Password Changed'`, `category: 'lifecycle'`. No broadcast flags (audit event).
+- 1.2 Run `yarn generate` so the typed emit surface picks up the new id.
+
+### Phase 2: Make service methods transaction-aware
+
+- 2.1 Add optional `em?: EntityManager` to `CustomerUserService.updatePassword` — when provided, use it instead of `this.em`.
+- 2.2 Add optional `em?: EntityManager` to `CustomerSessionService.revokeAllUserSessions` — when provided, use it instead of `this.em`.
+
+### Phase 3: Wire portal `password-change.ts`
+
+- 3.1 Resolve `em` from the container, wrap the two mutating calls in `em.transactional(...)`, emit `customer_accounts.password.changed` with `changedBy: 'self'` after commit.
+- 3.2 Extend `password-change.route.test.ts`:
+  - Happy-path event emission with full payload.
+  - Revoke-failure rollback: when `revokeAllUserSessions` throws, the handler returns 5xx and the event is NOT emitted.
+  - Event NOT emitted on short-circuits (wrong current password, missing auth, missing user, validation failure).
+- 3.3 Preserve all 6 pre-existing invariants from PR #1686.
+
+### Phase 4: Wire `reset-confirm.ts`
+
+- 4.1 After token verification, look up the user via `customerUserService.findById(result.userId, result.tenantId)` to obtain `organizationId`.
+- 4.2 Wrap the `updatePassword` + `revokeAllUserSessions` pair in `em.transactional(...)`. Leave the existing `emailVerifiedAt` native update outside the transaction (pre-existing behavior, out of scope to tighten here).
+- 4.3 Emit `customer_accounts.password.changed` with `changedBy: 'reset'` after commit.
+- 4.4 Create `reset-confirm.route.test.ts` pinning: happy-path emission, rollback-on-revoke-failure (no emission), no emission on invalid token / validation failure.
+
+### Phase 5: Wire admin `reset-password.ts`
+
+- 5.1 Wrap the two mutating calls in `em.transactional(...)`.
+- 5.2 Keep the existing `customer_accounts.password.reset` emission (BC) AND add `customer_accounts.password.changed` with `changedBy: 'admin'`, `changedById: auth.sub`.
+- 5.3 Create `reset-password.route.test.ts` pinning: happy-path both events emitted, rollback-on-revoke-failure emits NEITHER event, no emission on 401/403/404/validation short-circuits.
+
+### Phase 6: Full validation gate + PR
+
+- 6.1 Run: `yarn build:packages`, `yarn generate`, `yarn build:packages` (post-generate), `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`.
+- 6.2 Self code-review (`.ai/skills/code-review/SKILL.md`) + BC self-review (`BACKWARD_COMPATIBILITY.md`).
+- 6.3 Open PR against `develop`, apply `security` + `needs-qa` labels.
+- 6.4 Run `auto-review-pr` in autofix mode; iterate until clean or only non-actionable findings remain.
+- 6.5 Post comprehensive summary comment, flip `Status:` to `complete`, clean up worktree.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Declare the audit event
+
+- [ ] 1.1 Add `customer_accounts.password.changed` to events.ts
+- [ ] 1.2 Run yarn generate
+
+### Phase 2: Make service methods transaction-aware
+
+- [ ] 2.1 Add optional em param to CustomerUserService.updatePassword
+- [ ] 2.2 Add optional em param to CustomerSessionService.revokeAllUserSessions
+
+### Phase 3: Wire portal password-change.ts
+
+- [ ] 3.1 Wrap mutations in em.transactional and emit event
+- [ ] 3.2 Extend password-change.route.test.ts
+- [ ] 3.3 Verify pre-existing invariants still pass
+
+### Phase 4: Wire reset-confirm.ts
+
+- [ ] 4.1 Look up user to obtain organizationId
+- [ ] 4.2 Wrap mutations in em.transactional
+- [ ] 4.3 Emit event with changedBy: 'reset'
+- [ ] 4.4 Add reset-confirm.route.test.ts
+
+### Phase 5: Wire admin reset-password.ts
+
+- [ ] 5.1 Wrap mutations in em.transactional
+- [ ] 5.2 Emit password.changed alongside existing password.reset
+- [ ] 5.3 Add reset-password.route.test.ts
+
+### Phase 6: Full validation gate + PR
+
+- [ ] 6.1 Run full validation gate
+- [ ] 6.2 Self code-review + BC self-review
+- [ ] 6.3 Open PR with labels
+- [ ] 6.4 Run auto-review-pr autofix loop
+- [ ] 6.5 Post summary comment, flip Status to complete

--- a/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
+++ b/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
@@ -160,4 +160,4 @@ None — no `--skill-url` passed. Guidance derived from root `AGENTS.md` (PR wor
 - [x] 6.2 Self code-review + BC self-review — cf6d3886f
 - [x] 6.3 Open PR with labels — PR #1692
 - [x] 6.4 Run auto-review-pr autofix loop — 13927fc0b (M-1 reset-confirm 404→400, L-1 admin fallback cleanup)
-- [ ] 6.5 Post summary comment, flip Status to complete
+- [x] 6.5 Post summary comment, flip Status to complete — 79a9706a7

--- a/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
+++ b/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
@@ -127,8 +127,8 @@ None — no `--skill-url` passed. Guidance derived from root `AGENTS.md` (PR wor
 
 ### Phase 1: Declare the audit event
 
-- [ ] 1.1 Add `customer_accounts.password.changed` to events.ts
-- [ ] 1.2 Run yarn generate
+- [x] 1.1 Add `customer_accounts.password.changed` to events.ts — d56779fc1
+- [x] 1.2 Run yarn generate — d56779fc1
 
 ### Phase 2: Make service methods transaction-aware
 

--- a/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
+++ b/.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
@@ -132,14 +132,14 @@ None — no `--skill-url` passed. Guidance derived from root `AGENTS.md` (PR wor
 
 ### Phase 2: Make service methods transaction-aware
 
-- [ ] 2.1 Add optional em param to CustomerUserService.updatePassword
-- [ ] 2.2 Add optional em param to CustomerSessionService.revokeAllUserSessions
+- [x] 2.1 Add optional em param to CustomerUserService.updatePassword — 35add3054
+- [x] 2.2 Add optional em param to CustomerSessionService.revokeAllUserSessions — 35add3054
 
 ### Phase 3: Wire portal password-change.ts
 
-- [ ] 3.1 Wrap mutations in em.transactional and emit event
-- [ ] 3.2 Extend password-change.route.test.ts
-- [ ] 3.3 Verify pre-existing invariants still pass
+- [x] 3.1 Wrap mutations in em.transactional and emit event — 77d4334a8
+- [x] 3.2 Extend password-change.route.test.ts — 77d4334a8
+- [x] 3.3 Verify pre-existing invariants still pass — 77d4334a8
 
 ### Phase 4: Wire reset-confirm.ts
 

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/__tests__/reset-password.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/__tests__/reset-password.route.test.ts
@@ -1,0 +1,175 @@
+/** @jest-environment node */
+
+const mockGetAuth = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+const mockFindById = jest.fn()
+const mockUpdatePassword = jest.fn()
+const mockRevokeAllUserSessions = jest.fn()
+const mockTransactional = jest.fn(async (cb: (trx: unknown) => Promise<unknown>) => cb({}))
+const mockEmit = jest.fn(async () => undefined)
+
+const rbacService = { userHasAllFeatures: mockUserHasAllFeatures }
+
+const customerUserService = {
+  findById: mockFindById,
+  updatePassword: mockUpdatePassword,
+}
+
+const customerSessionService = {
+  revokeAllUserSessions: mockRevokeAllUserSessions,
+}
+
+const mockEm = {
+  transactional: (cb: (trx: unknown) => Promise<unknown>) => mockTransactional(cb),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'rbacService') return rbacService
+    if (token === 'customerUserService') return customerUserService
+    if (token === 'customerSessionService') return customerSessionService
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuth(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: (...args: unknown[]) => mockEmit(...args),
+}))
+
+import { POST } from '@open-mercato/core/modules/customer_accounts/api/admin/users/[id]/reset-password'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '33333333-3333-4333-8333-333333333333'
+const adminId = '44444444-4444-4444-8444-444444444444'
+const userId = '22222222-2222-4222-8222-222222222222'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request(`http://localhost/api/customer_accounts/admin/users/${userId}/reset-password`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('admin /api/customer_accounts/admin/users/[id]/reset-password — atomicity and audit events', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuth.mockResolvedValue({ sub: adminId, tenantId, orgId })
+    mockUserHasAllFeatures.mockResolvedValue(true)
+    mockFindById.mockResolvedValue({ id: userId, tenantId, organizationId: orgId, email: 'user@example.com' })
+    mockUpdatePassword.mockResolvedValue(undefined)
+    mockRevokeAllUserSessions.mockResolvedValue(undefined)
+    mockTransactional.mockImplementation(async (cb) => cb({}))
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  it('runs updatePassword + revokeAllUserSessions inside em.transactional and emits both password.reset and password.changed after commit', async () => {
+    const res = await POST(
+      makeRequest({ newPassword: 'new-strong-Passw0rd!' }),
+      { params: { id: userId } },
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(mockTransactional).toHaveBeenCalledTimes(1)
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledTimes(2)
+
+    const txOrder = mockTransactional.mock.invocationCallOrder[0]
+    const firstEmitOrder = mockEmit.mock.invocationCallOrder[0]
+    expect(txOrder).toBeLessThan(firstEmitOrder)
+
+    const emittedIds = mockEmit.mock.calls.map((c: unknown[]) => c[0])
+    expect(emittedIds).toContain('customer_accounts.password.reset')
+    expect(emittedIds).toContain('customer_accounts.password.changed')
+
+    const changedCall = mockEmit.mock.calls.find((c: unknown[]) => c[0] === 'customer_accounts.password.changed')
+    expect(changedCall).toBeDefined()
+    const payload = changedCall![1] as Record<string, unknown>
+    expect(payload).toMatchObject({
+      userId,
+      tenantId,
+      organizationId: orgId,
+      changedBy: 'admin',
+      changedById: adminId,
+    })
+    expect(typeof payload.at).toBe('string')
+    expect(() => new Date(payload.at as string).toISOString()).not.toThrow()
+  })
+
+  it('does NOT emit any audit event when the transaction rolls back because revokeAllUserSessions throws', async () => {
+    mockRevokeAllUserSessions.mockRejectedValue(new Error('boom'))
+
+    await expect(
+      POST(
+        makeRequest({ newPassword: 'new-strong-Passw0rd!' }),
+        { params: { id: userId } },
+      ),
+    ).rejects.toThrow('boom')
+
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT run the transaction or emit when the caller is not authenticated', async () => {
+    mockGetAuth.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({ newPassword: 'new-strong-Passw0rd!' }),
+      { params: { id: userId } },
+    )
+
+    expect(res.status).toBe(401)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT run the transaction or emit when the caller lacks customer_accounts.manage', async () => {
+    mockUserHasAllFeatures.mockResolvedValue(false)
+
+    const res = await POST(
+      makeRequest({ newPassword: 'new-strong-Passw0rd!' }),
+      { params: { id: userId } },
+    )
+
+    expect(res.status).toBe(403)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT run the transaction or emit when the target user cannot be found', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({ newPassword: 'new-strong-Passw0rd!' }),
+      { params: { id: userId } },
+    )
+
+    expect(res.status).toBe(404)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT run the transaction or emit when the body fails validation', async () => {
+    const res = await POST(
+      makeRequest({ newPassword: 'x' }),
+      { params: { id: userId } },
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
@@ -38,13 +39,16 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   const customerUserService = container.resolve('customerUserService') as CustomerUserService
   const customerSessionService = container.resolve('customerSessionService') as CustomerSessionService
+  const em = container.resolve('em') as EntityManager
   const user = await customerUserService.findById(params.id, auth.tenantId!)
   if (!user) {
     return NextResponse.json({ ok: false, error: 'User not found' }, { status: 404 })
   }
 
-  await customerUserService.updatePassword(user, parsed.data.newPassword)
-  await customerSessionService.revokeAllUserSessions(user.id)
+  await em.transactional(async (trx) => {
+    await customerUserService.updatePassword(user, parsed.data.newPassword, trx)
+    await customerSessionService.revokeAllUserSessions(user.id, trx)
+  })
 
   void emitCustomerAccountsEvent('customer_accounts.password.reset', {
     id: user.id,
@@ -52,6 +56,15 @@ export async function POST(req: Request, { params }: { params: { id: string } })
     tenantId: auth.tenantId,
     organizationId: auth.orgId,
     resetBy: auth.sub,
+  }).catch(() => undefined)
+
+  void emitCustomerAccountsEvent('customer_accounts.password.changed', {
+    userId: user.id,
+    tenantId: auth.tenantId ?? user.tenantId,
+    organizationId: auth.orgId ?? user.organizationId ?? null,
+    changedBy: 'admin',
+    changedById: auth.sub,
+    at: new Date().toISOString(),
   }).catch(() => undefined)
 
   return NextResponse.json({ ok: true })

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts
@@ -60,8 +60,8 @@ export async function POST(req: Request, { params }: { params: { id: string } })
 
   void emitCustomerAccountsEvent('customer_accounts.password.changed', {
     userId: user.id,
-    tenantId: auth.tenantId ?? user.tenantId,
-    organizationId: auth.orgId ?? user.organizationId ?? null,
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId ?? null,
     changedBy: 'admin',
     changedById: auth.sub,
     at: new Date().toISOString(),

--- a/packages/core/src/modules/customer_accounts/api/password/__tests__/reset-confirm.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/__tests__/reset-confirm.route.test.ts
@@ -1,0 +1,146 @@
+/** @jest-environment node */
+
+const mockVerifyPasswordResetToken = jest.fn()
+const mockFindById = jest.fn()
+const mockUpdatePassword = jest.fn()
+const mockRevokeAllUserSessions = jest.fn()
+const mockNativeUpdate = jest.fn()
+const mockTransactional = jest.fn(async (cb: (trx: unknown) => Promise<unknown>) => cb({}))
+const mockEmit = jest.fn(async () => undefined)
+
+const customerTokenService = {
+  verifyPasswordResetToken: mockVerifyPasswordResetToken,
+}
+
+const customerUserService = {
+  findById: mockFindById,
+  updatePassword: mockUpdatePassword,
+}
+
+const customerSessionService = {
+  revokeAllUserSessions: mockRevokeAllUserSessions,
+}
+
+const mockEm = {
+  transactional: (cb: (trx: unknown) => Promise<unknown>) => mockTransactional(cb),
+  nativeUpdate: (...args: unknown[]) => mockNativeUpdate(...args),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'customerTokenService') return customerTokenService
+    if (token === 'customerUserService') return customerUserService
+    if (token === 'customerSessionService') return customerSessionService
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: (...args: unknown[]) => mockEmit(...args),
+}))
+
+import { POST } from '@open-mercato/core/modules/customer_accounts/api/password/reset-confirm'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '33333333-3333-4333-8333-333333333333'
+const userId = '22222222-2222-4222-8222-222222222222'
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/customer_accounts/password/reset-confirm', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('customer /api/customer_accounts/password/reset-confirm — atomicity and audit event', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockVerifyPasswordResetToken.mockResolvedValue({ userId, tenantId })
+    mockFindById.mockResolvedValue({ id: userId, tenantId, organizationId: orgId, email: 'user@example.com' })
+    mockUpdatePassword.mockResolvedValue(undefined)
+    mockRevokeAllUserSessions.mockResolvedValue(undefined)
+    mockNativeUpdate.mockResolvedValue(undefined)
+    mockTransactional.mockImplementation(async (cb) => cb({}))
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  it('runs updatePassword + revokeAllUserSessions inside em.transactional and emits the audit event after commit', async () => {
+    const res = await POST(
+      makeRequest({ token: 'a'.repeat(40), password: 'new-strong-Passw0rd!' }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true })
+    expect(mockTransactional).toHaveBeenCalledTimes(1)
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+
+    const txOrder = mockTransactional.mock.invocationCallOrder[0]
+    const emitOrder = mockEmit.mock.invocationCallOrder[0]
+    expect(txOrder).toBeLessThan(emitOrder)
+
+    const [eventId, payload] = mockEmit.mock.calls[0]
+    expect(eventId).toBe('customer_accounts.password.changed')
+    expect(payload).toMatchObject({
+      userId,
+      tenantId,
+      organizationId: orgId,
+      changedBy: 'reset',
+      changedById: null,
+    })
+    expect(typeof payload.at).toBe('string')
+    expect(() => new Date(payload.at).toISOString()).not.toThrow()
+  })
+
+  it('does NOT emit the audit event when the transaction rolls back because revokeAllUserSessions throws', async () => {
+    mockRevokeAllUserSessions.mockRejectedValue(new Error('boom'))
+
+    await expect(
+      POST(makeRequest({ token: 'a'.repeat(40), password: 'new-strong-Passw0rd!' })),
+    ).rejects.toThrow('boom')
+
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the token is invalid', async () => {
+    mockVerifyPasswordResetToken.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({ token: 'a'.repeat(40), password: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the user cannot be found after token verification', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({ token: 'a'.repeat(40), password: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(res.status).toBe(404)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the request body fails validation', async () => {
+    const res = await POST(makeRequest({ token: '', password: 'x' }))
+
+    expect(res.status).toBe(400)
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/password/__tests__/reset-confirm.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/__tests__/reset-confirm.route.test.ts
@@ -124,14 +124,16 @@ describe('customer /api/customer_accounts/password/reset-confirm — atomicity a
     expect(mockEmit).not.toHaveBeenCalled()
   })
 
-  it('does NOT emit the audit event when the user cannot be found after token verification', async () => {
+  it('does NOT emit the audit event when the user cannot be found after token verification (returns the same 400 as an invalid token to avoid surface drift)', async () => {
     mockFindById.mockResolvedValue(null)
 
     const res = await POST(
       makeRequest({ token: 'a'.repeat(40), password: 'new-strong-Passw0rd!' }),
     )
+    const body = await res.json()
 
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
+    expect(body).toEqual({ ok: false, error: 'Invalid or expired token' })
     expect(mockTransactional).not.toHaveBeenCalled()
     expect(mockEmit).not.toHaveBeenCalled()
   })

--- a/packages/core/src/modules/customer_accounts/api/password/reset-confirm.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/reset-confirm.ts
@@ -37,7 +37,7 @@ export async function POST(req: Request) {
 
   const user = await customerUserService.findById(result.userId, result.tenantId)
   if (!user) {
-    return NextResponse.json({ ok: false, error: 'User not found' }, { status: 404 })
+    return NextResponse.json({ ok: false, error: 'Invalid or expired token' }, { status: 400 })
   }
 
   const em = container.resolve('em') as EntityManager

--- a/packages/core/src/modules/customer_accounts/api/password/reset-confirm.ts
+++ b/packages/core/src/modules/customer_accounts/api/password/reset-confirm.ts
@@ -7,6 +7,7 @@ import { CustomerUserService } from '@open-mercato/core/modules/customer_account
 import { CustomerTokenService } from '@open-mercato/core/modules/customer_accounts/services/customerTokenService'
 import { CustomerSessionService } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
+import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import type { EntityManager } from '@mikro-orm/postgresql'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
@@ -34,20 +35,31 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'Invalid or expired token' }, { status: 400 })
   }
 
-  await customerUserService.updatePassword(
-    { id: result.userId } as any,
-    parsed.data.password,
-  )
+  const user = await customerUserService.findById(result.userId, result.tenantId)
+  if (!user) {
+    return NextResponse.json({ ok: false, error: 'User not found' }, { status: 404 })
+  }
 
   const em = container.resolve('em') as EntityManager
+  await em.transactional(async (trx) => {
+    await customerUserService.updatePassword(user, parsed.data.password, trx)
+    await customerSessionService.revokeAllUserSessions(user.id, trx)
+  })
+
   await em.nativeUpdate(
     CustomerUser,
-    { id: result.userId, emailVerifiedAt: null },
+    { id: user.id, emailVerifiedAt: null },
     { emailVerifiedAt: new Date() },
   )
 
-  // Revoke all existing sessions for security
-  await customerSessionService.revokeAllUserSessions(result.userId)
+  void emitCustomerAccountsEvent('customer_accounts.password.changed', {
+    userId: user.id,
+    tenantId: user.tenantId,
+    organizationId: user.organizationId ?? null,
+    changedBy: 'reset',
+    changedById: null,
+    at: new Date().toISOString(),
+  }).catch(() => undefined)
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/customer_accounts/api/portal/__tests__/password-change.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/__tests__/password-change.route.test.ts
@@ -5,6 +5,8 @@ const mockFindById = jest.fn()
 const mockVerifyPassword = jest.fn()
 const mockUpdatePassword = jest.fn()
 const mockRevokeAllUserSessions = jest.fn()
+const mockTransactional = jest.fn(async (cb: (trx: unknown) => Promise<unknown>) => cb({}))
+const mockEmit = jest.fn(async () => undefined)
 
 const customerUserService = {
   findById: mockFindById,
@@ -16,10 +18,15 @@ const customerSessionService = {
   revokeAllUserSessions: mockRevokeAllUserSessions,
 }
 
+const mockEm = {
+  transactional: (cb: (trx: unknown) => Promise<unknown>) => mockTransactional(cb),
+}
+
 const mockContainer = {
   resolve: jest.fn((token: string) => {
     if (token === 'customerUserService') return customerUserService
     if (token === 'customerSessionService') return customerSessionService
+    if (token === 'em') return mockEm
     return null
   }),
 }
@@ -32,9 +39,14 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => mockContainer),
 }))
 
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: (...args: unknown[]) => mockEmit(...args),
+}))
+
 import { POST } from '@open-mercato/core/modules/customer_accounts/api/portal/password-change'
 
 const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '33333333-3333-4333-8333-333333333333'
 const userId = '22222222-2222-4222-8222-222222222222'
 
 function makeRequest(body: Record<string, unknown>) {
@@ -48,11 +60,13 @@ function makeRequest(body: Record<string, unknown>) {
 describe('portal /api/customer_accounts/portal/password-change — session revocation on self-service password change', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetCustomerAuth.mockResolvedValue({ sub: userId, tenantId })
+    mockGetCustomerAuth.mockResolvedValue({ sub: userId, tenantId, orgId })
     mockFindById.mockResolvedValue({ id: userId, email: 'user@example.com' })
     mockVerifyPassword.mockResolvedValue(true)
     mockUpdatePassword.mockResolvedValue(undefined)
     mockRevokeAllUserSessions.mockResolvedValue(undefined)
+    mockTransactional.mockImplementation(async (cb) => cb({}))
+    mockEmit.mockResolvedValue(undefined)
   })
 
   it('revokes all existing sessions after a successful password change', async () => {
@@ -65,7 +79,7 @@ describe('portal /api/customer_accounts/portal/password-change — session revoc
     expect(body).toEqual({ ok: true })
     expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
     expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
-    expect(mockRevokeAllUserSessions).toHaveBeenCalledWith(userId)
+    expect(mockRevokeAllUserSessions.mock.calls[0][0]).toBe(userId)
   })
 
   it('revokes sessions AFTER updatePassword, never before (ordering invariant)', async () => {
@@ -122,5 +136,109 @@ describe('portal /api/customer_accounts/portal/password-change — session revoc
     expect(res.status).toBe(400)
     expect(mockUpdatePassword).not.toHaveBeenCalled()
     expect(mockRevokeAllUserSessions).not.toHaveBeenCalled()
+  })
+})
+
+describe('portal /api/customer_accounts/portal/password-change — transactional atomicity and audit event', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetCustomerAuth.mockResolvedValue({ sub: userId, tenantId, orgId })
+    mockFindById.mockResolvedValue({ id: userId, email: 'user@example.com' })
+    mockVerifyPassword.mockResolvedValue(true)
+    mockUpdatePassword.mockResolvedValue(undefined)
+    mockRevokeAllUserSessions.mockResolvedValue(undefined)
+    mockTransactional.mockImplementation(async (cb) => cb({}))
+    mockEmit.mockResolvedValue(undefined)
+  })
+
+  it('runs updatePassword + revokeAllUserSessions inside em.transactional and emits the audit event after commit', async () => {
+    const res = await POST(
+      makeRequest({ currentPassword: 'old-correct-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockTransactional).toHaveBeenCalledTimes(1)
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockEmit).toHaveBeenCalledTimes(1)
+
+    const txOrder = mockTransactional.mock.invocationCallOrder[0]
+    const emitOrder = mockEmit.mock.invocationCallOrder[0]
+    expect(txOrder).toBeLessThan(emitOrder)
+
+    const [eventId, payload] = mockEmit.mock.calls[0]
+    expect(eventId).toBe('customer_accounts.password.changed')
+    expect(payload).toMatchObject({
+      userId,
+      tenantId,
+      organizationId: orgId,
+      changedBy: 'self',
+      changedById: null,
+    })
+    expect(typeof payload.at).toBe('string')
+    expect(() => new Date(payload.at).toISOString()).not.toThrow()
+  })
+
+  it('does NOT emit the audit event when the transaction rolls back because revokeAllUserSessions throws', async () => {
+    mockTransactional.mockImplementation(async (cb) => {
+      try {
+        await cb({})
+      } catch (err) {
+        throw err
+      }
+    })
+    mockRevokeAllUserSessions.mockRejectedValue(new Error('boom'))
+
+    await expect(
+      POST(
+        makeRequest({ currentPassword: 'old-correct-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+      ),
+    ).rejects.toThrow('boom')
+
+    expect(mockUpdatePassword).toHaveBeenCalledTimes(1)
+    expect(mockRevokeAllUserSessions).toHaveBeenCalledTimes(1)
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the caller is not authenticated', async () => {
+    mockGetCustomerAuth.mockResolvedValue(null)
+
+    await POST(
+      makeRequest({ currentPassword: 'any-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the current password is incorrect', async () => {
+    mockVerifyPassword.mockResolvedValue(false)
+
+    await POST(
+      makeRequest({ currentPassword: 'wrong', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the user cannot be found', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    await POST(
+      makeRequest({ currentPassword: 'any-Passw0rd!', newPassword: 'new-strong-Passw0rd!' }),
+    )
+
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit the audit event when the request body fails validation', async () => {
+    await POST(
+      makeRequest({ currentPassword: 'short', newPassword: 'x' }),
+    )
+
+    expect(mockTransactional).not.toHaveBeenCalled()
+    expect(mockEmit).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/customer_accounts/api/portal/password-change.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/password-change.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib/openapi'
 import { getCustomerAuthFromRequest } from '@open-mercato/core/modules/customer_accounts/lib/customerAuth'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { CustomerUserService } from '@open-mercato/core/modules/customer_accounts/services/customerUserService'
 import { CustomerSessionService } from '@open-mercato/core/modules/customer_accounts/services/customerSessionService'
 import { passwordChangeSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
+import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
 
@@ -30,6 +32,7 @@ export async function POST(req: Request) {
   const container = await createRequestContainer()
   const customerUserService = container.resolve('customerUserService') as CustomerUserService
   const customerSessionService = container.resolve('customerSessionService') as CustomerSessionService
+  const em = container.resolve('em') as EntityManager
 
   const user = await customerUserService.findById(auth.sub, auth.tenantId)
   if (!user) {
@@ -41,10 +44,19 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'Current password is incorrect' }, { status: 400 })
   }
 
-  await customerUserService.updatePassword(user, parsed.data.newPassword)
+  await em.transactional(async (trx) => {
+    await customerUserService.updatePassword(user, parsed.data.newPassword, trx)
+    await customerSessionService.revokeAllUserSessions(user.id, trx)
+  })
 
-  // Revoke all existing sessions for security
-  await customerSessionService.revokeAllUserSessions(user.id)
+  void emitCustomerAccountsEvent('customer_accounts.password.changed', {
+    userId: user.id,
+    tenantId: auth.tenantId,
+    organizationId: auth.orgId ?? null,
+    changedBy: 'self',
+    changedById: null,
+    at: new Date().toISOString(),
+  }).catch(() => undefined)
 
   return NextResponse.json({ ok: true })
 }

--- a/packages/core/src/modules/customer_accounts/events.ts
+++ b/packages/core/src/modules/customer_accounts/events.ts
@@ -12,6 +12,7 @@ const events = [
   { id: 'customer_accounts.email.verified', label: 'Customer Email Verified', category: 'lifecycle', portalBroadcast: true },
   { id: 'customer_accounts.password.reset_requested', label: 'Customer Password Reset Requested', category: 'lifecycle' },
   { id: 'customer_accounts.password.reset', label: 'Customer Password Reset', category: 'lifecycle', portalBroadcast: true },
+  { id: 'customer_accounts.password.changed', label: 'Customer Password Changed', category: 'lifecycle' },
   { id: 'customer_accounts.role.created', label: 'Customer Role Created', entity: 'role', category: 'crud' },
   { id: 'customer_accounts.role.updated', label: 'Customer Role Updated', entity: 'role', category: 'crud', portalBroadcast: true },
   { id: 'customer_accounts.role.deleted', label: 'Customer Role Deleted', entity: 'role', category: 'crud' },

--- a/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerSessionService.ts
@@ -137,14 +137,15 @@ export class CustomerSessionService {
     )
   }
 
-  async revokeAllUserSessions(userId: string): Promise<void> {
+  async revokeAllUserSessions(userId: string, em?: EntityManager): Promise<void> {
     const now = new Date()
-    await this.em.nativeUpdate(
+    const target = em ?? this.em
+    await target.nativeUpdate(
       CustomerUserSession,
       { user: userId as any, deletedAt: null },
       { deletedAt: now },
     )
-    await this.em.nativeUpdate(
+    await target.nativeUpdate(
       CustomerUser,
       { id: userId },
       { sessionsRevokedAt: now },

--- a/packages/core/src/modules/customer_accounts/services/customerUserService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerUserService.ts
@@ -82,9 +82,9 @@ export class CustomerUserService {
     user.lockedUntil = null
   }
 
-  async updatePassword(user: CustomerUser, newPassword: string): Promise<void> {
+  async updatePassword(user: CustomerUser, newPassword: string, em?: EntityManager): Promise<void> {
     const passwordHash = await hash(newPassword, BCRYPT_COST)
-    await this.em.nativeUpdate(CustomerUser, { id: user.id }, { passwordHash })
+    await (em ?? this.em).nativeUpdate(CustomerUser, { id: user.id }, { passwordHash })
     user.passwordHash = passwordHash
   }
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-04-24-atomic-password-change-and-audit-event.md
Status: complete

## Goal
Follow-up hardening from the review observations on #1686:
1. **Transactional atomicity** — `updatePassword` + `revokeAllUserSessions` now run inside a single `em.transactional(...)` on all three customer password-change handlers, so a revoke failure rolls back the password write.
2. **Audit event** — declare `customer_accounts.password.changed` and emit it from all three handlers after the transaction commits, with a `changedBy: 'self' | 'admin' | 'reset'` discriminator. A rollback never produces a ghost event.

Motivated by the two observations left in-scope on #1686:
- *"No transaction wrapping around updatePassword + revokeAllUserSessions. If the revoke call fails after the password was persisted, sessions linger."*
- *"No audit/event emission on password change. `customer_accounts.password.changed` would be useful for the audit trail."*

## What Changed
- `packages/core/src/modules/customer_accounts/events.ts` — declare `customer_accounts.password.changed` (lifecycle, no broadcast; audit event, not a UI signal).
- `packages/core/src/modules/customer_accounts/services/customerUserService.ts` — `updatePassword(user, newPassword, em?)`: optional trailing `em` so callers can thread a `trx` in.
- `packages/core/src/modules/customer_accounts/services/customerSessionService.ts` — `revokeAllUserSessions(userId, em?)`: same pattern.
- `packages/core/src/modules/customer_accounts/api/portal/password-change.ts` — wrap mutations in `em.transactional`, emit `password.changed` with `changedBy: 'self'` after commit.
- `packages/core/src/modules/customer_accounts/api/password/reset-confirm.ts` — look up user to obtain `organizationId`, wrap mutations in `em.transactional`, emit `password.changed` with `changedBy: 'reset'` after commit. The pre-existing `emailVerifiedAt` native update stays outside the transaction (pre-existing behavior, out of scope).
- `packages/core/src/modules/customer_accounts/api/admin/users/[id]/reset-password.ts` — wrap mutations in `em.transactional`, keep the existing `customer_accounts.password.reset` emission for BC, additionally emit `password.changed` with `changedBy: 'admin'` + `changedById: auth.sub`.

### Event payload
```ts
'customer_accounts.password.changed': {
  userId: string,
  tenantId: string,
  organizationId: string | null,
  changedBy: 'self' | 'admin' | 'reset',
  changedById: string | null, // admin actor id when changedBy === 'admin'
  at: string, // ISO8601
}
```

Single event with a discriminator is intentional — easier for future audit/notification subscribers than three separate events. No subscriber is added in this PR (declaration + emission only).

## Threat model
- **Pre-fix — atomicity**: if `revokeAllUserSessions` failed after `updatePassword` committed, the new password was in place but old sessions remained valid until expiry (≤30d). Low severity because the attacker can no longer log back in with old credentials, but any still-valid JWT/refresh-token survived until its TTL. This PR eliminates that window: a revoke failure rolls back the password write so the caller can retry from a consistent state.
- **Audit signal**: `customer_accounts.password.changed` gives ops/security a single subscribe-point to detect suspicious rotation patterns (many password changes in a short window, changes from unusual IPs, admin-reset bursts, etc.) without grepping logs across three handlers.

## Tests
New/extended Jest route tests (23 total, 23 pass), covering for every handler:
- Happy path — mutations run inside `em.transactional`, audit event emitted exactly once with correct payload, emit strictly after `transactional`.
- Rollback — when `revokeAllUserSessions` throws, the handler propagates the error AND the event is NOT emitted.
- Short-circuits — event NOT emitted on wrong current password (portal), invalid auth, missing user, invalid token (reset-confirm), insufficient permissions (admin), validation failure.

Pre-existing 6 invariants from #1686 on `password-change.route.test.ts` all still pass.

## Backward Compatibility
- **Function signatures (STABLE)**: adding an optional trailing `em?` param to two service methods is additive (BC category #3).
- **Event IDs (FROZEN)**: `customer_accounts.password.changed` is new — additive. Existing `customer_accounts.password.reset` unchanged (admin route dual-emits for BC).
- **API route URLs (STABLE)**: no change. No response field removed.
- **DB schema**: no change.
- **DI service names**: no change.
- No new subscribers or consumers; no cross-module contract impact.

## Validation
- `yarn build:packages` ✅
- `yarn generate` ✅
- `yarn build:packages` (post-generate) ✅
- `yarn i18n:check-sync` ✅ (4 locales in sync)
- `yarn i18n:check-usage` ✅ (advisory unused-keys baseline unchanged)
- `yarn typecheck` ✅ (all 18 workspaces)
- `yarn test` ✅ (3243/3243 tests, 393/393 suites)
- `yarn build:app` ✅

## Progress
See [Progress section in the plan](.ai/runs/2026-04-24-atomic-password-change-and-audit-event.md#progress).