### PR TITLE
feat(customers): add stage totals to deals pipeline view (#773)

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/lib/__tests__/computeStageTotals.test.ts
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/lib/__tests__/computeStageTotals.test.ts
@@ -1,0 +1,101 @@
+import { computeStageTotals } from '../computeStageTotals'
+
+describe('customers deals pipeline - computeStageTotals', () => {
+  it('returns an empty array when there are no deals', () => {
+    expect(computeStageTotals([], null)).toEqual([])
+  })
+
+  it('sums multiple deals in the same currency into a single entry', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 1000, valueCurrency: 'USD' },
+        { valueAmount: 500, valueCurrency: 'USD' },
+        { valueAmount: 250.5, valueCurrency: 'USD' },
+      ],
+      null,
+    )
+    expect(totals).toEqual([{ currency: 'USD', sum: 1750.5 }])
+  })
+
+  it('keeps distinct currencies as separate entries', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 1000, valueCurrency: 'USD' },
+        { valueAmount: 500, valueCurrency: 'EUR' },
+        { valueAmount: 200, valueCurrency: 'GBP' },
+      ],
+      null,
+    )
+    expect(totals).toHaveLength(3)
+    expect(totals.map((t) => t.currency).sort()).toEqual(['EUR', 'GBP', 'USD'])
+  })
+
+  it('skips deals with null valueAmount and aggregates the rest', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 1000, valueCurrency: 'USD' },
+        { valueAmount: null, valueCurrency: 'USD' },
+        { valueAmount: null, valueCurrency: 'EUR' },
+      ],
+      null,
+    )
+    expect(totals).toEqual([{ currency: 'USD', sum: 1000 }])
+  })
+
+  it('defaults null valueCurrency to USD', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 100, valueCurrency: null },
+        { valueAmount: 200, valueCurrency: 'USD' },
+      ],
+      null,
+    )
+    expect(totals).toEqual([{ currency: 'USD', sum: 300 }])
+  })
+
+  it('normalizes lowercase currency codes to uppercase', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 100, valueCurrency: 'usd' },
+        { valueAmount: 200, valueCurrency: 'USD' },
+      ],
+      null,
+    )
+    expect(totals).toEqual([{ currency: 'USD', sum: 300 }])
+  })
+
+  it('sorts currencies alphabetically when no base currency is provided', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 100, valueCurrency: 'USD' },
+        { valueAmount: 200, valueCurrency: 'EUR' },
+        { valueAmount: 300, valueCurrency: 'GBP' },
+      ],
+      null,
+    )
+    expect(totals.map((t) => t.currency)).toEqual(['EUR', 'GBP', 'USD'])
+  })
+
+  it('promotes the base currency to the first position when present in totals', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 100, valueCurrency: 'USD' },
+        { valueAmount: 200, valueCurrency: 'EUR' },
+        { valueAmount: 300, valueCurrency: 'PLN' },
+      ],
+      'PLN',
+    )
+    expect(totals.map((t) => t.currency)).toEqual(['PLN', 'EUR', 'USD'])
+  })
+
+  it('falls back to alphabetical sort when the base currency has no deals in totals', () => {
+    const totals = computeStageTotals(
+      [
+        { valueAmount: 100, valueCurrency: 'USD' },
+        { valueAmount: 200, valueCurrency: 'EUR' },
+      ],
+      'PLN',
+    )
+    expect(totals.map((t) => t.currency)).toEqual(['EUR', 'USD'])
+  })
+})

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/lib/computeStageTotals.ts
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/lib/computeStageTotals.ts
@@ -1,0 +1,27 @@
+export type StageTotal = { currency: string; sum: number }
+
+type DealValueLike = {
+  valueAmount: number | null
+  valueCurrency: string | null
+}
+
+export function computeStageTotals(
+  deals: ReadonlyArray<DealValueLike>,
+  baseCurrency: string | null,
+): StageTotal[] {
+  const byCurrency = new Map<string, number>()
+  deals.forEach((deal) => {
+    if (deal.valueAmount === null) return
+    const code = (deal.valueCurrency ?? 'USD').toUpperCase()
+    byCurrency.set(code, (byCurrency.get(code) ?? 0) + deal.valueAmount)
+  })
+  return Array.from(byCurrency.entries())
+    .map(([currency, sum]) => ({ currency, sum }))
+    .sort((a, b) => {
+      if (baseCurrency) {
+        if (a.currency === baseCurrency) return -1
+        if (b.currency === baseCurrency) return 1
+      }
+      return a.currency.localeCompare(b.currency)
+    })
+}

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
@@ -6,11 +6,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { ErrorNotice } from '@open-mercato/ui/primitives/ErrorNotice'
+import { SimpleTooltip, TooltipProvider } from '@open-mercato/ui/primitives/tooltip'
 import { apiCallOrThrow, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { translateWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
+import { computeStageTotals, type StageTotal } from './lib/computeStageTotals'
 
 type DealAssociation = { id: string; label: string }
 
@@ -52,6 +54,7 @@ type PipelineRecord = { id: string; name: string; isDefault: boolean }
 type PipelineStageRecord = { id: string; label: string; order: number; pipelineId: string }
 
 const DEALS_QUERY_LIMIT = 100
+const VISIBLE_TOTALS = 1
 
 const dealsQueryKey = (scopeVersion: number, pipelineId: string | null) =>
   ['customers', 'deals', 'pipeline', `scope:${scopeVersion}`, `pipeline:${pipelineId ?? 'none'}`] as const
@@ -213,6 +216,20 @@ export default function SalesPipelinePage(): React.ReactElement {
     },
   })
 
+  const baseCurrencyQuery = useQuery<string | null>({
+    queryKey: ['currencies', 'base', `scope:${scopeVersion}`],
+    staleTime: 5 * 60_000,
+    queryFn: async () => {
+      const payload = await readApiResultOrThrow<{ items: Array<{ code: string }> }>(
+        '/api/currencies/currencies?isBase=true&isActive=true&pageSize=1',
+        undefined,
+        { errorMessage: translate('customers.deals.pipeline.loadError', 'Failed to load currencies.') },
+      )
+      const code = payload?.items?.[0]?.code
+      return code ? code.toUpperCase() : null
+    },
+  })
+
   React.useEffect(() => {
     if (selectedPipelineId) return
     const pipelines = pipelinesQuery.data
@@ -336,6 +353,14 @@ export default function SalesPipelinePage(): React.ReactElement {
   const total = dealsQuery.data?.total ?? deals.length
   const dealMap = React.useMemo(() => createDealMap(deals), [deals])
   const groupedDeals = React.useMemo(() => groupDealsByStageId(deals), [deals])
+  const baseCurrency = baseCurrencyQuery.data ?? null
+  const stageTotalsByStageId = React.useMemo(() => {
+    const map = new Map<string | null, StageTotal[]>()
+    groupedDeals.forEach((laneDeals, stageKey) => {
+      map.set(stageKey, computeStageTotals(laneDeals, baseCurrency))
+    })
+    return map
+  }, [groupedDeals, baseCurrency])
   const stages = React.useMemo(
     () => buildStageDefinitionsFromPipelineStages(stagesQuery.data ?? [], deals, t),
     [stagesQuery.data, deals, t],
@@ -458,7 +483,52 @@ export default function SalesPipelinePage(): React.ReactElement {
     )
   }
 
+  const renderLaneFooter = (totals: StageTotal[]) => {
+    const visible = totals.slice(0, VISIBLE_TOTALS)
+    const hidden = totals.length - VISIBLE_TOTALS
+    const fullBreakdown = totals.length > 0 ? (
+      <div className="flex flex-col gap-1">
+        {totals.map((total) => (
+          <div key={total.currency} className="font-medium">
+            {formatCurrency(total.sum, total.currency, '—')}
+          </div>
+        ))}
+      </div>
+    ) : null
+
+    return (
+      <div className="flex items-center justify-between gap-2 border-t border-border bg-muted/20 px-4 py-3">
+        <span className="text-xs text-muted-foreground">
+          {translate('customers.deals.pipeline.stageTotal', 'Total')}
+        </span>
+        <span className="text-xs font-medium text-foreground">
+          {totals.length > 0 ? (
+            <>
+              {visible.map((total) => (
+                <span key={total.currency} className="whitespace-nowrap">
+                  {formatCurrency(total.sum, total.currency, '—')}
+                </span>
+              ))}
+              {hidden > 0 ? (
+                <SimpleTooltip content={fullBreakdown}>
+                  <span className="ml-2 cursor-help text-muted-foreground">
+                    (<span className="underline decoration-dotted decoration-muted-foreground underline-offset-2">
+                      {translate('customers.deals.pipeline.stageTotal.more', '+{count} more', { count: hidden })}
+                    </span>)
+                  </span>
+                </SimpleTooltip>
+              ) : null}
+            </>
+          ) : (
+            '—'
+          )}
+        </span>
+      </div>
+    )
+  }
+
   return (
+    <TooltipProvider delayDuration={250}>
     <Page>
       <PageBody>
         <div className="flex flex-col gap-4">
@@ -564,7 +634,7 @@ export default function SalesPipelinePage(): React.ReactElement {
                     return (
                       <div
                         key={stage.id}
-                        className={`flex min-h-[60vh] w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-all md:w-72 md:flex-none ${
+                        className={`flex min-h-[60vh] w-full flex-1 flex-col overflow-hidden rounded-lg border border-border bg-card shadow-sm transition-all md:max-h-[60vh] md:w-72 md:flex-none ${
                           isActive ? 'ring-2 ring-ring/40' : ''
                         }`}
                         onDragOver={handleDragOver(stage.id)}
@@ -680,6 +750,7 @@ export default function SalesPipelinePage(): React.ReactElement {
                             })
                           )}
                         </div>
+                        {renderLaneFooter(stageTotalsByStageId.get(stageKey) ?? [])}
                       </div>
                     )
                   })
@@ -690,5 +761,6 @@ export default function SalesPipelinePage(): React.ReactElement {
         </div>
       </PageBody>
     </Page>
+    </TooltipProvider>
   )
 }

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -827,6 +827,8 @@
   "customers.deals.pipeline.sort.expectedCloseAt": "Voraussichtlicher Abschluss (nächster zuerst)",
   "customers.deals.pipeline.sort.label": "Sortieren nach",
   "customers.deals.pipeline.sort.probability": "Wahrscheinlichkeit (absteigend)",
+  "customers.deals.pipeline.stageTotal": "Gesamt",
+  "customers.deals.pipeline.stageTotal.more": "+{count} weitere",
   "customers.deals.pipeline.subtitle": "Verfolge Deals nach Pipeline-Phase und ziehe sie zwischen den Spalten, um den Fortschritt zu aktualisieren.",
   "customers.deals.pipeline.switch.label": "Pipeline",
   "customers.deals.pipeline.title": "Sales-Pipeline",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -827,6 +827,8 @@
   "customers.deals.pipeline.sort.expectedCloseAt": "Expected close (soonest first)",
   "customers.deals.pipeline.sort.label": "Sort by",
   "customers.deals.pipeline.sort.probability": "Probability (high to low)",
+  "customers.deals.pipeline.stageTotal": "Total",
+  "customers.deals.pipeline.stageTotal.more": "+{count} more",
   "customers.deals.pipeline.subtitle": "Track deals by pipeline stage and drag them between lanes to update progress.",
   "customers.deals.pipeline.switch.label": "Pipeline",
   "customers.deals.pipeline.title": "Sales Pipeline",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -827,6 +827,8 @@
   "customers.deals.pipeline.sort.expectedCloseAt": "Cierre previsto (más próximo primero)",
   "customers.deals.pipeline.sort.label": "Ordenar por",
   "customers.deals.pipeline.sort.probability": "Probabilidad (de mayor a menor)",
+  "customers.deals.pipeline.stageTotal": "Total",
+  "customers.deals.pipeline.stageTotal.more": "+{count} más",
   "customers.deals.pipeline.subtitle": "Sigue las oportunidades por etapa del pipeline y arrástralas entre columnas para actualizar su progreso.",
   "customers.deals.pipeline.switch.label": "Pipeline",
   "customers.deals.pipeline.title": "Pipeline de ventas",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -827,6 +827,8 @@
   "customers.deals.pipeline.sort.expectedCloseAt": "Planowane zamknięcie (najbliższe pierwsze)",
   "customers.deals.pipeline.sort.label": "Sortuj według",
   "customers.deals.pipeline.sort.probability": "Prawdopodobieństwo (malejąco)",
+  "customers.deals.pipeline.stageTotal": "Razem",
+  "customers.deals.pipeline.stageTotal.more": "+{count} więcej",
   "customers.deals.pipeline.subtitle": "Monitoruj szanse według etapu lejka i przeciągaj je między kolumnami, aby aktualizować postęp.",
   "customers.deals.pipeline.switch.label": "Lejek",
   "customers.deals.pipeline.title": "Lejek sprzedaży",


### PR DESCRIPTION
## Summary                                  
                                                                                                                                                                                                             
  Adds totals per pipeline stage to the deals pipeline kanban view. Each column now shows a sticky-style footer with the aggregate value of all deals in that stage. The tenant's base currency is promoted
  to the first position when present in totals. When a stage contains deals in multiple currencies, only the first is shown inline with the rest collapsed into a hoverable `(+N more)` tooltip exposing the 
  full breakdown. 
                                                                                                                                                                                                             
  ## Changes      
                                                                                                                                                                                                             
  - Constrain pipeline column height to `md:max-h-[60vh]` so the footer becomes visible without page scroll on tall stages
  - Add `renderLaneFooter` to `pipeline/page.tsx` showing aggregate totals per currency
  - Aggregate deal values per currency client-side via new `computeStageTotals` helper (extracted to `pipeline/lib/computeStageTotals.ts` for testability)
  - Promote tenant base currency to the first position via `/api/currencies/currencies?isBase=true&isActive=true&pageSize=1`                                                                                 
  - Show top 1 currency inline + `(+N more)` tooltip with full breakdown for the rest, using `SimpleTooltip` from `@open-mercato/ui/primitives/tooltip`
  - Add `customers.deals.pipeline.stageTotal` and `customers.deals.pipeline.stageTotal.more` i18n keys for en/pl/es/de                                                                                       
  - Cover `computeStageTotals` with 9 unit tests in `pipeline/lib/__tests__/computeStageTotals.test.ts`       



 ## Visual 

<img width="2376" height="1239" alt="Screenshot 2026-04-27 at 15 27 59" src="https://github.com/user-attachments/assets/4ad6285c-b92b-42c4-a765-30aa83b3aa8d" />
                                                                                              
                                                                                                                                                                                                             
  ## Specification                                                                                                                                                                                           
                                                                                                                                                                                                             
  **Does a spec exist for this feature/module?**                                                                                                                                                             
  - [x] N/A (minor change, no spec needed)                                                                                                                                                                   
                                                                                                                                                                                                             
  UI-only computation with no API/data model/permissions/cross-module behavior changes. Additive only.                                                                                                       
                                          
  ## Testing                                                                                                                                                                                                 
                                                                                                                                                                                                             
  - `yarn turbo run lint --filter='!@open-mercato/app'` — green (matches CI exclusion)                                                                                                                       
  - `yarn typecheck` — green across 18/18 packages                                                                                                                                                           
  - `yarn turbo run test --filter=@open-mercato/core` — **394 suites / 3250 tests pass** (added 1 suite, 9 tests)
  - `yarn build:packages` — green across 18/18 packages                                                                                                                                                      
  - `yarn i18n:check-sync` — all 4 locales in sync
                                                                                                                                                                                                             
  Manual QA on `/backend/customers/deals/pipeline`:                                                                                                                                                          
  - empty stage → `Total —`                                                                                                                                                                                  
  - 1 currency → inline value                                                                                                                                                                                
  - 2+ currencies → 1 visible + `(+N more)` with tooltip showing full breakdown                                                                                                                              
  - base currency promoted to first when present in stage
  - drag & drop recomputes totals immediately                                                                                                                                                                
  - footer stays visible inside column scroll on md+                                                                                                                                                         
                                                                                                                                                                                                             
  ## Checklist                                                                                                                                                                                               
                                                                                                                                                                                                             
  - [x] This pull request targets `develop`.                                                                                                                                                                 
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).                                                                                                           
  - [x] I updated documentation, locales, or generators if the change requires it.                                                                                                                           
  - [x] I added or adjusted tests that cover the change.                                                                                                                                                     
  - [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A: pure UI computation with no new API endpoints; behavior is covered by unit
  tests on `computeStageTotals`.                                                                                                                                                                             
  - [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.                                                                                                         
                                                                                                                                                                                                             
  ### Design System Compliance                                                                                                                                                                               
                                                                                                                                                                                                             
  - [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, etc.) — uses semantic tokens (`text-foreground`, `text-muted-foreground`, `border-border`, `bg-muted/20`)                                    
  - [x] No arbitrary text sizes (`text-[Npx]`) — uses `text-xs` for label and value
  - [x] Empty state handled (`Total —`)                                                                                                                                                                      
  - [x] Loading state handled (parent component handles via `Spinner`)                                                                                                                                       
  - [x] `aria-label` on all icon-only buttons — N/A (no icon buttons added)
  - [x] Uses existing DS components (Alert, StatusBadge, FormField) — uses `SimpleTooltip` from `@open-mercato/ui/primitives/tooltip`                                                                        
                                                                                                                                                                                                             
  ## Linked issues                                                                                                                                                                                           
                                                                                                                                                                                                             
  Fixes #773                          