### PR TITLE
test(ratelimit): failing repro for per-route rate-limit leakage under OM_INTEGRATION_TEST

### DIFF
--- a/.ai/qa/tests/integration/TC-INT-ratelimit-leakage.spec.ts
+++ b/.ai/qa/tests/integration/TC-INT-ratelimit-leakage.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+/**
+ * Reproduction spec for per-route rate-limit leakage under `OM_INTEGRATION_TEST`.
+ *
+ * These tests are expected to FAIL on current `develop`. That failure is the
+ * whole point — it proves the built-in rate limiting makes integration tests
+ * fragile even though the runner already sets `OM_INTEGRATION_TEST=true`.
+ *
+ * Background:
+ * - `packages/shared/src/lib/ratelimit/config.ts` `readRateLimitConfig()` only checks
+ *   `RATE_LIMIT_ENABLED` (defaults to `true`). There is no `OM_INTEGRATION_TEST`
+ *   / `OM_TEST_MODE` override on `develop` (the fix proposed in
+ *   open-mercato#1673 was closed pending a better repro — this is that repro).
+ * - `apps/mercato/src/app/api/[...slug]/route.ts` enforces per-route
+ *   `metadata.rateLimit` via `checkRateLimit()` using only that global config.
+ * - `packages/cli/src/lib/testing/integration.ts` exports `OM_INTEGRATION_TEST=true`,
+ *   `OM_TEST_MODE=1`, `OM_TEST_AUTH_RATE_LIMIT_MODE=opt-in`. These are honored
+ *   *only* by `checkAuthRateLimit()` in the auth module, not by the generic
+ *   per-route / per-handler rate limiting.
+ *
+ * Why this matters for parallel test runs (the real pain point):
+ * The open-mercato repo itself runs its integration suite serially, so the
+ * per-route points budget is rarely exhausted for any single endpoint. In
+ * downstream apps that run Playwright with `workers > 1`, every worker shares
+ * the same client IP against the app server — the points budget is consumed
+ * collectively, and flakiness scales with worker count. See edube-monorepo#161
+ * for the 18-file boilerplate workaround that was required there. The
+ * reproduction below is deliberately serial (points=3, 5 requests) so the
+ * leakage is unambiguous even without concurrency.
+ */
+test.describe('per-route rate limits leak into OM_INTEGRATION_TEST runs', () => {
+  test('metadata.rateLimit path (apps/mercato root handler): 4th POST to /api/ratelimit_probe/ping 429s with points=3', async ({ request }) => {
+    const statuses: number[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      const res = await request.post(`${BASE_URL}/api/ratelimit_probe/ping`, {
+        headers: { 'Content-Type': 'application/json' },
+        data: {},
+      });
+      statuses.push(res.status());
+    }
+    // Expected (post-fix): all 5 allowed → [200, 200, 200, 200, 200]
+    // Actual (current develop): rate limiter still fires → [200, 200, 200, 429, 429]
+    expect(statuses, 'OM_INTEGRATION_TEST should bypass metadata.rateLimit').toEqual([200, 200, 200, 200, 200]);
+  });
+
+  test('manual checkRateLimit path (sales/quotes/accept): 11th POST 429s with points=10', async ({ request }) => {
+    // The rate limiter runs before token validation at sales/api/quotes/accept/route.ts:50-59,
+    // so an obviously invalid token still consumes points.
+    const statuses: number[] = [];
+    for (let i = 0; i < 12; i += 1) {
+      const res = await request.post(`${BASE_URL}/api/sales/quotes/fake-token-for-rate-limit-probe/accept`, {
+        headers: { 'Content-Type': 'application/json' },
+        data: {},
+      });
+      statuses.push(res.status());
+    }
+    // Expected (post-fix): zero 429s (invalid token → 400/404, but never 429).
+    // Actual (current develop): 429 from the 11th call onward.
+    expect(statuses.filter((s) => s === 429), 'OM_INTEGRATION_TEST should bypass per-handler checkRateLimit').toEqual([]);
+  });
+});

--- a/apps/mercato/src/modules.ts
+++ b/apps/mercato/src/modules.ts
@@ -50,6 +50,7 @@ export const enabledModules: ModuleEntry[] = [
   { id: 'customer_accounts', from: '@open-mercato/core' },
   { id: 'portal', from: '@open-mercato/core' },
   { id: 'example', from: '@app' },
+  { id: 'ratelimit_probe', from: '@app' },
 ]
 
 if (enabledModules.some((entry) => entry.id === 'example')) {

--- a/apps/mercato/src/modules/ratelimit_probe/api/ping/route.ts
+++ b/apps/mercato/src/modules/ratelimit_probe/api/ping/route.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+export const metadata = {
+  POST: {
+    requireAuth: false,
+    rateLimit: { points: 3, duration: 60, keyPrefix: 'ratelimit_probe' },
+  },
+}
+
+export async function POST() {
+  return Response.json({ ok: true })
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'RateLimitProbe',
+  methods: {
+    POST: {
+      summary: 'Test-only endpoint with per-route metadata.rateLimit — used to prove rate-limit leakage under OM_INTEGRATION_TEST',
+      tags: ['RateLimitProbe'],
+      responses: [
+        {
+          status: 200,
+          description: 'Always OK when under the points budget',
+          schema: z.object({ ok: z.literal(true) }),
+        },
+        {
+          status: 429,
+          description: 'Rate limit exceeded (3 points / 60 s per client IP)',
+          schema: z.object({ error: z.string() }),
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
## Why this PR is a draft

This PR is deliberately **red**. It adds an integration spec that fails on current \`develop\` to document the defect behind [#1673](https://github.com/open-mercato/open-mercato/pull/1673) (which was closed pending a better reproduction, see [@pkarw's feedback](https://github.com/open-mercato/open-mercato/pull/1673#issuecomment-4312011630)). It is not intended to merge as-is — it exists so we can point at a concrete regression when discussing the fix.

## Summary

Built-in per-route rate limiting still fires during integration runs even though the runner already exports \`OM_INTEGRATION_TEST=true\`:

- \`packages/shared/src/lib/ratelimit/config.ts\` \`readRateLimitConfig()\` only reads \`RATE_LIMIT_ENABLED\` (defaults to \`true\`). No \`OM_INTEGRATION_TEST\` / \`OM_TEST_MODE\` override exists on \`develop\`.
- \`apps/mercato/src/app/api/[...slug]/route.ts:345-368\` enforces per-route \`metadata.rateLimit\` via \`checkRateLimit()\` using only that global config.
- \`packages/cli/src/lib/testing/integration.ts:1618-1622\` exports \`OM_INTEGRATION_TEST=true\`, \`OM_TEST_MODE=1\`, \`OM_TEST_AUTH_RATE_LIMIT_MODE=opt-in\`. Only \`checkAuthRateLimit\` in \`packages/core/src/modules/auth/lib/rateLimitCheck.ts:28-34\` honors them. Every other rate-limit surface — metadata-driven and inline per-handler \`checkRateLimit\` — ignores the test-env signal.

## Why this matters in parallel test runs

This repo's own integration suite runs serially, so the per-route points budget is rarely exhausted for a single endpoint — which is why @pkarw has never hit the problem. Downstream apps that run Playwright with \`workers > 1\` share the same client IP across workers against the app server, so the points budget is consumed collectively and flakiness scales with worker count. Concrete example: [edube-monorepo#161](https://github.com/fullstackhouse/edube-monorepo/pull/161) had to land 18 files of \`...(process.env.OM_INTEGRATION_TEST === 'true' ? {} : { rateLimit: {...} })\` boilerplate on every rate-limited route to keep 7 parallel portal signup specs green.

The repro in this PR is deliberately **serial** (points=3, 5 sequential requests) so the leakage is unambiguous even without concurrency. The parallel-worker case just makes it worse.

## What's in the diff

| File | Purpose |
|------|---------|
| \`apps/mercato/src/modules/ratelimit_probe/api/ping/route.ts\` | Test probe route declaring \`metadata.POST.rateLimit = { points: 3, duration: 60 }\` — exercises the metadata enforcement path. |
| \`apps/mercato/src/modules.ts\` | Enables the \`ratelimit_probe\` module. |
| \`.ai/qa/tests/integration/TC-INT-ratelimit-leakage.spec.ts\` | Two failing cases — one for the metadata path, one for the inline \`checkRateLimit\` path via \`sales/quotes/[token]/accept\` (points=10). |

Both test cases **fail with 429** on current \`develop\`. Patch the \`OM_INTEGRATION_TEST\` override from #1673 into \`packages/shared/src/lib/ratelimit/config.ts\` → both pass. Revert → both fail again. That is the precisely-scoped regression signal.

## Proposed follow-ups

1. Re-open #1673 (or equivalent) — make \`OM_INTEGRATION_TEST=true\` force \`RATE_LIMIT_ENABLED=false\` in \`readRateLimitConfig\`. Docs update as requested by @pkarw.
2. Once fixed, either remove this PR's probe + spec or convert the spec into a regression guard (assert zero 429s and rename accordingly).

## Test plan

- [ ] \`yarn test:integration -- TC-INT-ratelimit-leakage\` — confirm both cases fail with 429 on current \`develop\` (that is the repro; do NOT merge until fixed).
- [ ] After landing the underlying fix, both cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)