### PR TITLE
fix(security): pin outbound webhook DNS to defeat rebinding (SSRF)

### DIFF
--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -16,7 +16,7 @@ import { WorkflowInstance } from '../data/entities'
 import { createModuleQueue, Queue } from '@open-mercato/queue'
 import { getRedisUrl } from '@open-mercato/shared/lib/redis/connection'
 import {
-  assertSafeOutboundUrl,
+  safeOutboundFetch,
   UnsafeOutboundUrlError,
   type HostLookup,
 } from '@open-mercato/shared/lib/url-safety'
@@ -646,12 +646,27 @@ export async function executeCallWebhook(
 
   const allowPrivate = deps.allowPrivate ?? isAllowPrivateWorkflowWebhookUrlsEnabled()
 
+  let response: Response
   try {
-    await assertSafeOutboundUrl(url, {
-      subject: 'Workflow webhook URL',
-      allowPrivate,
-      lookupHost: deps.lookupHost,
-    })
+    response = await safeOutboundFetch(
+      url,
+      {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
+        redirect: 'manual',
+        signal: deps.signal,
+      },
+      {
+        subject: 'Workflow webhook URL',
+        allowPrivate,
+        lookupHost: deps.lookupHost,
+        fetchImpl: deps.fetchImpl,
+      },
+    )
   } catch (error) {
     if (error instanceof UnsafeOutboundUrlError) {
       throw new Error(
@@ -660,18 +675,6 @@ export async function executeCallWebhook(
     }
     throw error
   }
-
-  const fetchImpl = deps.fetchImpl ?? fetch
-  const response = await fetchImpl(url, {
-    method,
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-    },
-    body: body !== undefined && body !== null ? JSON.stringify(body) : undefined,
-    redirect: 'manual',
-    signal: deps.signal,
-  })
 
   if (response.status >= 300 && response.status < 400) {
     const location = response.headers.get('location')

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -96,7 +96,8 @@
     "dotenv": "^17.4.2",
     "rate-limiter-flexible": "^11.0.1",
     "reflect-metadata": "^0.2.2",
-    "sanitize-html": "^2.17.2"
+    "sanitize-html": "^2.17.2",
+    "undici": "^7.24.0"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/packages/shared/src/lib/__tests__/url-safety.test.ts
+++ b/packages/shared/src/lib/__tests__/url-safety.test.ts
@@ -1,7 +1,10 @@
 import {
   assertSafeOutboundUrl,
   assertStaticallySafeOutboundUrl,
+  createPinnedDnsLookup,
   parseOutboundUrl,
+  resolveSafeOutboundUrl,
+  safeOutboundFetch,
   UnsafeOutboundUrlError,
 } from '../url-safety'
 
@@ -172,5 +175,134 @@ describe('url-safety — assertSafeOutboundUrl (DNS rebinding guard)', () => {
     await expect(
       assertSafeOutboundUrl('file:///etc/passwd', { allowPrivate: true }),
     ).rejects.toMatchObject({ reason: 'forbidden_protocol' })
+  })
+})
+
+describe('url-safety — resolveSafeOutboundUrl', () => {
+  it('returns the validated DNS records for use as pinning input', async () => {
+    const records = [
+      { address: '93.184.216.34', family: 4 },
+      { address: '93.184.216.35', family: 4 },
+    ]
+    const lookupHost = jest.fn(async () => records)
+    const result = await resolveSafeOutboundUrl('https://good.example/', {
+      lookupHost,
+      allowPrivate: false,
+    })
+    expect(result.hostname).toBe('good.example')
+    expect(result.addresses).toEqual(records)
+    expect(lookupHost).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null addresses for IP literal hosts (no DNS to pin)', async () => {
+    const result = await resolveSafeOutboundUrl('https://1.1.1.1/x', { allowPrivate: false })
+    expect(result.addresses).toBeNull()
+  })
+
+  it('returns null addresses when allowPrivate short-circuits validation', async () => {
+    const lookupHost = jest.fn()
+    const result = await resolveSafeOutboundUrl('http://internal.example/', {
+      lookupHost,
+      allowPrivate: true,
+    })
+    expect(result.addresses).toBeNull()
+    expect(lookupHost).not.toHaveBeenCalled()
+  })
+
+  it('throws on private resolution before returning addresses', async () => {
+    const lookupHost = jest.fn(async () => [{ address: '10.0.0.5', family: 4 }])
+    await expect(
+      resolveSafeOutboundUrl('https://rebind.evil.example/', {
+        lookupHost,
+        allowPrivate: false,
+      }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+  })
+})
+
+describe('url-safety — createPinnedDnsLookup', () => {
+  it('returns the pinned address only for the expected hostname', () => {
+    const lookup = createPinnedDnsLookup('good.example', { address: '93.184.216.34', family: 4 })
+    const cb = jest.fn()
+    lookup('good.example', {}, cb)
+    expect(cb).toHaveBeenCalledWith(null, '93.184.216.34', 4)
+  })
+
+  it('refuses to resolve a different hostname (defeats redirect to private host via Host header)', () => {
+    const lookup = createPinnedDnsLookup('good.example', { address: '93.184.216.34', family: 4 })
+    const cb = jest.fn()
+    lookup('attacker.example', {}, cb)
+    expect(cb).toHaveBeenCalledTimes(1)
+    const [err, address, family] = (cb as jest.Mock).mock.calls[0]
+    expect(err).toBeInstanceOf(Error)
+    expect((err as NodeJS.ErrnoException).code).toBe('EREFUSED')
+    expect(address).toBe('')
+    expect(family).toBe(0)
+  })
+})
+
+describe('url-safety — safeOutboundFetch', () => {
+  it('rejects unsafe URLs before invoking fetchImpl (no socket attempted)', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch
+    await expect(
+      safeOutboundFetch(
+        'http://169.254.169.254/latest/meta-data/',
+        {},
+        { fetchImpl, allowPrivate: false },
+      ),
+    ).rejects.toMatchObject({ reason: 'private_ip_literal' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects DNS-rebinding hosts (lookup returns private) before fetch', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch
+    const lookupHost = jest.fn(async () => [{ address: '10.0.0.5', family: 4 }])
+    await expect(
+      safeOutboundFetch(
+        'https://rebind.evil.example/',
+        {},
+        { fetchImpl, lookupHost, allowPrivate: false },
+      ),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('invokes fetchImpl with redirect:"manual" by default', async () => {
+    const fetchImpl = jest.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+    const lookupHost = jest.fn(async () => [{ address: '93.184.216.34', family: 4 }])
+    const response = await safeOutboundFetch(
+      'https://good.example/hook',
+      { method: 'POST' },
+      { fetchImpl, lookupHost, allowPrivate: false },
+    )
+    expect(response.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [calledUrl, calledInit] = (fetchImpl as unknown as jest.Mock).mock.calls[0]
+    expect(calledUrl).toBe('https://good.example/hook')
+    expect(calledInit).toEqual(
+      expect.objectContaining({ method: 'POST', redirect: 'manual' }),
+    )
+  })
+
+  it('preserves caller-provided redirect override', async () => {
+    const fetchImpl = jest.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+    await safeOutboundFetch(
+      'http://127.0.0.1:3000/dev',
+      { redirect: 'follow' },
+      { fetchImpl, allowPrivate: true },
+    )
+    const [, calledInit] = (fetchImpl as unknown as jest.Mock).mock.calls[0]
+    expect(calledInit.redirect).toBe('follow')
+  })
+
+  it('runs DNS validation exactly once (the same address is pinned for connect)', async () => {
+    const fetchImpl = jest.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+    const lookupHost = jest.fn(async () => [{ address: '93.184.216.34', family: 4 }])
+    await safeOutboundFetch(
+      'https://good.example/hook',
+      {},
+      { fetchImpl, lookupHost, allowPrivate: false },
+    )
+    expect(lookupHost).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/shared/src/lib/url-safety.ts
+++ b/packages/shared/src/lib/url-safety.ts
@@ -1,5 +1,6 @@
 import { lookup } from 'node:dns/promises'
 import { isIP } from 'node:net'
+import { Agent, type Dispatcher } from 'undici'
 import { isBlockedHostname, isPrivateIpAddress } from './network'
 
 export type UrlSafetyReason =
@@ -107,10 +108,35 @@ export async function assertSafeOutboundUrl(
   rawUrl: string,
   options: AssertSafeOutboundUrlOptions = {},
 ): Promise<void> {
+  await resolveSafeOutboundUrl(rawUrl, options)
+}
+
+export type ResolvedHostAddress = { address: string; family: number }
+
+export type ResolveSafeOutboundUrlResult = {
+  url: URL
+  hostname: string
+  /**
+   * The validated DNS records, in lookup order. `null` when the hostname is an IP literal
+   * (no DNS lookup performed) or when `allowPrivate` short-circuited validation.
+   */
+  addresses: ReadonlyArray<ResolvedHostAddress> | null
+}
+
+/**
+ * Validates an outbound URL exactly like `assertSafeOutboundUrl()` and additionally returns
+ * the resolved DNS records so the caller can pin the subsequent connection to the same
+ * address. This is what `safeOutboundFetch()` uses internally to defeat DNS rebinding —
+ * call it directly only if you need to drive the fetch yourself.
+ */
+export async function resolveSafeOutboundUrl(
+  rawUrl: string,
+  options: AssertSafeOutboundUrlOptions = {},
+): Promise<ResolveSafeOutboundUrlResult> {
   const subject = options.subject ?? 'URL'
   const factory = options.errorFactory ?? defaultErrorFactory
-  const { hostname } = parseOutboundUrl(rawUrl, options)
-  if (options.allowPrivate) return
+  const { url, hostname } = parseOutboundUrl(rawUrl, options)
+  if (options.allowPrivate) return { url, hostname, addresses: null }
 
   if (isBlockedHostname(hostname)) {
     throw factory('blocked_hostname', `${subject} host "${hostname}" is not allowed`)
@@ -123,7 +149,7 @@ export async function assertSafeOutboundUrl(
         `${subject} host "${hostname}" resolves to a private or reserved IP range`,
       )
     }
-    return
+    return { url, hostname, addresses: null }
   }
 
   const resolver: HostLookup =
@@ -133,7 +159,7 @@ export async function assertSafeOutboundUrl(
       return records
     })
 
-  let addresses: ReadonlyArray<{ address: string; family: number }>
+  let addresses: ReadonlyArray<ResolvedHostAddress>
   try {
     addresses = await resolver(hostname)
   } catch (error) {
@@ -159,5 +185,91 @@ export async function assertSafeOutboundUrl(
         `${subject} host "${hostname}" resolves to a private or reserved IP address (${record.address})`,
       )
     }
+  }
+
+  return { url, hostname, addresses }
+}
+
+export type SafeOutboundFetchOptions = AssertSafeOutboundUrlOptions & {
+  /**
+   * Test/seam injection. When provided, `safeOutboundFetch` calls `fetchImpl(url, init)` after
+   * URL validation instead of using the global `fetch` with a DNS-pinned dispatcher. Tests do
+   * not actually open sockets, so DNS pinning is unnecessary and would just complicate mocking.
+   */
+  fetchImpl?: typeof fetch
+}
+
+/**
+ * Validates an outbound URL and performs `fetch()` with the connection pinned to a
+ * pre-validated IP address, so DNS cannot be re-resolved between validation and connect
+ * (DNS rebinding). Always defaults to `redirect: 'manual'` — callers MUST decide what to
+ * do with 3xx responses (re-validate the redirect target before following).
+ *
+ * For IP literal hosts and `allowPrivate=true`, no DNS pinning is performed because there
+ * is no DNS lookup to defeat.
+ */
+export async function safeOutboundFetch(
+  rawUrl: string,
+  init: RequestInit = {},
+  options: SafeOutboundFetchOptions = {},
+): Promise<Response> {
+  const { url, hostname, addresses } = await resolveSafeOutboundUrl(rawUrl, options)
+  void url
+
+  const mergedInit: RequestInit = {
+    redirect: 'manual',
+    ...init,
+  }
+
+  const fetchImpl = options.fetchImpl
+  if (fetchImpl) {
+    return fetchImpl(rawUrl, mergedInit)
+  }
+
+  if (!addresses || addresses.length === 0) {
+    return globalThis.fetch(rawUrl, mergedInit)
+  }
+
+  const dispatcher: Dispatcher = new Agent({
+    connect: {
+      lookup: createPinnedDnsLookup(hostname, addresses[0]),
+    },
+  })
+
+  try {
+    return await globalThis.fetch(rawUrl, { ...mergedInit, dispatcher } as RequestInit & {
+      dispatcher: Dispatcher
+    })
+  } finally {
+    dispatcher.close().catch(() => {})
+  }
+}
+
+export type PinnedDnsLookup = (
+  host: string,
+  opts: unknown,
+  cb: (err: NodeJS.ErrnoException | null, address: string, family: number) => void,
+) => void
+
+/**
+ * Builds a `dns.lookup`-shaped callback that always returns the supplied pre-validated
+ * address for the expected hostname, and refuses to resolve any other hostname. Used as
+ * `Agent.connect.lookup` to bind an outbound TCP connect to an IP that has already been
+ * validated, so attacker-controlled DNS cannot rebind between validation and connect.
+ */
+export function createPinnedDnsLookup(
+  expectedHostname: string,
+  pinned: ResolvedHostAddress,
+): PinnedDnsLookup {
+  return (host, _opts, cb) => {
+    if (host !== expectedHostname) {
+      const err: NodeJS.ErrnoException = new Error(
+        `Refusing DNS lookup for unexpected host "${host}" (expected "${expectedHostname}")`,
+      )
+      err.code = 'EREFUSED'
+      cb(err, '', 0)
+      return
+    }
+    cb(null, pinned.address, pinned.family)
   }
 }

--- a/packages/webhooks/src/modules/webhooks/lib/__tests__/url-safety.test.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/__tests__/url-safety.test.ts
@@ -3,6 +3,7 @@ import {
   assertStaticallySafeWebhookUrl,
   isPrivateIpAddress,
   parseWebhookUrl,
+  safeWebhookFetch,
   UnsafeWebhookUrlError,
 } from '../url-safety'
 
@@ -189,5 +190,56 @@ describe('url-safety — assertSafeWebhookDeliveryUrl (DNS rebinding guard)', ()
     await expect(
       assertSafeWebhookDeliveryUrl('file:///etc/passwd', { allowPrivate: true }),
     ).rejects.toMatchObject({ reason: 'forbidden_protocol' })
+  })
+})
+
+describe('url-safety — safeWebhookFetch', () => {
+  it('rejects DNS-rebinding hosts before any fetch attempt', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch
+    const lookupHost = async () => [{ address: '10.0.0.5', family: 4 }]
+    await expect(
+      safeWebhookFetch('https://rebind.evil.example/', {}, {
+        fetchImpl,
+        lookupHost,
+        allowPrivate: false,
+      }),
+    ).rejects.toBeInstanceOf(UnsafeWebhookUrlError)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('reports the private resolved address in the error reason', async () => {
+    const fetchImpl = jest.fn() as unknown as typeof fetch
+    const lookupHost = async () => [{ address: '10.0.0.5', family: 4 }]
+    try {
+      await safeWebhookFetch('https://rebind.evil.example/', {}, {
+        fetchImpl,
+        lookupHost,
+        allowPrivate: false,
+      })
+      throw new Error('expected throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnsafeWebhookUrlError)
+      expect((error as UnsafeWebhookUrlError).reason).toBe('private_ip_resolved')
+    }
+  })
+
+  it('forwards init through fetchImpl with redirect:"manual"', async () => {
+    const fetchImpl = jest.fn(async () => new Response('ok', { status: 200 })) as unknown as typeof fetch
+    const lookupHost = async () => [{ address: '93.184.216.34', family: 4 }]
+    const response = await safeWebhookFetch(
+      'https://hooks.example.com/in',
+      { method: 'POST', body: 'payload' },
+      { fetchImpl, lookupHost, allowPrivate: false },
+    )
+    expect(response.status).toBe(200)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    const [, init] = (fetchImpl as unknown as jest.Mock).mock.calls[0]
+    expect(init).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        body: 'payload',
+        redirect: 'manual',
+      }),
+    )
   })
 })

--- a/packages/webhooks/src/modules/webhooks/lib/delivery.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/delivery.ts
@@ -5,7 +5,11 @@ import { WebhookDeliveryEntity, WebhookEntity } from '../data/entities'
 import { emitWebhooksEvent } from '../events'
 import { enqueueWebhookDelivery } from './queue'
 import { isWebhookIntegrationEnabled, WEBHOOK_INTEGRATION_DISABLED_MESSAGE } from './integration-state'
-import { assertSafeWebhookDeliveryUrl, UnsafeWebhookUrlError } from './url-safety'
+import {
+  assertSafeWebhookDeliveryUrl,
+  safeWebhookFetch,
+  UnsafeWebhookUrlError,
+} from './url-safety'
 
 export interface WebhookDeliveryJob {
   deliveryId: string
@@ -123,28 +127,12 @@ export async function processWebhookDeliveryJob(
   try {
     await assertSafeWebhookDeliveryUrl(webhook.url)
   } catch (error) {
-    const message = error instanceof UnsafeWebhookUrlError
-      ? error.message
-      : 'Webhook URL rejected by safety check'
-    delivery.status = 'failed'
-    delivery.errorMessage = message
-    delivery.nextRetryAt = null
-    delivery.lastAttemptAt = new Date()
-    delivery.attemptNumber += 1
-    webhook.consecutiveFailures += 1
-    webhook.lastFailureAt = new Date()
-    await em.flush()
-    await emitWebhooksEvent('webhooks.delivery.failed', {
-      deliveryId: delivery.id,
-      webhookId: webhook.id,
-      eventType: delivery.eventType,
-      errorMessage: message,
-      durationMs: 0,
-      organizationId: delivery.organizationId,
-      tenantId: delivery.tenantId,
-      willRetry: false,
+    return await recordWebhookSafetyFailure({
+      em,
+      delivery,
+      webhook,
+      error,
     })
-    return { status: delivery.status, deliveryId: delivery.id }
   }
 
   const bodyPayload = normalizeWebhookBody(delivery.eventType, delivery.payload)
@@ -170,19 +158,22 @@ export async function processWebhookDeliveryJob(
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), webhook.timeoutMs)
 
-    const response = await fetch(webhook.url, {
-      method: webhook.httpMethod,
-      redirect: 'manual',
-      headers: {
-        'content-type': 'application/json',
-        ...headers,
-        ...(webhook.customHeaders ?? {}),
-      },
-      body,
-      signal: controller.signal,
-    })
-
-    clearTimeout(timeoutId)
+    let response: Response
+    try {
+      response = await safeWebhookFetch(webhook.url, {
+        method: webhook.httpMethod,
+        redirect: 'manual',
+        headers: {
+          'content-type': 'application/json',
+          ...headers,
+          ...(webhook.customHeaders ?? {}),
+        },
+        body,
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
 
     delivery.attemptNumber += 1
     delivery.responseStatus = response.status
@@ -234,6 +225,20 @@ export async function processWebhookDeliveryJob(
 
     return { status: delivery.status, deliveryId: delivery.id }
   } catch (error) {
+    if (error instanceof UnsafeWebhookUrlError) {
+      // DNS rebinding caught between the upfront safety check and the pinned connect:
+      // the same attacker-controlled DNS would defeat retries too, so fail terminally.
+      const durationMs = Date.now() - delivery.enqueuedAt.getTime()
+      delivery.durationMs = durationMs
+      return await recordWebhookSafetyFailure({
+        em,
+        delivery,
+        webhook,
+        error,
+        durationMs,
+      })
+    }
+
     delivery.attemptNumber += 1
     delivery.durationMs = Date.now() - delivery.enqueuedAt.getTime()
     delivery.lastAttemptAt = new Date()
@@ -264,6 +269,45 @@ export async function processWebhookDeliveryJob(
 
     return { status: delivery.status, deliveryId: delivery.id }
   }
+}
+
+type RecordWebhookSafetyFailureInput = {
+  em: EntityManager
+  delivery: WebhookDeliveryEntity
+  webhook: WebhookEntity
+  error: unknown
+  durationMs?: number | null
+}
+
+async function recordWebhookSafetyFailure(
+  input: RecordWebhookSafetyFailureInput,
+): Promise<{ status: string; deliveryId: string }> {
+  const { em, delivery, webhook, error } = input
+  const message = error instanceof UnsafeWebhookUrlError
+    ? error.message
+    : 'Webhook URL rejected by safety check'
+
+  delivery.status = 'failed'
+  delivery.errorMessage = message
+  delivery.nextRetryAt = null
+  delivery.lastAttemptAt = new Date()
+  delivery.attemptNumber += 1
+  webhook.consecutiveFailures += 1
+  webhook.lastFailureAt = new Date()
+  await em.flush()
+
+  await emitWebhooksEvent('webhooks.delivery.failed', {
+    deliveryId: delivery.id,
+    webhookId: webhook.id,
+    eventType: delivery.eventType,
+    errorMessage: message,
+    durationMs: input.durationMs ?? 0,
+    organizationId: delivery.organizationId,
+    tenantId: delivery.tenantId,
+    willRetry: false,
+  })
+
+  return { status: delivery.status, deliveryId: delivery.id }
 }
 
 type HandleFailedDeliveryInput = {

--- a/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
+++ b/packages/webhooks/src/modules/webhooks/lib/url-safety.ts
@@ -2,7 +2,9 @@ import {
   assertSafeOutboundUrl,
   assertStaticallySafeOutboundUrl,
   parseOutboundUrl,
+  safeOutboundFetch,
   type HostLookup,
+  type SafeOutboundFetchOptions,
   type UrlSafetyReason,
 } from '@open-mercato/shared/lib/url-safety'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
@@ -69,5 +71,32 @@ export async function assertSafeWebhookDeliveryUrl(
     subject: SUBJECT,
     allowPrivate,
     lookupHost: deps.lookupHost,
+  })
+}
+
+export type SafeWebhookFetchDeps = {
+  lookupHost?: HostLookup
+  allowPrivate?: boolean
+  fetchImpl?: SafeOutboundFetchOptions['fetchImpl']
+}
+
+/**
+ * Validates the webhook URL and performs a `fetch()` with the connection pinned to a
+ * pre-validated address — defeats DNS rebinding by ensuring the validation lookup and
+ * the connect lookup return the same IP. Always sets `redirect: 'manual'` unless the
+ * caller overrides it.
+ */
+export async function safeWebhookFetch(
+  rawUrl: string,
+  init: RequestInit = {},
+  deps: SafeWebhookFetchDeps = {},
+): Promise<Response> {
+  const allowPrivate = deps.allowPrivate ?? isAllowPrivateWebhookUrlsEnabled()
+  return safeOutboundFetch(rawUrl, init, {
+    errorFactory: webhookErrorFactory,
+    subject: SUBJECT,
+    allowPrivate,
+    lookupHost: deps.lookupHost,
+    fetchImpl: deps.fetchImpl,
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6533,6 +6533,7 @@ __metadata:
     reflect-metadata: "npm:^0.2.2"
     sanitize-html: "npm:^2.17.2"
     ts-jest: "npm:^29.4.9"
+    undici: "npm:^7.24.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Two SSRF vulnerabilities via DNS rebinding closed in one pass.

- **Outbound webhooks** (`packages/webhooks/.../delivery.ts`) — `assertSafeWebhookDeliveryUrl()` resolved DNS at validation time, but the subsequent `fetch(webhook.url, ...)` performed a second, independent resolution. A tenant-controlled hostname could return a public IP for validation and a loopback / RFC1918 / cloud metadata IP at connect.
- **Workflow `CALL_WEBHOOK`** (`packages/core/.../workflows/lib/activity-executor.ts`) — same shape: `assertSafeOutboundUrl()` followed by an unrelated `fetchImpl(url)` call.

Both call sites now go through a new shared helper `safeOutboundFetch` that resolves DNS **once**, validates every returned address, and pins the TCP connect to the validated IP via an `undici.Agent` whose `connect.lookup` is bound to that address (and refuses to resolve any other hostname). Redirects remain `'manual'` and 3xx responses are still rejected.

## Changes

- `packages/shared/src/lib/url-safety.ts` — adds `resolveSafeOutboundUrl`, `safeOutboundFetch`, and `createPinnedDnsLookup`. `assertSafeOutboundUrl` is now a thin wrapper over the resolver (no behavior change). Adds `undici` to shared deps.
- `packages/webhooks/src/modules/webhooks/lib/url-safety.ts` — exports a webhook-typed `safeWebhookFetch` wrapper preserving `UnsafeWebhookUrlError`.
- `packages/webhooks/src/modules/webhooks/lib/delivery.ts` — replaces validate-then-fetch with `safeWebhookFetch`. Rebinding caught at pin-time is treated as a terminal `failed` (non-retryable) since the same attacker DNS would defeat retries too.
- `packages/core/src/modules/workflows/lib/activity-executor.ts` — `executeCallWebhook` switched to `safeOutboundFetch`.
- Tests: 14 new unit tests across shared + webhooks covering rebinding rejection, IP-literal short-circuit, redirect default, single-lookup contract, and the pinned-lookup factory's hostname guard.

## Test plan

- [x] `yarn workspace @open-mercato/shared test --testPathPatterns=url-safety` (31/31 pass)
- [x] `yarn workspace @open-mercato/webhooks test --testPathPatterns=lib/__tests__/url-safety` (51/51 pass)
- [x] `yarn workspace @open-mercato/shared build` clean
- [x] `yarn workspace @open-mercato/webhooks build` clean
- [x] `tsc --noEmit` shows no new errors in changed files
- [ ] QA: dispatch a test webhook to a known public endpoint (verify success) and a `127.0.0.1` URL (verify terminal `failed`, no retry)
- [ ] QA: run a workflow with `CALL_WEBHOOK` to a public URL and to a private URL with `OM_WORKFLOWS_ALLOW_PRIVATE_URLS` unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)