### PR TITLE
fix(create-app): anchor storage/ and data/ ignore patterns to repo root

### DIFF
--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -71,8 +71,8 @@ src/generated/
 
 # uploads and app data
 public/uploads/*
-storage/
-data/
+/storage/
+/data/
 
 # local package managers
 package-lock.json


### PR DESCRIPTION
## Summary

The scaffolded \`.gitignore\` shipped by \`create-mercato-app\` uses **unanchored** patterns for \`storage/\` and \`data/\`, which match directories of those names at **any** depth in the repository — not just the intended root-level runtime directories.

As a result, every \`data/\` folder inside \`src/modules/**/\` is silently ignored — including the ones that ship as part of the template (\`src/modules/example/data/\` and \`src/modules/example_customers_sync/data/\`).

## Impact (reproducible)

1. \`npx create-mercato-app my-app\` (v0.5.0)
2. \`cd my-app && yarn install && yarn generate\`
3. Build fails with:

\`\`\`
X [ERROR] Could not resolve "./data/entities"
    src/modules/example/cli.ts:4:21
X [ERROR] Could not resolve "../data/entities"
    src/modules/example/commands/todos.ts:18:21
X [ERROR] Could not resolve "../../example/data/entities"
    src/modules/example_customers_sync/lib/sync.ts:17:21
X [ERROR] Could not resolve "../data/entities"
    src/modules/example_customers_sync/lib/mappings.ts:3:50
\`\`\`

The \`data/entities.ts\` / \`data/enrichers.ts\` / \`data/validators.ts\` / \`data/guards.ts\` files are **present in the template source** under \`packages/create-app/template/src/modules/example/data/\` and \`.../example_customers_sync/data/\`, but the scaffolder (which honors the template's \`.gitignore\` when copying) drops them because the \`data/\` pattern matches.

Observed on Windows 11 with Node 24 / Yarn 4 and confirmed the files are absent on disk after scaffold (not just untracked).

## Fix

Anchor both patterns to the repo root by prefixing them with a leading slash:

\`\`\`diff
- storage/
- data/
+ /storage/
+ /data/
\`\`\`

This keeps the original intent (ignoring root-level \`storage/\` uploads and \`data/\` runtime state) while allowing \`src/modules/<id>/data/\` to ship with the template as intended.

## Test plan

- [x] Scaffold app with patched template, verify \`src/modules/example/data/\` and \`src/modules/example_customers_sync/data/\` are present
- [x] \`yarn generate\` completes without "Could not resolve" errors
- [x] \`yarn dev\` boots and serves http://localhost:3000
- [ ] Maintainer verifies the two intended ignores (\`/storage/\`, \`/data/\`) at repo root still function for uploads/runtime state

## Notes

- Fix is minimal (2 lines) and scoped to the create-app template — no runtime code touched.
- Reported via independent reproduction; no existing tracking issue found.