### PR TITLE
fix: bug: [Customer Portal] Self-registration success message says "you can now log in" but login fails until admin activates the account (#1742)

### DIFF
--- a/packages/core/src/modules/portal/i18n/de.json
+++ b/packages/core/src/modules/portal/i18n/de.json
@@ -84,7 +84,7 @@
   "portal.signup.password.placeholder": "Wählen Sie ein sicheres Passwort",
   "portal.signup.submit": "Konto erstellen",
   "portal.signup.submitting": "Konto wird erstellt…",
-  "portal.signup.success.description": "Ihr Konto wurde erstellt. Sie können sich jetzt anmelden.",
+  "portal.signup.success.description": "Ihr Konto wurde erstellt. Bitte überprüfen Sie Ihre E-Mail und bestätigen Sie Ihre Adresse, um sich anmelden zu können.",
   "portal.signup.success.loginLink": "Zur Anmeldung",
   "portal.signup.success.title": "Konto erstellt",
   "portal.signup.title": "Konto erstellen",

--- a/packages/core/src/modules/portal/i18n/en.json
+++ b/packages/core/src/modules/portal/i18n/en.json
@@ -84,7 +84,7 @@
   "portal.signup.password.placeholder": "Choose a strong password",
   "portal.signup.submit": "Create Account",
   "portal.signup.submitting": "Creating account…",
-  "portal.signup.success.description": "Your account has been created. You can now log in.",
+  "portal.signup.success.description": "Your account has been created. Please check your email and verify your address to log in.",
   "portal.signup.success.loginLink": "Go to login",
   "portal.signup.success.title": "Account Created",
   "portal.signup.title": "Create Account",

--- a/packages/core/src/modules/portal/i18n/es.json
+++ b/packages/core/src/modules/portal/i18n/es.json
@@ -84,7 +84,7 @@
   "portal.signup.password.placeholder": "Elige una contraseña segura",
   "portal.signup.submit": "Crear cuenta",
   "portal.signup.submitting": "Creando cuenta…",
-  "portal.signup.success.description": "Tu cuenta ha sido creada. Ya puedes iniciar sesión.",
+  "portal.signup.success.description": "Tu cuenta ha sido creada. Por favor, revisa tu correo electrónico y verifica tu dirección para iniciar sesión.",
   "portal.signup.success.loginLink": "Ir al inicio de sesión",
   "portal.signup.success.title": "Cuenta creada",
   "portal.signup.title": "Crear cuenta",

--- a/packages/core/src/modules/portal/i18n/pl.json
+++ b/packages/core/src/modules/portal/i18n/pl.json
@@ -84,7 +84,7 @@
   "portal.signup.password.placeholder": "Wybierz silne hasło",
   "portal.signup.submit": "Utwórz konto",
   "portal.signup.submitting": "Tworzenie konta…",
-  "portal.signup.success.description": "Twoje konto zostało utworzone. Możesz się teraz zalogować.",
+  "portal.signup.success.description": "Twoje konto zostało utworzone. Sprawdź swoją skrzynkę e-mail i zweryfikuj adres, aby móc się zalogować.",
   "portal.signup.success.loginLink": "Przejdź do logowania",
   "portal.signup.success.title": "Konto utworzone",
   "portal.signup.title": "Utwórz konto",


### PR DESCRIPTION
## Automated fix for #1742

Fixes #1742

> This PR was opened by [cezar](https://github.com/comerito/cezar) autofix. It is a **draft** — a human reviewer must verify correctness before it merges.

### Root cause
Self-registration success message misleading - login requires email verification first

The signup flow creates users successfully but requires email verification before login. However, the success message 'Możesz się teraz zalogować' (line 87 in pl.json) misleads users into thinking they can login immediately. The login API rejects unverified emails with 'Invalid email or password' (login.ts:74-81) instead of a clear verification message. Users must either click the email verification link or wait for admin manual verification.

### Approach
Updated the signup success message in all 4 language files to correctly inform users they need to verify their email before logging in, instead of the misleading 'you can now log in' message. This aligns the UI messaging with the actual login requirement that checks for emailVerifiedAt.

### Files changed
- `packages/core/src/modules/portal/i18n/en.json`
- `packages/core/src/modules/portal/i18n/pl.json`
- `packages/core/src/modules/portal/i18n/es.json`
- `packages/core/src/modules/portal/i18n/de.json`

### Verification
Commands run by the fixer:
- `node -e "console.log('JSON validation:'); JSON.parse(require('fs').readFileSync('packages/core/src/modules/portal/i18n/en.json', 'utf8')); console.log('✓ en.json valid');"`
- `node -e "console.log('JSON validation:'); JSON.parse(require('fs').readFileSync('packages/core/src/modules/portal/i18n/pl.json', 'utf8')); console.log('✓ pl.json valid');"`
- `node -e "console.log('JSON validation:'); JSON.parse(require('fs').readFileSync('packages/core/src/modules/portal/i18n/es.json', 'utf8')); console.log('✓ es.json valid');"`
- `node -e "console.log('JSON validation:'); JSON.parse(require('fs').readFileSync('packages/core/src/modules/portal/i18n/de.json', 'utf8')); console.log('✓ de.json valid');"`
- `grep -n "portal.signup.success.description" packages/core/src/modules/portal/i18n/*.json`

### Review (automated)
**Verdict:** `pass`

This fix correctly addresses the root cause by updating signup success messages across all 4 language files to accurately inform users they must verify their email before login, matching the actual requirement enforced in the login API. JSON validation and grep checks confirm all files are valid and updated consistently.

Issues raised:
_(no issues raised)_

### Remaining concerns
_(none)_
