### PR TITLE
fix(customers): align detail custom field response keys

### DIFF
--- a/.ai/runs/2026-04-24-custom-field-detail-response-alignment.md
+++ b/.ai/runs/2026-04-24-custom-field-detail-response-alignment.md
@@ -51,4 +51,4 @@
 
 ### Phase 3: Validation and delivery
 
-- [ ] 3.1 Run targeted validation, review the diff for BC/scope, and open the PR with the required summary
+- [x] 3.1 Run targeted validation, review the diff for BC/scope, and open the PR with the required summary — PR #1693

--- a/.ai/runs/2026-04-24-custom-field-detail-response-alignment.md
+++ b/.ai/runs/2026-04-24-custom-field-detail-response-alignment.md
@@ -41,13 +41,13 @@
 
 ### Phase 1: API contract alignment
 
-- [ ] 1.1 Extract or reuse the shared response normalization path for people and company detail custom fields
-- [ ] 1.2 Add focused coverage that locks the `customFields` response shape to bare keys for customer detail endpoints
+- [x] 1.1 Extract or reuse the shared response normalization path for people and company detail custom fields — 6805aa444
+- [x] 1.2 Add focused coverage that locks the `customFields` response shape to bare keys for customer detail endpoints — 6805aa444
 
 ### Phase 2: Guidance and cleanup
 
-- [ ] 2.1 Restore alphabetical dependency ordering in `packages/shared/package.json`
-- [ ] 2.2 Update monorepo and standalone AGENTS guidance to require bare-key `customFields` detail responses via the shared helper
+- [x] 2.1 Restore alphabetical dependency ordering in `packages/shared/package.json` — 6805aa444
+- [x] 2.2 Update monorepo and standalone AGENTS guidance to require bare-key `customFields` detail responses via the shared helper — 6805aa444
 
 ### Phase 3: Validation and delivery
 

--- a/.ai/runs/2026-04-24-custom-field-detail-response-alignment.md
+++ b/.ai/runs/2026-04-24-custom-field-detail-response-alignment.md
@@ -1,0 +1,54 @@
+## Overview
+
+- Goal: align customer detail endpoint custom-field responses with the existing shared convention, restore cosmetic dependency ordering in `packages/shared/package.json`, and document the correct response-shape rule in monorepo and standalone AGENTS guidance.
+- Scope:
+  - `packages/core/src/modules/customers/api/people/[id]/route.ts`
+  - `packages/core/src/modules/customers/api/companies/[id]/route.ts`
+  - focused test coverage for the response-shape normalization
+  - `packages/shared/package.json`
+  - root and standalone AGENTS guidance that covers custom-field detail endpoint response shape
+- Non-goals:
+  - root-cause rework for the example sync polling loops
+  - broader migration of every custom-field detail endpoint outside the targeted customer detail surfaces
+  - changes to persisted custom-field storage or request payload contracts
+- Source spec: `.ai/specs/implemented/SPEC-046-2026-02-25-customer-detail-pages-v2.md`
+
+## Risks
+
+- Detail endpoints are part of a stable API surface, so the response-shape alignment must preserve all existing fields and only normalize custom-field keys to the documented bare-key shape inside `customFields`.
+- AGENTS guidance must stay synchronized between monorepo and standalone templates; missing one copy would reintroduce drift.
+- Tests should avoid broad route integration setup and stay focused on the normalization contract to keep the change small and deterministic.
+
+## Implementation Plan
+
+### Phase 1: API contract alignment
+
+- 1.1 Extract or reuse the shared response normalization path for people and company detail custom fields
+- 1.2 Add focused coverage that locks the `customFields` response shape to bare keys for customer detail endpoints
+
+### Phase 2: Guidance and cleanup
+
+- 2.1 Restore alphabetical dependency ordering in `packages/shared/package.json`
+- 2.2 Update monorepo and standalone AGENTS guidance to require bare-key `customFields` detail responses via the shared helper
+
+### Phase 3: Validation and delivery
+
+- 3.1 Run targeted validation, review the diff for BC/scope, and open the PR with the required summary
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: API contract alignment
+
+- [ ] 1.1 Extract or reuse the shared response normalization path for people and company detail custom fields
+- [ ] 1.2 Add focused coverage that locks the `customFields` response shape to bare keys for customer detail endpoints
+
+### Phase 2: Guidance and cleanup
+
+- [ ] 2.1 Restore alphabetical dependency ordering in `packages/shared/package.json`
+- [ ] 2.2 Update monorepo and standalone AGENTS guidance to require bare-key `customFields` detail responses via the shared helper
+
+### Phase 3: Validation and delivery
+
+- [ ] 3.1 Run targeted validation, review the diff for BC/scope, and open the PR with the required summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,7 @@ All paths use `src/modules/<module>/` as shorthand. See `packages/core/AGENTS.md
 - setup.ts: always declare `defaultRoleFeatures` when adding features to `acl.ts`
 - Every module with guarded routes or pages MUST declare features in `acl.ts` — never ship an empty `acl.ts` with `requireRoles` guards
 - Custom fields: use `collectCustomFieldValues()` from `@open-mercato/ui/backend/utils/customFieldValues`
+- Detail/read-model APIs that expose `customFields` MUST normalize response keys to bare field names via `normalizeCustomFieldResponse()` (for example `{ priority: 3 }`). Reserve `cf_` / `cf:` prefixes for request payloads, query-engine selectors, and form wiring.
 - Events: use `createModuleEvents()` with `as const` for typed emit
 - Translations: when adding entities with user-facing text fields (title, name, description, label), create `translations.ts` at module root declaring translatable fields. Run `yarn generate` after adding.
 - Widget injection: declare in `widgets/injection/`, map via `injection-table.ts`

--- a/packages/core/src/modules/customers/api/__tests__/detailCustomFields.test.ts
+++ b/packages/core/src/modules/customers/api/__tests__/detailCustomFields.test.ts
@@ -1,0 +1,31 @@
+import { normalizeCustomerDetailCustomFields } from '../detailCustomFields'
+
+describe('normalizeCustomerDetailCustomFields', () => {
+  it('strips cf_ prefixes from detail custom field payloads', () => {
+    expect(
+      normalizeCustomerDetailCustomFields({
+        cf_priority: 3,
+        cf_status: 'hot',
+      }),
+    ).toEqual({
+      priority: 3,
+      status: 'hot',
+    })
+  })
+
+  it('strips cf: prefixes and keeps plain keys untouched', () => {
+    expect(
+      normalizeCustomerDetailCustomFields({
+        'cf:severity': 'high',
+        annual_revenue_currency: 'EUR',
+      }),
+    ).toEqual({
+      severity: 'high',
+      annual_revenue_currency: 'EUR',
+    })
+  })
+
+  it('returns an empty object for missing values', () => {
+    expect(normalizeCustomerDetailCustomFields(undefined)).toEqual({})
+  })
+})

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -43,6 +43,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { parseBooleanFromUnknown } from '@open-mercato/shared/lib/boolean'
 import { withActiveCustomerPersonCompanyLinkFilter } from '../../../lib/personCompanyLinkTable'
+import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.companies.view'] },
@@ -778,10 +779,12 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
   }
 
   const routing = await resolveCompanyCustomFieldRouting(em, company.tenantId ?? null, company.organizationId ?? null)
-  const customFields = mergeCompanyCustomFieldValues(
-    routing,
-    entityCustomFieldValues?.[company.id] ?? {},
-    profileId ? profileCustomFieldValues?.[profileId] ?? {} : {},
+  const customFields = normalizeCustomerDetailCustomFields(
+    mergeCompanyCustomFieldValues(
+      routing,
+      entityCustomFieldValues?.[company.id] ?? {},
+      profileId ? profileCustomFieldValues?.[profileId] ?? {} : {},
+    ),
   )
 
   const activityCount = await em.count(CustomerInteraction, {

--- a/packages/core/src/modules/customers/api/detailCustomFields.ts
+++ b/packages/core/src/modules/customers/api/detailCustomFields.ts
@@ -1,0 +1,7 @@
+import { normalizeCustomFieldResponse } from '@open-mercato/shared/lib/custom-fields/normalize'
+
+export function normalizeCustomerDetailCustomFields(
+  values: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  return normalizeCustomFieldResponse(values) ?? {}
+}

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -38,6 +38,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { parseBooleanFromUnknown, parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { loadPersonCompanyLinks, summarizePersonCompanies } from '../../../lib/personCompanies'
+import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
@@ -683,10 +684,12 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
 
     const routing = await resolvePersonCustomFieldRouting(em, person.tenantId ?? null, person.organizationId ?? null)
     profiler.mark('custom_field_routing_resolved', { keys: routing.size })
-    customFields = mergePersonCustomFieldValues(
-      routing,
-      entityCustomFieldValues?.[person.id] ?? {},
-      profileId ? profileCustomFieldValues?.[profileId] ?? {} : {},
+    customFields = normalizeCustomerDetailCustomFields(
+      mergePersonCustomFieldValues(
+        routing,
+        entityCustomFieldValues?.[person.id] ?? {},
+        profileId ? profileCustomFieldValues?.[profileId] ?? {} : {},
+      ),
     )
     profiler.mark('custom_fields_merged', { keys: Object.keys(customFields).length })
 

--- a/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
@@ -568,8 +568,8 @@ export default function CustomerCompanyDetailPage({ params }: { params?: { id?: 
   const companyId = company.id
 
   const annualRevenueCurrency =
-    typeof data.customFields?.cf_annual_revenue_currency === 'string'
-      ? (data.customFields.cf_annual_revenue_currency as string)
+    typeof data.customFields?.annual_revenue_currency === 'string'
+      ? (data.customFields.annual_revenue_currency as string)
       : null
 
   const detailFields: DetailFieldConfig[] = [

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -139,6 +139,7 @@ Register in `src/modules.ts`: `{ id: '<id>', from: '@app' }`
 - Custom modules use `from: '@app'` in `src/modules.ts`
 - Standalone apps expose `yarn mercato configs cache ...` because the template enables the `configs` module from `@open-mercato/core`
 - `yarn generate` automatically runs a best-effort structural cache purge (`yarn mercato configs cache structural --all-tenants`) after successful generation; if the cache command is unavailable, generation still succeeds
+- Detail/read-model APIs that expose `customFields` MUST return bare field keys via `normalizeCustomFieldResponse()` (for example `{ priority: 3 }`). Keep `cf_` / `cf:` prefixes for request payloads, filters, and form field IDs only.
 - Sidebar icons MUST use `lucide-react` components — never inline SVG via `React.createElement`
 - `page.meta.ts` MUST include `pageGroup`, `pageGroupKey`, and `pageOrder` for sidebar grouping
 - Settings pages MUST use `pageContext: 'settings' as const` with `navHidden: true`

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -149,6 +149,8 @@ Install official package-backed modules with `yarn mercato module add @open-merc
 
 The standalone template enables the `configs` module from `@open-mercato/core`, so `yarn mercato configs cache ...` is available here after installation. After structural changes such as enabling or disabling modules, adding or removing backend/frontend pages, or changing sidebar/navigation injections, run `yarn generate`. The generator now performs a best-effort structural cache purge automatically after successful generation; if the cache command is unavailable, generation still succeeds.
 
+Detail/read-model APIs that expose `customFields` must return bare field keys via `normalizeCustomFieldResponse()` (for example `{ priority: 3 }`). Keep `cf_` / `cf:` prefixes for request payloads, filters, and form field IDs only.
+
 ### Path Aliases
 
 - `@/*` → `./src/*`

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,10 +89,10 @@
     }
   },
   "dependencies": {
-    "@open-mercato/cache": "0.5.0",
     "@mikro-orm/core": "^7.0.10",
     "@mikro-orm/decorators": "^7.0.10",
     "@mikro-orm/postgresql": "^7.0.10",
+    "@open-mercato/cache": "0.5.0",
     "dotenv": "^17.4.2",
     "rate-limiter-flexible": "^11.0.1",
     "reflect-metadata": "^0.2.2",

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -323,6 +323,20 @@ function readByDotPath(source: Record<string, unknown> | undefined, path: string
   return current
 }
 
+function readInitialCustomFieldValue(
+  source: Record<string, unknown> | undefined,
+  key: string,
+): unknown {
+  if (!source || !key) return undefined
+  const candidates = [`cf_${key}`, `cf:${key}`, key]
+  for (const candidate of candidates) {
+    if (Object.prototype.hasOwnProperty.call(source, candidate)) {
+      return source[candidate]
+    }
+  }
+  return undefined
+}
+
 function serializeIssuePath(path: ReadonlyArray<string | number | symbol>): string | null {
   if (!Array.isArray(path) || path.length === 0) return null
   const segments = path
@@ -1972,17 +1986,30 @@ export function CrudForm<TValues extends Record<string, unknown>>({
   const dirtyBaselineSnapshotRef = React.useRef<string | undefined>(undefined)
   React.useLayoutEffect(() => {
     if (!initialValues) return
-    const snapshot = JSON.stringify(initialValues)
+    const snapshot = JSON.stringify({
+      initialValues,
+      injectedFieldIds: injectedFieldDefinitions.map((definition) => definition.id),
+      customFieldMappings: cfDefinitions.map((definition) => definition.key),
+    })
     if (appliedInitialValuesSnapshotRef.current === snapshot) return
     appliedInitialValuesSnapshotRef.current = snapshot
+    const initialRecord = initialValues as Record<string, unknown>
     let mergedValues: CrudFormValues<TValues> | null = null
     setValues((prev) => {
       const merged = { ...prev, ...initialValues } as CrudFormValues<TValues>
       for (const definition of injectedFieldDefinitions) {
         if (merged[definition.id] !== undefined) continue
-        const extracted = readByDotPath(initialValues as Record<string, unknown>, definition.id)
+        const extracted = readByDotPath(initialRecord, definition.id)
         if (extracted !== undefined) {
           ;(merged as Record<string, unknown>)[definition.id] = extracted
+        }
+      }
+      for (const definition of cfDefinitions) {
+        const targetId = customEntity ? definition.key : `cf_${definition.key}`
+        if (!targetId || merged[targetId] !== undefined) continue
+        const extracted = readInitialCustomFieldValue(initialRecord, definition.key)
+        if (extracted !== undefined) {
+          ;(merged as Record<string, unknown>)[targetId] = extracted
         }
       }
       mergedValues = merged
@@ -2012,7 +2039,14 @@ export function CrudForm<TValues extends Record<string, unknown>>({
     return () => {
       cancelled = true
     }
-  }, [extendedInjectionEventsEnabled, initialValues, injectedFieldDefinitions, triggerInjectionEvent])
+  }, [
+    cfDefinitions,
+    customEntity,
+    extendedInjectionEventsEnabled,
+    initialValues,
+    injectedFieldDefinitions,
+    triggerInjectionEvent,
+  ])
 
   // Apply custom field defaults on create flows (one-time, ref-guarded).
   // Mode is determined from the host-provided initialValues prop, not from

--- a/packages/ui/src/backend/__tests__/CrudForm.custom-fields.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.custom-fields.test.tsx
@@ -121,6 +121,89 @@ describe('CrudForm custom field loading', () => {
     expect(fetchCustomFieldFormStructureMock).toHaveBeenCalledTimes(1)
   })
 
+  it('hydrates bare-key custom field initialValues after definitions load and after remount', async () => {
+    const loadOptions = jest.fn().mockResolvedValue([
+      { value: 'CNY', label: 'CNY - Chinese Yuan' },
+    ])
+
+    buildFormFieldFromCustomFieldDefMock.mockImplementation((definition: any) => ({
+      id: `cf_${definition.key}`,
+      label: definition.label ?? definition.key,
+      type: 'select',
+      loadOptions,
+    }))
+    fetchCustomFieldFormStructureMock.mockResolvedValue({
+      fields: [],
+      definitions: [
+        {
+          entityId: 'customers:customer_company_profile',
+          key: 'preferred_currency',
+          label: 'Preferred currency',
+          kind: 'currency',
+        },
+      ],
+      metadata: {
+        items: [],
+        fieldsetsByEntity: {},
+        entitySettings: {},
+      },
+    })
+
+    function Host({ visible }: { visible: boolean }) {
+      if (!visible) return null
+      return (
+        <CrudForm
+          embedded
+          title="Form"
+          entityId="customers:customer_company_profile"
+          fields={fields}
+          groups={groups}
+          initialValues={{ name: 'Acme', preferred_currency: 'CNY' }}
+          onSubmit={() => {}}
+        />
+      )
+    }
+
+    const { container, rerender } = renderWithProviders(
+      <Host visible />,
+      {
+        dict: {
+          'ui.forms.actions.save': 'Save',
+          'entities.customFields.manageFieldset': 'Manage fields',
+        },
+      },
+    )
+
+    const getCurrencySelect = () =>
+      container.querySelector('[data-crud-field-id="cf_preferred_currency"] select') as HTMLSelectElement | null
+
+    await waitFor(() => {
+      expect(fetchCustomFieldFormStructureMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(getCurrencySelect()).not.toBeNull()
+    })
+    await waitFor(() => {
+      expect(getCurrencySelect()?.value).toBe('CNY')
+    })
+
+    await act(async () => {
+      rerender(<Host visible={false} />)
+    })
+
+    await act(async () => {
+      rerender(<Host visible />)
+    })
+
+    await waitFor(() => {
+      expect(getCurrencySelect()).not.toBeNull()
+    })
+    await waitFor(() => {
+      expect(getCurrencySelect()?.value).toBe('CNY')
+    })
+    expect(loadOptions).toHaveBeenCalled()
+  })
+
   it('opens the field manager without submitting the parent form', async () => {
     const handleSubmit = jest.fn().mockResolvedValue(undefined)
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-04-24-custom-field-detail-response-alignment.md
Status: complete

## Goal
- Align customer detail `customFields` responses with the existing bare-key convention, keep shared package dependencies sorted, and document the rule in monorepo and standalone AGENTS guidance.

## What Changed
- Normalized `people` and `companies` detail `customFields` through a shared customer-detail helper so they match `deals` detail behavior.
- Added focused unit coverage for customer detail custom-field response normalization.
- Updated the company detail page to read the canonical bare-key custom-field shape.
- Restored alphabetical dependency order in `packages/shared/package.json`.
- Added guidance for this response-shape rule to root and standalone AGENTS files.

## Tests
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

## Backward Compatibility
- No route URLs or top-level response fields changed.
- The canonical `customFields` shape on customer detail endpoints now matches the existing bare-key convention already used by deal detail and shared response helpers.

## Progress
See [Progress section in the plan](.ai/runs/2026-04-24-custom-field-detail-response-alignment.md#progress).
