### PR TITLE
fix: bug: [Custom Fields] Deleted custom fields still appear in API response after removal from entity definition (#1749)

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
@@ -1,10 +1,12 @@
 import {
   buildCustomFieldFiltersFromQuery,
+  decorateRecordWithCustomFields,
   extractAllCustomFieldEntries,
   loadCustomFieldDefinitionIndex,
   loadCustomFieldValues,
   splitCustomFieldPayload,
 } from '../custom-fields'
+import type { CustomFieldDefinitionIndex, CustomFieldDefinitionSummary } from '../custom-fields'
 import { encryptWithAesGcm } from '../../encryption/aes'
 
 const mockEntityManager = (defs: any[]) => ({
@@ -169,6 +171,75 @@ describe('loadCustomFieldValues (encryption)', () => {
       encryptionService: mockService as any,
     })
     expect(values['rec-1'].cf_note).toBe('secret-note')
+  })
+})
+
+describe('decorateRecordWithCustomFields', () => {
+  const buildDefinition = (
+    overrides: Partial<CustomFieldDefinitionSummary> = {},
+  ): CustomFieldDefinitionSummary => ({
+    key: 'priority',
+    label: 'Priority',
+    kind: 'integer',
+    multi: false,
+    organizationId: null,
+    tenantId: null,
+    priority: 0,
+    updatedAt: 1,
+    ...overrides,
+  })
+
+  const buildIndex = (
+    entries: Array<[string, CustomFieldDefinitionSummary[]]>,
+  ): CustomFieldDefinitionIndex => new Map(entries)
+
+  it('returns the value in customValues and customFields when an active definition exists', () => {
+    const index = buildIndex([
+      ['priority', [buildDefinition()]],
+    ])
+
+    const result = decorateRecordWithCustomFields(
+      { cf_priority: 3 },
+      index,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+
+    expect(result.customValues).toEqual({ priority: 3 })
+    expect(result.customFields).toEqual([
+      { key: 'priority', label: 'Priority', value: 3, kind: 'integer', multi: false },
+    ])
+  })
+
+  it('skips orphaned custom field values whose definition was deleted (regression for #1749)', () => {
+    const result = decorateRecordWithCustomFields(
+      { cf_my_test_key: 'leftover' },
+      buildIndex([]),
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+
+    expect(result.customValues).toBeNull()
+    expect(result.customFields).toEqual([])
+  })
+
+  it('keeps active fields and drops orphaned ones in mixed payloads', () => {
+    const index = buildIndex([
+      ['priority', [buildDefinition({ key: 'priority', label: 'Priority' })]],
+      ['severity', [buildDefinition({ key: 'severity', label: 'Severity', kind: 'text', priority: 1 })]],
+    ])
+
+    const result = decorateRecordWithCustomFields(
+      {
+        cf_priority: 5,
+        cf_severity: 'high',
+        cf_my_test_key: 'should-not-leak',
+      },
+      index,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+
+    expect(result.customValues).toEqual({ priority: 5, severity: 'high' })
+    expect(result.customFields.map((entry) => entry.key)).toEqual(['priority', 'severity'])
+    expect(result.customFields.find((entry) => entry.key === 'my_test_key')).toBeUndefined()
   })
 })
 

--- a/packages/shared/src/lib/crud/custom-fields.ts
+++ b/packages/shared/src/lib/crud/custom-fields.ts
@@ -427,20 +427,22 @@ export function decorateRecordWithCustomFields(
     const bareKey = prefixedKey.replace(/^cf_/, '')
     const normalizedKey = normalizeDefinitionKey(bareKey)
     if (!normalizedKey) return
-    values[bareKey] = value
     const defsForKey = definitions.get(normalizedKey) ?? []
     const resolvedDef = selectDefinitionForRecord(defsForKey, organizationId, tenantId)
+    // Skip custom field values without active definitions to prevent orphaned fields
+    if (!resolvedDef) return
+    values[bareKey] = value
     const entry: CustomFieldDisplayEntry = {
       key: bareKey,
-      label: resolvedDef?.label ?? bareKey,
+      label: resolvedDef.label ?? bareKey,
       value,
-      kind: resolvedDef?.kind ?? null,
-      multi: resolvedDef?.multi ?? Array.isArray(value),
+      kind: resolvedDef.kind ?? null,
+      multi: resolvedDef.multi ?? Array.isArray(value),
     }
     entries.push({
       entry,
-      priority: resolvedDef?.priority ?? Number.MAX_SAFE_INTEGER,
-      updatedAt: resolvedDef?.updatedAt ?? 0,
+      priority: resolvedDef.priority ?? Number.MAX_SAFE_INTEGER,
+      updatedAt: resolvedDef.updatedAt ?? 0,
     })
   })
 


### PR DESCRIPTION
## Automated fix for #1749

Fixes #1749

> This PR was opened by [cezar](https://github.com/comerito/cezar) autofix. It is a **draft** — a human reviewer must verify correctness before it merges.

### Root cause
Custom field values for deleted definitions remain in API responses

The bug occurs in the decorateRecordWithCustomFields function which processes ALL custom field values from raw records without filtering out those belonging to deleted/inactive field definitions. While the definition loading correctly filters for active definitions only (deletedAt: null, isActive: true), the raw custom field values contain historical data. The function creates entries for all values regardless of whether their definitions exist, resulting in orphaned fields appearing in API responses with fallback labels and null kinds.

### Approach
Fixed the decorateRecordWithCustomFields function to skip custom field values when no active definition exists. Added a null check for resolvedDef and return early to prevent orphaned fields from appearing in API responses. This addresses the root cause where deleted field definitions were leaving behind orphaned values in the response.

### Files changed
- `packages/shared/src/lib/crud/custom-fields.ts`

### Verification
Commands run by the fixer:
- `node -c packages/shared/src/lib/crud/custom-fields.ts`
- `node test-custom-fields-behavior.mjs`

### Review (automated)
**Verdict:** `pass`

The fix correctly addresses the root cause by skipping custom field values without active definitions, preventing orphaned fields in API responses. The early return on null resolvedDef is semantically sound and safe. Minor concern: full Jest test suite could not be run, though syntax and behavioral validation passed.

Issues raised:
_(no issues raised)_

### Remaining concerns
- The test environment dependencies (ts-jest, turbo) were not available for running the full Jest test suite. However, syntax validation passed and behavioral testing confirmed the fix works correctly by filtering out orphaned custom field values as intended.
