### PR TITLE
fix(test): skip ratelimit_probe path when module is absent (standalone scaffold)

### DIFF
--- a/.ai/qa/tests/integration/TC-INT-ratelimit-leakage.spec.ts
+++ b/.ai/qa/tests/integration/TC-INT-ratelimit-leakage.spec.ts
@@ -3,46 +3,42 @@ import { expect, test } from '@playwright/test';
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 
 /**
- * Reproduction spec for per-route rate-limit leakage under `OM_INTEGRATION_TEST`.
+ * Regression guard: `OM_INTEGRATION_TEST=true` must keep both the metadata-driven
+ * and the per-handler rate-limit paths bypassed.
  *
- * These tests are expected to FAIL on current `develop`. That failure is the
- * whole point — it proves the built-in rate limiting makes integration tests
- * fragile even though the runner already sets `OM_INTEGRATION_TEST=true`.
+ * `readRateLimitConfig()` flips `RATE_LIMIT_ENABLED=false` whenever
+ * `OM_INTEGRATION_TEST=true`, which the integration runner exports via
+ * `packages/cli/src/lib/testing/integration.ts`. Without that bypass every
+ * Playwright run shares a single client IP across workers and burns through
+ * per-route point budgets — flakiness that scales with worker count.
  *
- * Background:
- * - `packages/shared/src/lib/ratelimit/config.ts` `readRateLimitConfig()` only checks
- *   `RATE_LIMIT_ENABLED` (defaults to `true`). There is no `OM_INTEGRATION_TEST`
- *   / `OM_TEST_MODE` override on `develop` (the fix proposed in
- *   open-mercato#1673 was closed pending a better repro — this is that repro).
- * - `apps/mercato/src/app/api/[...slug]/route.ts` enforces per-route
- *   `metadata.rateLimit` via `checkRateLimit()` using only that global config.
- * - `packages/cli/src/lib/testing/integration.ts` exports `OM_INTEGRATION_TEST=true`,
- *   `OM_TEST_MODE=1`, `OM_TEST_AUTH_RATE_LIMIT_MODE=opt-in`. These are honored
- *   *only* by `checkAuthRateLimit()` in the auth module, not by the generic
- *   per-route / per-handler rate limiting.
- *
- * Why this matters for parallel test runs (the real pain point):
- * The open-mercato repo itself runs its integration suite serially, so the
- * per-route points budget is rarely exhausted for any single endpoint. In
- * downstream apps that run Playwright with `workers > 1`, every worker shares
- * the same client IP against the app server — the points budget is consumed
- * collectively, and flakiness scales with worker count. See edube-monorepo#161
- * for the 18-file boilerplate workaround that was required there. The
- * reproduction below is deliberately serial (points=3, 5 requests) so the
- * leakage is unambiguous even without concurrency.
+ * The metadata-path case depends on the dev-only `ratelimit_probe` module at
+ * `apps/mercato/src/modules/ratelimit_probe/`. That module ships only with
+ * the open-mercato monorepo and is intentionally absent from
+ * `create-mercato-app` scaffolds, so the metadata path self-skips when
+ * `/api/ratelimit_probe/ping` responds with 404.
  */
 test.describe('per-route rate limits leak into OM_INTEGRATION_TEST runs', () => {
-  test('metadata.rateLimit path (apps/mercato root handler): 4th POST to /api/ratelimit_probe/ping 429s with points=3', async ({ request }) => {
-    const statuses: number[] = [];
-    for (let i = 0; i < 5; i += 1) {
+  test('metadata.rateLimit path (apps/mercato root handler): 5 POSTs to /api/ratelimit_probe/ping all return 200 with points=3', async ({ request }) => {
+    const probe = await request.post(`${BASE_URL}/api/ratelimit_probe/ping`, {
+      headers: { 'Content-Type': 'application/json' },
+      data: {},
+    });
+    test.skip(
+      probe.status() === 404,
+      'ratelimit_probe module not registered (expected for create-mercato-app scaffolds)',
+    );
+
+    const statuses: number[] = [probe.status()];
+    for (let i = 0; i < 4; i += 1) {
       const res = await request.post(`${BASE_URL}/api/ratelimit_probe/ping`, {
         headers: { 'Content-Type': 'application/json' },
         data: {},
       });
       statuses.push(res.status());
     }
-    // Expected (post-fix): all 5 allowed → [200, 200, 200, 200, 200]
-    // Actual (current develop): rate limiter still fires → [200, 200, 200, 429, 429]
+    // With the OM_INTEGRATION_TEST bypass: all 5 calls return 200.
+    // Without it: rate limiter fires on the 4th call → [200, 200, 200, 429, 429].
     expect(statuses, 'OM_INTEGRATION_TEST should bypass metadata.rateLimit').toEqual([200, 200, 200, 200, 200]);
   });
 
@@ -57,8 +53,8 @@ test.describe('per-route rate limits leak into OM_INTEGRATION_TEST runs', () => 
       });
       statuses.push(res.status());
     }
-    // Expected (post-fix): zero 429s (invalid token → 400/404, but never 429).
-    // Actual (current develop): 429 from the 11th call onward.
+    // With the OM_INTEGRATION_TEST bypass: zero 429s (invalid token → 400/404, but never 429).
+    // Without it: 429 from the 11th call onward.
     expect(statuses.filter((s) => s === 429), 'OM_INTEGRATION_TEST should bypass per-handler checkRateLimit').toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the `Standalone App Integration Tests` failure introduced by #1673 on `.ai/qa/tests/integration/TC-INT-ratelimit-leakage.spec.ts:35` where the `metadata.rateLimit path` case POSTs to `/api/ratelimit_probe/ping` and gets `404` instead of `200` (assertion fails: `[200×5]` vs received `[404×5]`).
- Probe the endpoint once at the start of the test and `test.skip()` when it returns `404`. Reuse the probe response as the first slot in the rate-limit budget so the existing 5-POST / 3-points assertion stays intact under the `OM_INTEGRATION_TEST` bypass.
- Retitle the first test (`"4th POST … 429s"` → `"5 POSTs … all return 200"`) to match what the assertion actually checks now that the bypass has landed; reframe the file header from "reproduction expected to FAIL" to "regression guard".

## Why this is needed

`apps/mercato/src/modules/ratelimit_probe/` is a dev-only module shipped only with the open-mercato monorepo — `create-mercato-app`'s scaffold template intentionally does not include it. The standalone-app job (`.github/workflows/snapshot.yml` → `Standalone App Integration Tests`) scaffolds a fresh app via `create-mercato-app`, so the probe route is absent there and the spec fails on every PR.

Verified that develop's own commit `07af3a6a9` already shows this red on [run 25052705667](https://github.com/open-mercato/open-mercato/actions/runs/25052705667) (same line, same `expect [200×5]` vs received `[404×5]`). The fix needs to land directly on develop to unblock the snapshot pipeline; subsequent feature PRs (e.g. #1640) will pick it up via merge.

## What I considered and rejected

- **Ship `ratelimit_probe` via the scaffold template** — adds an `/api/ratelimit_probe/ping` endpoint to every customer's production app. The probe is purely a test fixture and has no place in user codebases.
- **Restrict the spec to monorepo `ephemeral-integration` shards via Playwright project filters** — heavier change to `.ai/qa/tests/playwright.config.ts` and would lose the regression coverage the second test (`sales/quotes/accept`) provides in the standalone job, since both cases live in the same file.
- **Skip via `OM_TEST_APP_ROOT` env detection** — brittle; depends on a specific job's env wiring rather than the actual condition (probe-route presence). Runtime probe is self-describing and survives future job changes.

## Test plan

- [ ] CI: `Standalone App Integration Tests` passes on this PR (test #1 skips with `ratelimit_probe module not registered (expected for create-mercato-app scaffolds)`, test #2 still runs).
- [ ] CI: `ephemeral-integration` shards still run test #1 to completion in the monorepo (the probe module is loaded, so it does not skip; assertion `[200×5]` holds under the `OM_INTEGRATION_TEST` bypass).
- [ ] Manual sanity: removing the bypass locally (e.g. `OM_INTEGRATION_TEST=false`) flips the assertion to `[200,200,200,429,429]` as expected — the regression guard remains effective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)