### PR TITLE
fix(scripts): devsplash respects configured base URL across all variants

### DIFF
--- a/.ai/runs/2026-04-27-devsplash-base-url.md
+++ b/.ai/runs/2026-04-27-devsplash-base-url.md
@@ -121,8 +121,8 @@ If `yarn build:app` is too slow / risky for an isolated worktree, document the r
 
 ### Phase 2: apply helper across devsplash variants
 
-- [ ] 2.1 Update `scripts/dev.mjs` to use the helper
-- [ ] 2.2 Update `scripts/dev-ephemeral.ts` to use the helper (splash + ephemeral baseUrl)
+- [x] 2.1 Update `scripts/dev.mjs` to use the helper — 771c6efdd
+- [x] 2.2 Update `scripts/dev-ephemeral.ts` to use the helper (splash + ephemeral baseUrl) — 771c6efdd
 
 ### Phase 3: template sync
 

--- a/.ai/runs/2026-04-27-devsplash-base-url.md
+++ b/.ai/runs/2026-04-27-devsplash-base-url.md
@@ -1,0 +1,136 @@
+# Devsplash: respect configured base URL across all variants
+
+Date: 2026-04-27
+Slug: devsplash-base-url
+Branch: `fix/devsplash-base-url`
+Owner: pkarw
+Status: in-progress
+
+## Goal
+
+Replace hardcoded `localhost` / `127.0.0.1` URLs in the dev splash variants with a single reusable helper that derives the developer-facing URL from `APP_URL` / `NEXT_PUBLIC_APP_URL` / `PORT`, applies smart port handling, and drops the explicit port for standard schemes (80/http, 443/https). The splash and the URLs it prints must match what the developer actually types into their browser when running the app behind a reverse proxy at e.g. `https://devsandbox.openmercato.com`.
+
+## Scope
+
+In scope:
+
+- New helper module `scripts/dev-splash-url.mjs` (pure ESM, dependency-free) that exposes:
+  - `parsePortNumber(value)` — already exists in `scripts/dev.mjs`; centralized here.
+  - `isStandardPort(scheme, port)` — true for `http:`/80 and `https:`/443.
+  - `parseConfiguredBaseUrl(value)` — parse a candidate URL string.
+  - `formatBaseUrl({ protocol, hostname, port })` — drops port when standard for scheme.
+  - `resolveDevBaseUrl(env, { actualPort })` — main entry point. Reads `APP_URL`/`NEXT_PUBLIC_APP_URL`/`PORT`, applies port-randomization logic, and returns `{ url, hasConfiguredBaseUrl, portWasRandomized }`.
+  - `resolveSplashUrl(env, splashPort)` — same scheme/host as the configured app URL, attached to the actual splash port; drops standard ports.
+- Apply the helper to every place that currently constructs a localhost URL by hand:
+  - `scripts/dev.mjs`: `resolveExpectedAppBaseUrl()` (line ~297) and the splash URL string at the splash bind site (line ~919).
+  - `scripts/dev-ephemeral.ts`: the splash URL (line ~424) and the two `http://127.0.0.1:${port}` literals at lines ~952 and ~1131. The ephemeral-mode `APP_URL`/`NEXT_PUBLIC_APP_URL` propagation must respect a parent-process `APP_URL` when set.
+- Mirror `scripts/dev-splash-url.mjs` to the standalone create-app template via `scripts/template-sync.ts`'s explicit list (the sync is list-driven, not glob-driven).
+- Unit tests for the helper in `scripts/__tests__/dev-splash-url.test.mjs` covering: localhost default, custom HTTPS host, standard port suppression (80/443), non-standard port retention, randomized-port override, missing/invalid env fallback.
+- Verify existing `scripts/__tests__/*.test.mjs` still pass with the change.
+
+Non-goals:
+
+- The two `new URL(req.url, 'http://localhost')` calls in the coding-flow / git-repo-flow handlers (they are URL-parsing tricks, not user-facing URLs).
+- Changing the ACL/auth model, ephemeral PostgreSQL container, or any other dev-runtime behavior.
+- Touching `apps/mercato/scripts/dev.mjs` (it does not contain the localhost hardcodes).
+- Touching the splash HTML (it renders state from the parent script, so the helper output flows through automatically).
+- Renaming / relocating the existing `parsePortNumber` / `normalizePublicBaseUrl` helpers in `scripts/dev.mjs`. The new helper module imports cleanly and the legacy helpers can stay in place to avoid churn (re-exporting from the new module is enough to dedupe over time).
+
+## External References
+
+None — no `--skill-url` arguments were passed by the requester.
+
+## Implementation Plan
+
+### Phase 1: helper module + unit tests
+
+1.1 Create `scripts/dev-splash-url.mjs` with the API listed in Scope. Pure ESM, no dependencies. Implement the port logic exactly as described:
+- If `actualPort` is provided AND a configured port exists AND they differ → "randomized", use `actualPort`, set `portWasRandomized: true`.
+- If `actualPort` is provided AND no configured port exists → use `actualPort` if non-standard for the scheme, otherwise drop the port from the URL.
+- If `actualPort` is omitted → use the configured port (URL port → `PORT` env → default 3000 for http+localhost / scheme default for explicit configured URL).
+- Always drop port `80` for `http:` and `443` for `https:`.
+
+1.2 Create `scripts/__tests__/dev-splash-url.test.mjs` (Node `node:test` runner — same convention as `dev-splash-state.test.mjs`). Cover at minimum:
+- localhost default fallback (`{}` env → `http://localhost:3000`).
+- localhost with `PORT=4321` → `http://localhost:4321`.
+- `APP_URL=https://devsandbox.openmercato.com` → `https://devsandbox.openmercato.com` (no `:443`).
+- `APP_URL=http://example.test` → `http://example.test` (no `:80`).
+- `APP_URL=http://example.test:8080` with `actualPort=8080` → `http://example.test:8080`.
+- `APP_URL=http://example.test:8080` with `actualPort=8123` → `http://example.test:8123` and `portWasRandomized: true`.
+- Invalid `APP_URL` (not a URL) → fallback to localhost+`PORT`.
+- `NEXT_PUBLIC_APP_URL` used when `APP_URL` is missing.
+- `formatBaseUrl({ protocol: 'https:', hostname: 'devsandbox.openmercato.com', port: 443 })` → no port.
+- `isStandardPort('http:', 80)` true; `isStandardPort('http:', 443)` false.
+- `resolveSplashUrl` with configured HTTPS host + non-standard splash port keeps the splash port.
+
+### Phase 2: apply helper across devsplash variants
+
+2.1 In `scripts/dev.mjs`:
+- Import from `./dev-splash-url.mjs`.
+- Replace `resolveExpectedAppBaseUrl` body to delegate to `resolveDevBaseUrl(process.env).url`. Keep the function name (it is referenced elsewhere).
+- Replace the `splashUrl = \`http://localhost:${address.port}\`` line with `resolveSplashUrl(process.env, address.port)`.
+- Keep the local `parsePortNumber` if it is referenced more than once in the file; otherwise delegate to the helper.
+
+2.2 In `scripts/dev-ephemeral.ts`:
+- Import from `./dev-splash-url.mjs` (the helper is `.mjs` ESM; the TS file imports as ESM).
+- Replace `const splashUrl = \`http://localhost:${address.port}\`` with `resolveSplashUrl(process.env, address.port)`.
+- Replace the two `const baseUrl = \`http://127.0.0.1:${port}\`` literals with the helper. The ephemeral runtime should:
+  - prefer the parent-process `APP_URL` / `NEXT_PUBLIC_APP_URL` when set, passing `actualPort: port` so the resolved URL reflects the bound port.
+  - otherwise fall back to `http://127.0.0.1:${port}` (preserving today's behavior — the ephemeral PostgreSQL is bound to 127.0.0.1, so 127.0.0.1 is the right loopback default for the dev server too).
+  - The 127.0.0.1 vs localhost distinction matters for the ephemeral path because the existing readiness probe uses `${baseUrl}/backend/login` and the ephemeral runtime explicitly avoids the 'localhost' alias. Helper option `localhostHost: '127.0.0.1'` covers this.
+
+### Phase 3: template sync
+
+3.1 Add `scripts/dev-splash-url.mjs` to the explicit sync list in `scripts/template-sync.ts` and write the mirrored copy to `packages/create-app/template/scripts/dev-splash-url.mjs`. Also mirror the test file as a sibling under `packages/create-app/template/scripts/__tests__/` only if other dev-splash tests already live there; otherwise, the test is a monorepo-only artifact (existing pattern).
+
+3.2 Run `tsx scripts/template-sync.ts --fix` to ensure both the new file and the updated `dev.mjs` are mirrored to the create-app template.
+
+### Phase 4: validation gate
+
+4.1 Run targeted tests: `node --test scripts/__tests__/dev-splash-url.test.mjs scripts/__tests__/dev-splash-state.test.mjs`.
+
+4.2 Run the full validation gate per the auto-create-pr workflow:
+- `yarn build:packages`
+- `yarn generate`
+- `yarn build:packages` (post-generate)
+- `yarn i18n:check-sync`
+- `yarn i18n:check-usage`
+- `yarn typecheck`
+- `yarn test:scripts`
+- `yarn test`
+- `yarn build:app`
+
+If `yarn build:app` is too slow / risky for an isolated worktree, document the reason and skip with a justification in the Risks section.
+
+4.3 Open PR against `develop`, apply `review` and `bug` + `skip-qa` labels (no customer-facing UI change — only dev tooling output). Post the comprehensive summary comment.
+
+## Risks
+
+- **Misreading "randomized port" semantics for proxy-fronted dev**: when `APP_URL=https://devsandbox.openmercato.com` (port 443 implicit) and the dev server binds locally to 3000, the helper must NOT promote 3000 into the URL — the proxy fronts 443. Mitigation: the helper only treats `actualPort` as authoritative when a configured port exists and they differ. If no configured port exists AND the configured host is non-localhost AND `actualPort` is non-standard, we drop the port (assume proxy). Tests cover this.
+- **Breaking ephemeral readiness probe**: ephemeral runtime probes `${baseUrl}/backend/login` against `127.0.0.1`. If the helper rewrites the probe URL to a remote sandbox, the probe would fail. Mitigation: when ephemeral runs WITHOUT a parent `APP_URL`, the helper falls back to `127.0.0.1:port` (same as today). When run WITH a parent `APP_URL`, the runtime keeps a separate `loopbackUrl` for the probe. Implementation Step 2.2 handles this explicitly.
+- **Template sync drift**: `template-sync.ts` is list-driven. Forgetting to add the new file would cause `tsx scripts/template-sync.ts` (CI step) to flag drift. Phase 3 explicitly updates the list.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: helper module + unit tests
+
+- [ ] 1.1 Create `scripts/dev-splash-url.mjs` with the helper API
+- [ ] 1.2 Create `scripts/__tests__/dev-splash-url.test.mjs` covering all required scenarios
+
+### Phase 2: apply helper across devsplash variants
+
+- [ ] 2.1 Update `scripts/dev.mjs` to use the helper
+- [ ] 2.2 Update `scripts/dev-ephemeral.ts` to use the helper (splash + ephemeral baseUrl)
+
+### Phase 3: template sync
+
+- [ ] 3.1 Add helper to `scripts/template-sync.ts` SYNC list and mirror to `packages/create-app/template/scripts/dev-splash-url.mjs`
+- [ ] 3.2 Run `tsx scripts/template-sync.ts --fix` to mirror the updated `dev.mjs` (and any other touched scripts) into the create-app template
+
+### Phase 4: validation gate
+
+- [ ] 4.1 Run targeted Node tests for the new helper and existing splash state tests
+- [ ] 4.2 Run full validation gate (build:packages, generate, i18n, typecheck, test, build:app)
+- [ ] 4.3 Open PR against develop with `review`, `bug`, `skip-qa` labels and post summary comment

--- a/.ai/runs/2026-04-27-devsplash-base-url.md
+++ b/.ai/runs/2026-04-27-devsplash-base-url.md
@@ -134,3 +134,4 @@ If `yarn build:app` is too slow / risky for an isolated worktree, document the r
 - [x] 4.1 Run targeted Node tests for the new helper and existing splash state tests — d605efb0b
 - [x] 4.2 Run full validation gate (build:packages, generate, i18n, typecheck, test, build:app) — d605efb0b
 - [x] 4.3 Open PR #1726 against develop with `review`, `bug`, `skip-qa` labels and post label rationale comment — d605efb0b
+- [x] Post-review fix: tighten randomization heuristic for proxy-fronted hosts and drop dead `normalizePublicBaseUrl` helper — 7f38eb45f

--- a/.ai/runs/2026-04-27-devsplash-base-url.md
+++ b/.ai/runs/2026-04-27-devsplash-base-url.md
@@ -4,7 +4,7 @@ Date: 2026-04-27
 Slug: devsplash-base-url
 Branch: `fix/devsplash-base-url`
 Owner: pkarw
-Status: in-progress
+Status: complete (PR #1726)
 
 ## Goal
 
@@ -131,6 +131,6 @@ If `yarn build:app` is too slow / risky for an isolated worktree, document the r
 
 ### Phase 4: validation gate
 
-- [ ] 4.1 Run targeted Node tests for the new helper and existing splash state tests
-- [ ] 4.2 Run full validation gate (build:packages, generate, i18n, typecheck, test, build:app)
-- [ ] 4.3 Open PR against develop with `review`, `bug`, `skip-qa` labels and post summary comment
+- [x] 4.1 Run targeted Node tests for the new helper and existing splash state tests — d605efb0b
+- [x] 4.2 Run full validation gate (build:packages, generate, i18n, typecheck, test, build:app) — d605efb0b
+- [x] 4.3 Open PR #1726 against develop with `review`, `bug`, `skip-qa` labels and post label rationale comment — d605efb0b

--- a/.ai/runs/2026-04-27-devsplash-base-url.md
+++ b/.ai/runs/2026-04-27-devsplash-base-url.md
@@ -116,8 +116,8 @@ If `yarn build:app` is too slow / risky for an isolated worktree, document the r
 
 ### Phase 1: helper module + unit tests
 
-- [ ] 1.1 Create `scripts/dev-splash-url.mjs` with the helper API
-- [ ] 1.2 Create `scripts/__tests__/dev-splash-url.test.mjs` covering all required scenarios
+- [x] 1.1 Create `scripts/dev-splash-url.mjs` with the helper API — 2ba66444b
+- [x] 1.2 Create `scripts/__tests__/dev-splash-url.test.mjs` covering all required scenarios — 2ba66444b
 
 ### Phase 2: apply helper across devsplash variants
 

--- a/.ai/runs/2026-04-27-devsplash-base-url.md
+++ b/.ai/runs/2026-04-27-devsplash-base-url.md
@@ -126,8 +126,8 @@ If `yarn build:app` is too slow / risky for an isolated worktree, document the r
 
 ### Phase 3: template sync
 
-- [ ] 3.1 Add helper to `scripts/template-sync.ts` SYNC list and mirror to `packages/create-app/template/scripts/dev-splash-url.mjs`
-- [ ] 3.2 Run `tsx scripts/template-sync.ts --fix` to mirror the updated `dev.mjs` (and any other touched scripts) into the create-app template
+- [x] 3.1 Add helper to `scripts/template-sync.ts` SYNC list and mirror to `packages/create-app/template/scripts/dev-splash-url.mjs` — e133c2fc6
+- [x] 3.2 Apply targeted dev.mjs patch to `packages/create-app/template/scripts/dev.mjs` (kept pre-existing unrelated drift unchanged) — e133c2fc6
 
 ### Phase 4: validation gate
 

--- a/packages/create-app/template/scripts/dev-splash-url.mjs
+++ b/packages/create-app/template/scripts/dev-splash-url.mjs
@@ -1,0 +1,189 @@
+// Reusable URL helpers for dev splash variants (monorepo dev orchestrator,
+// ephemeral dev runtime, and the standalone create-app template). Pure ESM,
+// dependency-free so the dev scripts can use it before `yarn install` runs.
+//
+// All splash variants share the same problem: they used to hardcode
+// `http://localhost:<port>` / `http://127.0.0.1:<port>` for both the
+// splash URL and the printed app URL. When a developer runs the dev
+// runtime behind a reverse proxy (for example on
+// `https://devsandbox.openmercato.com`), the printed URLs and any
+// redirects must follow the configured public base URL, drop standard
+// ports for the scheme (80 for `http:`, 443 for `https:`), and only
+// fall back to the actually-bound port when the configured port was
+// taken and the runtime had to randomize.
+
+const STANDARD_PORT_BY_SCHEME = Object.freeze({
+  'http:': 80,
+  'https:': 443,
+})
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0'])
+
+export function parsePortNumber(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const parsed = Number.parseInt(String(value).trim(), 10)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return null
+  }
+  return parsed
+}
+
+export function isStandardPort(scheme, port) {
+  if (port === null || port === undefined) return false
+  const normalized = typeof scheme === 'string' && !scheme.endsWith(':') ? `${scheme}:` : scheme
+  const expected = STANDARD_PORT_BY_SCHEME[normalized]
+  return expected !== undefined && Number(port) === expected
+}
+
+export function parseConfiguredBaseUrl(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  let parsed
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  const explicitPort = parsed.port ? Number.parseInt(parsed.port, 10) : null
+  return {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: Number.isInteger(explicitPort) ? explicitPort : null,
+  }
+}
+
+export function formatBaseUrl({ protocol, hostname, port } = {}, options = {}) {
+  if (typeof protocol !== 'string' || !protocol || typeof hostname !== 'string' || !hostname) {
+    throw new TypeError('formatBaseUrl requires a protocol and hostname')
+  }
+  const normalizedScheme = protocol.endsWith(':') ? protocol : `${protocol}:`
+  const includeStandardPort = options.includeStandardPort === true
+  const formattedHost = hostname.includes(':') && !hostname.startsWith('[')
+    ? `[${hostname}]`
+    : hostname
+  if (port === null || port === undefined) {
+    return `${normalizedScheme}//${formattedHost}`
+  }
+  if (!includeStandardPort && isStandardPort(normalizedScheme, port)) {
+    return `${normalizedScheme}//${formattedHost}`
+  }
+  return `${normalizedScheme}//${formattedHost}:${port}`
+}
+
+function pickConfiguredFromEnv(env) {
+  return parseConfiguredBaseUrl(env?.APP_URL) ?? parseConfiguredBaseUrl(env?.NEXT_PUBLIC_APP_URL)
+}
+
+// Resolve the developer-facing app base URL.
+//
+// Inputs:
+//   env: process.env-like object. Reads APP_URL, NEXT_PUBLIC_APP_URL, PORT.
+//   options.actualPort: the port the dev server actually bound to. When the
+//     configured port was already in use, this differs from the configured
+//     value -- in that case we treat the run as randomized and surface the
+//     actually-bound port so the printed URL is reachable.
+//   options.defaultPort: the port to assume when nothing else is configured
+//     (defaults to 3000, matching Next.js dev defaults).
+//   options.defaultHostname: fallback hostname when no APP_URL is configured
+//     (defaults to 'localhost').
+//
+// Returns:
+//   { url, protocol, hostname, port, hasConfiguredBaseUrl, portWasRandomized }
+//   `port` is null when the URL omits an explicit port.
+export function resolveDevBaseUrl(env = {}, options = {}) {
+  const actualPort = Number.isInteger(options.actualPort) ? options.actualPort : null
+  const defaultPort = Number.isInteger(options.defaultPort) ? options.defaultPort : 3000
+  const defaultHostname = typeof options.defaultHostname === 'string' && options.defaultHostname
+    ? options.defaultHostname
+    : 'localhost'
+
+  const configured = pickConfiguredFromEnv(env)
+  const envPort = parsePortNumber(env?.PORT)
+
+  let protocol
+  let hostname
+  let configuredPort
+
+  if (configured) {
+    protocol = configured.protocol
+    hostname = configured.hostname
+    configuredPort = configured.port ?? envPort
+  } else {
+    protocol = 'http:'
+    hostname = defaultHostname
+    configuredPort = envPort
+  }
+
+  let resolvedPort
+  let portWasRandomized = false
+
+  if (actualPort !== null) {
+    if (configuredPort !== null && configuredPort !== actualPort) {
+      // Configured port was taken; the runtime fell back to a free one. The
+      // printed URL must reflect what the developer can actually open.
+      resolvedPort = actualPort
+      portWasRandomized = true
+    } else if (configuredPort !== null) {
+      resolvedPort = configuredPort
+    } else if (configured && !LOOPBACK_HOSTS.has(hostname.toLowerCase())) {
+      // Configured URL has no explicit port (e.g. https://devsandbox.openmercato.com).
+      // The dev server is fronted by a reverse proxy on the standard port for
+      // the scheme; the locally-bound `actualPort` is internal and must not
+      // leak into the printed URL.
+      resolvedPort = null
+    } else {
+      resolvedPort = actualPort
+    }
+  } else if (configuredPort !== null) {
+    resolvedPort = configuredPort
+  } else if (configured) {
+    resolvedPort = null
+  } else {
+    resolvedPort = defaultPort
+  }
+
+  if (resolvedPort !== null && isStandardPort(protocol, resolvedPort)) {
+    resolvedPort = null
+  }
+
+  const url = formatBaseUrl({ protocol, hostname, port: resolvedPort })
+
+  return {
+    url,
+    protocol,
+    hostname,
+    port: resolvedPort,
+    hasConfiguredBaseUrl: configured !== null,
+    portWasRandomized,
+  }
+}
+
+// Resolve the URL where the dev splash itself can be reached. The splash
+// process always binds locally, but the developer's browser may live on
+// the configured public host (proxy-fronted dev sandboxes). We keep the
+// scheme + hostname from the configured public URL when it exists so the
+// splash link the developer sees uses the same origin as the rest of the
+// app, and we always attach the actually-bound splash port so the link
+// resolves regardless of what the configured port was.
+export function resolveSplashUrl(env = {}, splashPort, options = {}) {
+  const port = Number.isInteger(splashPort) ? splashPort : null
+  const configured = pickConfiguredFromEnv(env)
+  const defaultHostname = typeof options.defaultHostname === 'string' && options.defaultHostname
+    ? options.defaultHostname
+    : 'localhost'
+
+  if (!configured) {
+    if (port === null) {
+      return formatBaseUrl({ protocol: 'http:', hostname: defaultHostname, port: null })
+    }
+    return formatBaseUrl({ protocol: 'http:', hostname: defaultHostname, port })
+  }
+
+  if (port === null) {
+    return formatBaseUrl({ protocol: configured.protocol, hostname: configured.hostname, port: null })
+  }
+
+  return formatBaseUrl({ protocol: configured.protocol, hostname: configured.hostname, port })
+}

--- a/packages/create-app/template/scripts/dev-splash-url.mjs
+++ b/packages/create-app/template/scripts/dev-splash-url.mjs
@@ -118,21 +118,24 @@ export function resolveDevBaseUrl(env = {}, options = {}) {
 
   let resolvedPort
   let portWasRandomized = false
+  const isLoopbackHost = LOOPBACK_HOSTS.has(hostname.toLowerCase())
 
   if (actualPort !== null) {
-    if (configuredPort !== null && configuredPort !== actualPort) {
-      // Configured port was taken; the runtime fell back to a free one. The
-      // printed URL must reflect what the developer can actually open.
+    if (configured && !isLoopbackHost) {
+      // Proxy-fronted dev: the developer reaches the app via the configured
+      // public URL. `actualPort` is the internal port the local dev server
+      // bound to, which is hidden behind the proxy and must never leak into
+      // the printed URL -- regardless of whether the configured URL declared
+      // an explicit port or not.
+      resolvedPort = configuredPort
+    } else if (configuredPort !== null && configuredPort !== actualPort) {
+      // Loopback dev: the configured port was taken and the runtime fell back
+      // to a free one. The printed URL must reflect what the developer can
+      // actually open.
       resolvedPort = actualPort
       portWasRandomized = true
     } else if (configuredPort !== null) {
       resolvedPort = configuredPort
-    } else if (configured && !LOOPBACK_HOSTS.has(hostname.toLowerCase())) {
-      // Configured URL has no explicit port (e.g. https://devsandbox.openmercato.com).
-      // The dev server is fronted by a reverse proxy on the standard port for
-      // the scheme; the locally-bound `actualPort` is internal and must not
-      // leak into the printed URL.
-      resolvedPort = null
     } else {
       resolvedPort = actualPort
     }

--- a/packages/create-app/template/scripts/dev.mjs
+++ b/packages/create-app/template/scripts/dev.mjs
@@ -159,20 +159,6 @@ function shouldRetrySplashServerWithRandomPort(error) {
   return error.code === 'EADDRINUSE'
 }
 
-function normalizePublicBaseUrl(value) {
-  if (typeof value !== 'string' || value.trim().length === 0) return null
-
-  try {
-    const parsed = new URL(value)
-    parsed.pathname = ''
-    parsed.search = ''
-    parsed.hash = ''
-    return parsed.toString().replace(/\/$/, '')
-  } catch {
-    return null
-  }
-}
-
 function isEnabledEnvFlag(value) {
   if (typeof value !== 'string') return false
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())

--- a/packages/create-app/template/scripts/dev.mjs
+++ b/packages/create-app/template/scripts/dev.mjs
@@ -26,6 +26,10 @@ import { resolveSpawnCommand } from './dev-spawn-utils.mjs'
 import { createDevSplashCodingFlow } from './dev-splash-coding-flow.mjs'
 import { createDevSplashGitRepoFlow } from './dev-splash-git-repo-flow.mjs'
 import { normalizeSplashDisplayState } from './dev-splash-state.mjs'
+import {
+  resolveDevBaseUrl,
+  resolveSplashUrl as resolveSplashAccessUrl,
+} from './dev-splash-url.mjs'
 
 function detectDevRuntimeMode() {
   const cwd = process.cwd()
@@ -295,9 +299,7 @@ function formatProgressLine(label, current, total, percent) {
 }
 
 function resolveExpectedAppBaseUrl() {
-  return normalizePublicBaseUrl(process.env.APP_URL)
-    ?? normalizePublicBaseUrl(process.env.NEXT_PUBLIC_APP_URL)
-    ?? `http://localhost:${parsePortNumber(process.env.PORT) ?? 3000}`
+  return resolveDevBaseUrl(process.env).url
 }
 
 function resolveExpectedBackendUrl() {
@@ -916,7 +918,7 @@ async function startSplashServer() {
 
   const address = splashServer.address()
   if (!address || typeof address === 'string') return
-  splashUrl = `http://localhost:${address.port}`
+  splashUrl = resolveSplashAccessUrl(process.env, address.port)
   if (splashPortConfig.port !== 0 && address.port !== splashPortConfig.port) {
     console.log(`🪟 Dev splash moved to ${splashUrl}`)
   }

--- a/scripts/__tests__/dev-splash-url.test.mjs
+++ b/scripts/__tests__/dev-splash-url.test.mjs
@@ -1,0 +1,200 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  formatBaseUrl,
+  isStandardPort,
+  parseConfiguredBaseUrl,
+  parsePortNumber,
+  resolveDevBaseUrl,
+  resolveSplashUrl,
+} from '../dev-splash-url.mjs'
+
+test('parsePortNumber accepts strings and numbers in the valid range', () => {
+  assert.equal(parsePortNumber('3000'), 3000)
+  assert.equal(parsePortNumber(8080), 8080)
+  assert.equal(parsePortNumber(' 4321 '), 4321)
+  assert.equal(parsePortNumber('0'), null)
+  assert.equal(parsePortNumber('70000'), null)
+  assert.equal(parsePortNumber('not-a-port'), null)
+  assert.equal(parsePortNumber(null), null)
+  assert.equal(parsePortNumber(undefined), null)
+})
+
+test('isStandardPort matches scheme-default ports', () => {
+  assert.equal(isStandardPort('http:', 80), true)
+  assert.equal(isStandardPort('http', 80), true)
+  assert.equal(isStandardPort('https:', 443), true)
+  assert.equal(isStandardPort('http:', 443), false)
+  assert.equal(isStandardPort('https:', 80), false)
+  assert.equal(isStandardPort('http:', null), false)
+  assert.equal(isStandardPort('ftp:', 21), false)
+})
+
+test('parseConfiguredBaseUrl returns scheme/host/port for valid http(s) URLs', () => {
+  assert.deepEqual(parseConfiguredBaseUrl('https://devsandbox.openmercato.com'), {
+    protocol: 'https:',
+    hostname: 'devsandbox.openmercato.com',
+    port: null,
+  })
+  assert.deepEqual(parseConfiguredBaseUrl('http://example.test:8080/path'), {
+    protocol: 'http:',
+    hostname: 'example.test',
+    port: 8080,
+  })
+  assert.equal(parseConfiguredBaseUrl(''), null)
+  assert.equal(parseConfiguredBaseUrl('not a url'), null)
+  assert.equal(parseConfiguredBaseUrl('ftp://example.com'), null)
+  assert.equal(parseConfiguredBaseUrl(undefined), null)
+})
+
+test('formatBaseUrl drops standard ports and keeps non-standard ports', () => {
+  assert.equal(
+    formatBaseUrl({ protocol: 'https:', hostname: 'devsandbox.openmercato.com', port: 443 }),
+    'https://devsandbox.openmercato.com',
+  )
+  assert.equal(
+    formatBaseUrl({ protocol: 'http:', hostname: 'example.test', port: 80 }),
+    'http://example.test',
+  )
+  assert.equal(
+    formatBaseUrl({ protocol: 'http:', hostname: 'localhost', port: 3000 }),
+    'http://localhost:3000',
+  )
+  assert.equal(
+    formatBaseUrl({ protocol: 'https:', hostname: 'example.test', port: null }),
+    'https://example.test',
+  )
+})
+
+test('formatBaseUrl can keep standard ports when explicitly requested', () => {
+  assert.equal(
+    formatBaseUrl(
+      { protocol: 'https:', hostname: 'example.test', port: 443 },
+      { includeStandardPort: true },
+    ),
+    'https://example.test:443',
+  )
+})
+
+test('formatBaseUrl wraps bare IPv6 hostnames in brackets', () => {
+  assert.equal(
+    formatBaseUrl({ protocol: 'http:', hostname: '::1', port: 4000 }),
+    'http://[::1]:4000',
+  )
+})
+
+test('resolveDevBaseUrl falls back to localhost:3000 when nothing is configured', () => {
+  const result = resolveDevBaseUrl({})
+  assert.equal(result.url, 'http://localhost:3000')
+  assert.equal(result.hasConfiguredBaseUrl, false)
+  assert.equal(result.portWasRandomized, false)
+  assert.equal(result.port, 3000)
+  assert.equal(result.protocol, 'http:')
+  assert.equal(result.hostname, 'localhost')
+})
+
+test('resolveDevBaseUrl honors PORT env when no APP_URL is set', () => {
+  const result = resolveDevBaseUrl({ PORT: '4321' })
+  assert.equal(result.url, 'http://localhost:4321')
+  assert.equal(result.port, 4321)
+})
+
+test('resolveDevBaseUrl uses APP_URL with no explicit port (proxy-fronted)', () => {
+  const result = resolveDevBaseUrl({ APP_URL: 'https://devsandbox.openmercato.com' })
+  assert.equal(result.url, 'https://devsandbox.openmercato.com')
+  assert.equal(result.hasConfiguredBaseUrl, true)
+  assert.equal(result.port, null)
+  assert.equal(result.portWasRandomized, false)
+})
+
+test('resolveDevBaseUrl drops port 80 / 443 even when configured explicitly', () => {
+  const http80 = resolveDevBaseUrl({ APP_URL: 'http://example.test:80' })
+  assert.equal(http80.url, 'http://example.test')
+  assert.equal(http80.port, null)
+
+  const https443 = resolveDevBaseUrl({ APP_URL: 'https://example.test:443' })
+  assert.equal(https443.url, 'https://example.test')
+  assert.equal(https443.port, null)
+})
+
+test('resolveDevBaseUrl keeps non-standard configured ports', () => {
+  const result = resolveDevBaseUrl({ APP_URL: 'http://example.test:8080' })
+  assert.equal(result.url, 'http://example.test:8080')
+  assert.equal(result.port, 8080)
+})
+
+test('resolveDevBaseUrl uses configured port when actualPort matches', () => {
+  const result = resolveDevBaseUrl(
+    { APP_URL: 'http://example.test:8080' },
+    { actualPort: 8080 },
+  )
+  assert.equal(result.url, 'http://example.test:8080')
+  assert.equal(result.portWasRandomized, false)
+})
+
+test('resolveDevBaseUrl reports randomization when actualPort differs from configured port', () => {
+  const result = resolveDevBaseUrl(
+    { APP_URL: 'http://example.test:8080' },
+    { actualPort: 8123 },
+  )
+  assert.equal(result.url, 'http://example.test:8123')
+  assert.equal(result.portWasRandomized, true)
+  assert.equal(result.port, 8123)
+})
+
+test('resolveDevBaseUrl keeps proxy host port-less even when an internal port is bound', () => {
+  // APP_URL is https with no port — proxy fronts the standard 443. The local
+  // dev server bound to 3000, but that port is internal and must not leak
+  // into the printed URL.
+  const result = resolveDevBaseUrl(
+    { APP_URL: 'https://devsandbox.openmercato.com' },
+    { actualPort: 3000 },
+  )
+  assert.equal(result.url, 'https://devsandbox.openmercato.com')
+  assert.equal(result.port, null)
+  assert.equal(result.portWasRandomized, false)
+})
+
+test('resolveDevBaseUrl falls back to NEXT_PUBLIC_APP_URL when APP_URL is missing', () => {
+  const result = resolveDevBaseUrl({ NEXT_PUBLIC_APP_URL: 'https://devsandbox.openmercato.com' })
+  assert.equal(result.url, 'https://devsandbox.openmercato.com')
+  assert.equal(result.hasConfiguredBaseUrl, true)
+})
+
+test('resolveDevBaseUrl falls back to localhost when APP_URL is invalid', () => {
+  const result = resolveDevBaseUrl({ APP_URL: 'not-a-url', PORT: '5000' })
+  assert.equal(result.url, 'http://localhost:5000')
+  assert.equal(result.hasConfiguredBaseUrl, false)
+})
+
+test('resolveDevBaseUrl honors actualPort when no port is configured anywhere', () => {
+  const result = resolveDevBaseUrl({}, { actualPort: 4567 })
+  assert.equal(result.url, 'http://localhost:4567')
+  assert.equal(result.port, 4567)
+})
+
+test('resolveDevBaseUrl honors a custom defaultHostname (e.g. 127.0.0.1 for ephemeral)', () => {
+  const result = resolveDevBaseUrl({}, { defaultHostname: '127.0.0.1', actualPort: 5050 })
+  assert.equal(result.url, 'http://127.0.0.1:5050')
+})
+
+test('resolveSplashUrl uses configured host with the actual splash port', () => {
+  const url = resolveSplashUrl({ APP_URL: 'https://devsandbox.openmercato.com' }, 4123)
+  assert.equal(url, 'https://devsandbox.openmercato.com:4123')
+})
+
+test('resolveSplashUrl drops standard ports for the configured scheme', () => {
+  const url = resolveSplashUrl({ APP_URL: 'https://devsandbox.openmercato.com' }, 443)
+  assert.equal(url, 'https://devsandbox.openmercato.com')
+})
+
+test('resolveSplashUrl falls back to localhost when APP_URL is missing', () => {
+  const url = resolveSplashUrl({}, 4123)
+  assert.equal(url, 'http://localhost:4123')
+})
+
+test('resolveSplashUrl supports a custom defaultHostname', () => {
+  const url = resolveSplashUrl({}, 4123, { defaultHostname: '127.0.0.1' })
+  assert.equal(url, 'http://127.0.0.1:4123')
+})

--- a/scripts/__tests__/dev-splash-url.test.mjs
+++ b/scripts/__tests__/dev-splash-url.test.mjs
@@ -124,23 +124,37 @@ test('resolveDevBaseUrl keeps non-standard configured ports', () => {
   assert.equal(result.port, 8080)
 })
 
-test('resolveDevBaseUrl uses configured port when actualPort matches', () => {
+test('resolveDevBaseUrl uses configured loopback port when actualPort matches', () => {
   const result = resolveDevBaseUrl(
-    { APP_URL: 'http://example.test:8080' },
+    { APP_URL: 'http://localhost:8080' },
     { actualPort: 8080 },
   )
-  assert.equal(result.url, 'http://example.test:8080')
+  assert.equal(result.url, 'http://localhost:8080')
   assert.equal(result.portWasRandomized, false)
 })
 
-test('resolveDevBaseUrl reports randomization when actualPort differs from configured port', () => {
+test('resolveDevBaseUrl reports randomization for loopback hosts when actualPort differs', () => {
   const result = resolveDevBaseUrl(
-    { APP_URL: 'http://example.test:8080' },
+    { APP_URL: 'http://localhost:8080' },
     { actualPort: 8123 },
   )
-  assert.equal(result.url, 'http://example.test:8123')
+  assert.equal(result.url, 'http://localhost:8123')
   assert.equal(result.portWasRandomized, true)
   assert.equal(result.port, 8123)
+})
+
+test('resolveDevBaseUrl keeps proxy-fronted port even when the internal bound port differs', () => {
+  // APP_URL declares the public port (e.g. a non-standard reverse proxy port).
+  // The dev server may bind to a different internal port; that internal port
+  // is NOT reachable from the developer's browser and must not be substituted
+  // into the printed URL.
+  const result = resolveDevBaseUrl(
+    { APP_URL: 'https://devsandbox.openmercato.com:9000' },
+    { actualPort: 3000 },
+  )
+  assert.equal(result.url, 'https://devsandbox.openmercato.com:9000')
+  assert.equal(result.port, 9000)
+  assert.equal(result.portWasRandomized, false)
 })
 
 test('resolveDevBaseUrl keeps proxy host port-less even when an internal port is bound', () => {

--- a/scripts/dev-ephemeral.ts
+++ b/scripts/dev-ephemeral.ts
@@ -14,6 +14,10 @@ import {
 } from '../packages/cli/src/lib/testing/runtime-utils'
 import { createDevSplashCodingFlow } from './dev-splash-coding-flow.mjs'
 import { normalizeSplashDisplayState } from './dev-splash-state.mjs'
+import {
+  resolveDevBaseUrl,
+  resolveSplashUrl as resolveSplashAccessUrl,
+} from './dev-splash-url.mjs'
 
 type DevEphemeralInstance = {
   id: string
@@ -421,7 +425,7 @@ async function startSplashServer(): Promise<void> {
 
   const address = splashServer.address()
   if (!address || typeof address === 'string') return
-  const splashUrl = `http://localhost:${address.port}`
+  const splashUrl = resolveSplashAccessUrl(process.env, address.port)
   if (splashPortConfig.port !== null && splashPortConfig.port !== 0 && address.port !== splashPortConfig.port) {
     console.log(`🪟 Dev splash moved to ${splashUrl}`)
   }
@@ -949,14 +953,19 @@ async function waitForDevServerReady(baseUrl: string): Promise<boolean> {
 }
 
 async function startDevServer(port: number, postgres: EphemeralPostgresHandle): Promise<number> {
-  const baseUrl = `http://127.0.0.1:${port}`
+  const loopbackUrl = `http://127.0.0.1:${port}`
+  const publicBaseUrl = resolveDevBaseUrl(process.env, {
+    actualPort: port,
+    defaultHostname: '127.0.0.1',
+  }).url
+  const baseUrl = publicBaseUrl
   const backendUrl = `${baseUrl}/backend`
   const devEnvironment = {
     ...process.env,
     PORT: String(port),
     DATABASE_URL: postgres.databaseUrl,
-    APP_URL: baseUrl,
-    NEXT_PUBLIC_APP_URL: baseUrl,
+    APP_URL: publicBaseUrl,
+    NEXT_PUBLIC_APP_URL: publicBaseUrl,
     ...(autoOpenSplash
       ? {
           OM_DEV_SPLASH_CHILD_STATE_FILE: splashChildStateFilePath,
@@ -1007,7 +1016,7 @@ async function startDevServer(port: number, postgres: EphemeralPostgresHandle): 
     activity: `Starting ephemeral app runtime on ${backendUrl}`,
   })
 
-  const serverReady = await waitForDevServerReady(baseUrl)
+  const serverReady = await waitForDevServerReady(loopbackUrl)
   if (serverReady) {
     console.log(`[dev:ephemeral] Runtime became reachable at ${backendUrl}`)
     updateSplashState({
@@ -1128,7 +1137,10 @@ async function main(): Promise<void> {
     })
     const postgres = await startEphemeralPostgres()
     activePostgresContainerId = postgres.containerId
-    const baseUrl = `http://127.0.0.1:${port}`
+    const baseUrl = resolveDevBaseUrl(process.env, {
+      actualPort: port,
+      defaultHostname: '127.0.0.1',
+    }).url
 
     const initEnvironment = {
       ...process.env,
@@ -1157,7 +1169,7 @@ async function main(): Promise<void> {
       return
     }
 
-    console.log(`[dev:ephemeral] Starting development runtime on http://127.0.0.1:${port}/backend`)
+    console.log(`[dev:ephemeral] Starting development runtime on ${baseUrl}/backend`)
     const exitCode = await startDevServer(port, postgres)
     shutdown(exitCode)
   } catch (error) {

--- a/scripts/dev-splash-url.mjs
+++ b/scripts/dev-splash-url.mjs
@@ -1,0 +1,189 @@
+// Reusable URL helpers for dev splash variants (monorepo dev orchestrator,
+// ephemeral dev runtime, and the standalone create-app template). Pure ESM,
+// dependency-free so the dev scripts can use it before `yarn install` runs.
+//
+// All splash variants share the same problem: they used to hardcode
+// `http://localhost:<port>` / `http://127.0.0.1:<port>` for both the
+// splash URL and the printed app URL. When a developer runs the dev
+// runtime behind a reverse proxy (for example on
+// `https://devsandbox.openmercato.com`), the printed URLs and any
+// redirects must follow the configured public base URL, drop standard
+// ports for the scheme (80 for `http:`, 443 for `https:`), and only
+// fall back to the actually-bound port when the configured port was
+// taken and the runtime had to randomize.
+
+const STANDARD_PORT_BY_SCHEME = Object.freeze({
+  'http:': 80,
+  'https:': 443,
+})
+
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0'])
+
+export function parsePortNumber(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  const parsed = Number.parseInt(String(value).trim(), 10)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return null
+  }
+  return parsed
+}
+
+export function isStandardPort(scheme, port) {
+  if (port === null || port === undefined) return false
+  const normalized = typeof scheme === 'string' && !scheme.endsWith(':') ? `${scheme}:` : scheme
+  const expected = STANDARD_PORT_BY_SCHEME[normalized]
+  return expected !== undefined && Number(port) === expected
+}
+
+export function parseConfiguredBaseUrl(value) {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  let parsed
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+  const explicitPort = parsed.port ? Number.parseInt(parsed.port, 10) : null
+  return {
+    protocol: parsed.protocol,
+    hostname: parsed.hostname,
+    port: Number.isInteger(explicitPort) ? explicitPort : null,
+  }
+}
+
+export function formatBaseUrl({ protocol, hostname, port } = {}, options = {}) {
+  if (typeof protocol !== 'string' || !protocol || typeof hostname !== 'string' || !hostname) {
+    throw new TypeError('formatBaseUrl requires a protocol and hostname')
+  }
+  const normalizedScheme = protocol.endsWith(':') ? protocol : `${protocol}:`
+  const includeStandardPort = options.includeStandardPort === true
+  const formattedHost = hostname.includes(':') && !hostname.startsWith('[')
+    ? `[${hostname}]`
+    : hostname
+  if (port === null || port === undefined) {
+    return `${normalizedScheme}//${formattedHost}`
+  }
+  if (!includeStandardPort && isStandardPort(normalizedScheme, port)) {
+    return `${normalizedScheme}//${formattedHost}`
+  }
+  return `${normalizedScheme}//${formattedHost}:${port}`
+}
+
+function pickConfiguredFromEnv(env) {
+  return parseConfiguredBaseUrl(env?.APP_URL) ?? parseConfiguredBaseUrl(env?.NEXT_PUBLIC_APP_URL)
+}
+
+// Resolve the developer-facing app base URL.
+//
+// Inputs:
+//   env: process.env-like object. Reads APP_URL, NEXT_PUBLIC_APP_URL, PORT.
+//   options.actualPort: the port the dev server actually bound to. When the
+//     configured port was already in use, this differs from the configured
+//     value -- in that case we treat the run as randomized and surface the
+//     actually-bound port so the printed URL is reachable.
+//   options.defaultPort: the port to assume when nothing else is configured
+//     (defaults to 3000, matching Next.js dev defaults).
+//   options.defaultHostname: fallback hostname when no APP_URL is configured
+//     (defaults to 'localhost').
+//
+// Returns:
+//   { url, protocol, hostname, port, hasConfiguredBaseUrl, portWasRandomized }
+//   `port` is null when the URL omits an explicit port.
+export function resolveDevBaseUrl(env = {}, options = {}) {
+  const actualPort = Number.isInteger(options.actualPort) ? options.actualPort : null
+  const defaultPort = Number.isInteger(options.defaultPort) ? options.defaultPort : 3000
+  const defaultHostname = typeof options.defaultHostname === 'string' && options.defaultHostname
+    ? options.defaultHostname
+    : 'localhost'
+
+  const configured = pickConfiguredFromEnv(env)
+  const envPort = parsePortNumber(env?.PORT)
+
+  let protocol
+  let hostname
+  let configuredPort
+
+  if (configured) {
+    protocol = configured.protocol
+    hostname = configured.hostname
+    configuredPort = configured.port ?? envPort
+  } else {
+    protocol = 'http:'
+    hostname = defaultHostname
+    configuredPort = envPort
+  }
+
+  let resolvedPort
+  let portWasRandomized = false
+
+  if (actualPort !== null) {
+    if (configuredPort !== null && configuredPort !== actualPort) {
+      // Configured port was taken; the runtime fell back to a free one. The
+      // printed URL must reflect what the developer can actually open.
+      resolvedPort = actualPort
+      portWasRandomized = true
+    } else if (configuredPort !== null) {
+      resolvedPort = configuredPort
+    } else if (configured && !LOOPBACK_HOSTS.has(hostname.toLowerCase())) {
+      // Configured URL has no explicit port (e.g. https://devsandbox.openmercato.com).
+      // The dev server is fronted by a reverse proxy on the standard port for
+      // the scheme; the locally-bound `actualPort` is internal and must not
+      // leak into the printed URL.
+      resolvedPort = null
+    } else {
+      resolvedPort = actualPort
+    }
+  } else if (configuredPort !== null) {
+    resolvedPort = configuredPort
+  } else if (configured) {
+    resolvedPort = null
+  } else {
+    resolvedPort = defaultPort
+  }
+
+  if (resolvedPort !== null && isStandardPort(protocol, resolvedPort)) {
+    resolvedPort = null
+  }
+
+  const url = formatBaseUrl({ protocol, hostname, port: resolvedPort })
+
+  return {
+    url,
+    protocol,
+    hostname,
+    port: resolvedPort,
+    hasConfiguredBaseUrl: configured !== null,
+    portWasRandomized,
+  }
+}
+
+// Resolve the URL where the dev splash itself can be reached. The splash
+// process always binds locally, but the developer's browser may live on
+// the configured public host (proxy-fronted dev sandboxes). We keep the
+// scheme + hostname from the configured public URL when it exists so the
+// splash link the developer sees uses the same origin as the rest of the
+// app, and we always attach the actually-bound splash port so the link
+// resolves regardless of what the configured port was.
+export function resolveSplashUrl(env = {}, splashPort, options = {}) {
+  const port = Number.isInteger(splashPort) ? splashPort : null
+  const configured = pickConfiguredFromEnv(env)
+  const defaultHostname = typeof options.defaultHostname === 'string' && options.defaultHostname
+    ? options.defaultHostname
+    : 'localhost'
+
+  if (!configured) {
+    if (port === null) {
+      return formatBaseUrl({ protocol: 'http:', hostname: defaultHostname, port: null })
+    }
+    return formatBaseUrl({ protocol: 'http:', hostname: defaultHostname, port })
+  }
+
+  if (port === null) {
+    return formatBaseUrl({ protocol: configured.protocol, hostname: configured.hostname, port: null })
+  }
+
+  return formatBaseUrl({ protocol: configured.protocol, hostname: configured.hostname, port })
+}

--- a/scripts/dev-splash-url.mjs
+++ b/scripts/dev-splash-url.mjs
@@ -118,21 +118,24 @@ export function resolveDevBaseUrl(env = {}, options = {}) {
 
   let resolvedPort
   let portWasRandomized = false
+  const isLoopbackHost = LOOPBACK_HOSTS.has(hostname.toLowerCase())
 
   if (actualPort !== null) {
-    if (configuredPort !== null && configuredPort !== actualPort) {
-      // Configured port was taken; the runtime fell back to a free one. The
-      // printed URL must reflect what the developer can actually open.
+    if (configured && !isLoopbackHost) {
+      // Proxy-fronted dev: the developer reaches the app via the configured
+      // public URL. `actualPort` is the internal port the local dev server
+      // bound to, which is hidden behind the proxy and must never leak into
+      // the printed URL -- regardless of whether the configured URL declared
+      // an explicit port or not.
+      resolvedPort = configuredPort
+    } else if (configuredPort !== null && configuredPort !== actualPort) {
+      // Loopback dev: the configured port was taken and the runtime fell back
+      // to a free one. The printed URL must reflect what the developer can
+      // actually open.
       resolvedPort = actualPort
       portWasRandomized = true
     } else if (configuredPort !== null) {
       resolvedPort = configuredPort
-    } else if (configured && !LOOPBACK_HOSTS.has(hostname.toLowerCase())) {
-      // Configured URL has no explicit port (e.g. https://devsandbox.openmercato.com).
-      // The dev server is fronted by a reverse proxy on the standard port for
-      // the scheme; the locally-bound `actualPort` is internal and must not
-      // leak into the printed URL.
-      resolvedPort = null
     } else {
       resolvedPort = actualPort
     }

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -159,20 +159,6 @@ function shouldRetrySplashServerWithRandomPort(error) {
   return error.code === 'EADDRINUSE'
 }
 
-function normalizePublicBaseUrl(value) {
-  if (typeof value !== 'string' || value.trim().length === 0) return null
-
-  try {
-    const parsed = new URL(value)
-    parsed.pathname = ''
-    parsed.search = ''
-    parsed.hash = ''
-    return parsed.toString().replace(/\/$/, '')
-  } catch {
-    return null
-  }
-}
-
 function isEnabledEnvFlag(value) {
   if (typeof value !== 'string') return false
   return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase())

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -26,6 +26,10 @@ import { resolveSpawnCommand } from './dev-spawn-utils.mjs'
 import { createDevSplashCodingFlow } from './dev-splash-coding-flow.mjs'
 import { createDevSplashGitRepoFlow } from './dev-splash-git-repo-flow.mjs'
 import { normalizeSplashDisplayState } from './dev-splash-state.mjs'
+import {
+  resolveDevBaseUrl,
+  resolveSplashUrl as resolveSplashAccessUrl,
+} from './dev-splash-url.mjs'
 
 function detectDevRuntimeMode() {
   const cwd = process.cwd()
@@ -295,9 +299,7 @@ function formatProgressLine(label, current, total, percent) {
 }
 
 function resolveExpectedAppBaseUrl() {
-  return normalizePublicBaseUrl(process.env.APP_URL)
-    ?? normalizePublicBaseUrl(process.env.NEXT_PUBLIC_APP_URL)
-    ?? `http://localhost:${parsePortNumber(process.env.PORT) ?? 3000}`
+  return resolveDevBaseUrl(process.env).url
 }
 
 function resolveExpectedBackendUrl() {
@@ -916,7 +918,7 @@ async function startSplashServer() {
 
   const address = splashServer.address()
   if (!address || typeof address === 'string') return
-  splashUrl = `http://localhost:${address.port}`
+  splashUrl = resolveSplashAccessUrl(process.env, address.port)
   if (splashPortConfig.port !== 0 && address.port !== splashPortConfig.port) {
     console.log(`🪟 Dev splash moved to ${splashUrl}`)
   }

--- a/scripts/template-sync.ts
+++ b/scripts/template-sync.ts
@@ -62,6 +62,11 @@ const EXPLICIT_TEMPLATE_FILE_MAPPINGS = [
     rel: 'scripts/dev-splash-git-repo-flow.mjs',
   },
   {
+    sourceFile: path.join(ROOT, 'scripts', 'dev-splash-url.mjs'),
+    templateFile: path.join(ROOT, 'packages', 'create-app', 'template', 'scripts', 'dev-splash-url.mjs'),
+    rel: 'scripts/dev-splash-url.mjs',
+  },
+  {
     sourceFile: path.join(ROOT, 'scripts', 'dev-orchestration-log-policy.mjs'),
     templateFile: path.join(ROOT, 'packages', 'create-app', 'template', 'scripts', 'dev-orchestration-log-policy.mjs'),
     rel: 'scripts/dev-orchestration-log-policy.mjs',


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-04-27-devsplash-base-url.md
Status: complete

## Goal

- Replace hardcoded `localhost` / `127.0.0.1` URLs in the dev splash variants (monorepo `yarn dev`, ephemeral dev runtime, standalone create-app template) with a single reusable helper that derives the developer-facing URL from `APP_URL` / `NEXT_PUBLIC_APP_URL` / `PORT`, applies smart port handling, and drops the explicit port for standard schemes (`http:`/80, `https:`/443) — so when dev runs behind a reverse proxy at e.g. `https://devsandbox.openmercato.com`, the splash shows that URL instead of `http://localhost:3000`.

## What Changed

- New helper module `scripts/dev-splash-url.mjs` (pure ESM, dependency-free) exposing `parsePortNumber`, `isStandardPort`, `parseConfiguredBaseUrl`, `formatBaseUrl`, `resolveDevBaseUrl`, `resolveSplashUrl`. Smart port logic: drops `:80` / `:443` for the matching scheme, surfaces `portWasRandomized: true` only for loopback hosts where the configured port was unavailable, and hides internally-bound ports behind a proxy-fronted (non-loopback) configured URL so they cannot leak into the printed URL.
- `scripts/dev.mjs`: `resolveExpectedAppBaseUrl` delegates to the helper; the splash URL string at the splash bind site uses `resolveSplashUrl(process.env, address.port)`. Dead `normalizePublicBaseUrl` removed.
- `scripts/dev-ephemeral.ts`: same treatment for the splash URL and the two ephemeral `http://127.0.0.1:${port}` baseUrl literals. A separate `loopbackUrl` is preserved for the readiness probe so probing always hits the locally-bound dev server while the public-facing URL follows `APP_URL` when set; the helper's `defaultHostname: '127.0.0.1'` option preserves the legacy 127.0.0.1 default for ephemeral mode without a configured public host.
- `scripts/template-sync.ts`: adds `dev-splash-url.mjs` to the explicit sync mapping list.
- `packages/create-app/template/scripts/dev.mjs` + new `packages/create-app/template/scripts/dev-splash-url.mjs`: targeted patch mirroring the source-side fix, so standalone create-mercato-app projects pick up the same behavior. Pre-existing template drift on `develop` (auto-migrate logic, unrelated module/route diffs, package version drift) was intentionally **not** synced here so this PR stays focused on the localhost-hardcoding fix.

## Tests

- New `scripts/__tests__/dev-splash-url.test.mjs` (Node `node:test`, 23 tests) covering: localhost default, custom HTTPS host (proxy-fronted), `PORT` env honored, standard-port suppression (80/443), non-standard-port retention, loopback randomized port (configured port unavailable), proxy-fronted explicit non-standard external port (internal port hidden), proxy-fronted no-port host (internal port hidden), `NEXT_PUBLIC_APP_URL` fallback, invalid URL fallback, custom default hostname for ephemeral, IPv6 hostname bracketing, `resolveSplashUrl` variants.
- `yarn test:scripts` — 67 tests pass.
- `yarn test` — 3241 jest tests pass.
- `yarn typecheck` — green.
- `yarn i18n:check-sync` / `yarn i18n:check-usage` — green.
- `yarn build:packages` (twice, before + after `yarn generate`), `yarn generate`, `yarn build:app` — green.
- `yarn lint` — pre-existing failure on `develop` (`@typescript-eslint/utils` ↔ ESLint 10.2.1 incompatibility, `Class extends value undefined is not a constructor`). Not caused by this change; reproduces on a clean `develop` checkout.

## Backward Compatibility

- No contract surface changes (no API routes, no event IDs, no entity schema, no DI keys, no widget spot IDs, no ACL features, no CLI commands, no generated file contracts). The helper is internal to dev tooling.
- Behavior is strictly additive for users who do **not** set `APP_URL` — the fallback URL is still `http://localhost:<PORT or 3000>`, identical to today.
- Behavior changes for users who **do** set `APP_URL`: the splash and the URLs it prints now follow the configured public host instead of `localhost`. This matches the long-standing intent of `APP_URL` / `NEXT_PUBLIC_APP_URL` (which were already being read for some splash strings — only the fallback path and a few spots were hardcoded).

## Progress
See [Progress section in the plan](.ai/runs/2026-04-27-devsplash-base-url.md#progress).