### PR TITLE
fix(search): use OM_SEARCH_MIN_LEN env var for search query minimum length

### DIFF
--- a/apps/mercato/next.config.ts
+++ b/apps/mercato/next.config.ts
@@ -50,6 +50,11 @@ const nextConfig: NextConfig = {
     '@esbuild/darwin-arm64',
     '@open-mercato/cli',
   ],
+  // Mirror server-only env vars that client components must observe. Keep this
+  // list minimal — anything added here is inlined into the client bundle.
+  env: {
+    OM_SEARCH_MIN_LEN: process.env.OM_SEARCH_MIN_LEN,
+  },
   async headers() {
     return [
       {

--- a/packages/create-app/template/next.config.ts
+++ b/packages/create-app/template/next.config.ts
@@ -34,6 +34,11 @@ const nextConfig: NextConfig = {
     '@esbuild/darwin-arm64',
     '@open-mercato/cli',
   ],
+  // Mirror server-only env vars that client components must observe. Keep this
+  // list minimal — anything added here is inlined into the client bundle.
+  env: {
+    OM_SEARCH_MIN_LEN: process.env.OM_SEARCH_MIN_LEN,
+  },
 }
 
 export default nextConfig

--- a/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
+++ b/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
@@ -58,7 +58,7 @@ import { parseSelectedOrganizationCookie } from '@open-mercato/core/modules/dire
 import { ForbiddenError } from '@open-mercato/ui/backend/utils/api'
 import { fetchGlobalSearchResults } from '../utils'
 
-const MIN_QUERY_LENGTH = 2
+const MIN_QUERY_LENGTH = 3
 
 /** Default strategies used when none are configured */
 const DEFAULT_STRATEGIES: SearchStrategyId[] = ['fulltext', 'vector', 'tokens']

--- a/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
+++ b/packages/search/src/modules/search/frontend/components/GlobalSearchDialog.tsx
@@ -56,9 +56,10 @@ import {
 import { isAllOrganizationsSelection } from '@open-mercato/core/modules/directory/constants'
 import { parseSelectedOrganizationCookie } from '@open-mercato/core/modules/directory/utils/scopeCookies'
 import { ForbiddenError } from '@open-mercato/ui/backend/utils/api'
+import { resolveSearchMinTokenLength } from '@open-mercato/shared/lib/search/config'
 import { fetchGlobalSearchResults } from '../utils'
 
-const MIN_QUERY_LENGTH = 3
+const MIN_QUERY_LENGTH = resolveSearchMinTokenLength()
 
 /** Default strategies used when none are configured */
 const DEFAULT_STRATEGIES: SearchStrategyId[] = ['fulltext', 'vector', 'tokens']
@@ -387,7 +388,7 @@ export function GlobalSearchDialog({
             {results.length === 0 && !loading && !error ? (
               <div className="px-4 py-6 text-sm text-muted-foreground">
                 {query.trim().length < MIN_QUERY_LENGTH
-                  ? t('search.dialog.empty.hint')
+                  ? t('search.dialog.empty.hint', { count: MIN_QUERY_LENGTH })
                   : t('search.dialog.empty.none')}
               </div>
             ) : null}

--- a/packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx
+++ b/packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx
@@ -30,7 +30,7 @@ type Row = {
   metadata: Record<string, unknown> | null
 }
 
-const MIN_QUERY_LENGTH = 2
+const MIN_QUERY_LENGTH = 3
 const ALL_STRATEGIES: SearchStrategyId[] = ['fulltext', 'vector', 'tokens']
 
 type Translator = (

--- a/packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx
+++ b/packages/search/src/modules/search/frontend/components/HybridSearchTable.tsx
@@ -17,6 +17,7 @@ import {
 } from '@open-mercato/shared/lib/frontend/organizationEvents'
 import { isAllOrganizationsSelection } from '@open-mercato/core/modules/directory/constants'
 import { parseSelectedOrganizationCookie } from '@open-mercato/core/modules/directory/utils/scopeCookies'
+import { resolveSearchMinTokenLength } from '@open-mercato/shared/lib/search/config'
 import { fetchHybridSearchResults } from '../utils'
 
 type Row = {
@@ -30,7 +31,7 @@ type Row = {
   metadata: Record<string, unknown> | null
 }
 
-const MIN_QUERY_LENGTH = 3
+const MIN_QUERY_LENGTH = resolveSearchMinTokenLength()
 const ALL_STRATEGIES: SearchStrategyId[] = ['fulltext', 'vector', 'tokens']
 
 type Translator = (

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Globale Suche öffnen",
   "search.dialog.actions.openSelected": "Öffnen (Enter)",
   "search.dialog.actions.search": "Suchen",
-  "search.dialog.empty.hint": "Mindestens zwei Zeichen eingeben, um in indizierten Datensätzen zu suchen.",
+  "search.dialog.empty.hint": "Mindestens drei Zeichen eingeben, um in indizierten Datensätzen zu suchen.",
   "search.dialog.empty.none": "Keine Ergebnisse gefunden.",
   "search.dialog.errors.noPermission": "Sie haben keine Berechtigung, die globale Suche zu verwenden.",
   "search.dialog.errors.searchFailed": "Suche ist fehlgeschlagen.",

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Globale Suche öffnen",
   "search.dialog.actions.openSelected": "Öffnen (Enter)",
   "search.dialog.actions.search": "Suchen",
-  "search.dialog.empty.hint": "Mindestens drei Zeichen eingeben, um in indizierten Datensätzen zu suchen.",
+  "search.dialog.empty.hint": "Mindestens {{count}} Zeichen eingeben, um in indizierten Datensätzen zu suchen.",
   "search.dialog.empty.none": "Keine Ergebnisse gefunden.",
   "search.dialog.errors.noPermission": "Sie haben keine Berechtigung, die globale Suche zu verwenden.",
   "search.dialog.errors.searchFailed": "Suche ist fehlgeschlagen.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Open global search",
   "search.dialog.actions.openSelected": "Open (Enter)",
   "search.dialog.actions.search": "Search",
-  "search.dialog.empty.hint": "Type at least two characters to search indexed records.",
+  "search.dialog.empty.hint": "Type at least three characters to search indexed records.",
   "search.dialog.empty.none": "No results found.",
   "search.dialog.errors.noPermission": "You do not have permission to use global search.",
   "search.dialog.errors.searchFailed": "Search failed.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Open global search",
   "search.dialog.actions.openSelected": "Open (Enter)",
   "search.dialog.actions.search": "Search",
-  "search.dialog.empty.hint": "Type at least three characters to search indexed records.",
+  "search.dialog.empty.hint": "Type at least {{count}} characters to search indexed records.",
   "search.dialog.empty.none": "No results found.",
   "search.dialog.errors.noPermission": "You do not have permission to use global search.",
   "search.dialog.errors.searchFailed": "Search failed.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Abrir búsqueda global",
   "search.dialog.actions.openSelected": "Abrir (Enter)",
   "search.dialog.actions.search": "Buscar",
-  "search.dialog.empty.hint": "Escribe al menos dos caracteres para buscar en los registros indexados.",
+  "search.dialog.empty.hint": "Escribe al menos tres caracteres para buscar en los registros indexados.",
   "search.dialog.empty.none": "No se encontraron resultados.",
   "search.dialog.errors.noPermission": "No tienes permiso para usar la búsqueda global.",
   "search.dialog.errors.searchFailed": "La búsqueda falló.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Abrir búsqueda global",
   "search.dialog.actions.openSelected": "Abrir (Enter)",
   "search.dialog.actions.search": "Buscar",
-  "search.dialog.empty.hint": "Escribe al menos tres caracteres para buscar en los registros indexados.",
+  "search.dialog.empty.hint": "Escribe al menos {{count}} caracteres para buscar en los registros indexados.",
   "search.dialog.empty.none": "No se encontraron resultados.",
   "search.dialog.errors.noPermission": "No tienes permiso para usar la búsqueda global.",
   "search.dialog.errors.searchFailed": "La búsqueda falló.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Otwórz globalne wyszukiwanie",
   "search.dialog.actions.openSelected": "Otwórz (Enter)",
   "search.dialog.actions.search": "Szukaj",
-  "search.dialog.empty.hint": "Wpisz co najmniej trzy znaki, aby przeszukać zindeksowane rekordy.",
+  "search.dialog.empty.hint": "Wpisz co najmniej {{count}} znaki, aby przeszukać zindeksowane rekordy.",
   "search.dialog.empty.none": "Brak wyników.",
   "search.dialog.errors.noPermission": "Nie masz uprawnień do korzystania z wyszukiwania globalnego.",
   "search.dialog.errors.searchFailed": "Wyszukiwanie nie powiodło się.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -25,7 +25,7 @@
   "search.dialog.actions.openGlobalSearch": "Otwórz globalne wyszukiwanie",
   "search.dialog.actions.openSelected": "Otwórz (Enter)",
   "search.dialog.actions.search": "Szukaj",
-  "search.dialog.empty.hint": "Wpisz co najmniej dwa znaki, aby przeszukać zindeksowane rekordy.",
+  "search.dialog.empty.hint": "Wpisz co najmniej trzy znaki, aby przeszukać zindeksowane rekordy.",
   "search.dialog.empty.none": "Brak wyników.",
   "search.dialog.errors.noPermission": "Nie masz uprawnień do korzystania z wyszukiwania globalnego.",
   "search.dialog.errors.searchFailed": "Wyszukiwanie nie powiodło się.",

--- a/packages/shared/src/lib/search/__tests__/config.test.ts
+++ b/packages/shared/src/lib/search/__tests__/config.test.ts
@@ -1,0 +1,42 @@
+import {
+  DEFAULT_SEARCH_MIN_TOKEN_LENGTH,
+  resolveSearchConfig,
+  resolveSearchMinTokenLength,
+} from '../config'
+
+describe('resolveSearchMinTokenLength', () => {
+  const originalValue = process.env.OM_SEARCH_MIN_LEN
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.OM_SEARCH_MIN_LEN
+    } else {
+      process.env.OM_SEARCH_MIN_LEN = originalValue
+    }
+  })
+
+  it('returns the default when OM_SEARCH_MIN_LEN is unset', () => {
+    delete process.env.OM_SEARCH_MIN_LEN
+    expect(resolveSearchMinTokenLength()).toBe(DEFAULT_SEARCH_MIN_TOKEN_LENGTH)
+  })
+
+  it('parses a positive integer', () => {
+    process.env.OM_SEARCH_MIN_LEN = '4'
+    expect(resolveSearchMinTokenLength()).toBe(4)
+  })
+
+  it('falls back to the default for non-numeric values', () => {
+    process.env.OM_SEARCH_MIN_LEN = 'abc'
+    expect(resolveSearchMinTokenLength()).toBe(DEFAULT_SEARCH_MIN_TOKEN_LENGTH)
+  })
+
+  it('falls back to the default for values below the floor', () => {
+    process.env.OM_SEARCH_MIN_LEN = '0'
+    expect(resolveSearchMinTokenLength()).toBe(DEFAULT_SEARCH_MIN_TOKEN_LENGTH)
+  })
+
+  it('keeps resolveSearchConfig().minTokenLength in sync', () => {
+    process.env.OM_SEARCH_MIN_LEN = '5'
+    expect(resolveSearchConfig().minTokenLength).toBe(resolveSearchMinTokenLength())
+  })
+})

--- a/packages/shared/src/lib/search/config.ts
+++ b/packages/shared/src/lib/search/config.ts
@@ -9,6 +9,8 @@ export type SearchConfig = {
   blocklistedFields: string[]
 }
 
+export const DEFAULT_SEARCH_MIN_TOKEN_LENGTH = 3
+
 const DEFAULT_BLOCKLIST = ['password', 'token', 'secret', 'hash']
 
 function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
@@ -33,7 +35,7 @@ function parseHashAlgorithm(raw: string | undefined): 'sha256' | 'sha1' | 'md5' 
 export function resolveSearchConfig(): SearchConfig {
   return {
     enabled: parseBoolean(process.env.OM_SEARCH_ENABLED, true),
-    minTokenLength: parseNumber(process.env.OM_SEARCH_MIN_LEN, 3, 1),
+    minTokenLength: resolveSearchMinTokenLength(),
     enablePartials: parseBoolean(process.env.OM_SEARCH_ENABLE_PARTIAL, true),
     hashAlgorithm: parseHashAlgorithm(process.env.OM_SEARCH_HASH_ALGO),
     storeRawTokens: parseBoolean(process.env.OM_SEARCH_STORE_RAW_TOKENS, false),
@@ -46,4 +48,19 @@ export function resolveSearchConfig(): SearchConfig {
       .concat(DEFAULT_BLOCKLIST)
       .filter((value, index, arr) => arr.indexOf(value) === index),
   }
+}
+
+/**
+ * Browser-safe accessor for the minimum search token length.
+ *
+ * Why: client components (e.g. global search dialog) must mirror the server-side
+ * tokenizer's `minTokenLength` so the UI gates the request before hitting an
+ * empty result set. Pulling the value through this single helper keeps the env
+ * contract (`OM_SEARCH_MIN_LEN`) authoritative on both sides.
+ *
+ * How to apply: call from anywhere — server, client (when the host app exposes
+ * `OM_SEARCH_MIN_LEN` through `next.config.ts`'s `env` block), or tests.
+ */
+export function resolveSearchMinTokenLength(): number {
+  return parseNumber(process.env.OM_SEARCH_MIN_LEN, DEFAULT_SEARCH_MIN_TOKEN_LENGTH, 1)
 }


### PR DESCRIPTION
Supersedes #1761

Credit: original implementation by @haxiorz. This follow-up PR carries that work forward with the requested fix so it can merge without waiting on the original fork branch.

## Summary
- Pulls the search query minimum-length value from the existing `OM_SEARCH_MIN_LEN` environment variable instead of hardcoding `3` in two client components.
- Adds a `resolveSearchMinTokenLength()` helper in `@open-mercato/shared` so server and client share the same source of truth.
- Exposes `OM_SEARCH_MIN_LEN` to the browser via the `env` block in `apps/mercato/next.config.ts` and `packages/create-app/template/next.config.ts` (Next.js inlines listed env vars into the client bundle).
- Parameterises `search.dialog.empty.hint` across `en`/`de`/`es`/`pl` with `{{count}}` so the hint message follows whatever length the server enforces.
- Adds unit-test coverage for `resolveSearchMinTokenLength` covering unset, valid, non-numeric, below-floor, and parity-with-`resolveSearchConfig` cases.

## Why
Originally the dialog and table inferred the minimum from a magic number constant — bumping it to 3 fixed the immediate UX bug, but left the value out of sync with the tokenizer's `OM_SEARCH_MIN_LEN` setting consumed by `resolveSearchConfig().minTokenLength`. This PR makes that env var the single source of truth in both server and client paths.

## Included work
- Original changes from #1761 (3 → minimum char hint + gate fix)
- Follow-up wiring so the value is sourced from `OM_SEARCH_MIN_LEN`

## Test plan
- [x] `yarn workspace @open-mercato/shared test --testPathPatterns='search/__tests__/config'`
- [x] `yarn workspace @open-mercato/search test`
- [x] `yarn workspace @open-mercato/shared typecheck`
- [x] `yarn workspace @open-mercato/search typecheck`
- [x] `yarn workspace @open-mercato/app typecheck`
- [x] `yarn i18n:check-sync` (all 4 locales in sync)
- [x] `yarn i18n:check-usage` (`search.dialog.empty.hint` still referenced)
- [x] `yarn build:packages`
- [ ] Manual QA: open Cmd+K with `OM_SEARCH_MIN_LEN` unset → hint shows "Type at least 3 characters…"; with `OM_SEARCH_MIN_LEN=4` → hint shows "Type at least 4 characters…" and gate fires at 4 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)