### PR TITLE
feat(auth): add `mercato auth sync-role-acls` CLI for re-applying default role features

### DIFF
--- a/.ai/specs/2026-04-25-auth-sync-role-acls-cli.md
+++ b/.ai/specs/2026-04-25-auth-sync-role-acls-cli.md
@@ -1,0 +1,96 @@
+# `mercato auth sync-role-acls` CLI
+
+**Date**: 2026-04-25
+**Status**: Implemented
+**Module**: `auth` (`packages/core/src/modules/auth/`)
+**Related**: SPEC-013 (Decouple Module Setup)
+
+---
+
+## TLDR
+
+Adds an idempotent CLI command that re-applies every enabled module's `defaultRoleFeatures` to existing tenants. Closes the gap left by `setupTenantAndPrimaryUser` (which only runs during initial bootstrap): when a module ships new features in `acl.ts` + `setup.ts`, those features never reach existing production/staging tenants until something runs the merge again.
+
+---
+
+## Problem
+
+When a module adds a new feature:
+
+1. `acl.ts` declares the feature.
+2. `setup.ts` adds it to `defaultRoleFeatures`.
+3. New tenants pick it up via `setupInitialTenant` → `ensureDefaultRoleAcls`.
+4. **Existing tenants do not.** Their `RoleAcl.featuresJson` rows were written by an older deploy and never re-merged.
+
+Operators previously had to write ad-hoc scripts or apply features by hand from the UI per tenant.
+
+---
+
+## Contract
+
+```
+mercato auth sync-role-acls [--tenant <tenantId>] [--no-superadmin]
+```
+
+**Behaviour:**
+- Resolves enabled modules from `getCliModules()` (the generated CLI registry); errors out if generators have not run.
+- Without `--tenant`: iterates every `Tenant` row, applies `ensureDefaultRoleAcls` + `ensureCustomRoleAcls`. Logs and exits cleanly when no tenants exist.
+- With `--tenant <id>`: validates the value is a non-empty string, **looks up the `Tenant` row, errors out if missing**, then runs the sync against that tenant only.
+- `--no-superadmin`: skips writing the superadmin RoleAcl (matches the same flag on `setupInitialTenant`).
+- Sync is **additive**: existing custom features in `RoleAcl.featuresJson` are preserved; only missing default features are merged in. Superadmin's `isSuperAdmin` flag is upgraded if currently false.
+
+**Exit / output contract:**
+- `❌ Invalid --tenant value: <raw>` — empty/whitespace `--tenant`.
+- `❌ Tenant not found: <id>` — `--tenant` value is a syntactically valid id but no `Tenant` row exists.
+- `❌ No CLI modules registered. Run \`yarn generate\` first.` — generators not run.
+- `No tenants found; nothing to sync.` — no `--tenant` and no rows.
+- `✅ Synced role ACLs for tenant <id>` — per tenant on success.
+
+---
+
+## Integration Coverage
+
+### Unit (`packages/core/src/modules/auth/__tests__/cli-sync-role-acls.test.ts`)
+
+- Built-in + custom roles get RoleAcl rows with the correct merged feature list when `--tenant <id>` targets an existing tenant.
+- Sync is additive and idempotent — existing custom features (`legacy.custom.kept`) survive, missing defaults get added.
+- `--no-superadmin` skips the superadmin RoleAcl write but still writes the rest.
+- Without `--tenant`, every `Tenant` row is iterated.
+- `No tenants found; nothing to sync.` is logged when there are no tenants.
+- `--tenant <missing-id>` writes nothing and emits `❌ Tenant not found: <id>`.
+
+### Integration (`packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts`)
+
+- **Recovery path:** snapshots the admin role's ACL, clears it via `PUT /api/auth/roles/acl`, runs the CLI, asserts that the admin features are restored (must include `auth.*`). Restores original state in `finally` to avoid leaking into other tests. Uses a `superadmin` token for state mutation so the cleared admin role cannot lock the test runner out.
+- **Idempotency:** running twice in a row produces the same `✅ Synced role ACLs for tenant <id>` output without error.
+- **Invalid `--tenant`:** whitespace-only value yields `Invalid --tenant value` and no sync runs.
+- **Missing `--tenant`:** a syntactically valid but non-existent UUID yields `Tenant not found: <id>` and never logs `Synced role ACLs for tenant <id>`.
+
+---
+
+## Migration & Backward Compatibility
+
+- **No breaking change.** New CLI command; nothing renamed or removed.
+- The auth CLI list export (`packages/core/src/modules/auth/cli.ts` default export) gains one entry; existing entries (`add-user`, `seed-roles`, `setup`, `add-org`, `set-password`, `rotate-encryption-key`, `list-organizations`, `list-tenants`, `list-users`) are unchanged.
+- No DB schema change. `RoleAcl` is read/written via the same path as `setupInitialTenant`.
+- Operators running the command against a tenant that already has the latest features see no row mutation (the merge is a no-op when nothing is missing).
+
+**Operator workflow after deploying new features:**
+
+```bash
+# All tenants
+yarn mercato auth sync-role-acls
+
+# Single tenant (e.g. staging)
+yarn mercato auth sync-role-acls --tenant <tenantId>
+```
+
+---
+
+## Files Touched
+
+- `packages/core/src/modules/auth/cli.ts` — adds `syncRoleAcls` ModuleCli entry.
+- `packages/core/src/modules/auth/__tests__/cli-sync-role-acls.test.ts` — unit coverage.
+- `packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts` — integration coverage.
+- `packages/core/src/modules/auth/README.md` — CLI usage line.
+- `packages/core/src/modules/auth/AGENTS.md` — already documents calling `sync-role-acls` from the "Adding New Features" workflow.

--- a/apps/docs/docs/cli/auth-sync-role-acls.mdx
+++ b/apps/docs/docs/cli/auth-sync-role-acls.mdx
@@ -1,0 +1,61 @@
+---
+title: mercato auth sync-role-acls
+sidebar_label: auth sync-role-acls
+description: Re-applies default feature ACLs from every enabled module to the built-in and custom roles of existing tenants.
+---
+
+`yarn mercato auth sync-role-acls` merges each enabled module's `setup.defaultRoleFeatures` into the `RoleAcl` rows of the target tenant(s). It is the recovery command when a tenant's role ACLs have drifted — for example, after a demo user detached features from `admin`, or after a module upgrade introduced new features that were never propagated to pre-existing tenants.
+
+## Usage
+
+```bash
+# Sync a single tenant (recommended)
+yarn mercato auth sync-role-acls --tenant <tenantId>
+
+# Sync every tenant in the connected database
+yarn mercato auth sync-role-acls
+
+# Skip the superadmin role (defensive — superadmin grants isSuperAdmin)
+yarn mercato auth sync-role-acls --tenant <tenantId> --no-superadmin
+```
+
+## Flags
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--tenant <id>` | none — iterates every tenant | Restrict the sync to one tenant. Accepts `--tenantId` and `--tenant_id` as aliases. |
+| `--no-superadmin` | off (superadmin is synced) | Skip writing the `superadmin` role ACL. Use when you do not want to touch `isSuperAdmin` on the target tenant. |
+
+## Behavior
+
+- Collects `defaultRoleFeatures` from every enabled module (via `getCliModules()`).
+- Resolves `superadmin`, `admin`, `employee`, and any custom roles declared by modules.
+- For each role, calls `ensureRoleAclFor`, which:
+  - Creates the `RoleAcl` row if missing.
+  - Merges missing features into an existing ACL — **additive only**. Features that are already granted (including ones not declared by any module) are preserved.
+- Runs tenant-by-tenant; logs `✅ Synced role ACLs for tenant <id>` per tenant.
+- Safe to run multiple times — idempotent.
+
+## When to Run
+
+- **Recovery:** a demo/staging tenant's `admin` role lost features and users can no longer reach guarded pages.
+- **Upgrade hygiene:** a module release added new `defaultRoleFeatures` that existing tenants never received (`setupTenantAndPrimaryUser` only runs during initial tenant creation).
+- **Custom roles declared by modules:** `defaultRoleFeatures` entries for non-built-in roles are synced for every tenant that already has those roles.
+
+## When NOT to Use
+
+- **Not a replacement for `mercato auth seed-roles`.** This command assumes the roles already exist — it does not create them.
+- **Not a replacement for `seed:defaults`.** It does not seed dictionaries, currencies, or example data. It only syncs role feature ACLs.
+- **Does not revoke features.** If a user deliberately removed a feature, that feature is re-added by this command. Use the roles admin UI for curated edits.
+
+## Troubleshooting
+
+- **`❌ No CLI modules registered. Run \`yarn generate\` first.`** — regenerate the module aggregation files.
+- **`❌ Invalid --tenant value: …`** — the value was empty or whitespace. Pass a UUID from `yarn mercato auth list-tenants`.
+- **`No tenants found; nothing to sync.`** — the no-flag form found zero tenants. Ensure `DATABASE_URL` points to the expected environment.
+- **Missing features after run** — confirm the module that owns the feature is enabled in `src/modules.ts` and that its `setup.ts` lists the feature under `defaultRoleFeatures`.
+
+## Related
+
+- [`auth seed-roles`](./auth-seed-roles) — ensures the `employee`/`admin`/`superadmin` roles exist.
+- [`auth setup`](./auth-setup) — full initial tenant bootstrap (calls this logic internally).

--- a/apps/docs/docs/cli/overview.mdx
+++ b/apps/docs/docs/cli/overview.mdx
@@ -40,6 +40,7 @@ Run `yarn mercato --help` to list modules and `yarn mercato <module> --help` to 
   - `mercato db greenfield --yes` – destructive reset and regenerate schema.
 - **Auth module**
   - [`mercato auth seed-roles`](./auth-seed-roles)
+  - [`mercato auth sync-role-acls`](./auth-sync-role-acls)
   - [`mercato auth setup`](./auth-setup)
   - [`mercato auth add-user`](./auth-add-user)
   - [`mercato auth set-password`](./auth-set-password)

--- a/packages/core/src/modules/auth/AGENTS.md
+++ b/packages/core/src/modules/auth/AGENTS.md
@@ -88,6 +88,7 @@ When adding features to any module:
 1. Declare in `acl.ts`: `export const features = ['module.view', 'module.edit', ...]`
 2. Add to `setup.ts` `defaultRoleFeatures` so roles are seeded during tenant creation
 3. Guard pages/APIs with `requireFeatures` in metadata
+4. For tenants that already exist (production, staging, demo), run `yarn mercato auth sync-role-acls --tenant <id>` after deploying — this re-applies `defaultRoleFeatures` idempotently so the new features land in existing `RoleAcl` rows. `setupTenantAndPrimaryUser` only runs during the initial tenant bootstrap.
 
 ```typescript
 // acl.ts

--- a/packages/core/src/modules/auth/README.md
+++ b/packages/core/src/modules/auth/README.md
@@ -9,6 +9,7 @@ Features:
   - `mercato auth seed-roles`
   - `mercato auth add-org --name <org>`
   - `mercato auth setup --orgName <org> --email <e> --password <p> [--roles superadmin,admin] [--skip-password-policy]`
+  - `mercato auth sync-role-acls [--tenant <tenantId>] [--no-superadmin]` — re-applies each enabled module's `defaultRoleFeatures` to existing tenants. Idempotent and additive (existing custom features are preserved). Run after deploying new module features to ensure existing tenants pick them up; without `--tenant` it iterates every tenant.
 
 DB entities used (defined in root schema):
 - `users` with: `email`, `password_hash`, `is_confirmed`, `last_login_at`, `organization_id`, timestamps.

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
@@ -7,7 +8,28 @@ import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__i
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-const repoRoot = path.resolve(__dirname, '..', '..', '..', '..', '..', '..', '..')
+
+function findRepoRoot(startDir: string): string {
+  let current = startDir
+  while (true) {
+    const candidate = path.join(current, 'package.json')
+    if (fs.existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(candidate, 'utf8'))
+        if (pkg && (pkg.workspaces || pkg.name === 'open-mercato')) return current
+      } catch {
+        // ignore JSON parse failures and keep walking
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) {
+      throw new Error(`Could not locate Open Mercato repo root above ${startDir}`)
+    }
+    current = parent
+  }
+}
+
+const repoRoot = findRepoRoot(__dirname)
 
 function runMercato(args: string[]): string {
   return execFileSync('yarn', ['mercato', ...args], {

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -43,6 +43,22 @@ function runMercato(args: string[]): string {
   })
 }
 
+function runMercatoCapture(args: string[]): { status: number | null; output: string } {
+  const result = spawnSync('yarn', ['mercato', ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NODE_NO_WARNINGS: '1',
+    },
+  })
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  }
+}
+
 test.describe('TC-AUTH-033: auth sync-role-acls CLI', () => {
   test.slow()
 
@@ -82,13 +98,7 @@ test.describe('TC-AUTH-033: auth sync-role-acls CLI', () => {
   })
 
   test('fails cleanly with an invalid --tenant value', async () => {
-    let errorOutput = ''
-    try {
-      runMercato(['auth', 'sync-role-acls', '--tenant', '   '])
-    } catch (err) {
-      errorOutput = String((err as NodeJS.ErrnoException & { stdout?: string; stderr?: string }).stdout ?? '')
-        + String((err as NodeJS.ErrnoException & { stdout?: string; stderr?: string }).stderr ?? '')
-    }
-    expect(errorOutput).toContain('Invalid --tenant value')
+    const { output } = runMercatoCapture(['auth', 'sync-role-acls', '--tenant', '   '])
+    expect(output).toContain('Invalid --tenant value')
   })
 })

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
@@ -62,16 +62,23 @@ function runMercatoCapture(args: string[]): { status: number | null; output: str
   }
 }
 
+type RoleAclResponse = {
+  isSuperAdmin?: boolean
+  features?: string[]
+  organizations?: string[] | null
+}
+
 test.describe('TC-AUTH-033: auth sync-role-acls CLI', () => {
   test.slow()
 
   test('restores default feature ACLs for the admin role after the admin ACL is cleared', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
     const adminToken = await getAuthToken(request, 'admin')
     const { tenantId } = getTokenScope(adminToken)
     expect(tenantId).toBeTruthy()
 
     const rolesResponse = await apiRequest(request, 'GET', '/api/auth/roles?pageSize=100&search=admin', {
-      token: adminToken,
+      token: superadminToken,
     })
     expect(rolesResponse.status()).toBe(200)
     const rolesBody = await readJsonSafe<{
@@ -79,14 +86,52 @@ test.describe('TC-AUTH-033: auth sync-role-acls CLI', () => {
     }>(rolesResponse)
     const adminRole = (rolesBody?.items ?? []).find((r) => r.name === 'admin' && r.tenantId === tenantId)
     expect(adminRole?.id, 'admin role not found for this tenant').toBeTruthy()
+    const adminRoleId = adminRole!.id!
 
-    const output = runMercato(['auth', 'sync-role-acls', '--tenant', tenantId])
-    expect(output).toContain(`Synced role ACLs for tenant ${tenantId}`)
+    const aclPath = `/api/auth/roles/acl?roleId=${encodeURIComponent(adminRoleId)}&tenantId=${encodeURIComponent(tenantId)}`
+    const beforeResponse = await apiRequest(request, 'GET', aclPath, { token: superadminToken })
+    expect(beforeResponse.status()).toBe(200)
+    const beforeBody = await readJsonSafe<RoleAclResponse>(beforeResponse)
+    const originalFeatures = Array.isArray(beforeBody?.features) ? beforeBody!.features! : []
+    const originalIsSuperAdmin = !!beforeBody?.isSuperAdmin
+    const originalOrganizations = beforeBody?.organizations ?? null
+    expect(originalFeatures.length, 'admin ACL must have features before clearing').toBeGreaterThan(0)
 
-    const postAdminResponse = await apiRequest(request, 'GET', '/api/auth/roles?pageSize=10', {
-      token: adminToken,
-    })
-    expect(postAdminResponse.status(), 'admin token should still work after sync').toBe(200)
+    try {
+      const clearResponse = await apiRequest(request, 'PUT', '/api/auth/roles/acl', {
+        token: superadminToken,
+        data: { roleId: adminRoleId, tenantId, features: [], isSuperAdmin: originalIsSuperAdmin },
+      })
+      expect(clearResponse.status(), 'clearing admin ACL must succeed').toBe(200)
+
+      const clearedResponse = await apiRequest(request, 'GET', aclPath, { token: superadminToken })
+      const clearedBody = await readJsonSafe<RoleAclResponse>(clearedResponse)
+      expect(clearedBody?.features ?? [], 'admin ACL features must be empty before sync').toEqual([])
+
+      const output = runMercato(['auth', 'sync-role-acls', '--tenant', tenantId])
+      expect(output).toContain(`Synced role ACLs for tenant ${tenantId}`)
+
+      const restoredResponse = await apiRequest(request, 'GET', aclPath, { token: superadminToken })
+      expect(restoredResponse.status()).toBe(200)
+      const restoredBody = await readJsonSafe<RoleAclResponse>(restoredResponse)
+      const restoredFeatures = Array.isArray(restoredBody?.features) ? restoredBody!.features! : []
+      expect(
+        restoredFeatures.length,
+        'sync-role-acls must restore admin features from defaultRoleFeatures',
+      ).toBeGreaterThan(0)
+      expect(restoredFeatures, 'restored admin features must include auth.*').toContain('auth.*')
+    } finally {
+      await apiRequest(request, 'PUT', '/api/auth/roles/acl', {
+        token: superadminToken,
+        data: {
+          roleId: adminRoleId,
+          tenantId,
+          features: originalFeatures,
+          isSuperAdmin: originalIsSuperAdmin,
+          organizations: originalOrganizations,
+        },
+      }).catch(() => null)
+    }
   })
 
   test('is idempotent — second run adds no new ACL changes and exits cleanly', async ({ request }) => {
@@ -103,5 +148,12 @@ test.describe('TC-AUTH-033: auth sync-role-acls CLI', () => {
   test('fails cleanly with an invalid --tenant value', async () => {
     const { output } = runMercatoCapture(['auth', 'sync-role-acls', '--tenant', '   '])
     expect(output).toContain('Invalid --tenant value')
+  })
+
+  test('fails when --tenant points at a non-existent tenant id', async () => {
+    const missingTenantId = '00000000-0000-0000-0000-000000000000'
+    const { output } = runMercatoCapture(['auth', 'sync-role-acls', '--tenant', missingTenantId])
+    expect(output).toContain(`Tenant not found: ${missingTenantId}`)
+    expect(output).not.toContain(`Synced role ACLs for tenant ${missingTenantId}`)
   })
 })

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
@@ -30,10 +30,13 @@ function findRepoRoot(startDir: string): string {
 }
 
 const repoRoot = findRepoRoot(__dirname)
+const mercatoCwd = process.env.OM_TEST_APP_ROOT?.trim()
+  ? path.resolve(process.env.OM_TEST_APP_ROOT.trim())
+  : repoRoot
 
 function runMercato(args: string[]): string {
   return execFileSync('yarn', ['mercato', ...args], {
-    cwd: repoRoot,
+    cwd: mercatoCwd,
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -45,7 +48,7 @@ function runMercato(args: string[]): string {
 
 function runMercatoCapture(args: string[]): { status: number | null; output: string } {
   const result = spawnSync('yarn', ['mercato', ...args], {
-    cwd: repoRoot,
+    cwd: mercatoCwd,
     encoding: 'utf8',
     env: {
       ...process.env,

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-033.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test'
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..', '..', '..', '..')
+
+function runMercato(args: string[]): string {
+  return execFileSync('yarn', ['mercato', ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      FORCE_COLOR: '0',
+      NODE_NO_WARNINGS: '1',
+    },
+  })
+}
+
+test.describe('TC-AUTH-033: auth sync-role-acls CLI', () => {
+  test.slow()
+
+  test('restores default feature ACLs for the admin role after the admin ACL is cleared', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenScope(adminToken)
+    expect(tenantId).toBeTruthy()
+
+    const rolesResponse = await apiRequest(request, 'GET', '/api/auth/roles?pageSize=100&search=admin', {
+      token: adminToken,
+    })
+    expect(rolesResponse.status()).toBe(200)
+    const rolesBody = await readJsonSafe<{
+      items?: Array<{ id?: string; name?: string; tenantId?: string | null }>
+    }>(rolesResponse)
+    const adminRole = (rolesBody?.items ?? []).find((r) => r.name === 'admin' && r.tenantId === tenantId)
+    expect(adminRole?.id, 'admin role not found for this tenant').toBeTruthy()
+
+    const output = runMercato(['auth', 'sync-role-acls', '--tenant', tenantId])
+    expect(output).toContain(`Synced role ACLs for tenant ${tenantId}`)
+
+    const postAdminResponse = await apiRequest(request, 'GET', '/api/auth/roles?pageSize=10', {
+      token: adminToken,
+    })
+    expect(postAdminResponse.status(), 'admin token should still work after sync').toBe(200)
+  })
+
+  test('is idempotent — second run adds no new ACL changes and exits cleanly', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    const { tenantId } = getTokenScope(adminToken)
+
+    const first = runMercato(['auth', 'sync-role-acls', '--tenant', tenantId])
+    const second = runMercato(['auth', 'sync-role-acls', '--tenant', tenantId])
+
+    expect(first).toContain(`Synced role ACLs for tenant ${tenantId}`)
+    expect(second).toContain(`Synced role ACLs for tenant ${tenantId}`)
+  })
+
+  test('fails cleanly with an invalid --tenant value', async () => {
+    let errorOutput = ''
+    try {
+      runMercato(['auth', 'sync-role-acls', '--tenant', '   '])
+    } catch (err) {
+      errorOutput = String((err as NodeJS.ErrnoException & { stdout?: string; stderr?: string }).stdout ?? '')
+        + String((err as NodeJS.ErrnoException & { stdout?: string; stderr?: string }).stderr ?? '')
+    }
+    expect(errorOutput).toContain('Invalid --tenant value')
+  })
+})

--- a/packages/core/src/modules/auth/__tests__/cli-sync-role-acls.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-sync-role-acls.test.ts
@@ -29,6 +29,11 @@ const findOne = jest.fn(async (Entity: any, where: any) => {
   if (Entity?.name === 'RoleAcl') {
     return existingAcls.find((a) => a.role?.id === where?.role?.id && a.tenantId === where?.tenantId) ?? null
   }
+  if (Entity?.name === 'Tenant') {
+    const id = where?.id
+    if (!id) return null
+    return tenantsList.find((t) => t.id === id) ?? null
+  }
   return null
 })
 const find = jest.fn(async (Entity: any) => {
@@ -71,6 +76,7 @@ function seedRoles(tenantId: string) {
     { id: `r-employee-${tenantId}`, name: 'employee', tenantId },
     { id: `r-reports-${tenantId}`, name: 'reports_viewer', tenantId },
   ]
+  if (!tenantsList.some((t) => t.id === tenantId)) tenantsList.push({ id: tenantId })
 }
 
 describe('auth CLI sync-role-acls', () => {
@@ -155,5 +161,17 @@ describe('auth CLI sync-role-acls', () => {
     expect(persistedAcls).toEqual([])
     expect(logSpy).toHaveBeenCalledWith('No tenants found; nothing to sync.')
     logSpy.mockRestore()
+  })
+
+  it('errors and writes nothing when --tenant points at a non-existent tenant', async () => {
+    const cmd = cli.find((c: any) => c.command === 'sync-role-acls')!
+    seedRoles('t-1')
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    await cmd.run(['--tenant', 't-missing'])
+
+    expect(persistedAcls).toEqual([])
+    expect(errorSpy).toHaveBeenCalledWith('❌ Tenant not found: t-missing')
+    errorSpy.mockRestore()
   })
 })

--- a/packages/core/src/modules/auth/__tests__/cli-sync-role-acls.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-sync-role-acls.test.ts
@@ -1,0 +1,159 @@
+/** @jest-environment node */
+import { registerModules } from '@open-mercato/shared/lib/modules/registry'
+import { registerCliModules } from '@open-mercato/shared/modules/registry'
+import type { Module } from '@open-mercato/shared/modules/registry'
+import cli from '@open-mercato/core/modules/auth/cli'
+
+const testModules: Module[] = [
+  { id: 'auth', setup: { defaultRoleFeatures: { superadmin: ['auth.admin'], admin: ['auth.*'], employee: ['auth.view'] } } },
+  { id: 'customers', setup: { defaultRoleFeatures: { admin: ['customers.*'], employee: ['customers.view'] } } },
+  { id: 'reports', setup: { defaultRoleFeatures: { reports_viewer: ['reports.view'] } } },
+]
+registerModules(testModules)
+registerCliModules(testModules)
+
+type RoleStub = { id: string; name: string; tenantId: string | null }
+type RoleAclStub = { role: RoleStub; tenantId: string; featuresJson: string[]; isSuperAdmin: boolean }
+
+let persistedAcls: RoleAclStub[] = []
+let existingAcls: RoleAclStub[] = []
+let tenantsList: Array<{ id: string }> = []
+let rolesByTenant: Record<string, RoleStub[]> = {}
+
+const findOne = jest.fn(async (Entity: any, where: any) => {
+  if (Entity?.name === 'Role') {
+    const tid = where?.tenantId ?? null
+    const roles = rolesByTenant[tid ?? '__null__'] ?? []
+    return roles.find((r) => r.name === where?.name) ?? null
+  }
+  if (Entity?.name === 'RoleAcl') {
+    return existingAcls.find((a) => a.role?.id === where?.role?.id && a.tenantId === where?.tenantId) ?? null
+  }
+  return null
+})
+const find = jest.fn(async (Entity: any) => {
+  if (Entity?.name === 'Tenant') return tenantsList
+  return []
+})
+const create = jest.fn((_entity: any, data: any) => ({ ...data }))
+const persist = jest.fn(function persist(this: any, entity: any) {
+  if (entity && 'featuresJson' in entity) {
+    const existingIdx = persistedAcls.findIndex((a) => a.role?.id === entity.role?.id && a.tenantId === entity.tenantId)
+    if (existingIdx >= 0) persistedAcls[existingIdx] = entity
+    else persistedAcls.push(entity)
+  }
+  return this
+})
+const flush = jest.fn(async () => {})
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (_: string) => ({
+      findOne,
+      find,
+      create,
+      persist,
+      flush,
+      transactional: async (cb: (tem: any) => any) => cb({ findOne, find, create, persist, flush }),
+    }),
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: async (em: any, Entity: any, where: any) => em.findOne(Entity, where),
+  findWithDecryption: async (em: any, Entity: any, where: any) => em.find(Entity, where),
+}))
+
+function seedRoles(tenantId: string) {
+  rolesByTenant[tenantId] = [
+    { id: `r-superadmin-${tenantId}`, name: 'superadmin', tenantId },
+    { id: `r-admin-${tenantId}`, name: 'admin', tenantId },
+    { id: `r-employee-${tenantId}`, name: 'employee', tenantId },
+    { id: `r-reports-${tenantId}`, name: 'reports_viewer', tenantId },
+  ]
+}
+
+describe('auth CLI sync-role-acls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    persistedAcls = []
+    existingAcls = []
+    tenantsList = []
+    rolesByTenant = {}
+  })
+
+  it('creates RoleAcl rows for built-in + custom roles on --tenant <id>', async () => {
+    const cmd = cli.find((c: any) => c.command === 'sync-role-acls')!
+    expect(cmd).toBeDefined()
+    seedRoles('t-1')
+
+    await cmd.run(['--tenant', 't-1'])
+
+    const superadminAcl = persistedAcls.find((a) => a.role?.name === 'superadmin')
+    const adminAcl = persistedAcls.find((a) => a.role?.name === 'admin')
+    const employeeAcl = persistedAcls.find((a) => a.role?.name === 'employee')
+    const reportsAcl = persistedAcls.find((a) => a.role?.name === 'reports_viewer')
+
+    expect(superadminAcl?.isSuperAdmin).toBe(true)
+    expect(superadminAcl?.featuresJson).toEqual(expect.arrayContaining(['auth.admin']))
+    expect(adminAcl?.featuresJson).toEqual(expect.arrayContaining(['auth.*', 'customers.*']))
+    expect(employeeAcl?.featuresJson).toEqual(expect.arrayContaining(['auth.view', 'customers.view']))
+    expect(reportsAcl?.featuresJson).toEqual(['reports.view'])
+  })
+
+  it('is additive and idempotent — preserves existing features, adds missing ones', async () => {
+    const cmd = cli.find((c: any) => c.command === 'sync-role-acls')!
+    seedRoles('t-1')
+    const adminRole = rolesByTenant['t-1'].find((r) => r.name === 'admin')!
+    existingAcls = [
+      {
+        role: adminRole,
+        tenantId: 't-1',
+        featuresJson: ['auth.*', 'legacy.custom.kept'],
+        isSuperAdmin: false,
+      },
+    ]
+
+    await cmd.run(['--tenant', 't-1'])
+
+    const adminAcl = persistedAcls.find((a) => a.role?.name === 'admin')
+    expect(adminAcl?.featuresJson).toEqual(expect.arrayContaining(['auth.*', 'customers.*', 'legacy.custom.kept']))
+  })
+
+  it('--no-superadmin skips writing the superadmin ACL', async () => {
+    const cmd = cli.find((c: any) => c.command === 'sync-role-acls')!
+    seedRoles('t-1')
+
+    await cmd.run(['--tenant', 't-1', '--no-superadmin'])
+
+    const superadminAcl = persistedAcls.find((a) => a.role?.name === 'superadmin')
+    expect(superadminAcl).toBeUndefined()
+    const adminAcl = persistedAcls.find((a) => a.role?.name === 'admin')
+    expect(adminAcl).toBeDefined()
+  })
+
+  it('iterates every tenant when --tenant is omitted', async () => {
+    const cmd = cli.find((c: any) => c.command === 'sync-role-acls')!
+    tenantsList = [{ id: 't-1' }, { id: 't-2' }]
+    seedRoles('t-1')
+    seedRoles('t-2')
+
+    await cmd.run([])
+
+    const adminAclT1 = persistedAcls.find((a) => a.role?.name === 'admin' && a.tenantId === 't-1')
+    const adminAclT2 = persistedAcls.find((a) => a.role?.name === 'admin' && a.tenantId === 't-2')
+    expect(adminAclT1).toBeDefined()
+    expect(adminAclT2).toBeDefined()
+  })
+
+  it('logs and exits when no tenants found (no-flag mode)', async () => {
+    const cmd = cli.find((c: any) => c.command === 'sync-role-acls')!
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await cmd.run([])
+
+    expect(persistedAcls).toEqual([])
+    expect(logSpy).toHaveBeenCalledWith('No tenants found; nothing to sync.')
+    logSpy.mockRestore()
+  })
+})

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -5,7 +5,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { User, Role, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 import { Tenant, Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { rebuildHierarchyForTenant } from '@open-mercato/core/modules/directory/lib/hierarchy'
-import { ensureRoles, setupInitialTenant } from './lib/setup-app'
+import { ensureRoles, setupInitialTenant, ensureDefaultRoleAcls, ensureCustomRoleAcls } from './lib/setup-app'
 import { normalizeTenantId } from './lib/tenantAccess'
 import { computeEmailHash } from './lib/emailHash'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -643,4 +643,61 @@ const setPassword: ModuleCli = {
 }
 
 // Export the full CLI list
-export default [addUser, seedRoles, rotateEncryptionKey, addOrganization, setupApp, listOrganizations, listTenants, listUsers, setPassword]
+const syncRoleAcls: ModuleCli = {
+  command: 'sync-role-acls',
+  async run(rest) {
+    const args: Record<string, string> = {}
+    const flags = new Set<string>()
+    for (let i = 0; i < rest.length; i++) {
+      const token = rest[i]
+      if (!token?.startsWith('--')) continue
+      const key = token.replace(/^--/, '')
+      const next = rest[i + 1]
+      if (next && !next.startsWith('--')) {
+        args[key] = next
+        i++
+      } else {
+        flags.add(key)
+      }
+    }
+    const tenantArg = args.tenantId ?? args.tenant ?? args.tenant_id ?? null
+    const includeSuperadminRole = !flags.has('no-superadmin')
+
+    const modules = getCliModules()
+    if (!modules.length) {
+      console.error('❌ No CLI modules registered. Run `yarn generate` first.')
+      return
+    }
+
+    const { resolve } = await createRequestContainer()
+    const em = resolve<EntityManager>('em')
+
+    const targetTenantIds: string[] = []
+    if (tenantArg) {
+      const normalized = normalizeTenantId(tenantArg)
+      if (!normalized) {
+        console.error(`❌ Invalid --tenant value: ${tenantArg}`)
+        return
+      }
+      targetTenantIds.push(normalized)
+    } else {
+      const tenants = await em.find(Tenant, {})
+      if (!tenants.length) {
+        console.log('No tenants found; nothing to sync.')
+        return
+      }
+      for (const tenant of tenants) {
+        const id = tenant.id ? String(tenant.id) : null
+        if (id) targetTenantIds.push(id)
+      }
+    }
+
+    for (const tenantId of targetTenantIds) {
+      await ensureDefaultRoleAcls(em, tenantId, modules, { includeSuperadminRole })
+      await ensureCustomRoleAcls(em, tenantId, modules)
+      console.log(`✅ Synced role ACLs for tenant ${tenantId}`)
+    }
+  },
+}
+
+export default [addUser, seedRoles, syncRoleAcls, rotateEncryptionKey, addOrganization, setupApp, listOrganizations, listTenants, listUsers, setPassword]

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -679,6 +679,11 @@ const syncRoleAcls: ModuleCli = {
         console.error(`❌ Invalid --tenant value: ${tenantArg}`)
         return
       }
+      const tenant = await em.findOne(Tenant, { id: normalized })
+      if (!tenant) {
+        console.error(`❌ Tenant not found: ${normalized}`)
+        return
+      }
       targetTenantIds.push(normalized)
     } else {
       const tenants = await em.find(Tenant, {})

--- a/packages/core/src/modules/auth/lib/setup-app.ts
+++ b/packages/core/src/modules/auth/lib/setup-app.ts
@@ -392,7 +392,7 @@ async function resolvePasswordHash(input: PrimaryUserInput): Promise<string | nu
   return null
 }
 
-async function ensureDefaultRoleAcls(
+export async function ensureDefaultRoleAcls(
   em: EntityManager,
   tenantId: string,
   modules: Module[],


### PR DESCRIPTION
## Summary
- New `yarn mercato auth sync-role-acls [--tenant <id>] [--no-superadmin]` CLI that merges every enabled module's `setup.defaultRoleFeatures` into the `RoleAcl` rows of an existing tenant — idempotent, additive-only. Fixes the "admin user lost the progress-bar role on demo" class of issues without touching example data (unlike `seed:defaults`).
- Exports `ensureDefaultRoleAcls` from `packages/core/src/modules/auth/lib/setup-app.ts` so the new command reuses the exact logic `setupTenantAndPrimaryUser` runs during initial tenant bootstrap. No behavior change to existing call sites.
- Adds unit tests (5 cases, jest) and Playwright integration coverage (TC-AUTH-033, 3 cases) exercising the real CLI via `execFileSync`.
- Docs: new CLI reference page + overview entry + step 4 added to auth module `AGENTS.md` "Adding New Features" workflow.

## Test plan
- [x] `yarn workspace @open-mercato/core test --testPathPatterns="cli-sync-role-acls"` — 5/5 pass
- [x] `yarn workspace @open-mercato/core test --testPathPatterns="cli-setup-acl"` — 1/1 pass (reference test, no regression)
- [x] `npx playwright test --config .ai/qa/tests/playwright.config.ts --list` — TC-AUTH-033 discovered and parsed
- [ ] Run the CLI end-to-end on the demo tenant and verify admin regains missing features: `yarn mercato auth sync-role-acls --tenant <demo-tenant-id>`
- [ ] Confirm idempotency: re-run the command, verify no extra ACL writes and clean exit
- [ ] Confirm `--no-superadmin` path skips the superadmin ACL write

🤖 Generated with [Claude Code](https://claude.com/claude-code)