### PR TITLE
chore(ds-guardian): document v2 form primitives + new tokens

### DIFF
--- a/.ai/skills/ds-guardian/SKILL.md
+++ b/.ai/skills/ds-guardian/SKILL.md
@@ -52,6 +52,42 @@ grep -rn '<svg' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/nu
 
 echo "--- Missing aria-labels ---"
 grep -rn 'size="icon"' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null | grep -v 'aria-label'
+
+echo "--- Raw <input type='text|email|password|number|tel|url|search'> (use <Input>) ---"
+grep -rln '<input ' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null \
+  | xargs grep -l 'type=["'\'']\(text\|email\|password\|number\|tel\|url\|search\)["'\'']' 2>/dev/null
+
+echo "--- Raw <input type='checkbox'> (use <Checkbox> / <CheckboxField>) ---"
+grep -rln '<input ' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null \
+  | xargs grep -l 'type=["'\'']checkbox["'\'']' 2>/dev/null
+
+echo "--- Raw <input type='radio'> (use <Radio> + <RadioGroup>) ---"
+grep -rln '<input ' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null \
+  | xargs grep -l 'type=["'\'']radio["'\'']' 2>/dev/null
+
+echo "--- Raw <select> (use <Select> family) ---"
+grep -rn '<select' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
+
+echo "--- Raw <textarea> (use <Textarea>) ---"
+grep -rn '<textarea' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
+
+echo "--- Custom role='switch' or role='radio' (use Switch / Radio primitives) ---"
+grep -rn 'role=["'\'']switch["'\'']\|role=["'\'']radio["'\'']' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
+
+echo "--- disabled:opacity-50 (use --bg-disabled / --text-disabled tokens) ---"
+grep -rn 'disabled:opacity-50\|disabled.*opacity-50' "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
+
+echo "--- Hardcoded brand colors (use --brand-* tokens) ---"
+grep -rn '#1877F2\|#0A66C2\|#0061FF\|#181717\|#BC9AFF\|#D4F372\|bg-\[#[0-9A-Fa-f]\{3,6\}\]' \
+  "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
+
+echo "--- Old focus ring (use shadow-focus token) ---"
+grep -rn 'focus.*ring-2.*ring-offset-2\|focus:ring-2 focus:ring-blue-' \
+  "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
+
+echo "--- bg-primary on selection controls (use bg-accent-indigo) ---"
+grep -rn 'data-\[state=checked\]:bg-primary\|state=checked.*bg-primary' \
+  "packages/core/src/modules/$MODULE/" --include="*.tsx" 2>/dev/null
 ```
 
 Present results as a structured report:
@@ -74,8 +110,8 @@ Summary: N files, N violations. Estimated migration: ~Xh
 ```
 
 Severity rules:
-- **CRITICAL**: Hardcoded status colors (broken dark mode), missing loading/empty states
-- **WARNING**: Arbitrary text sizes, deprecated Notice usage, missing aria-labels
+- **CRITICAL**: Hardcoded status colors (broken dark mode), missing loading/empty states, raw `<input>` / `<select>` / `<textarea>` (skips DS focus/disabled/error patterns), `data-[state=checked]:bg-primary` on selection controls (wrong color contract)
+- **WARNING**: Arbitrary text sizes, deprecated Notice usage, missing aria-labels, `disabled:opacity-50` (use disabled tokens), hardcoded brand hex (`#1877F2`, `#0A66C2`, etc.), custom `role="switch"` / `role="radio"` (use Switch / Radio primitive), old focus rings (`focus:ring-2 ring-offset-2`)
 - **INFO**: Inline SVG, non-standard spacing, minor inconsistencies
 
 ---
@@ -140,6 +176,21 @@ For complex cases, open each file and replace using the mapping table from `refe
 | Solid background for buttons (`bg-red-600`) | Use `bg-destructive`, not `bg-status-error-bg` |
 | `text-emerald-300` in dark context | Use `text-status-success-icon` (lighter variant) |
 
+**Mode C: Raw HTML form controls → DS primitives**
+
+Use the recipes in `references/token-mapping.md` ("Raw HTML → DS Primitive" section). Rules per type:
+
+| Raw HTML | Replace with | Critical migration rules |
+|----------|--------------|--------------------------|
+| `<input type="text\|email\|password\|number\|tel\|url\|search">` | `<Input>` | Drop width/height/border/radius/padding classes; map `h-8`→`size="sm"` / `h-10`→`size="lg"`; convert absolute icons to `leftIcon` / `rightIcon`; replace `border-red-*` with `aria-invalid={...}`; drop `disabled:opacity-50` |
+| `<input type="checkbox">` | `<Checkbox>` or `<CheckboxField>` | Use `<CheckboxField>` whenever there's a label; ON state is `--accent-indigo`, never `bg-primary` |
+| `<input type="radio">` | `<Radio>` inside `<RadioGroup>` (or `<RadioField>`) | RadioGroup provides keyboard nav and shared name; for card-style selectors keep custom styling but wrap in `<RadioGroup>` |
+| `<select>` | `<Select>` family | NEVER use `<SelectItem value="">` (Radix forbids); move empty label to `<SelectValue placeholder="...">`; pass `value={x \|\| undefined}` for optional; `<optgroup>` → `<SelectGroup><SelectLabel>` |
+| `<textarea>` | `<Textarea>` | Drop hardcoded styling; for character counters set `maxLength` + `showCount` |
+| Custom `role="switch"` button | `<Switch>` or `<SwitchField>` | Track is 28×16 — do not override sizing; ON state is `--accent-indigo` |
+
+Skip when: forwardRef-bound `<select>` with consumer tests asserting native `getByRole('option')` (Tenant/Organization/Category selects). Migration requires updating consumers + tests — escalate to a separate task.
+
 **After EVERY migration:**
 ```bash
 # Verify zero remaining violations
@@ -195,6 +246,11 @@ Review code (file, PR diff, or staged changes) against DS principles. Check thes
 | Colors | Hardcoded `text-red-*`, `bg-green-*`, etc. | Use semantic tokens (`text-status-error-text`) |
 | Typography | `text-[Npx]` arbitrary sizes | Use scale (`text-xs`, `text-sm`) or `text-overline` |
 | Components | Raw `<table>`, custom error div, hardcoded status badge | Use `DataTable`, `Alert`, `StatusBadge` |
+| Form controls | Raw `<input>` / `<select>` / `<textarea>` / `<input type=checkbox\|radio>` / custom `role="switch"` | Use `<Input>` / `<Select>` / `<Textarea>` / `<Checkbox>` / `<Radio>+<RadioGroup>` / `<Switch>` |
+| Selection color | `data-[state=checked]:bg-primary` on Checkbox/Radio/Switch | Use `bg-accent-indigo` (color contract) |
+| Disabled state | `disabled:opacity-50` | Use `disabled:bg-bg-disabled disabled:text-text-disabled disabled:border-border-disabled` |
+| Focus ring | `focus:ring-2 ring-offset-2` | Use `focus-visible:outline-none focus-visible:shadow-focus` |
+| Brand colors | Hardcoded brand hex (`#1877F2`, `#0A66C2`, `#181717`, etc.) | Use `bg-brand-*` tokens or `<SocialButton>` |
 | Feedback | Missing empty state on list page, missing loading state | Add `EmptyState`, `LoadingMessage` |
 | Accessibility | IconButton without `aria-label`, color as only info carrier | Add `aria-label`, add text/icon alongside color |
 | Forms | Input without label, FormField not used in standalone form | Add `<Label>`, wrap in `<FormField>` |

--- a/.ai/skills/ds-guardian/references/component-guide.md
+++ b/.ai/skills/ds-guardian/references/component-guide.md
@@ -18,6 +18,17 @@
 | Build a CRUD form | `<CrudForm fields={...} onSubmit={...} />` | `@open-mercato/ui/backend/CrudForm` |
 | Add a metadata badge (count, tag) | `<Badge variant="secondary">` | `@open-mercato/ui/primitives/badge` |
 | Use an icon | `<IconName className="size-4" />` from lucide-react | `lucide-react` |
+| Render text input (text/email/password/number/tel/url/search) | `<Input leftIcon={...} rightIcon={...} size="sm\|default\|lg" />` | `@open-mercato/ui/primitives/input` |
+| Render multi-line text with optional char counter | `<Textarea showCount maxLength={...} />` | `@open-mercato/ui/primitives/textarea` |
+| Render dropdown / single-select | `<Select><SelectTrigger><SelectValue/></SelectTrigger><SelectContent>...</SelectContent></Select>` | `@open-mercato/ui/primitives/select` |
+| Render checkbox (binary toggle inside form) | `<Checkbox checked={...} onCheckedChange={...} />` | `@open-mercato/ui/primitives/checkbox` |
+| Render checkbox with label + description | `<CheckboxField label="..." description="..." />` | `@open-mercato/ui/primitives/checkbox-field` |
+| Render binary toggle (immediate effect, e.g. setting on/off) | `<Switch />` or `<SwitchField label="..." />` | `@open-mercato/ui/primitives/switch` / `@open-mercato/ui/primitives/switch-field` |
+| Render mutually-exclusive choice | `<RadioGroup><Radio value="..." />...</RadioGroup>` or `<RadioField label="..." />` | `@open-mercato/ui/primitives/radio` / `@open-mercato/ui/primitives/radio-field` |
+| Show hover hint with arrow | `<SimpleTooltip content="..." arrow>` | `@open-mercato/ui/primitives/tooltip` |
+| Show inline link styled as button | `<LinkButton variant="..." />` | `@open-mercato/ui/primitives/link-button` |
+| Show OAuth/social sign-in button | `<SocialButton brand="apple\|github\|google\|x\|facebook\|dropbox\|linkedin" />` | `@open-mercato/ui/primitives/social-button` |
+| Show marketing CTA with brand gradient | `<FancyButton intent="..." />` | `@open-mercato/ui/primitives/fancy-button` |
 
 ## FormField
 
@@ -167,6 +178,236 @@ Rule 1-1-N: Max 1 `default`, max 1 `destructive`, any number of others per secti
 | `size-6` | 24px | Large icons, empty states |
 
 Always use `lucide-react`. Never inline `<svg>`. Icon-only buttons MUST have `aria-label`.
+
+## Form Primitives — Raw HTML → DS Replacement
+
+NEVER use raw HTML form controls. Always use the DS primitive equivalent.
+
+| Raw HTML | Use this | Why |
+|---|---|---|
+| `<input type="text\|email\|password\|number\|tel\|url\|search">` | `<Input>` | Token-driven focus/disabled, icon slots, FormField error pickup |
+| `<input type="checkbox">` | `<Checkbox>` (or `<CheckboxField>`) | Indeterminate, indigo selection, focus halo |
+| `<input type="radio">` | `<Radio>` inside `<RadioGroup>` (or `<RadioField>`) | Group keyboard nav, indigo selection, focus halo |
+| `<select>` | `<Select>` family | Themed popper, scroll on long lists, no empty-string items |
+| `<textarea>` | `<Textarea>` | Token disabled/focus, optional `showCount` |
+| Custom `role="switch"` button | `<Switch>` (or `<SwitchField>`) | Figma-aligned 28×16 track, indigo on, hit area 32×20 |
+
+## Input
+
+Single-line text input (text, email, password, number, tel, url, search).
+
+```typescript
+type InputProps = {
+  size?: 'sm' | 'default' | 'lg'      // h-8 / h-9 / h-10
+  leftIcon?: ReactNode                 // size-4 lucide icon
+  rightIcon?: ReactNode
+  className?: string                   // wrapper
+  inputClassName?: string              // inner <input>
+} & React.InputHTMLAttributes<HTMLInputElement>
+```
+
+**Example:**
+```tsx
+<FormField label="Email" required error={errors.email}>
+  <Input
+    type="email"
+    leftIcon={<Mail />}
+    value={email}
+    onChange={(e) => setEmail(e.target.value)}
+  />
+</FormField>
+```
+
+**Rules:**
+- NEVER pass width/height/border/radius/padding/text-size in `className` — DS scales handle them
+- For error styling: do NOT add `border-red-*` — set `aria-invalid={!!error}` (FormField does this automatically)
+- Convert absolute-positioned input icons to `leftIcon` / `rightIcon` slots
+- Do NOT add `disabled:opacity-50` — primitive uses `--bg-disabled` / `--text-disabled` / `--border-disabled` tokens
+
+## Textarea
+
+Multi-line text input.
+
+```typescript
+type TextareaProps = {
+  showCount?: boolean         // shows aria-live counter under field
+  maxLength?: number          // bounds counter, no typing past max
+} & React.TextareaHTMLAttributes<HTMLTextAreaElement>
+```
+
+**Example:**
+```tsx
+<FormField label="Notes">
+  <Textarea showCount maxLength={500} rows={4} />
+</FormField>
+```
+
+**Rules:**
+- Default `min-h-[80px]`, `resize-y` — do NOT override unless layout demands it
+- Counter renders below field, switches to `text-destructive` when over max
+- For CrudForm fields, set `maxLength` and `showCount` directly on the `CrudField` definition
+
+## Select
+
+Dropdown / single-select. Built on Radix Select.
+
+```tsx
+import {
+  Select, SelectGroup, SelectValue, SelectTrigger,
+  SelectContent, SelectLabel, SelectItem, SelectSeparator,
+} from '@open-mercato/ui/primitives/select'
+
+<Select value={status || undefined} onValueChange={setStatus}>
+  <SelectTrigger size="sm">
+    <SelectValue placeholder={t('module.status.placeholder', 'Select status')} />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectGroup>
+      <SelectLabel>{t('module.status.label', 'Status')}</SelectLabel>
+      <SelectItem value="active">Active</SelectItem>
+      <SelectItem value="inactive">Inactive</SelectItem>
+      <SelectSeparator />
+      <SelectItem value="archived">Archived</SelectItem>
+    </SelectGroup>
+  </SelectContent>
+</Select>
+```
+
+**Rules:**
+- NEVER use `<SelectItem value="">` — Radix forbids empty values. Use `placeholder` on `SelectValue` instead.
+- For optional fields with controlled state, pass `value={x || undefined}` so placeholder shows when empty.
+- Trigger sizes match `<Input>`: `sm` (h-8), default (h-9), `lg` (h-10).
+- Long lists scroll automatically — do NOT add `max-h` or `overflow` overrides on `SelectContent`.
+
+## Checkbox / CheckboxField
+
+Binary toggle inside a form (state visible only on submit, not immediate effect).
+
+```typescript
+type CheckboxFieldProps = {
+  label: ReactNode
+  sublabel?: ReactNode
+  description?: ReactNode
+  badge?: ReactNode
+  link?: ReactNode
+  flip?: boolean                  // checkbox on right (default: left)
+} & CheckboxProps
+```
+
+**Example:**
+```tsx
+<CheckboxField
+  label={t('settings.notifications.label', 'Email notifications')}
+  description={t('settings.notifications.help', 'Receive updates about your account')}
+  checked={notify}
+  onCheckedChange={setNotify}
+/>
+```
+
+**Rules:**
+- ON state uses `--accent-indigo` (#6366f1). NEVER override with `data-[state=checked]:bg-primary`.
+- Use `<CheckboxField>` whenever the checkbox has a label — it handles `htmlFor`, alignment, and disabled propagation.
+- For indeterminate state, pass `checked="indeterminate"`.
+
+## Switch / SwitchField
+
+Binary toggle with **immediate effect** (e.g., feature flag, sync on/off).
+
+```typescript
+type SwitchFieldProps = {
+  label: ReactNode
+  sublabel?: ReactNode
+  description?: ReactNode
+  badge?: ReactNode
+  link?: ReactNode
+  flip?: boolean                  // switch on left (default: switch on right)
+} & SwitchProps
+```
+
+**Example:**
+```tsx
+<SwitchField
+  label={t('users.active.label', 'Active')}
+  description={t('users.active.help', 'Disable to revoke access immediately')}
+  checked={isActive}
+  onCheckedChange={toggleActive}
+/>
+```
+
+**Decision: Switch vs Checkbox**
+- **Switch** — immediate effect (toggle a setting that changes behavior right now)
+- **Checkbox** — deferred state (collected on form submit)
+
+**Rules:**
+- ON state uses `--accent-indigo` (color contract with Checkbox/Radio).
+- Track is 28×16, thumb 12px — do NOT override sizing.
+- `<SwitchField>` defaults to label-LEFT, switch-RIGHT (preference style). Use `flip` to swap.
+
+## Radio / RadioGroup / RadioField
+
+Mutually-exclusive choice from a list. Built on Radix RadioGroup.
+
+```tsx
+import { RadioGroup, Radio } from '@open-mercato/ui/primitives/radio'
+import { RadioField } from '@open-mercato/ui/primitives/radio-field'
+
+// Pattern A — manual layout (cards, table rows)
+<RadioGroup value={mode} onValueChange={setMode}>
+  <label className="flex items-center gap-2">
+    <Radio value="auto" />
+    <span>{t('settings.mode.auto', 'Automatic')}</span>
+  </label>
+</RadioGroup>
+
+// Pattern B — labeled list
+<RadioGroup value={mode} onValueChange={setMode}>
+  <RadioField value="inherit" label={t('users.role.inherit', 'Inherit from roles')} />
+  <RadioField value="override" label={t('users.role.override', 'Override for this user')} description={...} />
+</RadioGroup>
+```
+
+**Rules:**
+- ON state uses `--accent-indigo` (color contract).
+- Always wrap `<Radio>` in `<RadioGroup>` — provides keyboard navigation and shared name.
+- For card-style selectors with selected highlighting, use Pattern A and keep custom card styling.
+
+## Tooltip / SimpleTooltip
+
+Hover hint with optional arrow.
+
+```tsx
+import { SimpleTooltip } from '@open-mercato/ui/primitives/tooltip'
+
+<SimpleTooltip content={t('actions.delete.help', 'Permanently delete this item')} arrow>
+  <IconButton aria-label={t('common.delete', 'Delete')}>
+    <Trash />
+  </IconButton>
+</SimpleTooltip>
+```
+
+**Variants:**
+- `default` (dark, high contrast — like iOS) — most use cases
+- `light` (white with border) — when dark conflicts with surrounding context
+
+**Sizes:** `sm` (table cells, icon buttons), `default`, `lg` (multi-line / rich content)
+
+**Rules:**
+- `arrow` defaults to `true` — keep it on for clarity unless the tooltip is multi-element popover-style.
+- Wrap `<IconButton>` in `<SimpleTooltip>` to surface its `aria-label` visually on hover.
+
+## LinkButton / SocialButton / FancyButton
+
+Specialized button primitives.
+
+| Primitive | Use case |
+|---|---|
+| `<LinkButton>` | Inline text link styled like a button (in body copy, footers, table cells) |
+| `<SocialButton brand="...">` | OAuth sign-in (Google / Apple / GitHub / X / Facebook / Dropbox / LinkedIn) |
+| `<FancyButton intent="...">` | Marketing CTA with brand-violet/lime gradient (NOT for backend admin) |
+
+**Rules:**
+- Brand colors come from `--brand-*` tokens. NEVER hardcode `#1877F2` etc.
+- `<FancyButton>` is theme-invariant by design — no `dark:` overrides needed.
 
 ## Typography Scale
 

--- a/.ai/skills/ds-guardian/references/token-mapping.md
+++ b/.ai/skills/ds-guardian/references/token-mapping.md
@@ -76,6 +76,71 @@ Lookup reference for DS Guardian. No prose — just tables.
 | `border-sky-600/30` | `border-status-info-border` | Regex 1:1 |
 | `bg-sky-500/10` | `bg-status-info-bg` | Regex 1:1 |
 
+## Selection Control Color (Checkbox / Radio / Switch ON state)
+
+| Current | Replace with | Notes |
+|---------|-------------|-------|
+| `data-[state=checked]:bg-primary` | `data-[state=checked]:bg-accent-indigo` | Color contract for selection controls |
+| `data-[state=checked]:text-primary-foreground` | `data-[state=checked]:text-accent-indigo-foreground` | |
+| `bg-primary` (on Checkbox/Radio/Switch) | `bg-accent-indigo` | Selection only — leave Button `bg-primary` alone |
+| Custom `#6366f1` / `#818cf8` hex on toggles | `bg-accent-indigo` | Use the token |
+
+Tokens (defined in `apps/mercato/src/app/globals.css` + `packages/create-app/template/src/app/globals.css`):
+- `--accent-indigo` — light `#6366f1`, dark `#818cf8`
+- `--accent-indigo-foreground` — `white`
+
+## Disabled State
+
+| Current | Replace with | Notes |
+|---------|-------------|-------|
+| `disabled:opacity-50` | `disabled:bg-bg-disabled disabled:text-text-disabled disabled:border-border-disabled` | Token-driven, preserves contrast |
+| `opacity-50` (in disabled context) | Same as above | Only when used to indicate disabled |
+| `text-gray-400` (placeholder/disabled) | `text-muted-foreground` (placeholder) or `text-text-disabled` (disabled) | |
+
+Tokens:
+- `--bg-disabled` — `#f7f7f7` light, `oklch(0.25 0 0)` dark
+- `--text-disabled` — `#d1d1d1` light, `oklch(0.45 0 0)` dark
+- `--border-disabled` — `#ebebeb` light, `oklch(0.30 0 0)` dark
+
+NEVER apply `disabled:text-text-disabled` to placeholder-bearing controls (Input/Select/Textarea) — placeholder must stay readable. The primitive handles this internally.
+
+## Focus Ring (Figma 2-ring halo)
+
+| Current | Replace with |
+|---------|-------------|
+| `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` | `focus-visible:outline-none focus-visible:shadow-focus` |
+| `focus:ring-2 focus:ring-blue-500` | `focus-visible:outline-none focus-visible:shadow-focus` |
+| `focus:outline focus:outline-2` | `focus-visible:outline-none focus-visible:shadow-focus` |
+
+Token: `--shadow-focus` = `0 0 0 2px var(--focus-ring-inner), 0 0 0 4px var(--focus-ring-outer)` (white inner ring + soft outer ring).
+
+## Hover State
+
+| Current | Replace with | Notes |
+|---------|-------------|-------|
+| `hover:bg-primary/90` (on primary buttons) | `hover:bg-primary-hover` | |
+| `hover:bg-blue-600` | `hover:bg-primary-hover` | If primary action |
+
+Token: `--primary-hover` — light `oklch(0.145 0 0)`, dark `oklch(0.85 0 0)`.
+
+## Brand Colors (theme-invariant)
+
+Used by SocialButton / FancyButton / brand surfaces. NEVER hardcode brand hex values.
+
+| Current | Replace with |
+|---------|-------------|
+| `bg-[#1877F2]` (Facebook blue) | `bg-brand-facebook` |
+| `bg-[#0A66C2]` (LinkedIn blue) | `bg-brand-linkedin` |
+| `bg-[#0061FF]` (Dropbox blue) | `bg-brand-dropbox` |
+| `bg-[#181717]` (GitHub black) | `bg-brand-github` |
+| `bg-black` (Apple / X) | `bg-brand-apple` / `bg-brand-x` |
+| `bg-white border-[#dadce0]` (Google) | `bg-background border-brand-google-stroke` |
+| `bg-[#BC9AFF]` (FancyButton violet) | `bg-brand-violet` |
+| `bg-[#D4F372]` (FancyButton lime) | `bg-brand-lime` |
+
+Tokens (theme-invariant — same value light & dark):
+- `--brand-violet`, `--brand-lime`, `--brand-apple`, `--brand-github`, `--brand-x`, `--brand-google-stroke`, `--brand-facebook`, `--brand-dropbox`, `--brand-linkedin`
+
 ## Color Mapping: DO NOT MIGRATE
 
 | Pattern | Reason |
@@ -118,3 +183,146 @@ Lookup reference for DS Guardian. No prose — just tables.
 | `title="..."` (Notice prop) | `<AlertTitle>...</AlertTitle>` | Composition pattern |
 | `message="..."` (Notice prop) | `<AlertDescription>...</AlertDescription>` | Composition pattern |
 | `action={<Button>}` (Notice prop) | `<AlertAction><Button></AlertAction>` | Explicit slot |
+
+## Raw HTML → DS Primitive (form controls)
+
+### `<input type="text|email|password|number|tel|url|search">` → `<Input>`
+
+```diff
+- import { Search } from 'lucide-react'
++ import { Input } from '@open-mercato/ui/primitives/input'
++ import { Search } from 'lucide-react'
+
+- <div className="relative">
+-   <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-gray-400" />
+-   <input
+-     type="text"
+-     className="h-9 w-full rounded-md border border-gray-300 pl-9 pr-3 text-sm focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+-     placeholder="Search..."
+-     value={query}
+-     onChange={(e) => setQuery(e.target.value)}
+-   />
+- </div>
++ <Input
++   type="text"
++   leftIcon={<Search />}
++   placeholder="Search..."
++   value={query}
++   onChange={(e) => setQuery(e.target.value)}
++ />
+```
+
+Rules:
+- Strip width/height/border/radius/padding/text-size classes — primitive handles them.
+- Map size: `h-8` → `size="sm"`, `h-10` → `size="lg"`, `h-9` → default (omit).
+- Convert absolute-positioned icons to `leftIcon` / `rightIcon`.
+- Replace `border-red-*` with `aria-invalid={...}` (or wrap in `<FormField error={...}>`).
+- Drop `disabled:opacity-50` — primitive uses disabled tokens.
+
+### `<input type="checkbox">` → `<Checkbox>` / `<CheckboxField>`
+
+```diff
+- import { Checkbox } from '@open-mercato/ui/primitives/checkbox'
++ import { CheckboxField } from '@open-mercato/ui/primitives/checkbox-field'
+
+- <label className="flex items-center gap-2">
+-   <input
+-     type="checkbox"
+-     checked={notify}
+-     onChange={(e) => setNotify(e.target.checked)}
+-     className="h-4 w-4 rounded border-gray-300 text-indigo-600"
+-   />
+-   <span className="text-sm">Email notifications</span>
+- </label>
++ <CheckboxField
++   label="Email notifications"
++   checked={notify}
++   onCheckedChange={setNotify}
++ />
+```
+
+### `<input type="radio">` → `<Radio>` + `<RadioGroup>`
+
+```diff
++ import { RadioGroup, Radio } from '@open-mercato/ui/primitives/radio'
++ import { RadioField } from '@open-mercato/ui/primitives/radio-field'
+
+- <div>
+-   <label><input type="radio" name="mode" value="auto" checked={mode === 'auto'} onChange={() => setMode('auto')} /> Auto</label>
+-   <label><input type="radio" name="mode" value="manual" checked={mode === 'manual'} onChange={() => setMode('manual')} /> Manual</label>
+- </div>
++ <RadioGroup value={mode} onValueChange={setMode}>
++   <RadioField value="auto" label="Auto" />
++   <RadioField value="manual" label="Manual" />
++ </RadioGroup>
+```
+
+### `<select>` → `<Select>` family
+
+```diff
++ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@open-mercato/ui/primitives/select'
+
+- <select
+-   value={status}
+-   onChange={(e) => setStatus(e.target.value)}
+-   className="h-9 rounded-md border border-gray-300 px-3 text-sm"
+- >
+-   <option value="">Select status...</option>
+-   <option value="active">Active</option>
+-   <option value="inactive">Inactive</option>
+- </select>
++ <Select value={status || undefined} onValueChange={setStatus}>
++   <SelectTrigger>
++     <SelectValue placeholder="Select status..." />
++   </SelectTrigger>
++   <SelectContent>
++     <SelectItem value="active">Active</SelectItem>
++     <SelectItem value="inactive">Inactive</SelectItem>
++   </SelectContent>
++ </Select>
+```
+
+Rules:
+- NEVER `<SelectItem value="">` — Radix forbids empty values. Move the empty-state label to `placeholder` on `<SelectValue>`.
+- For controlled state where `""` means "nothing selected", pass `value={x || undefined}`.
+- `<optgroup label="X">` → `<SelectGroup><SelectLabel>X</SelectLabel>...</SelectGroup>`.
+
+### `<textarea>` → `<Textarea>`
+
+```diff
++ import { Textarea } from '@open-mercato/ui/primitives/textarea'
+
+- <textarea
+-   className="min-h-20 w-full rounded-md border border-gray-300 p-2 text-sm focus:ring-2"
+-   value={notes}
+-   onChange={(e) => setNotes(e.target.value)}
+-   maxLength={500}
+- />
++ <Textarea
++   value={notes}
++   onChange={(e) => setNotes(e.target.value)}
++   maxLength={500}
++   showCount
++ />
+```
+
+### Custom `role="switch"` button → `<Switch>` / `<SwitchField>`
+
+```diff
++ import { SwitchField } from '@open-mercato/ui/primitives/switch-field'
+
+- <button
+-   type="button"
+-   role="switch"
+-   aria-checked={isActive}
+-   onClick={() => setIsActive(!isActive)}
+-   className={cn('relative h-6 w-11 rounded-full', isActive ? 'bg-indigo-600' : 'bg-gray-300')}
+- >
+-   <span className={cn('absolute top-0.5 size-5 rounded-full bg-white transition', isActive ? 'left-5' : 'left-0.5')} />
+- </button>
++ <SwitchField
++   label="Active"
++   checked={isActive}
++   onCheckedChange={setIsActive}
++ />
+```

--- a/.ai/skills/ds-guardian/scripts/ds-health-check.sh
+++ b/.ai/skills/ds-guardian/scripts/ds-health-check.sh
@@ -105,6 +105,41 @@ ST=$(count_matches 'status-error-|status-success-|status-warning-|status-info-|s
 report "  Semantic token usages: $ST"
 
 report ""
+report "--- Raw HTML Form Controls (use DS primitives) ---"
+RAW_TEXT_INPUT=$(count_matches '<input[^>]*type=["'\''](text|email|password|number|tel|url|search)["'\'']')
+report "  Raw <input type='text|email|password|number|tel|url|search'>: $RAW_TEXT_INPUT (target: 0)"
+RAW_CHECKBOX=$(count_matches '<input[^>]*type=["'\'']checkbox["'\'']')
+report "  Raw <input type='checkbox'>: $RAW_CHECKBOX (target: 0)"
+RAW_RADIO=$(count_matches '<input[^>]*type=["'\'']radio["'\'']')
+report "  Raw <input type='radio'>: $RAW_RADIO (target: 0)"
+RAW_SELECT=$(count_matches '<select[ >]')
+report "  Raw <select>: $RAW_SELECT (target: 0)"
+RAW_TEXTAREA=$(count_matches '<textarea[ >]')
+report "  Raw <textarea>: $RAW_TEXTAREA (target: 0)"
+CUSTOM_SWITCH=$(count_matches 'role=["'\'']switch["'\'']')
+report "  Custom role='switch': $CUSTOM_SWITCH (target: 0)"
+
+report ""
+report "--- Disabled state (use --bg-disabled / --text-disabled tokens) ---"
+OPACITY_DISABLED=$(count_matches 'disabled:opacity-50')
+report "  disabled:opacity-50: $OPACITY_DISABLED (target: 0)"
+
+report ""
+report "--- Selection control color contract (use --accent-indigo) ---"
+WRONG_SELECTION_COLOR=$(count_matches 'data-\[state=checked\]:bg-primary')
+report "  data-[state=checked]:bg-primary on selection controls: $WRONG_SELECTION_COLOR (target: 0)"
+
+report ""
+report "--- Brand colors hardcoded (use --brand-* tokens / SocialButton) ---"
+BRAND_HEX=$(count_matches '#1877F2|#0A66C2|#0061FF|#181717|#BC9AFF|#D4F372')
+report "  Hardcoded brand hex: $BRAND_HEX (target: 0)"
+
+report ""
+report "--- Old focus rings (use --shadow-focus token) ---"
+OLD_FOCUS=$(count_matches 'focus.*ring-2.*ring-offset-2')
+report "  focus:ring-2 ring-offset-2: $OLD_FOCUS (target: 0)"
+
+report ""
 report "=== END REPORT ==="
 
 PREV=$(ls -1 "$REPORT_DIR"/ds-health-*.txt 2>/dev/null | grep -v "$DATE" | sort | tail -1 || true)


### PR DESCRIPTION
## Summary

Updates the DS Guardian skill (`.ai/skills/ds-guardian/`) to cover the form primitives and new tokens introduced in DS Foundation v1+v2. Doc-only change — no code paths, no runtime behavior.

## Changes

**`references/component-guide.md`** (+241 lines)
- Decision table: 11 new primitives (Input, Textarea, Select, Checkbox/Field, Switch/Field, Radio/Group/Field, Tooltip, LinkButton, SocialButton, FancyButton)
- New "Form Primitives — Raw HTML → DS Replacement" section
- Per-primitive reference (API, examples, MUST rules) for each new primitive

**`references/token-mapping.md`** (+207 lines)
- 5 new token mapping sections: Selection Color (`--accent-indigo`), Disabled (`--bg-disabled` / `--text-disabled` / `--border-disabled`), Focus Ring (`--shadow-focus`), Hover (`--primary-hover`), Brand Colors (`--brand-*`)
- "Raw HTML → DS Primitive" section with diff-style migration recipes for input, checkbox, radio, select, textarea, custom switch

**`SKILL.md`** (+56 lines)
- ANALYZE: 8 new grep patterns (raw inputs, custom switches, `opacity-50`, brand hex, old focus rings, wrong selection color)
- MIGRATE: new "Mode C: Raw HTML form controls" with critical migration rules + skip list (forwardRef Selects requiring consumer test updates)
- REVIEW: 5 new categories (Form controls, Selection color, Disabled state, Focus ring, Brand colors)
- Severity rules: extended CRITICAL/WARNING

**`scripts/ds-health-check.sh`** (+34 lines)
- 10 new metrics: raw HTML controls (5), custom switch, `opacity-50`, wrong selection color, brand hex, old focus rings

## Specification

Brings the DS Guardian skill in sync with primitives delivered by the DS Foundation refactor:

- **v1**: Button family, Checkbox, LinkButton, SocialButton, FancyButton, Tag, Avatar, AvatarStack, Kbd
- **v2**: Input, Select, Switch, Radio, Textarea, Tooltip + sweep migration of ~250 raw HTML form controls

Doc-only — references to primitives delivered by v1/v2 are docs-ahead-of-code until those PRs land. Markdown isn't compiled, so no runtime impact.

## Testing

- [x] `bash -n scripts/ds-health-check.sh` — syntax OK
- [ ] Run health check once v2 lands to verify new metrics produce sane numbers

## Checklist

- [x] Doc-only update to `.ai/skills/ds-guardian/`
- [x] Independent of v1/v2 (branched from `develop`)
- [x] Follows AGENTS.md conventions (commit message format, no AI signatures)
- [x] No code changes — no build/typecheck impact

## Linked issues
None.

## Notes

Merging this skill update first means future DS-related PRs (after v1+v2 land) immediately benefit from updated DS Guardian guidance — including raw HTML form-control detection, selection-color contract enforcement, and disabled-state token migration. Independent of v1/v2 — can land in any order.