### PR TITLE
fix(auth): resolve owning module from registry, not feature-id prefix (main)

### DIFF
--- a/.ai/analysis/2026-05-02-acme-admin-analytics-view-redirect.md
+++ b/.ai/analysis/2026-05-02-acme-admin-analytics-view-redirect.md
@@ -1,0 +1,108 @@
+# Diagnosis: dashboard kicks users to login with `requireFeature=analytics.view`
+
+**Date:** 2026-05-02
+**Reporter:** Patryk Lewczuk
+**Environment:** `demo.openmercato.com` and `develop` (locally)
+**Symptom:** After successful login, the dashboard renders for ~1–2 seconds, then a toast appears (`Insufficient permissions. Redirecting to login…`) and the browser is redirected to `/login?requireFeature=analytics.view&redirect=%2Fbackend`. The behaviour is "random" — sometimes the dashboard loads fine; sometimes it doesn't. Some users report being unable to log back in once they're in the loop. `admin@comerito.com` (a freshly-provisioned tenant) is also affected the moment they explicitly add an analytics widget such as Pipeline Summary.
+
+> **Note on previous version of this document.** An earlier draft attributed the issue to `acme` being an "old tenant whose `RoleAcl` was seeded before `analytics.view` was added to `defaultRoleFeatures`". That theory was disproved when `admin@comerito.com` (a tenant created on the current code) hit the same 403 immediately after adding Pipeline Summary. Both tenants do have `analytics.view` in storage; the bug is at runtime, not in seeding. The corrected diagnosis is below.
+
+## Root cause
+
+`packages/core/src/modules/auth/services/rbacService.ts:393` — `userHasAllFeatures` strips a granted feature whose owning module is not in the enabled-modules registry **before** the check, and the function it uses to derive the owning module (`getOwningModuleId`) computes it from the feature-id **prefix** rather than from the registry's declared `module` field.
+
+The single feature where this matters is `packages/core/src/modules/dashboards/acl.ts:5`:
+
+```ts
+{ id: 'analytics.view', title: 'View analytics widgets', module: 'dashboards' },
+```
+
+- `id` prefix is `analytics`
+- declared owning module is `dashboards`
+- there is no module called `analytics` in `apps/mercato/src/modules.ts`
+
+So at every check:
+
+1. `loadAcl(...)` returns `acl.features` correctly including `analytics.view`.
+2. `userHasAllFeatures` calls `filterGrantsByEnabledModules(acl.features)`.
+3. `filterGrantsByEnabledModules` (`packages/shared/src/security/enabledModulesRegistry.ts:43`) walks each grant; for `analytics.view` it computes `getOwningModuleId('analytics.view') === 'analytics'`, sees that `analytics` is not in the enabled set, and **drops the grant**.
+4. `hasAllFeatures(['analytics.view'], [/* analytics.view removed */])` returns `false`.
+5. The catch-all guard in `apps/mercato/src/app/api/[...slug]/route.ts:225` returns:
+   ```json
+   { "error": "Forbidden", "requiredFeatures": ["analytics.view"] }
+   ```
+   …with HTTP 403.
+6. `packages/ui/src/backend/utils/api.ts:71` (`redirectToForbiddenLogin`) reads `requiredFeatures` from the body, flashes `'Insufficient permissions. Redirecting to login…'`, and pushes the user to `/login?requireFeature=analytics.view&redirect=%2Fbackend`. Exactly the URL in both screenshots.
+
+### Why the dashboard appears to render briefly first
+
+The dashboard layout endpoint (`packages/core/src/modules/dashboards/api/layout/route.ts`) does **not** go through the same filter. It uses `acl.features` directly when building `allowedIds`. So:
+
+- `GET /api/dashboards/layout` → succeeds (and even includes analytics widgets in the returned catalog because `acl.features` still has `analytics.view`).
+- Frontend renders the cards.
+- Each tile fires `POST /api/dashboards/widgets/data`, which has `requireFeatures: ['analytics.view']`.
+- Catch-all guard runs `userHasAllFeatures` → `filterGrantsByEnabledModules` strips `analytics.view` → 403.
+- The first 403 trips the redirect.
+
+That inconsistency between the layout API (raw `acl.features`) and the catch-all guard (filtered grants) is what makes the bug feel non-deterministic to users:
+
+- A user whose saved `DashboardLayout` contains *any* analytics tile gets kicked immediately on every dashboard visit.
+- A user whose layout has none never triggers the widget data POST and never sees the bug — until they explicitly add an analytics widget (which the layout API readily offers them, because it doesn't filter).
+
+This explains every observation in the bug report and the Discord thread:
+
+- "Random — sometimes the main page loads fine" → depends on the user's saved layout.
+- "Once it kicks me out, I can't log in at all" → not a credentials problem; it's a redirect loop. Login succeeds, post-login dashboard fetches a tile, 403, back to `/login`, repeat.
+- "Everyone on develop has it" → confirmed; this is purely a code regression, not a data issue.
+- "`admin@comerito.com` worked fine, but kicked me out when I added Pipeline Summary" → comerito's default layout has zero analytics widgets (`defaultEnabled: false` for all of them), so the bug is dormant. Adding any analytics tile fires the widget data POST → 403.
+
+## When the regression landed
+
+Commit **`d219402e0` ("fix(auth): hide UI and gate APIs when backing module is disabled (#1641)", 2026-04-22)** added the `filterGrantsByEnabledModules` call inside `userHasAllFeatures`:
+
+```ts
+// before d219402e0
+return this.hasAllFeatures(required, acl.features)
+// after
+return this.hasAllFeatures(required, filterGrantsByEnabledModules(acl.features))
+```
+
+That PR's intent is correct — features whose backing module has been disabled in `modules.ts` should not act as live grants — but the implementation derives the owning module from the feature id prefix and so it strips features whose id doesn't match their declared module. `analytics.view` is the only such feature in core today, but the same trap will catch any future feature with an off-convention name.
+
+The Discord thread (4/27) puts the user-visible onset within five days of the merge, which fits.
+
+## Confirmed unrelated
+
+Commit `e12c33b01` ("fix(zod): restore optional-key behavior under zod 4.4.x", 2026-04-30) only changes `.optional()` placement around `z.preprocess(...)` for four schema helpers in `packages/checkout/.../validators.ts` and `optionalBooleanQuery` in `packages/core/src/modules/integrations/data/validators.ts`. It does not touch RBAC, role ACLs, the feature matcher, or the enabled-modules registry, and cannot affect what `userHasAllFeatures` returns.
+
+## Fix
+
+Make `getOwningModuleId` consult the registry's declared `module` field on the feature definition first, falling back to the id prefix only when the feature is unknown to the registry.
+
+Edits:
+
+- `packages/shared/src/security/enabledModulesRegistry.ts` — replace the prefix-only `getOwningModuleId` with a registry-aware variant. Build a `Map<featureId, moduleId>` from `getModules().flatMap((m) => m.features ?? [])` (each entry has `{ id, title, module }`); use it in `getOwningModuleId(featureId)` and `filterGrantsByEnabledModules`. Cache lazily and invalidate when modules are re-registered.
+- `packages/shared/src/security/__tests__/enabledModulesRegistry.test.ts` — extend the existing test for the off-convention case (a feature whose id prefix doesn't match its declared module).
+
+This is purely a code fix. No database migration. No `sync-role-acls` run required: existing `RoleAcl.featuresJson` already carries `analytics.view`. After deploy, the dashboard works again for every tenant.
+
+### Why not (b) hard-coded `analytics → dashboards` alias
+
+Cheap but leaks the alias forever and only fixes the one symptom we know about today.
+
+### Why not (c) rename the feature to `dashboards.analytics.view`
+
+`BACKWARD_COMPATIBILITY.md` lists ACL feature IDs as FROZEN (category 10). Renaming requires a data migration and a deprecation window for downstream modules. Not justified for one feature when the underlying helper can simply respect the registry.
+
+## References
+
+- `packages/core/src/modules/dashboards/api/widgets/data/route.ts:18` — `requireFeatures: ['analytics.view']`
+- `apps/mercato/src/app/api/[...slug]/route.ts:191`/`:225` — feature guard and 403 response shape
+- `packages/ui/src/backend/utils/api.ts:71` — `redirectToForbiddenLogin`
+- `packages/core/src/modules/auth/services/rbacService.ts:393` — `userHasAllFeatures` (regression site)
+- `packages/shared/src/security/enabledModulesRegistry.ts:19` — `getOwningModuleId` (the prefix-derivation bug)
+- `packages/shared/src/modules/registry.ts:222` — `Module.features: Array<{ id, title, module }>` (the source of truth that should be consulted)
+- `packages/core/src/modules/dashboards/acl.ts:5` — the off-convention feature declaration
+- `apps/mercato/src/modules.ts` — enabled module list (no `analytics` entry)
+- Commit `d219402e0` (2026-04-22) — introduced `filterGrantsByEnabledModules` in `userHasAllFeatures`
+- Commit `e12c33b01` (2026-04-30) — **unrelated** zod 4.4 fix

--- a/packages/shared/src/security/__tests__/enabledModulesRegistry.test.ts
+++ b/packages/shared/src/security/__tests__/enabledModulesRegistry.test.ts
@@ -17,9 +17,26 @@ describe('enabledModulesRegistry', () => {
     jest.resetAllMocks()
   })
 
-  it('derives the owning module from the feature id prefix', () => {
+  it('derives the owning module from the feature id prefix when the registry has no declarations', () => {
+    mockGetModules.mockReturnValue([{ id: 'auth' } as Module])
     expect(getOwningModuleId('ai_assistant.view')).toBe('ai_assistant')
     expect(getOwningModuleId('plain-feature')).toBe('plain-feature')
+  })
+
+  it('uses the declared module from the registry for off-convention feature ids (e.g. analytics.view)', () => {
+    mockGetModules.mockReturnValue([
+      {
+        id: 'dashboards',
+        features: [
+          { id: 'dashboards.view', title: 'View dashboard', module: 'dashboards' },
+          { id: 'analytics.view', title: 'View analytics widgets', module: 'dashboards' },
+        ],
+      } as Module,
+      { id: 'auth' } as Module,
+    ])
+
+    expect(getOwningModuleId('analytics.view')).toBe('dashboards')
+    expect(getOwningModuleId('dashboards.view')).toBe('dashboards')
   })
 
   it('reads enabled module ids from the registered module list', () => {
@@ -46,6 +63,28 @@ describe('enabledModulesRegistry', () => {
     ).toEqual(['auth.*', 'customer_accounts.view'])
   })
 
+  it('keeps an off-convention grant when its declared owning module is enabled', () => {
+    mockGetModules.mockReturnValue([
+      {
+        id: 'dashboards',
+        features: [
+          { id: 'analytics.view', title: 'View analytics widgets', module: 'dashboards' },
+        ],
+      } as Module,
+      { id: 'auth' } as Module,
+    ])
+
+    expect(
+      filterGrantsByEnabledModules(['analytics.view', 'auth.users.view', 'unknown.feature']),
+    ).toEqual(['analytics.view', 'auth.users.view'])
+  })
+
+  it('drops an off-convention grant when its declared owning module is disabled', () => {
+    mockGetModules.mockReturnValue([{ id: 'auth' } as Module])
+
+    expect(filterGrantsByEnabledModules(['analytics.view'])).toEqual([])
+  })
+
   it('expands the superadmin wildcard into enabled-module wildcards', () => {
     mockGetModules.mockReturnValue([
       { id: 'auth' } as Module,
@@ -53,6 +92,25 @@ describe('enabledModulesRegistry', () => {
     ])
 
     expect(filterGrantsByEnabledModules(['*'])).toEqual(['auth.*', 'customer_accounts.*'])
+  })
+
+  it('also expands the superadmin wildcard to off-convention prefixes whose owning module is enabled', () => {
+    mockGetModules.mockReturnValue([
+      {
+        id: 'dashboards',
+        features: [
+          { id: 'dashboards.view', title: 'View dashboard', module: 'dashboards' },
+          { id: 'analytics.view', title: 'View analytics widgets', module: 'dashboards' },
+        ],
+      } as Module,
+      { id: 'auth' } as Module,
+    ])
+
+    expect(filterGrantsByEnabledModules(['*'])).toEqual([
+      'dashboards.*',
+      'auth.*',
+      'analytics.*',
+    ])
   })
 
   it('falls back to the raw grant list when the module registry is unavailable', () => {

--- a/packages/shared/src/security/enabledModulesRegistry.ts
+++ b/packages/shared/src/security/enabledModulesRegistry.ts
@@ -8,6 +8,15 @@
  * whose owning module is not enabled — otherwise stale grants re-open the
  * 404-class bug PR #1567 only partially fixed.
  *
+ * Owning-module resolution:
+ * - Most features follow the convention so `id.split('.')[0]` matches the
+ *   module id. For those, the prefix is correct.
+ * - A few features (e.g. `analytics.view`) deliberately use a different
+ *   namespace from their owning module. For those, the registry's declared
+ *   `module` field on the `Module.features` entry is authoritative. We
+ *   consult it first and fall back to the prefix only when the feature is
+ *   unknown to the registry.
+ *
  * This helper is server-only: it reads the enabled module set from the
  * bootstrapped module registry. The browser never imports it; instead,
  * server code pre-filters `BackendChromePayload.grantedFeatures` so
@@ -15,42 +24,100 @@
  */
 
 import { getModules } from '../lib/modules/registry'
+import type { Module } from '../modules/registry'
 
-export function getOwningModuleId(featureId: string): string {
-  const dot = featureId.indexOf('.')
-  return dot === -1 ? featureId : featureId.slice(0, dot)
+type FeatureRegistry = {
+  enabledModuleIds: string[]
+  enabledModuleSet: Set<string>
+  featureToModule: Map<string, string>
+  prefixToModule: Map<string, string>
 }
 
-function safeGetEnabledModuleIds(): string[] | null {
+let cachedRegistry: FeatureRegistry | null = null
+let cachedModulesRef: readonly Module[] | null = null
+
+function buildRegistry(modules: readonly Module[]): FeatureRegistry {
+  const enabledModuleIds = modules.map((mod) => mod.id)
+  const enabledModuleSet = new Set(enabledModuleIds)
+  const featureToModule = new Map<string, string>()
+  const prefixToModule = new Map<string, string>()
+  for (const mod of modules) {
+    const features = mod.features
+    if (!Array.isArray(features)) continue
+    for (const feature of features) {
+      if (!feature || typeof feature.id !== 'string' || !feature.id) continue
+      const declared = typeof feature.module === 'string' && feature.module.length > 0
+        ? feature.module
+        : mod.id
+      featureToModule.set(feature.id, declared)
+      const dot = feature.id.indexOf('.')
+      if (dot > 0) {
+        const prefix = feature.id.slice(0, dot)
+        if (!prefixToModule.has(prefix)) prefixToModule.set(prefix, declared)
+      }
+    }
+  }
+  return { enabledModuleIds, enabledModuleSet, featureToModule, prefixToModule }
+}
+
+function getRegistry(): FeatureRegistry | null {
   try {
-    return getModules().map((mod) => mod.id)
+    const modules = getModules() as readonly Module[]
+    if (cachedRegistry && cachedModulesRef === modules) return cachedRegistry
+    cachedModulesRef = modules
+    cachedRegistry = buildRegistry(modules)
+    return cachedRegistry
   } catch {
     return null
   }
 }
 
+export function getOwningModuleId(featureId: string): string {
+  const registry = getRegistry()
+  if (registry) {
+    const direct = registry.featureToModule.get(featureId)
+    if (direct) return direct
+    if (featureId.endsWith('.*')) {
+      const prefix = featureId.slice(0, -2)
+      const fromPrefix = registry.prefixToModule.get(prefix)
+      if (fromPrefix) return fromPrefix
+      return prefix
+    }
+  }
+  const dot = featureId.indexOf('.')
+  return dot === -1 ? featureId : featureId.slice(0, dot)
+}
+
 export function getEnabledModuleIds(): string[] {
-  return safeGetEnabledModuleIds() ?? []
+  const registry = getRegistry()
+  return registry ? [...registry.enabledModuleIds] : []
 }
 
 /**
  * Filters a raw granted-features list down to the grants whose owning
  * module is currently enabled. Expands `*` (superadmin) into one wildcard
  * per enabled module so the result is still safe to feed into a pure
- * `matchFeature` check. If the module registry is not populated (tests,
- * CLI), returns the input unchanged — preserves legacy behavior.
+ * `matchFeature` check, plus one wildcard per off-convention feature
+ * prefix (e.g. `analytics.*`) whose declared owning module is enabled.
+ * If the module registry is not populated (tests, CLI), returns the input
+ * unchanged — preserves legacy behavior.
  */
 export function filterGrantsByEnabledModules(granted: readonly string[]): string[] {
-  const enabledIds = safeGetEnabledModuleIds()
-  if (enabledIds === null) return [...granted]
-  const enabledSet = new Set(enabledIds)
+  const registry = getRegistry()
+  if (!registry) return [...granted]
+  const { enabledModuleIds, enabledModuleSet, prefixToModule } = registry
   const result: string[] = []
   for (const grant of granted) {
     if (grant === '*') {
-      for (const id of enabledIds) result.push(`${id}.*`)
+      for (const id of enabledModuleIds) result.push(`${id}.*`)
+      for (const [prefix, owningModule] of prefixToModule) {
+        if (!enabledModuleSet.has(prefix) && enabledModuleSet.has(owningModule)) {
+          result.push(`${prefix}.*`)
+        }
+      }
       continue
     }
-    if (enabledSet.has(getOwningModuleId(grant))) result.push(grant)
+    if (enabledModuleSet.has(getOwningModuleId(grant))) result.push(grant)
   }
   return result
 }


### PR DESCRIPTION
## Summary

Cherry-picks the `analytics.view` runtime-strip fix from PR #1768 (develop) onto `main`, so the same fix can ship via the main release channel without waiting for the next develop → main merge.

- The bug is the same one PR #1768 documents in detail: `filterGrantsByEnabledModules` (introduced in #1641, present on `main` since the v0.5.0 release) derives a feature's owning module by splitting the id at the first `.` and treating the prefix as the module id. `analytics.view` is declared with `module: 'dashboards'` in `packages/core/src/modules/dashboards/acl.ts:5`, but its prefix is `analytics`, which is not a module in `apps/mercato/src/modules.ts`. Result: every check inside `rbacService.userHasAllFeatures` strips the grant, the dashboard widget data API returns `403 { requiredFeatures: ['analytics.view'] }`, and `apiFetch` redirects to `/login?requireFeature=analytics.view` in a loop.
- Reported on demo by `admin@acme.com` and reproduced on a freshly-provisioned `admin@comerito.com` the moment they added Pipeline Summary. Affects every tenant with an analytics widget in their saved `DashboardLayout`.

## Cherry-picked commit

- `bf2eb5786` (develop) → `480a69819` (this branch). One commit, with the original `(cherry picked from commit …)` trailer.

The CI-stabilization commits on PR #1768 (`e11df013d`, `97c08e33b`, `a2f1204c8`) are **not** carried over — they are workarounds for develop-only flakiness on PRs that haven't merged into develop yet, or for regressions caused by post-main develop activity. None apply to main.

## What the fix does

- `getOwningModuleId(featureId)` now consults the aggregated `Module.features` registry (each entry is `{ id, title, module }`) first, so the feature's *declared* owning module is authoritative. Falls back to the id prefix only when the feature is unknown to the registry, so conventional features and CLI / test contexts behave identically.
- `filterGrantsByEnabledModules`, when expanding the `*` superadmin grant, also emits a `<prefix>.*` for any off-convention feature prefix whose declared owning module is enabled, so client-side `hasFeature` checks for the same off-convention features keep working for superadmins.
- The build is cached by reference identity of the modules array, so it only rebuilds when modules are re-registered (HMR / tests).

Pure code fix. **No data migration required.** Existing `RoleAcl.featuresJson` already carries `analytics.view` — after deploy, dashboards with analytics widgets render normally for every tenant.

## Test plan

- [x] `yarn jest packages/shared/src/security` — 9/9 passing on this branch (4 new cases: off-convention lookup, drop/keep based on declared owning module, superadmin wildcard expansion to off-convention prefixes; existing prefix-fallback case preserved).
- [ ] On a deployed environment: log in as a regular admin user, confirm dashboard renders without the redirect, confirm adding/removing analytics widgets (Pipeline Summary, Revenue, Top products by revenue, etc.) works.
- [ ] Confirm a superadmin still sees and can fetch data for analytics widgets.
- [ ] Confirm disabling the `dashboards` module in `apps/mercato/src/modules.ts` still hides analytics features from non-superadmin grants (regression test for #1641's original intent).

### Note on the pre-existing main-branch Jest infra

`packages/core/jest.config.cjs` on `main` is missing the `transformIgnorePatterns: ['node_modules/(?!(@mikro-orm)/)']` line that develop has. So `yarn jest packages/core/src/modules/auth/services/rbacService.test.ts` fails on main with `SyntaxError: Unexpected token 'export'` (Jest can't transform `@mikro-orm/core` ESM) — independent of this change. The targeted unit tests for the helper this PR modifies (`packages/shared/src/security`) pass cleanly.

## Diagnosis

Full root-cause walkthrough — from the user-reported screenshots through the catch-all guard, the `apiFetch` redirect, and the regression site at `rbacService.userHasAllFeatures` — is committed as `.ai/analysis/2026-05-02-acme-admin-analytics-view-redirect.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)