### PR TITLE
fix: expand auth users search to organizations and roles

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -172,10 +172,12 @@ describe('GET /api/auth/users', () => {
       return params.some((p) => p && typeof p === 'object' && 'value' in p && p.value === tenantId)
     })
     expect(tenantScopeCall).toBeDefined()
-    const where = mockEm.findAndCount.mock.calls[0][1] as { id?: { $in: string[] }; email?: unknown; tenantId?: string }
-    expect(where.id?.$in).toEqual([matchedUserId])
-    expect(where.tenantId).toBe(tenantId)
-    expect(where.email).toBeUndefined()
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { deletedAt: null },
+      { tenantId },
+      { id: { $in: [matchedUserId] } },
+    ]))
     expect(body.total).toBe(1)
     expect(body.items).toHaveLength(1)
     expect(body.items[0]).toMatchObject({
@@ -184,6 +186,46 @@ describe('GET /api/auth/users', () => {
       organizationId,
     })
     expect(body.isSuperAdmin).toBe(false)
+  })
+
+  test('includes matching organization names in the unified search clause', async () => {
+    mockEm.find
+      .mockResolvedValueOnce([{ id: organizationId }])
+      .mockResolvedValueOnce([])
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    const response = await GET(makeRequest('/api/auth/users?search=Acme&page=1&pageSize=50'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { deletedAt: null },
+      { tenantId },
+      { organizationId: { $in: [organizationId] } },
+    ]))
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1, isSuperAdmin: false })
+  })
+
+  test('includes users whose role names match the unified search term', async () => {
+    const matchedUserId = '523e4567-e89b-12d3-a456-426614174055'
+    mockEm.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: roleId, name: 'admin', tenantId }])
+      .mockResolvedValueOnce([{ user: { id: matchedUserId }, role: { id: roleId } }])
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    const response = await GET(makeRequest('/api/auth/users?search=admin&page=1&pageSize=50'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { deletedAt: null },
+      { tenantId },
+      { id: { $in: [matchedUserId] } },
+    ]))
+    expect(body).toEqual({ items: [], total: 0, totalPages: 1, isSuperAdmin: false })
   })
 
   test('returns empty result when search_tokens yield no matches', async () => {
@@ -245,8 +287,11 @@ describe('GET /api/auth/users', () => {
     const response = await GET(makeRequest(`/api/auth/users?roleId=${roleId}&search=match`))
     const body = await response.json()
 
-    const where = mockEm.findAndCount.mock.calls[0][1] as { id?: { $in: string[] } }
-    expect(where.id?.$in).toEqual([secondUserId])
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { id: { $in: [firstUserId, secondUserId] } },
+      { id: { $in: [secondUserId] } },
+    ]))
     expect(body.total).toBe(1)
     expect(body.items[0].id).toBe(secondUserId)
   })
@@ -273,8 +318,10 @@ describe('GET /api/auth/users', () => {
     const response = await GET(makeRequest(`/api/auth/users?roleId=${roleId}`))
     const body = await response.json()
 
-    const where = mockEm.findAndCount.mock.calls[0][1] as { id?: { $in: string[] } }
-    expect(where.id?.$in).toEqual([matchedUserId])
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { id: { $in: [matchedUserId] } },
+    ]))
     expect(body.total).toBe(1)
     expect(body.items).toHaveLength(1)
     expect(body.items[0].email).toBe('role-filtered@example.com')
@@ -306,9 +353,13 @@ describe('GET /api/auth/users', () => {
     expect(roleFilter.role?.$in).toEqual(expect.arrayContaining([roleId, secondRoleId]))
     expect(roleFilter.role?.$in).toHaveLength(2)
 
-    const where = mockEm.findAndCount.mock.calls[0][1] as { id?: { $in: string[] } }
-    expect(where.id?.$in).toEqual(expect.arrayContaining([firstUserId, secondUserId]))
-    expect(where.id?.$in).toHaveLength(2)
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    const idClause = where.$and.find((clause) => {
+      const value = (clause as { id?: { $in?: string[] } }).id
+      return Array.isArray(value?.$in)
+    }) as { id: { $in: string[] } }
+    expect(idClause.id.$in).toEqual(expect.arrayContaining([firstUserId, secondUserId]))
+    expect(idClause.id.$in).toHaveLength(2)
     expect(body.total).toBe(2)
     expect(body.items).toHaveLength(2)
   })
@@ -328,9 +379,13 @@ describe('GET /api/auth/users', () => {
     )
     const body = await response.json()
 
-    const where = mockEm.findAndCount.mock.calls[0][1] as Record<string, unknown>
-    expect(where.organizationId).toBe(secondaryOrganizationId)
-    expect(where).not.toHaveProperty('tenantId')
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { organizationId: secondaryOrganizationId },
+    ]))
+    expect(where.$and).not.toEqual(expect.arrayContaining([
+      { tenantId },
+    ]))
     expect(body.isSuperAdmin).toBe(true)
   })
 })

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -15,6 +15,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { userCrudEvents, userCrudIndexer } from '@open-mercato/core/modules/auth/commands/users'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { sql } from 'kysely'
@@ -156,14 +157,15 @@ export async function GET(req: Request) {
     console.error('users: failed to resolve rbac', err)
   }
   const { id, page, pageSize, search, organizationId, roleIds } = parsed.data
-  const where: any = { deletedAt: null }
+  const filters: any[] = [{ deletedAt: null }]
+  const actorTenantId = auth.tenantId ? String(auth.tenantId) : null
   if (!isSuperAdmin) {
-    if (!auth.tenantId) {
+    if (!actorTenantId) {
       return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
     }
-    where.tenantId = auth.tenantId
+    filters.push({ tenantId: actorTenantId })
   }
-  if (organizationId) where.organizationId = organizationId
+  if (organizationId) filters.push({ organizationId })
   let idFilter: Set<string> | null = id ? new Set([id]) : null
   if (Array.isArray(roleIds) && roleIds.length > 0) {
     const uniqueRoleIds = Array.from(new Set(roleIds))
@@ -183,33 +185,81 @@ export async function GET(req: Request) {
     }
     if (!idFilter || idFilter.size === 0) return NextResponse.json({ items: [], total: 0, totalPages: 1 })
   }
-  if (search) {
-    // Email is encrypted at rest, so $ilike on the column cannot match plaintext input.
-    // Resolve candidate users via search_tokens (tokens are built from the decrypted index doc).
+  const trimmedSearch = typeof search === 'string' ? search.trim() : ''
+  if (trimmedSearch) {
+    // Email is encrypted at rest, so plaintext search must go through search_tokens.
     const tenantScope: string | null | undefined = isSuperAdmin ? undefined : auth.tenantId ?? null
-    const matchedIds = await findUserIdsBySearchTokens(em, E.auth.user, search, tenantScope)
-    if (matchedIds !== null) {
-      if (matchedIds.length === 0) {
-        return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
-      }
-      const matchedSet = new Set(matchedIds)
-      if (idFilter) {
-        for (const uid of Array.from(idFilter)) {
-          if (!matchedSet.has(uid)) idFilter.delete(uid)
-        }
-        if (idFilter.size === 0) {
-          return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
-        }
-      } else {
-        idFilter = matchedSet
+    const searchFilters: any[] = []
+
+    const matchedIds = await findUserIdsBySearchTokens(em, E.auth.user, trimmedSearch, tenantScope)
+    if (matchedIds && matchedIds.length) {
+      searchFilters.push({ id: { $in: matchedIds as any } })
+    }
+
+    const searchPattern = `%${escapeLikePattern(trimmedSearch)}%`
+    const organizationSearchFilters: any[] = [
+      { deletedAt: null },
+      { name: { $ilike: searchPattern } },
+    ]
+    if (tenantScope) {
+      organizationSearchFilters.push({ tenant: tenantScope })
+    }
+    const matchingOrganizations = await em.find(
+      Organization,
+      organizationSearchFilters.length > 1 ? { $and: organizationSearchFilters } : organizationSearchFilters[0],
+    )
+    const matchingOrganizationIds = matchingOrganizations
+      .map((org) => (org?.id ? String(org.id) : null))
+      .filter((orgId): orgId is string => typeof orgId === 'string' && orgId.length > 0)
+    if (matchingOrganizationIds.length) {
+      searchFilters.push({ organizationId: { $in: matchingOrganizationIds as any } })
+    }
+
+    const roleSearchFilters: any[] = [
+      { deletedAt: null },
+      { name: { $ilike: searchPattern } },
+    ]
+    if (tenantScope) {
+      roleSearchFilters.push({ $or: [{ tenantId: tenantScope }, { tenantId: null }] })
+    }
+    const matchingRoles = await em.find(
+      Role,
+      roleSearchFilters.length > 1 ? { $and: roleSearchFilters } : roleSearchFilters[0],
+    )
+    const matchingRoleIds = matchingRoles
+      .map((role) => (role?.id ? String(role.id) : null))
+      .filter((roleId): roleId is string => typeof roleId === 'string' && roleId.length > 0)
+    if (matchingRoleIds.length) {
+      const roleSearchLinks = await em.find(
+        UserRole,
+        { role: { $in: matchingRoleIds as any } } as any,
+      )
+      const matchingRoleUserIds = Array.from(new Set(
+        roleSearchLinks
+          .map((link) => {
+            const userRef = (link as any).user
+            const userId = userRef?.id ?? userRef
+            return userId ? String(userId) : null
+          })
+          .filter((userId): userId is string => typeof userId === 'string' && userId.length > 0),
+      ))
+      if (matchingRoleUserIds.length) {
+        searchFilters.push({ id: { $in: matchingRoleUserIds as any } })
       }
     }
+
+    if (!searchFilters.length) {
+      return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
+    }
+
+    filters.push(searchFilters.length > 1 ? { $or: searchFilters } : searchFilters[0])
   }
   if (idFilter && idFilter.size) {
-    where.id = { $in: Array.from(idFilter) as any }
+    filters.push({ id: { $in: Array.from(idFilter) as any } })
   } else if (id) {
-    where.id = id
+    filters.push({ id })
   }
+  const where = filters.length > 1 ? { $and: filters } : filters[0]
   const [rows, count] = await em.findAndCount(User, where, { limit: pageSize, offset: (page - 1) * pageSize })
   const userIds = rows.map((u: any) => u.id)
   const links = userIds.length
@@ -402,7 +452,7 @@ export const openApi: OpenApiRouteDoc = {
     GET: {
       summary: 'List users',
       description:
-        'Returns users for the current tenant. Super administrators may scope the response via organization or role filters.',
+        'Returns users for the current tenant. Search matches email, organization name, and role name. Super administrators may scope the response via organization or role filters.',
       query: querySchema,
       responses: [
         { status: 200, description: 'User collection', schema: userListResponseSchema },


### PR DESCRIPTION
## Summary
- extend `/backend/users` search to match user email, organization name, and role name
- keep search behavior unified with OR logic across those fields
- preserve existing tenant scoping plus explicit `organizationId` and `roleId` filters
- add regression coverage for the new search cases

## Problem
The users list shows email, organization, and roles, but the global search only filtered by email. That meant searches like `Acme` or `admin` returned no results even when matching users were visible in the table.

## Solution
The users API now treats `search` as a multi-field query:
- email matches directly on the user record
- organization matches resolve organization IDs by name, then filter users by `organizationId`
- role matches resolve role IDs by name, then filter users by linked `user_roles`
- all three match paths are combined with OR logic inside the existing access and scope constraints

No UI changes were required.

## Testing
- `jest --config jest.config.cjs src/modules/auth/api/__tests__/users.route.test.ts --runInBand` in `packages/core`

## Expected behavior
- searching part of an organization name filters users in that organization
- searching a role name like `admin` or `employee` filters users with that role
- email search continues to work as before
