### PR TITLE
fix(zod): unblock standalone CI under zod 4.4.x + capture app log

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -333,7 +333,7 @@ jobs:
           OM_SECURITY_MFA_SETUP_SECRET: ci-standalone-test-mfa-setup-secret
           MOCK_CARRIER_WEBHOOK_SECRET: open-mercato-mock-dev-carrier-webhook-secret
         run: |
-          PORT=3001 yarn start &
+          PORT=3001 yarn start > /tmp/standalone-app.log 2>&1 &
           echo "Waiting for standalone app to be ready..."
           for i in $(seq 1 180); do
             if curl -sf http://localhost:3001/login > /dev/null 2>&1; then
@@ -343,6 +343,8 @@ jobs:
             sleep 1
           done
           echo "App failed to start within 180s"
+          echo "=== last 200 lines of /tmp/standalone-app.log ==="
+          tail -n 200 /tmp/standalone-app.log || true
           exit 1
 
       # --- Run integration tests ---
@@ -357,6 +359,12 @@ jobs:
           MOCK_CARRIER_WEBHOOK_SECRET: open-mercato-mock-dev-carrier-webhook-secret
         run: yarn test:integration
 
+      - name: Print standalone app log on test failure
+        if: failure()
+        run: |
+          echo "=== /tmp/standalone-app.log (last 1000 lines) ==="
+          tail -n 1000 /tmp/standalone-app.log || echo "(no log file)"
+
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -366,4 +374,12 @@ jobs:
             .ai/qa/test-results/html/
             .ai/qa/test-results/artifacts/
             .ai/qa/test-results/results.json
+          if-no-files-found: ignore
+
+      - name: Upload standalone app log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: standalone-app-log
+          path: /tmp/standalone-app.log
           if-no-files-found: ignore

--- a/packages/checkout/src/modules/checkout/data/validators.ts
+++ b/packages/checkout/src/modules/checkout/data/validators.ts
@@ -32,17 +32,17 @@ const currencyCodeSchema = z.string().trim().toUpperCase().regex(/^[A-Z]{3}$/, {
 const optionalTrimmedString = z.preprocess(
   normalizeBlankString,
   z.string().trim().min(1, { message: 'checkout.validation.common.required' }).optional().nullable(),
-)
+).optional()
 const optionalUrlSchema = z.preprocess(
   normalizeBlankString,
   z.string().url('checkout.validation.common.invalidUrl').optional().nullable(),
-)
+).optional()
 const optionalFieldsetCodeSchema = z.preprocess(
   normalizeBlankString,
   z.string().regex(fieldsetCodeRegex, {
     message: 'checkout.validation.common.invalidFieldsetCode',
   }).optional().nullable(),
-)
+).optional()
 const positiveMoneySchema = z.coerce.number().finite('checkout.validation.common.invalidNumber').nonnegative('checkout.validation.common.nonNegativeNumber')
 const linkStatusSchema = z.enum(CHECKOUT_LINK_STATUSES)
 

--- a/packages/core/src/modules/integrations/data/validators.ts
+++ b/packages/core/src/modules/integrations/data/validators.ts
@@ -45,7 +45,7 @@ const optionalBooleanQuery = z.preprocess((value) => {
   if (value === true || value === 'true' || value === '1') return true
   if (value === false || value === 'false' || value === '0') return false
   return value
-}, z.boolean().optional())
+}, z.boolean().optional()).optional()
 
 export const integrationMarketplaceHealthStatusSchema = z.enum(['healthy', 'degraded', 'unhealthy', 'unconfigured'])
 

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -133,7 +133,8 @@
   },
   "resolutions": {
     "lodash": "4.18.1",
-    "lodash-es": "4.18.1"
+    "lodash-es": "4.18.1",
+    "zod": "4.3.6"
   },
   "imports": {
     "#generated/entities.ids.generated": {


### PR DESCRIPTION
## Summary
- Standalone integration CI on develop has been failing with 43 opaque 400s (38 TC-CHKT-* + 5 TC-INT-*) since the morning of 2026-04-30. Diff between the last green and first red snapshot was test-file-only — no source change.
- Captured the standalone app's stdout/stderr (previously discarded by bare \`&\`) and discovered the real error: \`POST /api/checkout/links\` was rejecting valid payloads with zod \`Invalid input: expected nonoptional, received undefined\` for ten optional fields (\`logoUrl\`, \`customFieldsetCode\`, \`successTitle\`, etc.).
- Root cause: **zod 4.4.0** (released 2026-04-29 22:39 UTC) and **4.4.1** (23:13 UTC) changed how \`.optional()\` chained inside \`z.preprocess(fn, schema)\` participates in object-key optionality. The monorepo pins \`zod: 4.3.6\` via \`resolutions\`, so ephemeral CI stayed green; the standalone scaffold has no zod resolution, so \`yarn install\` started resolving to 4.4.1 within hours and the same schemas began rejecting valid input.

## Repro (locally confirmed)
\`\`\`
zod 4.3.6 → safeParse({}) → {success: true, data: {}}
zod 4.4.1 → safeParse({}) → ZodError: Invalid input: expected nonoptional, received undefined
\`\`\`

## Fix (two-pronged)
1. **Pin zod in scaffold resolutions** (\`packages/create-app/template/package.json.template\`) so fresh standalone apps mirror the monorepo lockfile semantics.
2. **Move \`.optional()\` to the outer wrapper** in the two validator files using the broken pattern, restoring identical behavior across all input cases under both 4.3.6 and 4.4.1:
   - \`packages/checkout/src/modules/checkout/data/validators.ts\` (3 schemas)
   - \`packages/core/src/modules/integrations/data/validators.ts\` (1 schema)

Plus a CI plumbing change to make the next regression diagnosable: \`yarn start\` now writes to \`/tmp/standalone-app.log\`, the test step tails it on failure, and it's uploaded as a \`standalone-app-log\` artifact.

## Test plan
- [ ] Snapshot CI runs against this branch — Standalone job goes green.
- [ ] If anything still fails, the \`standalone-app-log\` artifact contains the full server trace (this PR proved that mechanism works).
- [ ] Existing unit tests for the touched validators continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)