### PR TITLE
fix(auth): harden reset origin checks and require password confirmation

### DIFF
--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-006.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-006.spec.ts
@@ -10,6 +10,7 @@ test.describe('TC-AUTH-006: Complete Password Reset', () => {
     await expect(page.getByText(/set a new password/i)).toBeVisible();
 
     await page.getByLabel(/new password/i).fill('Valid1!Pass');
+    await page.getByLabel(/confirm new password/i).fill('Valid1!Pass');
     await page.getByRole('button', { name: /update password/i }).click();
 
     await expect(page.getByText(/invalid or expired token/i)).toBeVisible();

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-006.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-006.spec.ts
@@ -9,8 +9,8 @@ test.describe('TC-AUTH-006: Complete Password Reset', () => {
     await page.goto('/reset/qa-invalid-token');
     await expect(page.getByText(/set a new password/i)).toBeVisible();
 
-    await page.getByLabel(/new password/i).fill('Valid1!Pass');
-    await page.getByLabel(/confirm new password/i).fill('Valid1!Pass');
+    await page.getByLabel(/^new password$/i).fill('Valid1!Pass');
+    await page.getByLabel(/^confirm new password$/i).fill('Valid1!Pass');
     await page.getByRole('button', { name: /update password/i }).click();
 
     await expect(page.getByText(/invalid or expired token/i)).toBeVisible();

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-007.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-007.spec.ts
@@ -8,11 +8,13 @@ test.describe('TC-AUTH-007: Password Reset with Expired Token', () => {
   test('should reject invalid and expired reset tokens', async ({ page }) => {
     await page.goto('/reset/qa-expired-token');
     await page.getByLabel(/new password/i).fill('Valid1!Pass');
+    await page.getByLabel(/confirm new password/i).fill('Valid1!Pass');
     await page.getByRole('button', { name: /update password/i }).click();
     await expect(page.getByText(/invalid or expired token/i)).toBeVisible();
 
     await page.goto('/reset/qa-malformed-token');
     await page.getByLabel(/new password/i).fill('Valid1!Pass');
+    await page.getByLabel(/confirm new password/i).fill('Valid1!Pass');
     await page.getByRole('button', { name: /update password/i }).click();
     await expect(page.getByText(/invalid or expired token/i)).toBeVisible();
   });

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-007.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-007.spec.ts
@@ -7,14 +7,14 @@ import { expect, test } from '@playwright/test';
 test.describe('TC-AUTH-007: Password Reset with Expired Token', () => {
   test('should reject invalid and expired reset tokens', async ({ page }) => {
     await page.goto('/reset/qa-expired-token');
-    await page.getByLabel(/new password/i).fill('Valid1!Pass');
-    await page.getByLabel(/confirm new password/i).fill('Valid1!Pass');
+    await page.getByLabel(/^new password$/i).fill('Valid1!Pass');
+    await page.getByLabel(/^confirm new password$/i).fill('Valid1!Pass');
     await page.getByRole('button', { name: /update password/i }).click();
     await expect(page.getByText(/invalid or expired token/i)).toBeVisible();
 
     await page.goto('/reset/qa-malformed-token');
-    await page.getByLabel(/new password/i).fill('Valid1!Pass');
-    await page.getByLabel(/confirm new password/i).fill('Valid1!Pass');
+    await page.getByLabel(/^new password$/i).fill('Valid1!Pass');
+    await page.getByLabel(/^confirm new password$/i).fill('Valid1!Pass');
     await page.getByRole('button', { name: /update password/i }).click();
     await expect(page.getByText(/invalid or expired token/i)).toBeVisible();
   });

--- a/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
+++ b/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
@@ -24,8 +24,8 @@ export default function ResetWithTokenPage({ params }: { params: { token: string
     e.preventDefault()
     setError(null)
     const form = new FormData(e.currentTarget)
-    const password = String(form.get('password') ?? '').trim()
-    const confirmPassword = String(form.get('confirmPassword') ?? '').trim()
+    const password = String(form.get('password') ?? '')
+    const confirmPassword = String(form.get('confirmPassword') ?? '')
 
     if (!password) {
       setError(t('auth.profile.form.errors.newPasswordRequired', 'New password is required.'))

--- a/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
+++ b/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
@@ -23,9 +23,25 @@ export default function ResetWithTokenPage({ params }: { params: { token: string
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     setError(null)
+    const form = new FormData(e.currentTarget)
+    const password = String(form.get('password') ?? '').trim()
+    const confirmPassword = String(form.get('confirmPassword') ?? '').trim()
+
+    if (!password) {
+      setError(t('auth.profile.form.errors.newPasswordRequired', 'New password is required.'))
+      return
+    }
+    if (!confirmPassword) {
+      setError(t('auth.profile.form.errors.confirmPasswordRequired', 'Please confirm the new password.'))
+      return
+    }
+    if (password !== confirmPassword) {
+      setError(t('auth.profile.form.errors.passwordMismatch', 'Passwords do not match.'))
+      return
+    }
+
     setSubmitting(true)
     try {
-      const form = new FormData(e.currentTarget)
       form.set('token', params.token)
       const { ok, result } = await apiCall<{ ok?: boolean; error?: string; redirect?: string }>(
         '/api/auth/reset/confirm',
@@ -50,13 +66,23 @@ export default function ResetWithTokenPage({ params }: { params: { token: string
         </CardHeader>
         <CardContent>
           <form className="grid gap-3" onSubmit={onSubmit}>
-            {error && <div className="text-sm text-red-600">{error}</div>}
+            {error && <div className="text-sm text-status-error-text">{error}</div>}
             <div className="grid gap-1">
               <Label htmlFor="password">{t('auth.reset.form.password', 'New password')}</Label>
               <Input id="password" name="password" type="password" required minLength={passwordPolicy.minLength} />
               {passwordDescription ? (
                 <p className="text-xs text-muted-foreground">{passwordDescription}</p>
               ) : null}
+            </div>
+            <div className="grid gap-1">
+              <Label htmlFor="confirmPassword">{t('auth.profile.form.confirmPassword', 'Confirm new password')}</Label>
+              <Input
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                required
+                minLength={passwordPolicy.minLength}
+              />
             </div>
             <Button type="submit" className="mt-2 w-full" disabled={submitting}>
               {submitting ? t('auth.reset.form.loading', '...') : t('auth.reset.form.submit', 'Update password')}

--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts
@@ -125,7 +125,12 @@ test.describe('TC-TRANS-005: Translation Manager Standalone', () => {
       await titleInput.fill('Deutscher Titel QA')
 
       await page.getByRole('button', { name: 'Save translations' }).click()
-      await expect(page.getByText('Translations saved').first()).toBeVisible()
+      await expect.poll(async () => {
+        const response = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
+        if (!response.ok()) return null
+        const body = (await response.json()) as { translations: Record<string, Record<string, string>> }
+        return body.translations?.de?.title ?? null
+      }).toBe('Deutscher Titel QA')
 
       const getResponse = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
       expect(getResponse.ok()).toBeTruthy()

--- a/packages/shared/src/lib/__tests__/url.test.ts
+++ b/packages/shared/src/lib/__tests__/url.test.ts
@@ -34,6 +34,22 @@ describe('security email URL helpers', () => {
     expect(() => assertAllowedAppOrigin(request, env)).toThrow(AppOriginRejectedError)
   })
 
+  test('rejects an untrusted request URL even when forwarded host matches the configured app origin', () => {
+    const env = {
+      APP_URL: 'https://auth.openmercato.com',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://evil.example/api/auth/reset', {
+      headers: {
+        host: 'auth.openmercato.com',
+        'x-forwarded-host': 'auth.openmercato.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
+
+    expect(() => assertAllowedAppOrigin(request, env)).toThrow(AppOriginRejectedError)
+  })
+
   test('rejects a mismatched Host header even when the request URL origin is allowed', () => {
     const env = {
       APP_URL: 'https://app.example.com',
@@ -53,6 +69,22 @@ describe('security email URL helpers', () => {
       NODE_ENV: 'production',
     }
     const request = new Request('https://admin.example.com/api/auth/reset')
+
+    expect(() => assertAllowedAppOrigin(request, env)).not.toThrow()
+  })
+
+  test('allows internal request URLs when forwarded host matches the configured app origin', () => {
+    const env = {
+      APP_URL: 'https://auth.openmercato.com',
+      NODE_ENV: 'production',
+    }
+    const request = new Request('https://localhost:9876/api/auth/reset', {
+      headers: {
+        host: 'auth.openmercato.com',
+        'x-forwarded-host': 'auth.openmercato.com',
+        'x-forwarded-proto': 'https',
+      },
+    })
 
     expect(() => assertAllowedAppOrigin(request, env)).not.toThrow()
   })

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -117,9 +117,18 @@ function requestOrigins(input: RequestInput): Set<string> {
   return origins
 }
 
-function logOriginDebugContext(input: RequestInput, allowedOrigins: Set<string>, rejectedOrigin?: string): void {
+function logOriginDebugContext(
+  input: RequestInput,
+  allowedOrigins: Set<string>,
+  rejectedOrigin?: string,
+  level: 'error' | 'warn' = 'error',
+  nodeEnv?: string,
+): void {
+  if (level === 'warn' && nodeEnv === 'test') return
+  const log = level === 'warn' ? console.warn : console.error
+
   if (typeof input === 'string') {
-    console.error('[origin-check] rejected string input', {
+    log('[origin-check] rejected string input', {
       requestUrl: input,
       rejectedOrigin: rejectedOrigin ?? null,
       allowedOrigins: Array.from(allowedOrigins),
@@ -128,14 +137,14 @@ function logOriginDebugContext(input: RequestInput, allowedOrigins: Set<string>,
   }
 
   if (!input) {
-    console.error('[origin-check] rejected empty input', {
+    log('[origin-check] rejected empty input', {
       rejectedOrigin: rejectedOrigin ?? null,
       allowedOrigins: Array.from(allowedOrigins),
     })
     return
   }
 
-  console.error('[origin-check] rejected request', {
+  log('[origin-check] rejected request', {
     requestUrl: input.url,
     host: input.headers.get('host'),
     forwardedHost: input.headers.get('x-forwarded-host'),
@@ -203,7 +212,7 @@ export function assertAllowedAppOrigin(input: RequestInput, env: EnvLike = proce
   for (const origin of headerOrigins) {
     if (allowedOrigins.has(origin)) continue
     if (shouldAllowLoopbackOrigin(origin, allowedOrigins, env)) continue
-    logOriginDebugContext(input, allowedOrigins, origin)
+    logOriginDebugContext(input, allowedOrigins, origin, 'warn', env.NODE_ENV)
     throw new AppOriginRejectedError('Request origin is not allowed')
   }
 
@@ -212,7 +221,7 @@ export function assertAllowedAppOrigin(input: RequestInput, env: EnvLike = proce
   if (shouldAllowLoopbackOrigin(urlOrigin, allowedOrigins, env)) return
   if (isLoopbackOrigin(urlOrigin) && hasAllowedHeaderOrigin) return
 
-  logOriginDebugContext(input, allowedOrigins, urlOrigin)
+  logOriginDebugContext(input, allowedOrigins, urlOrigin, 'warn', env.NODE_ENV)
   throw new AppOriginRejectedError('Request origin is not allowed')
 }
 

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -77,29 +77,43 @@ function originFromHost(protocol: string, rawHost: string | null): string | null
   return normalizeOrigin(`${protocol}//${host}`)
 }
 
-function requestOrigins(input: RequestInput): Set<string> {
-  const origins = new Set<string>()
-  if (!input) return origins
+type RequestOriginCandidates = {
+  urlOrigin: string | null
+  headerOrigins: Set<string>
+}
+
+function readRequestOriginCandidates(input: RequestInput): RequestOriginCandidates {
+  const candidates: RequestOriginCandidates = {
+    urlOrigin: null,
+    headerOrigins: new Set<string>(),
+  }
+  if (!input) return candidates
 
   const requestUrl = typeof input === 'string' ? input : input.url
   let parsedUrl: URL
   try {
     parsedUrl = new URL(requestUrl)
   } catch {
-    return origins
+    return candidates
   }
 
-  const urlOrigin = normalizeOrigin(parsedUrl.origin)
-  if (urlOrigin) origins.add(urlOrigin)
-
-  if (typeof input === 'string') return origins
+  candidates.urlOrigin = normalizeOrigin(parsedUrl.origin)
+  if (typeof input === 'string') return candidates
 
   const forwardedProto = readFirstHeaderValue(input.headers.get('x-forwarded-proto')) ?? parsedUrl.protocol.replace(/:$/, '')
   const protocol = forwardedProto.endsWith(':') ? forwardedProto : `${forwardedProto}:`
   const hostOrigin = originFromHost(protocol, input.headers.get('host'))
   const forwardedHostOrigin = originFromHost(protocol, input.headers.get('x-forwarded-host'))
-  if (hostOrigin) origins.add(hostOrigin)
-  if (forwardedHostOrigin) origins.add(forwardedHostOrigin)
+  if (hostOrigin) candidates.headerOrigins.add(hostOrigin)
+  if (forwardedHostOrigin) candidates.headerOrigins.add(forwardedHostOrigin)
+  return candidates
+}
+
+function requestOrigins(input: RequestInput): Set<string> {
+  const origins = new Set<string>()
+  const { urlOrigin, headerOrigins } = readRequestOriginCandidates(input)
+  if (urlOrigin) origins.add(urlOrigin)
+  for (const origin of headerOrigins) origins.add(origin)
   return origins
 }
 
@@ -183,16 +197,23 @@ export function assertAllowedAppOrigin(input: RequestInput, env: EnvLike = proce
     }
     return
   }
-  const origins = requestOrigins(input)
-  if (origins.size === 0) return
+  const { urlOrigin, headerOrigins } = readRequestOriginCandidates(input)
+  const hasAllowedHeaderOrigin = Array.from(headerOrigins).some((origin) => allowedOrigins.has(origin))
 
-  for (const origin of origins) {
-    if (!allowedOrigins.has(origin)) {
-      if (shouldAllowLoopbackOrigin(origin, allowedOrigins, env)) continue
-      logOriginDebugContext(input, allowedOrigins, origin)
-      throw new AppOriginRejectedError('Request origin is not allowed')
-    }
+  for (const origin of headerOrigins) {
+    if (allowedOrigins.has(origin)) continue
+    if (shouldAllowLoopbackOrigin(origin, allowedOrigins, env)) continue
+    logOriginDebugContext(input, allowedOrigins, origin)
+    throw new AppOriginRejectedError('Request origin is not allowed')
   }
+
+  if (!urlOrigin) return
+  if (allowedOrigins.has(urlOrigin)) return
+  if (shouldAllowLoopbackOrigin(urlOrigin, allowedOrigins, env)) return
+  if (isLoopbackOrigin(urlOrigin) && hasAllowedHeaderOrigin) return
+
+  logOriginDebugContext(input, allowedOrigins, urlOrigin)
+  throw new AppOriginRejectedError('Request origin is not allowed')
 }
 
 export function resolveRequestOrigin(req: Request): string {

--- a/packages/shared/src/lib/url.ts
+++ b/packages/shared/src/lib/url.ts
@@ -103,6 +103,35 @@ function requestOrigins(input: RequestInput): Set<string> {
   return origins
 }
 
+function logOriginDebugContext(input: RequestInput, allowedOrigins: Set<string>, rejectedOrigin?: string): void {
+  if (typeof input === 'string') {
+    console.error('[origin-check] rejected string input', {
+      requestUrl: input,
+      rejectedOrigin: rejectedOrigin ?? null,
+      allowedOrigins: Array.from(allowedOrigins),
+    })
+    return
+  }
+
+  if (!input) {
+    console.error('[origin-check] rejected empty input', {
+      rejectedOrigin: rejectedOrigin ?? null,
+      allowedOrigins: Array.from(allowedOrigins),
+    })
+    return
+  }
+
+  console.error('[origin-check] rejected request', {
+    requestUrl: input.url,
+    host: input.headers.get('host'),
+    forwardedHost: input.headers.get('x-forwarded-host'),
+    forwardedProto: input.headers.get('x-forwarded-proto'),
+    derivedOrigins: Array.from(requestOrigins(input)),
+    rejectedOrigin: rejectedOrigin ?? null,
+    allowedOrigins: Array.from(allowedOrigins),
+  })
+}
+
 function isLoopbackHostname(hostname: string): boolean {
   return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1'
 }
@@ -149,6 +178,7 @@ export function assertAllowedAppOrigin(input: RequestInput, env: EnvLike = proce
   const allowedOrigins = readAllowedOrigins(env)
   if (allowedOrigins.size === 0) {
     if (env.NODE_ENV === 'production') {
+      logOriginDebugContext(input, allowedOrigins)
       throw new AppOriginConfigurationError('APP_URL must be configured in production')
     }
     return
@@ -159,6 +189,7 @@ export function assertAllowedAppOrigin(input: RequestInput, env: EnvLike = proce
   for (const origin of origins) {
     if (!allowedOrigins.has(origin)) {
       if (shouldAllowLoopbackOrigin(origin, allowedOrigins, env)) continue
+      logOriginDebugContext(input, allowedOrigins, origin)
       throw new AppOriginRejectedError('Request origin is not allowed')
     }
   }


### PR DESCRIPTION
## Summary

Fix the security email origin validation for reverse-proxied auth reset requests and add password confirmation to the public reset form.

## Changes

- restore request URL origin validation while still allowing internal loopback request URLs when an allowed forwarded host is present
- add regression coverage for spoofed host headers and proxied internal auth reset requests
- require password confirmation on the public reset page and update reset integration specs to fill the new field

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A

## Testing

- `corepack yarn workspace @open-mercato/shared test -- src/lib/__tests__/url.test.ts`
- `corepack yarn workspace @open-mercato/core test -- src/modules/auth/api/__tests__/reset.test.ts`
- `corepack yarn workspace @open-mercato/core run typecheck` *(failed in this environment: `command not found: tsc`)*

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `apps/docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

None.
