### PR TITLE
fix: 3 vs 2 char issue

### DIFF
--- a/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
+++ b/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
@@ -58,7 +58,7 @@ import { parseSelectedOrganizationCookie } from '@open-mercato/core/modules/dire
 import { ForbiddenError } from '@open-mercato/ui/backend/utils/api'
 import { fetchGlobalSearchResults } from '../utils'
 
-const MIN_QUERY_LENGTH = 2
+const MIN_QUERY_LENGTH = 3
 
 /** Default strategies used when none are configured */
 const DEFAULT_STRATEGIES: SearchStrategyId[] = ['fulltext', 'vector', 'tokens']

--- a/packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx
+++ b/packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx
@@ -30,7 +30,7 @@ type Row = {
   metadata: Record<string, unknown> | null
 }
 
-const MIN_QUERY_LENGTH = 2
+const MIN_QUERY_LENGTH = 3
 const ALL_STRATEGIES: SearchStrategyId[] = ['fulltext', 'vector', 'tokens']
 
 type Translator = (

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Globale Suche öffnen",
   "search.dialog.actions.openSelected": "Öffnen (Enter)",
   "search.dialog.actions.search": "Suchen",
-  "search.dialog.empty.hint": "Mindestens zwei Zeichen eingeben, um in indizierten Datensätzen zu suchen.",
+  "search.dialog.empty.hint": "Mindestens drei Zeichen eingeben, um in indizierten Datensätzen zu suchen.",
   "search.dialog.empty.none": "Keine Ergebnisse gefunden.",
   "search.dialog.errors.noPermission": "Sie haben keine Berechtigung, die globale Suche zu verwenden.",
   "search.dialog.errors.searchFailed": "Suche ist fehlgeschlagen.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Open global search",
   "search.dialog.actions.openSelected": "Open (Enter)",
   "search.dialog.actions.search": "Search",
-  "search.dialog.empty.hint": "Type at least two characters to search indexed records.",
+  "search.dialog.empty.hint": "Type at least three characters to search indexed records.",
   "search.dialog.empty.none": "No results found.",
   "search.dialog.errors.noPermission": "You do not have permission to use global search.",
   "search.dialog.errors.searchFailed": "Search failed.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Abrir búsqueda global",
   "search.dialog.actions.openSelected": "Abrir (Enter)",
   "search.dialog.actions.search": "Buscar",
-  "search.dialog.empty.hint": "Escribe al menos dos caracteres para buscar en los registros indexados.",
+  "search.dialog.empty.hint": "Escribe al menos tres caracteres para buscar en los registros indexados.",
   "search.dialog.empty.none": "No se encontraron resultados.",
   "search.dialog.errors.noPermission": "No tienes permiso para usar la búsqueda global.",
   "search.dialog.errors.searchFailed": "La búsqueda falló.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Otwórz globalne wyszukiwanie",
   "search.dialog.actions.openSelected": "Otwórz (Enter)",
   "search.dialog.actions.search": "Szukaj",
-  "search.dialog.empty.hint": "Wpisz co najmniej dwa znaki, aby przeszukać zindeksowane rekordy.",
+  "search.dialog.empty.hint": "Wpisz co najmniej trzy znaki, aby przeszukać zindeksowane rekordy.",
   "search.dialog.empty.none": "Brak wyników.",
   "search.dialog.errors.noPermission": "Nie masz uprawnień do korzystania z wyszukiwania globalnego.",
   "search.dialog.errors.searchFailed": "Wyszukiwanie nie powiodło się.",


### PR DESCRIPTION
## Summary

The global search hint in the Cmd+K dialog promised results at "two characters", but the indexed-search backend silently required three. With `OM_SEARCH_MIN_LEN=3` (the documented default in `apps/docs/docs/framework/database/hybrid-search.mdx`), `tokenizeText()` drops anything shorter, so 2-char queries produced zero hashes, the token strategy returned `[]`, and the user saw "No results found" — a direct contradiction of the hint. This PR aligns the user-facing surface (hint copy + frontend `MIN_QUERY_LENGTH`) with the documented 3-character backend threshold. Lowering the backend threshold to 2 was rejected because it would force a full reindex of `search_tokens` and roughly double the table size — the issue itself flags this as the higher-risk path.

## Changes

- Update `search.dialog.empty.hint` in `en.json`, `de.json`, `es.json`, `pl.json` to say three characters instead of two.
- Bump `MIN_QUERY_LENGTH` from 2 to 3 in `packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx` so 2-char input keeps showing the hint instead of firing a doomed request.
- Bump `MIN_QUERY_LENGTH` from 2 to 3 in `packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx` for consistency with the same backend threshold.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

- `yarn jest --testPathPatterns="packages/search/src" --testPathIgnorePatterns="\.ai/tmp"` — 87/87 tests passing. The two suite-level failures (`workers.test.ts`, `queue.test.ts`) are pre-existing duplicate-package errors caused by leftover code-review snapshots under `.ai/tmp/code-review-pr/` and are unrelated to this change.
- `node -e` parse check on all four updated locale JSON files — all parse cleanly and emit the new "three characters" copy.
- Started the Next.js dev server and confirmed the search package compiles with no errors after the edits.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #1732