### PR TITLE
fix: CRM - fix 2 of newly reported issues in CRM (by Alina)

### DIFF
--- a/packages/core/src/modules/audit_logs/services/actionLogService.ts
+++ b/packages/core/src/modules/audit_logs/services/actionLogService.ts
@@ -15,7 +15,10 @@ import {
   deriveActionLogProjection,
 } from '@open-mercato/core/modules/audit_logs/lib/projections'
 import { decryptWithAesGcm } from '@open-mercato/shared/lib/encryption/aes'
-import { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
+import {
+  TenantDataEncryptionService,
+  parseDecryptedFieldValue,
+} from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { toOptionalString } from '@open-mercato/shared/lib/string/coerce'
 
 let validationWarningLogged = false
@@ -123,11 +126,7 @@ export class ActionLogService {
         if (typeof value === 'string' && value.split(':').length === 4 && value.endsWith(':v1')) {
           const decrypted = decryptWithAesGcm(value, dek.key)
           if (decrypted === null) return value
-          try {
-            return JSON.parse(decrypted)
-          } catch {
-            return decrypted
-          }
+          return parseDecryptedFieldValue(decrypted)
         }
         if (Array.isArray(value)) return value.map((item) => deepDecrypt(item))
         if (value && typeof value === 'object') {

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-049.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-049.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures'
+
+/**
+ * TC-CRM-049: Numeric / JSON-primitive display names round-trip as strings (issue #1734).
+ *
+ * Before the encryption layer fix, display names that happened to be valid JSON
+ * primitives (purely numeric like "123", "true", "null", "false") were
+ * round-tripped through the tenant-data encryption pipeline as their parsed
+ * type — `JSON.parse("123") === 123` (number) — which crashed the company
+ * (and person) detail page at `displayName.trim()`.
+ *
+ * This test exercises the full create → fetch → render path for a few
+ * adversarial display-name shapes and asserts that:
+ *   1. the API GET response keeps the value as a string,
+ *   2. the v2 detail page mounts without the runtime overlay, and
+ *   3. the rendered header shows the entered text.
+ */
+test.describe('TC-CRM-049: numeric and JSON-primitive display names render safely', () => {
+  const adversarialDisplayNames = ['123', 'true', 'null', 'false', '00042']
+
+  for (const displayName of adversarialDisplayNames) {
+    test(`company detail page renders for displayName "${displayName}"`, async ({ page, request }) => {
+      test.slow()
+
+      let token: string | null = null
+      let companyId: string | null = null
+
+      try {
+        token = await getAuthToken(request, 'admin')
+        companyId = await createCompanyFixture(
+          request,
+          token,
+          `${displayName}-QA-CRM049-${Date.now()}-co`,
+        )
+
+        // Update so the actual display_name in storage equals the adversarial value.
+        const updateResponse = await apiRequest(request, 'PUT', '/api/customers/companies', {
+          token,
+          data: { id: companyId, displayName },
+        })
+        expect(updateResponse.ok(), 'PUT companies should succeed for adversarial name').toBeTruthy()
+
+        const detailResponse = await apiRequest(request, 'GET', `/api/customers/companies/${companyId}`, {
+          token,
+        })
+        expect(detailResponse.ok(), 'GET company detail should succeed').toBeTruthy()
+        const detailJson = await detailResponse.json()
+        expect(typeof detailJson?.company?.displayName).toBe('string')
+        expect(detailJson?.company?.displayName).toBe(displayName)
+
+        await login(page, 'admin')
+        const consoleErrors: string[] = []
+        page.on('console', (msg) => {
+          if (msg.type() === 'error') consoleErrors.push(msg.text())
+        })
+        const pageErrors: string[] = []
+        page.on('pageerror', (err) => {
+          pageErrors.push(err.message)
+        })
+
+        await page.goto(`/backend/customers/companies-v2/${companyId}`, {
+          waitUntil: 'domcontentloaded',
+        })
+        // The Save button only renders once the detail loads successfully (no error overlay).
+        await expect(page.getByRole('button', { name: /save/i }).first()).toBeVisible({
+          timeout: 15_000,
+        })
+
+        // Header must show the literal adversarial text — nothing should have been coerced.
+        await expect(page.getByText(displayName, { exact: true }).first()).toBeVisible({
+          timeout: 5_000,
+        })
+
+        const trimErrors = [...consoleErrors, ...pageErrors].filter((line) =>
+          /displayName\.trim is not a function|displayName.*trim/.test(line),
+        )
+        expect(trimErrors, 'no displayName.trim() runtime errors').toEqual([])
+      } finally {
+        await deleteEntityIfExists(request, token, '/api/customers/companies', companyId)
+      }
+    })
+  }
+
+  test('person detail page renders for numeric displayName', async ({ page, request }) => {
+    test.slow()
+
+    let token: string | null = null
+    let personId: string | null = null
+    const stamp = Date.now()
+    const numericDisplayName = '777'
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      personId = await createPersonFixture(request, token, {
+        firstName: 'QA',
+        lastName: `TC049-${stamp}`,
+        displayName: `placeholder-${stamp}`,
+      })
+
+      const updateResponse = await apiRequest(request, 'PUT', '/api/customers/people', {
+        token,
+        data: { id: personId, displayName: numericDisplayName },
+      })
+      expect(updateResponse.ok(), 'PUT people should succeed').toBeTruthy()
+
+      const detailResponse = await apiRequest(request, 'GET', `/api/customers/people/${personId}`, {
+        token,
+      })
+      expect(detailResponse.ok()).toBeTruthy()
+      const detailJson = await detailResponse.json()
+      expect(typeof detailJson?.person?.displayName).toBe('string')
+      expect(detailJson?.person?.displayName).toBe(numericDisplayName)
+
+      await login(page, 'admin')
+      const pageErrors: string[] = []
+      page.on('pageerror', (err) => {
+        pageErrors.push(err.message)
+      })
+      await page.goto(`/backend/customers/people-v2/${personId}`, { waitUntil: 'domcontentloaded' })
+      await expect(page.getByRole('button', { name: /save/i }).first()).toBeVisible({
+        timeout: 15_000,
+      })
+      const trimErrors = pageErrors.filter((line) => /displayName\.trim/.test(line))
+      expect(trimErrors).toEqual([])
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-050.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-050.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createCompanyFixture,
+  deleteEntityIfExists,
+} from '@open-mercato/core/helpers/integration/crmFixtures'
+
+/**
+ * TC-CRM-050: Collapsed-rail section icons drive section navigation (issue #1731).
+ *
+ * On the company-v2 detail page, when the form panel is in its collapsed-rail
+ * state (viewport between 1024px and 1280px wide), the vertical icon strip
+ * representing form sections (Identity, Contact, Classification, …) MUST be
+ * fully interactive: clicking an icon expands the form panel, scrolls to the
+ * matching section, expands the inner CollapsibleGroup if it was previously
+ * collapsed, and focuses the first input of that section.
+ *
+ * This guards against regressions where icons appear interactive (cursor /
+ * tooltip) but produce no visible navigation — the original failure mode
+ * reported in #1731.
+ */
+test.describe('TC-CRM-050: Collapsed rail icons navigate to form sections', () => {
+  test('clicking a section icon expands the panel, opens the group, and focuses the first input', async ({
+    page,
+    request,
+  }) => {
+    test.slow()
+
+    let token: string | null = null
+    let companyId: string | null = null
+    const stamp = Date.now()
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      companyId = await createCompanyFixture(request, token, `QA TC-CRM-050 Co ${stamp}`)
+
+      await login(page, 'admin')
+
+      // 1024px ≤ width < 1280px → CollapsibleZoneLayout renders the collapsed rail.
+      await page.setViewportSize({ width: 1200, height: 900 })
+      await page.goto(`/backend/customers/companies-v2/${companyId}`, {
+        waitUntil: 'domcontentloaded',
+      })
+
+      // Wait for the layout container with its mode attribute.
+      const layout = page.locator('[data-zone-layout-mode]').first()
+      await expect(layout).toBeVisible({ timeout: 15_000 })
+      await expect(layout).toHaveAttribute('data-zone-layout-mode', 'collapsed')
+
+      // The Contact icon must exist in the rail and be a real button (not just a div).
+      const contactIcon = page.getByRole('button', { name: 'Contact' })
+      await expect(contactIcon).toBeVisible()
+
+      await contactIcon.click()
+
+      // After click: the layout expands (stacked) and the Contact group is open.
+      await expect(layout).toHaveAttribute('data-zone-layout-mode', 'stacked', { timeout: 5_000 })
+      const contactWrapper = page.locator('#collapsible-group-wrapper-contact').first()
+      await expect(contactWrapper).toBeVisible()
+      await expect(
+        contactWrapper.locator('button[aria-controls]').first(),
+      ).toHaveAttribute('aria-expanded', 'true')
+
+      // The first input of the Contact group is reachable now that the panel
+      // and inner group are both expanded. We assert visibility (not focus) —
+      // headless browsers can drop programmatic focus across React re-renders;
+      // the precise focus landing is covered by the unit test in
+      // packages/ui/src/backend/__tests__/CollapsibleZoneLayout.test.tsx.
+      await expect(
+        contactWrapper.locator('input:not([type="hidden"])').first(),
+      ).toBeVisible({ timeout: 5_000 })
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
@@ -25,6 +25,7 @@ import { ActivityLogTab } from '../../../../components/detail/ActivityLogTab'
 import { CompanyPeopleSection, type CompanyPersonSummary } from '../../../../components/detail/CompanyPeopleSection'
 import type { TagSummary } from '../../../../components/detail/types'
 import type { TagsSectionController } from '@open-mercato/ui/backend/detail'
+import { coerceDisplayName } from '../../../../lib/displayName'
 import { CompanyDetailHeader } from '../../../../components/detail/CompanyDetailHeader'
 import { CompanyDetailTabs, resolveLegacyTab, type CompanyTabId } from '../../../../components/detail/CompanyDetailTabs'
 import { CompanyKpiBar } from '../../../../components/detail/CompanyKpiBar'
@@ -103,13 +104,7 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
     blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
   })
 
-  const rawCompanyDisplayName = data?.company?.displayName
-  const companyDisplayName =
-    typeof rawCompanyDisplayName === 'string'
-      ? rawCompanyDisplayName
-      : rawCompanyDisplayName == null
-        ? ''
-        : String(rawCompanyDisplayName)
+  const companyDisplayName = coerceDisplayName(data?.company?.displayName)
   const companyName = companyDisplayName.trim().length
     ? companyDisplayName
     : t('customers.companies.list.deleteFallbackName', 'this company')

--- a/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
@@ -103,10 +103,16 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
     blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
   })
 
-  const companyName =
-    data?.company?.displayName && data.company.displayName.trim().length
-      ? data.company.displayName
-      : t('customers.companies.list.deleteFallbackName', 'this company')
+  const rawCompanyDisplayName = data?.company?.displayName
+  const companyDisplayName =
+    typeof rawCompanyDisplayName === 'string'
+      ? rawCompanyDisplayName
+      : rawCompanyDisplayName == null
+        ? ''
+        : String(rawCompanyDisplayName)
+  const companyName = companyDisplayName.trim().length
+    ? companyDisplayName
+    : t('customers.companies.list.deleteFallbackName', 'this company')
 
   // Data loading
   const initialLoadDoneRef = React.useRef(false)
@@ -425,7 +431,7 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
                 {activeTab === 'people' && (
                   <CompanyPeopleSection
                     companyId={companyId}
-                    companyName={data.company?.displayName ?? ''}
+                    companyName={companyDisplayName}
                     initialPeople={[]}
                     addActionLabel={t('customers.companies.detail.people.add', 'Add person')}
                     emptyLabel={t('customers.companies.detail.people.empty', 'No people linked to this company yet.')}

--- a/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
@@ -117,10 +117,16 @@ export default function CustomerCompanyDetailPage({ params }: { params?: { id?: 
   const [sectionAction, setSectionAction] = React.useState<SectionAction | null>(null)
   const [isDeleting, setIsDeleting] = React.useState(false)
   const currentCompanyId = data?.company?.id ?? null
-  const companyName =
-    data?.company?.displayName && data.company.displayName.trim().length
-      ? data.company.displayName
-      : t('customers.companies.list.deleteFallbackName', 'this company')
+  const rawCompanyDisplayName = data?.company?.displayName
+  const companyDisplayName =
+    typeof rawCompanyDisplayName === 'string'
+      ? rawCompanyDisplayName
+      : rawCompanyDisplayName == null
+        ? ''
+        : String(rawCompanyDisplayName)
+  const companyName = companyDisplayName.trim().length
+    ? companyDisplayName
+    : t('customers.companies.list.deleteFallbackName', 'this company')
   const translateCompanyDetail = React.useCallback(
     (key: string, fallback?: string, params?: Record<string, string | number>) => {
       const mappedKey = key.startsWith('customers.people.detail.')

--- a/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies/[id]/page.tsx
@@ -35,6 +35,7 @@ import { CompanyHighlights } from '../../../../components/detail/CompanyHighligh
 import { normalizeCustomFieldSubmitValue } from '../../../../components/detail/customFieldUtils'
 import { InlineDictionaryEditor, renderMultilineMarkdownDisplay } from '../../../../components/detail/InlineEditors'
 import { formatTemplate } from '../../../../components/detail/utils'
+import { coerceDisplayName } from '../../../../lib/displayName'
 import { createTranslatorWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import {
   CompanyPeopleSection,
@@ -117,13 +118,7 @@ export default function CustomerCompanyDetailPage({ params }: { params?: { id?: 
   const [sectionAction, setSectionAction] = React.useState<SectionAction | null>(null)
   const [isDeleting, setIsDeleting] = React.useState(false)
   const currentCompanyId = data?.company?.id ?? null
-  const rawCompanyDisplayName = data?.company?.displayName
-  const companyDisplayName =
-    typeof rawCompanyDisplayName === 'string'
-      ? rawCompanyDisplayName
-      : rawCompanyDisplayName == null
-        ? ''
-        : String(rawCompanyDisplayName)
+  const companyDisplayName = coerceDisplayName(data?.company?.displayName)
   const companyName = companyDisplayName.trim().length
     ? companyDisplayName
     : t('customers.companies.list.deleteFallbackName', 'this company')

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
@@ -95,15 +95,20 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
     contextId: mutationContextId,
     blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
   })
-  const personName =
-    data?.person?.displayName && data.person.displayName.trim().length
-      ? data.person.displayName
-      : t('customers.people.list.deleteFallbackName', 'this person')
+  const rawPersonDisplayName = data?.person?.displayName
+  const personDisplayName =
+    typeof rawPersonDisplayName === 'string'
+      ? rawPersonDisplayName
+      : rawPersonDisplayName == null
+        ? ''
+        : String(rawPersonDisplayName)
+  const personName = personDisplayName.trim().length
+    ? personDisplayName
+    : t('customers.people.list.deleteFallbackName', 'this person')
 
-  const personDisplayNameForGroups =
-    typeof data?.person?.displayName === 'string' && data.person.displayName.trim().length
-      ? data.person.displayName.trim()
-      : null
+  const personDisplayNameForGroups = personDisplayName.trim().length
+    ? personDisplayName.trim()
+    : null
 
   const groups = React.useMemo(
     () => createPersonPersonalDataGroups(t, { entityName: personDisplayNameForGroups }),
@@ -579,7 +584,13 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
             onClose={() => { setScheduleDialogOpen(false); setScheduleEditData(null) }}
             entityId={personId}
             entityName={personName}
-            companyName={data.company?.displayName ?? data.companies?.[0]?.displayName ?? null}
+            companyName={
+              (() => {
+                const candidate = data.company?.displayName ?? data.companies?.[0]?.displayName ?? null
+                if (candidate == null) return null
+                return typeof candidate === 'string' ? candidate : String(candidate)
+              })()
+            }
             entityType="person"
             onActivityCreated={handleActivityCreated}
             editData={scheduleEditData}

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
@@ -45,6 +45,7 @@ import {
   type PersonEditFormValues,
   type PersonOverview,
 } from '../../../../components/formConfig'
+import { coerceDisplayName, coerceDisplayNameOrNull } from '../../../../lib/displayName'
 
 export default function PersonDetailV2Page({ params }: { params?: { id?: string } }) {
   const id = params?.id
@@ -95,13 +96,7 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
     contextId: mutationContextId,
     blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
   })
-  const rawPersonDisplayName = data?.person?.displayName
-  const personDisplayName =
-    typeof rawPersonDisplayName === 'string'
-      ? rawPersonDisplayName
-      : rawPersonDisplayName == null
-        ? ''
-        : String(rawPersonDisplayName)
+  const personDisplayName = coerceDisplayName(data?.person?.displayName)
   const personName = personDisplayName.trim().length
     ? personDisplayName
     : t('customers.people.list.deleteFallbackName', 'this person')
@@ -109,6 +104,10 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
   const personDisplayNameForGroups = personDisplayName.trim().length
     ? personDisplayName.trim()
     : null
+
+  const scheduleDialogCompanyName = coerceDisplayNameOrNull(
+    data?.company?.displayName ?? data?.companies?.[0]?.displayName ?? null,
+  )
 
   const groups = React.useMemo(
     () => createPersonPersonalDataGroups(t, { entityName: personDisplayNameForGroups }),
@@ -584,13 +583,7 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
             onClose={() => { setScheduleDialogOpen(false); setScheduleEditData(null) }}
             entityId={personId}
             entityName={personName}
-            companyName={
-              (() => {
-                const candidate = data.company?.displayName ?? data.companies?.[0]?.displayName ?? null
-                if (candidate == null) return null
-                return typeof candidate === 'string' ? candidate : String(candidate)
-              })()
-            }
+            companyName={scheduleDialogCompanyName}
             entityType="person"
             onActivityCreated={handleActivityCreated}
             editData={scheduleEditData}

--- a/packages/core/src/modules/customers/components/detail/CompanyPeopleSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/CompanyPeopleSection.tsx
@@ -17,6 +17,7 @@ import { useAppEvent } from '@open-mercato/ui/backend/injection/useAppEvent'
 import type { SectionAction, TabEmptyStateConfig, Translator } from './types'
 import { CreatePersonDialog } from './CreatePersonDialog'
 import { PersonCard } from './PersonCard'
+import { coerceDisplayName } from '../../lib/displayName'
 import { DecisionMakersFooter } from './DecisionMakersFooter'
 import { RolesSection } from './RolesSection'
 import { LinkEntityDialog, type LinkEntityOption } from '../linking/LinkEntityDialog'
@@ -165,12 +166,8 @@ function sortCompanyPeople(
       const rightTimestamp = Date.parse(right.linkedAt ?? right.createdAt ?? '') || 0
       return rightTimestamp - leftTimestamp
     }
-    const leftLabel = (typeof left.displayName === 'string' ? left.displayName : String(left.displayName ?? ''))
-      .trim()
-      .toLowerCase()
-    const rightLabel = (typeof right.displayName === 'string' ? right.displayName : String(right.displayName ?? ''))
-      .trim()
-      .toLowerCase()
+    const leftLabel = coerceDisplayName(left.displayName).trim().toLowerCase()
+    const rightLabel = coerceDisplayName(right.displayName).trim().toLowerCase()
     if (sortMode === 'name-desc') return rightLabel.localeCompare(leftLabel)
     return leftLabel.localeCompare(rightLabel)
   })

--- a/packages/core/src/modules/customers/components/detail/CompanyPeopleSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/CompanyPeopleSection.tsx
@@ -165,8 +165,12 @@ function sortCompanyPeople(
       const rightTimestamp = Date.parse(right.linkedAt ?? right.createdAt ?? '') || 0
       return rightTimestamp - leftTimestamp
     }
-    const leftLabel = left.displayName.trim().toLowerCase()
-    const rightLabel = right.displayName.trim().toLowerCase()
+    const leftLabel = (typeof left.displayName === 'string' ? left.displayName : String(left.displayName ?? ''))
+      .trim()
+      .toLowerCase()
+    const rightLabel = (typeof right.displayName === 'string' ? right.displayName : String(right.displayName ?? ''))
+      .trim()
+      .toLowerCase()
     if (sortMode === 'name-desc') return rightLabel.localeCompare(leftLabel)
     return leftLabel.localeCompare(rightLabel)
   })

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -1942,9 +1942,16 @@ export type PersonOverview = {
 export function mapCompanyOverviewToFormValues(overview: CompanyOverview): Partial<CompanyEditFormValues> {
   const rawPhone = overview.company.primaryPhone
   const phoneValue = rawPhone == null ? '' : String(rawPhone)
+  const rawDisplayName = overview.company.displayName as unknown
+  const displayNameValue =
+    typeof rawDisplayName === 'string'
+      ? rawDisplayName
+      : rawDisplayName == null
+        ? ''
+        : String(rawDisplayName)
   return {
     id: overview.company.id,
-    displayName: overview.company.displayName,
+    displayName: displayNameValue,
     primaryEmail: overview.company.primaryEmail ?? '',
     primaryPhone: phoneValue,
     status: overview.company.status ?? '',
@@ -1965,9 +1972,16 @@ export function mapCompanyOverviewToFormValues(overview: CompanyOverview): Parti
 export function mapPersonOverviewToFormValues(overview: PersonOverview): Partial<PersonEditFormValues> {
   const rawPhone = overview.person.primaryPhone
   const phoneValue = rawPhone == null ? '' : String(rawPhone)
+  const rawDisplayName = overview.person.displayName as unknown
+  const displayNameValue =
+    typeof rawDisplayName === 'string'
+      ? rawDisplayName
+      : rawDisplayName == null
+        ? ''
+        : String(rawDisplayName)
   return {
     id: overview.person.id,
-    displayName: overview.person.displayName,
+    displayName: displayNameValue,
     firstName: overview.profile?.firstName ?? '',
     lastName: overview.profile?.lastName ?? '',
     primaryEmail: overview.person.primaryEmail ?? '',

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -7,7 +7,7 @@ import { Check, Pencil, Plus, Settings } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { Button } from '@open-mercato/ui/primitives/button'
-import { deriveDisplayName, isDerivedDisplayName } from '../lib/displayName'
+import { coerceDisplayName, deriveDisplayName, isDerivedDisplayName } from '../lib/displayName'
 import {
   Dialog,
   DialogContent,
@@ -1942,16 +1942,9 @@ export type PersonOverview = {
 export function mapCompanyOverviewToFormValues(overview: CompanyOverview): Partial<CompanyEditFormValues> {
   const rawPhone = overview.company.primaryPhone
   const phoneValue = rawPhone == null ? '' : String(rawPhone)
-  const rawDisplayName = overview.company.displayName as unknown
-  const displayNameValue =
-    typeof rawDisplayName === 'string'
-      ? rawDisplayName
-      : rawDisplayName == null
-        ? ''
-        : String(rawDisplayName)
   return {
     id: overview.company.id,
-    displayName: displayNameValue,
+    displayName: coerceDisplayName(overview.company.displayName),
     primaryEmail: overview.company.primaryEmail ?? '',
     primaryPhone: phoneValue,
     status: overview.company.status ?? '',
@@ -1972,16 +1965,9 @@ export function mapCompanyOverviewToFormValues(overview: CompanyOverview): Parti
 export function mapPersonOverviewToFormValues(overview: PersonOverview): Partial<PersonEditFormValues> {
   const rawPhone = overview.person.primaryPhone
   const phoneValue = rawPhone == null ? '' : String(rawPhone)
-  const rawDisplayName = overview.person.displayName as unknown
-  const displayNameValue =
-    typeof rawDisplayName === 'string'
-      ? rawDisplayName
-      : rawDisplayName == null
-        ? ''
-        : String(rawDisplayName)
   return {
     id: overview.person.id,
-    displayName: displayNameValue,
+    displayName: coerceDisplayName(overview.person.displayName),
     firstName: overview.profile?.firstName ?? '',
     lastName: overview.profile?.lastName ?? '',
     primaryEmail: overview.person.primaryEmail ?? '',

--- a/packages/core/src/modules/customers/lib/__tests__/displayName.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/displayName.test.ts
@@ -1,9 +1,51 @@
 /** @jest-environment node */
 import {
+  coerceDisplayName,
+  coerceDisplayNameOrNull,
   deriveDisplayName,
   deriveDisplayNameFromEmail,
   isDerivedDisplayName,
 } from '../displayName'
+
+describe('coerceDisplayName', () => {
+  it('returns the original string when input is already a string', () => {
+    expect(coerceDisplayName('Acme Corp')).toBe('Acme Corp')
+    expect(coerceDisplayName('123')).toBe('123')
+    expect(coerceDisplayName('')).toBe('')
+  })
+
+  it('returns empty string for null and undefined', () => {
+    expect(coerceDisplayName(null)).toBe('')
+    expect(coerceDisplayName(undefined)).toBe('')
+  })
+
+  it('coerces non-string primitives to strings (issue #1734 belt-and-suspenders)', () => {
+    expect(coerceDisplayName(123)).toBe('123')
+    expect(coerceDisplayName(0)).toBe('0')
+    expect(coerceDisplayName(true)).toBe('true')
+    expect(coerceDisplayName(false)).toBe('false')
+  })
+
+  it('coerces objects via String() (defensive — should not happen in practice)', () => {
+    expect(coerceDisplayName({ toString: () => 'custom' })).toBe('custom')
+  })
+})
+
+describe('coerceDisplayNameOrNull', () => {
+  it('returns null for null/undefined', () => {
+    expect(coerceDisplayNameOrNull(null)).toBeNull()
+    expect(coerceDisplayNameOrNull(undefined)).toBeNull()
+  })
+
+  it('returns the original string when input is a string (including empty)', () => {
+    expect(coerceDisplayNameOrNull('Acme')).toBe('Acme')
+    expect(coerceDisplayNameOrNull('')).toBe('')
+  })
+
+  it('coerces numeric values to strings', () => {
+    expect(coerceDisplayNameOrNull(42)).toBe('42')
+  })
+})
 
 describe('deriveDisplayName', () => {
   it('joins first and last name with a single space', () => {

--- a/packages/core/src/modules/customers/lib/displayName.ts
+++ b/packages/core/src/modules/customers/lib/displayName.ts
@@ -1,3 +1,24 @@
+/**
+ * Coerce an arbitrary `displayName` payload to a string for safe UI consumption.
+ *
+ * The encryption pipeline used to coerce numeric-looking string display names
+ * back into numbers (issue #1734). The root cause is fixed in
+ * `parseDecryptedFieldValue`, but this helper remains as belt-and-suspenders
+ * for any persisted data that was already corrupted on read paths that bypass
+ * the new heuristic.
+ */
+export function coerceDisplayName(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (value == null) return ''
+  return String(value)
+}
+
+export function coerceDisplayNameOrNull(value: unknown): string | null {
+  if (value == null) return null
+  if (typeof value === 'string') return value
+  return String(value)
+}
+
 export function deriveDisplayName(
   firstName: string | null | undefined,
   lastName: string | null | undefined,

--- a/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
+++ b/packages/core/src/modules/entities/__tests__/cli-rotate-encryption.test.ts
@@ -39,6 +39,12 @@ jest.mock('@open-mercato/shared/lib/encryption/tenantDataEncryptionService', () 
       return next
     }),
   })),
+  parseDecryptedFieldValue: (decrypted: string) => {
+    if (decrypted.length === 0) return decrypted
+    const first = decrypted[0]
+    if (first !== '{' && first !== '[') return decrypted
+    try { return JSON.parse(decrypted) } catch { return decrypted }
+  },
 }))
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({

--- a/packages/core/src/modules/entities/cli.ts
+++ b/packages/core/src/modules/entities/cli.ts
@@ -17,7 +17,10 @@ import {
   TenantDataEncryptionError,
   TenantDataEncryptionErrorCode,
 } from '@open-mercato/shared/lib/encryption/aes'
-import { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
+import {
+  TenantDataEncryptionService,
+  parseDecryptedFieldValue,
+} from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
 import { resolveEntityIdFromMetadata } from '@open-mercato/shared/lib/encryption/entityIds'
 import { Organization } from '../directory/data/entities'
 import crypto from 'node:crypto'
@@ -563,11 +566,7 @@ const rotateEncryptionKey: ModuleCli = {
             if (typeof value !== 'string' || !isEncryptedPayload(value)) continue
             const decrypted = decryptWithOldKey(value, oldDek)
             if (decrypted === null) continue
-            try {
-              payload[rule.field] = JSON.parse(decrypted)
-            } catch {
-              payload[rule.field] = decrypted
-            }
+            payload[rule.field] = parseDecryptedFieldValue(decrypted)
           }
         }
         const encrypted = await encryptionService.encryptEntityPayload(

--- a/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
@@ -145,9 +145,10 @@ describe('extractAllCustomFieldEntries', () => {
 })
 
 describe('loadCustomFieldValues (encryption)', () => {
-  it('decrypts encrypted custom field payloads when definitions mark them encrypted', async () => {
+  it('decrypts encrypted text custom field payloads as strings', async () => {
     const dek = Buffer.alloc(32, 2).toString('base64')
-    const encrypted = encryptWithAesGcm(JSON.stringify('secret-note'), dek).value
+    // Mirrors production encrypt path: strings stored unwrapped, non-strings JSON-stringified.
+    const encrypted = encryptWithAesGcm('secret-note', dek).value
     const em = {
       find: jest.fn().mockImplementation((_, where) => {
         if ((where as any).recordId) {
@@ -169,6 +170,60 @@ describe('loadCustomFieldValues (encryption)', () => {
       encryptionService: mockService as any,
     })
     expect(values['rec-1'].cf_note).toBe('secret-note')
+  })
+
+  it('preserves numeric-looking text values as strings (regression: issue #1734)', async () => {
+    const dek = Buffer.alloc(32, 2).toString('base64')
+    const encrypted = encryptWithAesGcm('123', dek).value
+    const em = {
+      find: jest.fn().mockImplementation((_, where) => {
+        if ((where as any).recordId) {
+          return Promise.resolve([
+            { recordId: 'rec-1', fieldKey: 'note', organizationId: null, tenantId: 'tenant-1', valueText: encrypted, valueMultiline: null, valueInt: null, valueFloat: null, valueBool: null, deletedAt: null },
+          ])
+        }
+        return Promise.resolve([
+          { key: 'note', entityId: 'demo:entity', organizationId: null, tenantId: 'tenant-1', kind: 'text', configJson: { encrypted: true }, isActive: true },
+        ])
+      }),
+    }
+    const mockService = { isEnabled: () => true, getDek: async () => ({ key: dek }) }
+    const values = await loadCustomFieldValues({
+      em: em as any,
+      entityId: 'demo:entity',
+      recordIds: ['rec-1'],
+      tenantIdByRecord: { 'rec-1': 'tenant-1' },
+      encryptionService: mockService as any,
+    })
+    expect(values['rec-1'].cf_note).toBe('123')
+    expect(typeof values['rec-1'].cf_note).toBe('string')
+  })
+
+  it('still parses typed integer custom field payloads back to numbers', async () => {
+    const dek = Buffer.alloc(32, 2).toString('base64')
+    // Numeric kinds are JSON-stringified by encryptCustomFieldValue in production.
+    const encrypted = encryptWithAesGcm(JSON.stringify(42), dek).value
+    const em = {
+      find: jest.fn().mockImplementation((_, where) => {
+        if ((where as any).recordId) {
+          return Promise.resolve([
+            { recordId: 'rec-1', fieldKey: 'priority', organizationId: null, tenantId: 'tenant-1', valueText: encrypted, valueMultiline: null, valueInt: null, valueFloat: null, valueBool: null, deletedAt: null },
+          ])
+        }
+        return Promise.resolve([
+          { key: 'priority', entityId: 'demo:entity', organizationId: null, tenantId: 'tenant-1', kind: 'integer', configJson: { encrypted: true }, isActive: true },
+        ])
+      }),
+    }
+    const mockService = { isEnabled: () => true, getDek: async () => ({ key: dek }) }
+    const values = await loadCustomFieldValues({
+      em: em as any,
+      entityId: 'demo:entity',
+      recordIds: ['rec-1'],
+      tenantIdByRecord: { 'rec-1': 'tenant-1' },
+      encryptionService: mockService as any,
+    })
+    expect(values['rec-1'].cf_priority).toBe(42)
   })
 })
 

--- a/packages/shared/src/lib/crud/custom-fields.ts
+++ b/packages/shared/src/lib/crud/custom-fields.ts
@@ -582,7 +582,13 @@ export async function loadCustomFieldValues(opts: {
     const encrypted = Boolean(def?.configJson && (def as any).configJson?.encrypted)
     const value = valueFromRow(row)
     const decrypted = encrypted
-      ? await decryptCustomFieldValue(value, resolvedTenantId ?? tenantId ?? null, getEncryptionService(), encryptionCache)
+      ? await decryptCustomFieldValue(
+          value,
+          resolvedTenantId ?? tenantId ?? null,
+          getEncryptionService(),
+          encryptionCache,
+          { kind: def?.kind ?? null },
+        )
       : value
     const existing = buckets.get(bucketKey)
     if (existing) {

--- a/packages/shared/src/lib/encryption/__tests__/customFieldValues.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/customFieldValues.test.ts
@@ -60,4 +60,41 @@ describe('customFieldValues encryption helpers', () => {
     expect(await decryptCustomFieldValue('plain', 'tenant-1', disabledService)).toBe('plain')
     expect(await encryptCustomFieldValue('plain', null, disabledService)).toBe('plain')
   })
+
+  it('preserves text-typed values verbatim when kind is provided (regression: issue #1734)', async () => {
+    const service = {
+      isEnabled: () => true,
+      getDek: async () => ({ key: fixedKey }),
+    } as any
+    const cache = new Map<string | null, string | null>()
+
+    const numericText = await encryptCustomFieldValue('123', 'tenant-1', service, cache)
+    const decryptedAsText = await decryptCustomFieldValue(numericText, 'tenant-1', service, cache, { kind: 'text' })
+    expect(decryptedAsText).toBe('123')
+    expect(typeof decryptedAsText).toBe('string')
+
+    const booleanText = await encryptCustomFieldValue('true', 'tenant-1', service, cache)
+    expect(await decryptCustomFieldValue(booleanText, 'tenant-1', service, cache, { kind: 'multiline' })).toBe('true')
+    expect(await decryptCustomFieldValue(booleanText, 'tenant-1', service, cache, { kind: 'select' })).toBe('true')
+    expect(await decryptCustomFieldValue(booleanText, 'tenant-1', service, cache, { kind: 'currency' })).toBe('true')
+    expect(await decryptCustomFieldValue(booleanText, 'tenant-1', service, cache, { kind: 'dictionary' })).toBe('true')
+    expect(await decryptCustomFieldValue(booleanText, 'tenant-1', service, cache, { kind: 'email' })).toBe('true')
+  })
+
+  it('still parses typed kinds (integer/float/boolean) so legacy round-trip stays correct', async () => {
+    const service = {
+      isEnabled: () => true,
+      getDek: async () => ({ key: fixedKey }),
+    } as any
+    const cache = new Map<string | null, string | null>()
+
+    const encryptedInt = await encryptCustomFieldValue(42, 'tenant-1', service, cache)
+    expect(await decryptCustomFieldValue(encryptedInt, 'tenant-1', service, cache, { kind: 'integer' })).toBe(42)
+
+    const encryptedFloat = await encryptCustomFieldValue(3.14, 'tenant-1', service, cache)
+    expect(await decryptCustomFieldValue(encryptedFloat, 'tenant-1', service, cache, { kind: 'float' })).toBe(3.14)
+
+    const encryptedBool = await encryptCustomFieldValue(true, 'tenant-1', service, cache)
+    expect(await decryptCustomFieldValue(encryptedBool, 'tenant-1', service, cache, { kind: 'boolean' })).toBe(true)
+  })
 })

--- a/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
@@ -1,0 +1,109 @@
+import { encryptWithAesGcm } from '../aes'
+import {
+  TenantDataEncryptionService,
+  parseDecryptedFieldValue,
+} from '../tenantDataEncryptionService'
+
+const fixedKey = Buffer.alloc(32, 1).toString('base64')
+
+describe('parseDecryptedFieldValue', () => {
+  it('keeps purely-numeric strings as strings (regression: issue #1734)', () => {
+    expect(parseDecryptedFieldValue('123')).toBe('123')
+    expect(parseDecryptedFieldValue('00042')).toBe('00042')
+    expect(parseDecryptedFieldValue('-9.5')).toBe('-9.5')
+  })
+
+  it('keeps boolean-like and null-like text as strings', () => {
+    expect(parseDecryptedFieldValue('true')).toBe('true')
+    expect(parseDecryptedFieldValue('false')).toBe('false')
+    expect(parseDecryptedFieldValue('null')).toBe('null')
+  })
+
+  it('keeps ordinary text untouched', () => {
+    expect(parseDecryptedFieldValue('Acme Corp')).toBe('Acme Corp')
+    expect(parseDecryptedFieldValue('')).toBe('')
+  })
+
+  it('parses JSON objects and arrays back to structured values', () => {
+    expect(parseDecryptedFieldValue('{"a":1,"b":"x"}')).toEqual({ a: 1, b: 'x' })
+    expect(parseDecryptedFieldValue('[1,2,3]')).toEqual([1, 2, 3])
+    expect(parseDecryptedFieldValue('[]')).toEqual([])
+  })
+
+  it('returns the raw text when the JSON-looking payload fails to parse', () => {
+    expect(parseDecryptedFieldValue('{not json')).toBe('{not json')
+    expect(parseDecryptedFieldValue('[broken')).toBe('[broken')
+  })
+})
+
+describe('TenantDataEncryptionService.decryptFields (issue #1734)', () => {
+  function makeService() {
+    type Anything = Record<string, unknown>
+    const service = new TenantDataEncryptionService({} as never) as unknown as {
+      decryptFields: (
+        obj: Anything,
+        fields: { field: string }[],
+        dek: { key: string },
+      ) => Anything
+    }
+    return service
+  }
+
+  function encrypt(value: string): string {
+    return encryptWithAesGcm(value, fixedKey).value as string
+  }
+
+  it('preserves a numeric-string display name through encrypt/decrypt round-trip', () => {
+    const service = makeService()
+    const obj = { display_name: encrypt('123') }
+    const out = service.decryptFields(obj, [{ field: 'display_name' }], { key: fixedKey } as never)
+    expect(out.display_name).toBe('123')
+    expect(typeof out.display_name).toBe('string')
+  })
+
+  it('preserves arbitrary text values through encrypt/decrypt round-trip', () => {
+    const service = makeService()
+    const obj = {
+      display_name: encrypt('Acme Corp'),
+      primary_email: encrypt('mail@example.com'),
+    }
+    const out = service.decryptFields(
+      obj,
+      [{ field: 'display_name' }, { field: 'primary_email' }],
+      { key: fixedKey } as never,
+    )
+    expect(out.display_name).toBe('Acme Corp')
+    expect(out.primary_email).toBe('mail@example.com')
+  })
+
+  it('still recovers JSON object payloads (audit_logs use case)', () => {
+    const service = makeService()
+    const payload = { actor: 'user-1', changes: { name: 'old → new' } }
+    const obj = { context_json: encrypt(JSON.stringify(payload)) }
+    const out = service.decryptFields(obj, [{ field: 'context_json' }], { key: fixedKey } as never)
+    expect(out.context_json).toEqual(payload)
+  })
+
+  it('still recovers JSON array payloads', () => {
+    const service = makeService()
+    const arr = [{ id: 1 }, { id: 2 }]
+    const obj = { thread_messages: encrypt(JSON.stringify(arr)) }
+    const out = service.decryptFields(obj, [{ field: 'thread_messages' }], { key: fixedKey } as never)
+    expect(out.thread_messages).toEqual(arr)
+  })
+
+  it('keeps boolean-like and null-like text strings as strings', () => {
+    const service = makeService()
+    const obj = {
+      display_name: encrypt('true'),
+      description: encrypt('null'),
+    }
+    const out = service.decryptFields(
+      obj,
+      [{ field: 'display_name' }, { field: 'description' }],
+      { key: fixedKey } as never,
+    )
+    expect(out.display_name).toBe('true')
+    expect(out.description).toBe('null')
+  })
+})

--- a/packages/shared/src/lib/encryption/customFieldValues.ts
+++ b/packages/shared/src/lib/encryption/customFieldValues.ts
@@ -2,6 +2,39 @@ import type { EntityManager } from '@mikro-orm/core'
 import { encryptWithAesGcm, decryptWithAesGcm } from './aes'
 import { TenantDataEncryptionService } from './tenantDataEncryptionService'
 
+/**
+ * Custom field kinds that ALWAYS round-trip as a string. The encrypt path
+ * stores raw strings unwrapped, so blindly running `JSON.parse` on the
+ * decrypted payload coerces text values like `"123"` or `"true"` back into
+ * numbers/booleans (issue #1734). For these kinds, callers MUST pass the
+ * `kind` option so we keep the decrypted value as a string.
+ *
+ * Numeric (`integer`/`float`) and `boolean` kinds rely on JSON round-trip
+ * because the encrypt path JSON-stringifies the typed value before storage.
+ * Omitting the kind preserves legacy round-trip behavior for backward
+ * compatibility.
+ */
+const STRING_TYPED_CUSTOM_FIELD_KINDS = new Set([
+  'text',
+  'multiline',
+  'select',
+  'currency',
+  'dictionary',
+  'email',
+  'url',
+  'string',
+])
+
+export type DecryptCustomFieldOptions = {
+  /** Field kind, e.g. from `CustomFieldDef.kind`. When string-typed, the helper preserves the decrypted string verbatim. */
+  kind?: string | null
+}
+
+function shouldPreserveAsString(kind: string | null | undefined): boolean {
+  if (!kind) return false
+  return STRING_TYPED_CUSTOM_FIELD_KINDS.has(kind)
+}
+
 const serviceCache = new WeakMap<EntityManager, TenantDataEncryptionService>()
 
 export function resolveTenantEncryptionService(
@@ -53,12 +86,14 @@ export async function decryptCustomFieldValue(
   tenantId: string | null | undefined,
   service: TenantDataEncryptionService | null,
   cache?: Map<string | null, string | null>,
+  options?: DecryptCustomFieldOptions,
 ): Promise<unknown> {
   if (value === undefined || value === null || typeof value !== 'string') return value
   const key = await resolveDekKey(service, tenantId, cache)
   if (!key) return value
   const decrypted = decryptWithAesGcm(value, key)
   if (decrypted === null) return value
+  if (shouldPreserveAsString(options?.kind ?? null)) return decrypted
   try {
     return JSON.parse(decrypted)
   } catch {

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -56,6 +56,29 @@ function findKey(obj: Record<string, unknown>, key: string): string | null {
   return null
 }
 
+/**
+ * Decode a decrypted entity-field payload back into its original value.
+ *
+ * The encrypt path stores raw strings unwrapped and JSON-stringifies non-string
+ * values. Blindly running `JSON.parse` on every decrypted value would coerce
+ * text columns whose contents happen to be valid JSON primitives — e.g. the
+ * string `"123"` — back into numbers/booleans, which then breaks string-typed
+ * consumers (see issue #1734). Only restructure the value when the decrypted
+ * payload is unambiguously a JSON object or array; otherwise return the raw
+ * decrypted string. Numeric/boolean entity columns are not in any current
+ * encryption map, so this is backward-compatible.
+ */
+export function parseDecryptedFieldValue(decrypted: string): unknown {
+  if (decrypted.length === 0) return decrypted
+  const first = decrypted[0]
+  if (first !== '{' && first !== '[') return decrypted
+  try {
+    return JSON.parse(decrypted)
+  } catch {
+    return decrypted
+  }
+}
+
 function isEncryptedPayload(value: unknown): boolean {
   if (typeof value !== 'string') return false
   const parts = value.split(':')
@@ -254,11 +277,7 @@ export class TenantDataEncryptionService {
       if (typeof value !== 'string') continue
       const decrypted = maybeDecrypt(value)
       if (decrypted === null) continue
-      try {
-        clone[key] = JSON.parse(decrypted)
-      } catch {
-        clone[key] = decrypted
-      }
+      clone[key] = parseDecryptedFieldValue(decrypted)
     }
     return clone
   }

--- a/packages/ui/src/backend/__tests__/CollapsibleZoneLayout.test.tsx
+++ b/packages/ui/src/backend/__tests__/CollapsibleZoneLayout.test.tsx
@@ -228,4 +228,105 @@ describe('CollapsibleZoneLayout', () => {
     })
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'start' })
   })
+
+  it('focuses the first input field inside the activated section when available', async () => {
+    currentWidth = 1180
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: currentWidth,
+    })
+    const scrollIntoView = jest.fn()
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: scrollIntoView,
+    })
+
+    const { container } = renderWithProviders(
+      <CollapsibleZoneLayout
+        zone1={(
+          <div id="collapsible-group-wrapper-personalData">
+            <button type="button" aria-controls="collapsible-group-personalData" aria-expanded="true">Personal group</button>
+            <input type="hidden" name="hidden-field" defaultValue="hidden" />
+            <input type="text" name="first-name" placeholder="First name" />
+            <input type="text" name="last-name" placeholder="Last name" />
+          </div>
+        )}
+        zone2={<div>Zone 2</div>}
+        entityName="Ada Lovelace"
+        pageType="person-v2"
+        sections={[
+          { id: 'personalData', icon: User, label: 'Personal data' },
+        ]}
+      />,
+      { dict: {} },
+    )
+
+    const layout = container.firstElementChild as HTMLElement
+
+    await waitFor(() => {
+      expect(layout).toHaveAttribute('data-zone-layout-mode', 'collapsed')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Personal data' }))
+
+    await waitFor(() => {
+      expect(layout).toHaveAttribute('data-zone-layout-mode', 'stacked')
+      expect(screen.getByPlaceholderText('First name')).toHaveFocus()
+    })
+  })
+
+  it('expands a collapsed inner group when activated from the rail', async () => {
+    currentWidth = 1180
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: currentWidth,
+    })
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      writable: true,
+      value: jest.fn(),
+    })
+
+    const headingClickHandler = jest.fn()
+
+    const { container } = renderWithProviders(
+      <CollapsibleZoneLayout
+        zone1={(
+          <div id="collapsible-group-wrapper-personalData">
+            <button
+              type="button"
+              aria-controls="collapsible-group-personalData"
+              aria-expanded="false"
+              onClick={headingClickHandler}
+            >
+              Personal group
+            </button>
+          </div>
+        )}
+        zone2={<div>Zone 2</div>}
+        entityName="Ada Lovelace"
+        pageType="person-v2"
+        sections={[
+          { id: 'personalData', icon: User, label: 'Personal data' },
+        ]}
+      />,
+      { dict: {} },
+    )
+
+    const layout = container.firstElementChild as HTMLElement
+
+    await waitFor(() => {
+      expect(layout).toHaveAttribute('data-zone-layout-mode', 'collapsed')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Personal data' }))
+
+    await waitFor(() => {
+      expect(layout).toHaveAttribute('data-zone-layout-mode', 'stacked')
+      expect(headingClickHandler).toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/ui/src/backend/crud/CollapsibleZoneLayout.tsx
+++ b/packages/ui/src/backend/crud/CollapsibleZoneLayout.tsx
@@ -125,9 +125,34 @@ export function CollapsibleZoneLayout({
       const target =
         document.getElementById(section.targetId ?? `collapsible-group-wrapper-${section.id}`)
         ?? document.getElementById(`collapsible-group-${section.id}`)
-      const headingButton = target?.querySelector<HTMLButtonElement>('button[aria-controls]')
-      target?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-      headingButton?.focus({ preventScroll: true })
+      if (!target) return
+      const headingButton = target.querySelector<HTMLButtonElement>('button[aria-controls]')
+      // If the inner CollapsibleGroup is currently collapsed, expand it so its
+      // contents become visible and tabbable for the user who just navigated here.
+      if (headingButton?.getAttribute('aria-expanded') === 'false') {
+        headingButton.click()
+      }
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      // Prefer focusing the first focusable input/textarea/select inside the
+      // section so the user can start typing immediately. Skip hidden, disabled,
+      // or non-interactive controls. Fall back to the section heading.
+      requestAnimationFrame(() => {
+        const focusables = Array.from(
+          target.querySelectorAll<HTMLElement>(
+            'input:not([type="hidden"]), textarea, select, [contenteditable="true"]',
+          ),
+        )
+        const firstInput = focusables.find((el) => {
+          if (el.hasAttribute('disabled') || el.getAttribute('aria-hidden') === 'true') return false
+          if (el instanceof HTMLInputElement && el.readOnly) return false
+          return true
+        })
+        if (firstInput) {
+          firstInput.focus({ preventScroll: true })
+          return
+        }
+        headingButton?.focus({ preventScroll: true })
+      })
     })
   }, [canCollapse, canShowSideBySide, setCollapsed])
 


### PR DESCRIPTION

## Summary

Fixes two related CRM detail-page issues:

1. **Bug #1734** — A purely-numeric Display Name (e.g. `"123"`) crashed the Company / Person v2 detail pages with `TypeError: data.company.displayName.trim is not a function`. Root cause: `TenantDataEncryptionService.decryptFields` called `JSON.parse(decrypted)` on every decrypted text-column value, so encrypted strings that happened to be valid JSON primitives (`"123"`, `"true"`, `"null"`) were re-typed back into their JSON-parsed form (number / boolean / null), breaking every downstream `.trim()` consumer.
2. **Feature #1731** — The collapsed form-panel rail on Company/Person v2 detail pages exposed a strip of section icons (Identity, Contact, Classification, Business Profile, Notes, Custom Attributes). They were already wired to expand the panel and scroll to the section, but the inner `CollapsibleGroup` was not auto-expanded and focus did not land in the activated section, so the click felt like a no-op when the section happened to be collapsed.

Both fixes are scoped to the `customers` module surface and the shared encryption + UI layout primitives.

## Changes

- `packages/shared/src/lib/encryption/tenantDataEncryptionService.ts` — extracted a new `parseDecryptedFieldValue()` helper. Decrypted blobs are only `JSON.parse`d when they unambiguously start with `{` or `[` (object / array). Plain primitives — including numeric strings, `"true"`, `"null"`, `"false"` — are returned as raw strings. Backward-compatible: every existing entity-level encryption map (auth, customers, sales, inbox, audit_logs, …) targets `text` or JSON object/array columns; no map relies on encrypted primitive numbers/booleans.
- `packages/core/src/modules/customers/backend/customers/{companies-v2,companies,people-v2}/[id]/page.tsx` — added belt-and-suspenders type guards before every `displayName.trim()` so even legacy already-encrypted records survive.
- `packages/core/src/modules/customers/components/formConfig.tsx` — `mapCompanyOverviewToFormValues` / `mapPersonOverviewToFormValues` now coerce a non-string `displayName` into a string (matching the existing `primaryPhone` pattern) so the CrudForm always receives a `string` for its Zod `z.string().trim().min(1)` schema.
- `packages/core/src/modules/customers/components/detail/CompanyPeopleSection.tsx` — sort comparator no longer assumes `displayName` is a string.
- `packages/ui/src/backend/crud/CollapsibleZoneLayout.tsx` — `handleSectionActivate` now (a) clicks the inner `CollapsibleGroup` heading button if it currently reports `aria-expanded="false"` so the section actually opens, and (b) prefers focusing the first non-hidden, non-disabled `input` / `textarea` / `select` inside the activated section, falling back to the heading button.
- `packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts` — new unit tests (10 cases) covering both `parseDecryptedFieldValue` and end-to-end `decryptFields` round-trips for primitives + JSON object/array payloads.
- `packages/ui/src/backend/__tests__/CollapsibleZoneLayout.test.tsx` — added two new tests: focus lands on the first input field inside the activated section, and a previously-collapsed inner group is auto-expanded on rail-icon activation.
- `packages/core/src/modules/customers/__integration__/TC-CRM-049.spec.ts` — new integration test exercising the full create → encrypt → decrypt → render flow for adversarial display names (`"123"`, `"true"`, `"null"`, `"false"`, `"00042"`) on both company and person detail pages.
- `packages/core/src/modules/customers/__integration__/TC-CRM-050.spec.ts` — new integration test verifying the collapsed-rail icon click expands the panel, opens the inner CollapsibleGroup, and surfaces the first input.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/[notifications-module.md](http://notifications-module.md) -->

Both items are scoped within `SPEC-046` (Customer Detail Pages v2) / `SPEC-041` (Universal Module Extension System) — issue #1734 is a runtime bug in the shared encryption layer, and issue #1731 is a UX refinement of an already-spec'd component (the icon strip already existed and was already wired). No spec changes were required.

## Testing

- `yarn typecheck` — 18/18 packages green
- `yarn build:packages && yarn generate && yarn build:app` — full build green
- `yarn jest --testPathPatterns="encryption/__tests__/tenantDataEncryptionService"` — 10/10
- `yarn jest --testPathPatterns="^packages/ui/src/backend/__tests__/CollapsibleZoneLayout"` — 5/5
- `yarn jest --testPathPatterns="(tenantDataEncryptionService|CollapsibleZoneLayout|formConfig|CompanyPeopleSection|companies-v2|people-v2|companies/\[id\]|customFieldValues)" --modulePathIgnorePatterns="\.ai/tmp"` — 45/45 across 10 affected suites
- `yarn test:integration TC-CRM-049 TC-CRM-050` — 7/7
- `yarn test:integration` (full suite, dev server up) — **699 passed**, 32 skipped, 32 unique failures all confirmed pre-existing on clean `develop` (verified by re-running a sample of the failing specs with `git stash`'d changes — same failure set: TC-CAT-018, TC-INT-002, TC-WEBHOOK-002, TC-AUTH-016, …)
- Manual preview validation in browser (1200×900 viewport, dev server): created a company with `displayName: "123"`, GET response now returns the value as a `string`, the v2 detail page mounts without the runtime overlay, and clicking the Contact icon in the collapsed rail expands the panel, opens the Contact group, and lands focus on Primary email. Repeated for `"true"`, `"null"`, `"false"`, `"00042"`, and a numeric person displayName — all string-preserving end-to-end.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/[cla.md](http://cla.md)`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

- Closes #1734
- Closes #1731