### PR TITLE
fix(custom-fields): omit orphaned values from responses

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
@@ -170,6 +170,39 @@ describe('loadCustomFieldValues (encryption)', () => {
     })
     expect(values['rec-1'].cf_note).toBe('secret-note')
   })
+
+  it('omits values whose definitions are no longer active', async () => {
+    const em = {
+      find: jest.fn().mockImplementation((_, where) => {
+        if ((where as any).recordId) {
+          return Promise.resolve([
+            {
+              recordId: 'rec-1',
+              fieldKey: 'deleted_field',
+              organizationId: null,
+              tenantId: 'tenant-1',
+              valueText: 'stale-value',
+              valueMultiline: null,
+              valueInt: null,
+              valueFloat: null,
+              valueBool: null,
+              deletedAt: null,
+            },
+          ])
+        }
+        return Promise.resolve([])
+      }),
+    }
+
+    const values = await loadCustomFieldValues({
+      em: em as any,
+      entityId: 'demo:entity',
+      recordIds: ['rec-1'],
+      tenantIdByRecord: { 'rec-1': 'tenant-1' },
+    })
+
+    expect(values).toEqual({})
+  })
 })
 
 describe('loadCustomFieldDefinitionIndex', () => {

--- a/packages/shared/src/lib/crud/custom-fields.ts
+++ b/packages/shared/src/lib/crud/custom-fields.ts
@@ -599,10 +599,11 @@ export async function loadCustomFieldValues(opts: {
   const result: Record<string, Record<string, unknown>> = {}
   for (const [compoundKey, bucket] of buckets.entries()) {
     const [recordId, fieldKey] = compoundKey.split('::')
+    const def = bucket.def ?? pickDefinition(fieldKey, bucket.orgId ?? (opts.organizationIdByRecord?.[recordId] ?? null), bucket.tenantId ?? (opts.tenantIdByRecord?.[recordId] ?? null))
+    if (!def) continue
     if (!result[recordId]) result[recordId] = {}
     const prefixed = `cf_${fieldKey}`
-    const def = bucket.def ?? pickDefinition(fieldKey, bucket.orgId ?? (opts.organizationIdByRecord?.[recordId] ?? null), bucket.tenantId ?? (opts.tenantIdByRecord?.[recordId] ?? null))
-    if (def && def.configJson && typeof def.configJson === 'object' && (def.configJson as any).multi) {
+    if (def.configJson && typeof def.configJson === 'object' && (def.configJson as any).multi) {
       const cleaned = bucket.values.filter((v) => v !== undefined && v !== null)
       result[recordId][prefixed] = cleaned
     } else if (bucket.values.length > 1) {


### PR DESCRIPTION

Summary

This PR fixes an issue where deleted custom field definitions continued to appear in API customFields payloads for existing records.

After a field was removed from the entity definition editor, the definition was correctly hidden from forms and UI editors, but its previously saved value could still be returned indefinitely in detail responses such as GET /api/customers/companies/:id. That created orphaned keys in the API contract with no indication that the field no longer existed.

Root Cause

The shared custom-field value loader still materialized stored custom-field rows even when no active field definition could be resolved for the key anymore. As a result, soft-deleted definitions stopped driving UI rendering, but their historical values still leaked into response payloads.

Changes

Update the shared custom-field loading path to only include values when an active definition still resolves for the field key.
Keep historical stored rows untouched in persistence, so restoring a field definition remains possible.
Add regression coverage proving that values for deleted/inactive custom fields are omitted from API-facing loaded custom fields.
Behavior After This Change

Active custom fields continue to load normally.
Deleted custom field definitions no longer surface orphaned keys in customFields response payloads.
Historical rows remain in storage and can still be reused if the field definition is restored later.
Testing

Added regression test for loadCustomFieldValues() covering inactive/deleted definitions.
Passed targeted Jest test:
packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
Notes

A broader package TypeScript check was attempted, but the current environment has unrelated baseline type/dependency issues (for example kysely and @mikro-orm/decorators/legacy) that are not introduced by this PR.