### PR TITLE
ci(snapshot): capture standalone app log to surface server-side errors

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -333,7 +333,7 @@ jobs:
           OM_SECURITY_MFA_SETUP_SECRET: ci-standalone-test-mfa-setup-secret
           MOCK_CARRIER_WEBHOOK_SECRET: open-mercato-mock-dev-carrier-webhook-secret
         run: |
-          PORT=3001 yarn start &
+          PORT=3001 yarn start > /tmp/standalone-app.log 2>&1 &
           echo "Waiting for standalone app to be ready..."
           for i in $(seq 1 180); do
             if curl -sf http://localhost:3001/login > /dev/null 2>&1; then
@@ -343,6 +343,8 @@ jobs:
             sleep 1
           done
           echo "App failed to start within 180s"
+          echo "=== last 200 lines of /tmp/standalone-app.log ==="
+          tail -n 200 /tmp/standalone-app.log || true
           exit 1
 
       # --- Run integration tests ---
@@ -357,6 +359,12 @@ jobs:
           MOCK_CARRIER_WEBHOOK_SECRET: open-mercato-mock-dev-carrier-webhook-secret
         run: yarn test:integration
 
+      - name: Print standalone app log on test failure
+        if: failure()
+        run: |
+          echo "=== /tmp/standalone-app.log (last 1000 lines) ==="
+          tail -n 1000 /tmp/standalone-app.log || echo "(no log file)"
+
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -366,4 +374,12 @@ jobs:
             .ai/qa/test-results/html/
             .ai/qa/test-results/artifacts/
             .ai/qa/test-results/results.json
+          if-no-files-found: ignore
+
+      - name: Upload standalone app log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: standalone-app-log
+          path: /tmp/standalone-app.log
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Standalone integration tests on develop have been failing with 43 opaque 400 responses (TC-CHKT-* fixture creation, TC-INT-002/003 integrations endpoints) since around 2026-04-29 (#1756 / `8d7b1fef2`).
- The job currently starts the Next.js app with bare `&`, so stdout/stderr is discarded — there is no way to see the actual zod / interceptor error from CI logs.
- Redirect `yarn start` to `/tmp/standalone-app.log`, tail it inline on test-step failure, and upload it as a `standalone-app-log` artifact so the next failing run reveals the real cause.

## Why a separate PR
- Pure CI plumbing change. No test/source changes.
- Diagnostic step before deciding whether to revert the suspect commits (`07af3a6a9`, `8d7b1fef2`) or land a targeted fix.

## Test plan
- [ ] Snapshot CI runs against this branch.
- [ ] If standalone tests fail, the inline tail dumps the real server-side error and the `standalone-app-log` artifact contains the full trace.
- [ ] If standalone passes, the change is a no-op for green runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)