### PR TITLE
feat(ui): make AppShell and PortalShell logo configurable

### DIFF
--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -41,8 +41,14 @@ import {
   GLOBAL_SIDEBAR_STATUS_BADGES_INJECTION_SPOT_ID,
 } from './injection/spotIds'
 
+export type ShellLogo = {
+  src: string
+  alt?: string
+}
+
 export type AppShellProps = {
   productName?: string
+  logo?: ShellLogo
   email?: string
   groups: {
     id?: string
@@ -398,7 +404,7 @@ export function AppShell(props: AppShellProps) {
   )
 }
 
-function AppShellBody({ productName, email, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot }: AppShellProps) {
+function AppShellBody({ productName, logo, email, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot }: AppShellProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const t = useT()
@@ -808,7 +814,7 @@ function AppShellBody({ productName, email, groups, rightHeaderSlot, children, s
         {!hideHeader && (
           <div className={`flex items-center ${compact ? 'justify-center' : 'justify-between'} mb-2`}>
             <Link href="/backend" className="flex items-center gap-2" aria-label={t('appShell.goToDashboard')}>
-              <Image src="/open-mercato.svg" alt={resolvedProductName} width={32} height={32} className="rounded m-4" />
+              <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? resolvedProductName} width={32} height={32} className="rounded m-4" />
               {!compact && <div className="text-m font-semibold">{resolvedProductName}</div>}
             </Link>
           </div>
@@ -919,7 +925,7 @@ function AppShellBody({ productName, email, groups, rightHeaderSlot, children, s
           {!hideHeader ? (
             <div className={`flex items-center ${compact ? 'justify-center' : 'justify-between'} mb-2`}>
               <Link href="/backend" className="flex items-center gap-2" aria-label={t('appShell.goToDashboard')}>
-                <Image src="/open-mercato.svg" alt={resolvedProductName} width={32} height={32} className="rounded m-4" />
+                <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? resolvedProductName} width={32} height={32} className="rounded m-4" />
                 {!compact && <div className="text-m font-semibold">{resolvedProductName}</div>}
               </Link>
             </div>
@@ -1168,7 +1174,7 @@ function AppShellBody({ productName, email, groups, rightHeaderSlot, children, s
         {!hideHeader && (
           <div className={`flex items-center ${compact ? 'justify-center' : 'justify-between'} mb-2`}>
             <Link href="/backend" className="flex items-center gap-2" aria-label={t('appShell.goToDashboard')}>
-              <Image src="/open-mercato.svg" alt={resolvedProductName} width={32} height={32} className="rounded m-4" />
+              <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? resolvedProductName} width={32} height={32} className="rounded m-4" />
               {!compact && <div className="text-m font-semibold">{resolvedProductName}</div>}
             </Link>
           </div>
@@ -1552,7 +1558,7 @@ function AppShellBody({ productName, email, groups, rightHeaderSlot, children, s
           <aside className="absolute left-0 top-0 flex h-full w-[260px] flex-col bg-background border-r overflow-hidden">
             <div className="shrink-0 p-3 pb-2 flex items-center justify-between border-b">
               <Link href="/backend" className="flex items-center gap-2 text-sm font-semibold" onClick={() => setMobileOpen(false)} aria-label={t('appShell.goToDashboard')}>
-                <Image src="/open-mercato.svg" alt={resolvedProductName} width={28} height={28} className="rounded" />
+                <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? resolvedProductName} width={28} height={28} className="rounded" />
                 {resolvedProductName}
               </Link>
               <IconButton variant="outline" size="sm" onClick={() => setMobileOpen(false)} aria-label={t('appShell.closeMenu')}>✕</IconButton>

--- a/packages/ui/src/portal/PortalShell.tsx
+++ b/packages/ui/src/portal/PortalShell.tsx
@@ -22,12 +22,19 @@ export const PORTAL_FOOTER_HANDLE = 'section:portal:footer'
 export const PORTAL_SIDEBAR_HANDLE = 'section:portal:sidebar'
 export const PORTAL_USER_MENU_HANDLE = 'section:portal:user-menu'
 
+export type ShellLogo = {
+  src: string
+  alt?: string
+}
+
 export type PortalShellProps = {
   children: ReactNode
   /** Override orgSlug (used on public pages without context) */
   orgSlug?: string
   /** Override organization name (used on public pages without context) */
   organizationName?: string
+  /** Override the brand logo rendered in the header, footer, and sidebar. */
+  logo?: ShellLogo
   /** Whether to show authenticated layout. Auto-detected from context when omitted. */
   authenticated?: boolean
   /** Logout handler. Auto-provided from context when omitted. */
@@ -148,6 +155,7 @@ export function PortalShell({
   children,
   orgSlug: orgSlugProp,
   organizationName: orgNameProp,
+  logo,
   authenticated: authenticatedProp,
   onLogout: onLogoutProp,
   enableEventBridge = false,
@@ -237,7 +245,7 @@ export function PortalShell({
         <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80" data-portal-handle={PORTAL_HEADER_HANDLE}>
           <div className="mx-auto flex h-16 w-full max-w-screen-lg items-center justify-between px-6">
             <Link href={portalHome} className="flex items-center gap-2.5 text-foreground transition hover:opacity-80" aria-label={headerTitle}>
-              <Image src="/open-mercato.svg" alt="" width={28} height={28} className="" priority />
+              <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? ""} width={28} height={28} className="" priority />
               <span className="text-[15px] font-semibold tracking-tight">{headerTitle}</span>
             </Link>
             <nav aria-label="Primary" className="flex items-center gap-1">
@@ -260,7 +268,7 @@ export function PortalShell({
         <footer className="border-t" data-portal-handle={PORTAL_FOOTER_HANDLE}>
           <div className="mx-auto flex w-full max-w-screen-lg items-center justify-between px-6 py-6">
             <Link href={portalHome} className="flex items-center gap-2 text-muted-foreground transition hover:text-foreground">
-              <Image src="/open-mercato.svg" alt="" width={20} height={20} className="" />
+              <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? ""} width={20} height={20} className="" />
               <span className="text-sm font-medium text-foreground">{headerTitle}</span>
             </Link>
             <p className="text-xs text-muted-foreground/60">
@@ -278,7 +286,7 @@ export function PortalShell({
     <div className="flex h-full flex-col" data-portal-handle={PORTAL_SIDEBAR_HANDLE}>
       <div className="flex h-16 items-center gap-2.5 border-b px-5">
         <Link href={portalHome} className="flex items-center gap-2.5 text-foreground transition hover:opacity-80" aria-label={headerTitle}>
-          <Image src="/open-mercato.svg" alt="" width={22} height={22} className="" />
+          <Image src={logo?.src ?? "/open-mercato.svg"} alt={logo?.alt ?? ""} width={22} height={22} className="" />
           <span className="text-[14px] font-semibold tracking-tight truncate">{headerTitle}</span>
         </Link>
       </div>


### PR DESCRIPTION
## Summary

`@open-mercato/ui` `AppShell` and `PortalShell` hardcoded `<Image src=\"/open-mercato.svg\" />` in 7 places, forcing downstream apps to ship a misnamed `public/open-mercato.svg` containing their own logo. This PR adds an optional `logo` prop to both shells so apps can supply their own brand asset; defaults preserve existing behavior.

## Changes

- Add `ShellLogo = { src: string; alt?: string }` and `logo?: ShellLogo` prop to `AppShellProps` and `PortalShellProps`.
- Thread `logo` through `AppShellBody` destructuring and `PortalShell` destructuring.
- Replace 4 hardcoded `<Image>` sites in `packages/ui/src/backend/AppShell.tsx` and 3 in `packages/ui/src/portal/PortalShell.tsx` with `logo?.src ?? \"/open-mercato.svg\"` and `logo?.alt ?? <existing fallback>`.

Backward compatible — additive optional prop per the BC contract (surface #2). Apps that don't pass `logo` get the same `/open-mercato.svg` path as before.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

## Testing

- \`yarn build:packages\` — green.
- Defaults verified by inspection: when `logo` is omitted, both shells render the original `/open-mercato.svg` with the original `alt` fallbacks (`resolvedProductName` for AppShell, `\"\"` for PortalShell).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement.
- [ ] Documentation/locales/generators — no updates needed (additive optional prop, behavior unchanged by default).
- [ ] Tests — no behavior change; existing tests cover both shells.
- [ ] Integration tests — N/A (cosmetic prop, no new flow).
- [ ] Spec — N/A.

### Design System Compliance
- [x] No hardcoded status colors
- [x] No arbitrary text sizes
- [x] N/A — no list/data pages touched
- [x] N/A — no async pages touched
- [x] N/A — no icon-only buttons added
- [x] Uses existing DS components

🤖 Generated with [Claude Code](https://claude.com/claude-code)