### PR TITLE
fix(ui): keep organization switcher in topbar at all viewport widths (#1795)

### DIFF
--- a/apps/mercato/src/app/(backend)/backend/layout.tsx
+++ b/apps/mercato/src/app/(backend)/backend/layout.tsx
@@ -10,7 +10,6 @@ import { APP_VERSION } from '@open-mercato/shared/lib/version'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { PageInjectionBoundary } from '@open-mercato/ui/backend/injection/PageInjectionBoundary'
 import { DemoFeedbackWidget } from '@/components/DemoFeedbackWidget'
-import OrganizationSwitcher from '@/components/OrganizationSwitcher'
 import { BackendHeaderChrome } from '@/components/BackendHeaderChrome'
 
 registerBackendRouteManifests(backendRoutes)
@@ -114,7 +113,6 @@ export default async function BackendLayout({
             organizationId={auth?.orgId ?? null}
           />
         )}
-        mobileSidebarSlot={<OrganizationSwitcher compact />}
         adminNavApi="/api/auth/admin/nav"
         version={APP_VERSION}
         settingsPathPrefixes={collectStaticSettingsPathPrefixes()}

--- a/apps/mercato/src/components/BackendHeaderChrome.tsx
+++ b/apps/mercato/src/components/BackendHeaderChrome.tsx
@@ -89,9 +89,7 @@ export function BackendHeaderChrome({
           missingConfigMessage={missingConfigMessage}
         />
       ) : null}
-      <div className="hidden lg:contents">
-        {isReady ? <LazyOrganizationSwitcher /> : null}
-      </div>
+      {isReady ? <LazyOrganizationSwitcher /> : null}
       {showIntegrationsButton ? <IntegrationsButton /> : null}
       <SettingsButton />
       <ProfileDropdown email={email} />

--- a/apps/mercato/src/components/__tests__/BackendHeaderChrome.test.tsx
+++ b/apps/mercato/src/components/__tests__/BackendHeaderChrome.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { BackendHeaderChrome } from '../BackendHeaderChrome'
+
+jest.mock('next/dynamic', () => (loader: () => Promise<unknown>) => {
+  const source = loader.toString()
+  const isOrganizationSwitcher = source.includes('OrganizationSwitcher')
+  const Lazy = () =>
+    isOrganizationSwitcher ? (
+      <div data-testid="lazy-organization-switcher" />
+    ) : (
+      <div data-testid="lazy-other" />
+    )
+  return Lazy
+})
+
+jest.mock('@open-mercato/ui/backend/BackendChromeProvider', () => ({
+  useBackendChrome: () => ({ payload: { groups: [], grantedFeatures: [] }, isReady: true }),
+}))
+
+jest.mock('@open-mercato/ui/backend/IntegrationsButton', () => ({
+  IntegrationsButton: () => <div data-testid="integrations-button" />,
+}))
+
+jest.mock('@open-mercato/ui/backend/ProfileDropdown', () => ({
+  ProfileDropdown: () => <div data-testid="profile-dropdown" />,
+}))
+
+jest.mock('@open-mercato/ui/backend/SettingsButton', () => ({
+  SettingsButton: () => <div data-testid="settings-button" />,
+}))
+
+jest.mock('@/components/AiAssistantShellIntegration', () => ({
+  AiAssistantShellIntegration: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+describe('BackendHeaderChrome', () => {
+  it('renders the organization switcher in the topbar without a viewport-gated wrapper', () => {
+    const { container } = render(
+      <BackendHeaderChrome
+        email="demo@example.com"
+        embeddingConfigured={false}
+        missingConfigMessage=""
+        tenantId={null}
+        organizationId={null}
+      />,
+    )
+
+    const switcher = screen.getByTestId('lazy-organization-switcher')
+    expect(switcher).toBeInTheDocument()
+
+    // Regression for issue #1795: the topbar OrganizationSwitcher must not be
+    // wrapped in a viewport-gated container that hides it at narrow widths.
+    // Previously `<div className="hidden lg:contents">` removed it below 1024px,
+    // which combined with `mobileSidebarSlot={<OrganizationSwitcher compact />}`
+    // caused the dropdown to reappear inside the mobile sidebar drawer.
+    const hiddenWrappers = container.querySelectorAll('.hidden')
+    for (const wrapper of Array.from(hiddenWrappers)) {
+      expect(wrapper.contains(switcher)).toBe(false)
+    }
+  })
+})

--- a/packages/create-app/template/src/app/(backend)/backend/layout.tsx
+++ b/packages/create-app/template/src/app/(backend)/backend/layout.tsx
@@ -10,7 +10,6 @@ import { APP_VERSION } from '@open-mercato/shared/lib/version'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { PageInjectionBoundary } from '@open-mercato/ui/backend/injection/PageInjectionBoundary'
 import { DemoFeedbackWidget } from '@/components/DemoFeedbackWidget'
-import OrganizationSwitcher from '@/components/OrganizationSwitcher'
 import { BackendHeaderChrome } from '@/components/BackendHeaderChrome'
 
 registerBackendRouteManifests(backendRoutes)
@@ -114,7 +113,6 @@ export default async function BackendLayout({
             organizationId={auth?.orgId ?? null}
           />
         )}
-        mobileSidebarSlot={<OrganizationSwitcher compact />}
         adminNavApi="/api/auth/admin/nav"
         version={APP_VERSION}
         settingsPathPrefixes={collectStaticSettingsPathPrefixes()}

--- a/packages/create-app/template/src/components/BackendHeaderChrome.tsx
+++ b/packages/create-app/template/src/components/BackendHeaderChrome.tsx
@@ -89,9 +89,7 @@ export function BackendHeaderChrome({
           missingConfigMessage={missingConfigMessage}
         />
       ) : null}
-      <div className="hidden lg:contents">
-        {isReady ? <LazyOrganizationSwitcher /> : null}
-      </div>
+      {isReady ? <LazyOrganizationSwitcher /> : null}
       {showIntegrationsButton ? <IntegrationsButton /> : null}
       <SettingsButton />
       <ProfileDropdown email={email} />

--- a/packages/create-app/template/src/components/__tests__/BackendHeaderChrome.test.tsx
+++ b/packages/create-app/template/src/components/__tests__/BackendHeaderChrome.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { BackendHeaderChrome } from '../BackendHeaderChrome'
+
+jest.mock('next/dynamic', () => (loader: () => Promise<unknown>) => {
+  const source = loader.toString()
+  const isOrganizationSwitcher = source.includes('OrganizationSwitcher')
+  const Lazy = () =>
+    isOrganizationSwitcher ? (
+      <div data-testid="lazy-organization-switcher" />
+    ) : (
+      <div data-testid="lazy-other" />
+    )
+  return Lazy
+})
+
+jest.mock('@open-mercato/ui/backend/BackendChromeProvider', () => ({
+  useBackendChrome: () => ({ payload: { groups: [], grantedFeatures: [] }, isReady: true }),
+}))
+
+jest.mock('@open-mercato/ui/backend/IntegrationsButton', () => ({
+  IntegrationsButton: () => <div data-testid="integrations-button" />,
+}))
+
+jest.mock('@open-mercato/ui/backend/ProfileDropdown', () => ({
+  ProfileDropdown: () => <div data-testid="profile-dropdown" />,
+}))
+
+jest.mock('@open-mercato/ui/backend/SettingsButton', () => ({
+  SettingsButton: () => <div data-testid="settings-button" />,
+}))
+
+jest.mock('@/components/AiAssistantShellIntegration', () => ({
+  AiAssistantShellIntegration: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+describe('BackendHeaderChrome', () => {
+  it('renders the organization switcher in the topbar without a viewport-gated wrapper', () => {
+    const { container } = render(
+      <BackendHeaderChrome
+        email="demo@example.com"
+        embeddingConfigured={false}
+        missingConfigMessage=""
+        tenantId={null}
+        organizationId={null}
+      />,
+    )
+
+    const switcher = screen.getByTestId('lazy-organization-switcher')
+    expect(switcher).toBeInTheDocument()
+
+    // Regression for issue #1795: the topbar OrganizationSwitcher must not be
+    // wrapped in a viewport-gated container that hides it at narrow widths.
+    // Previously `<div className="hidden lg:contents">` removed it below 1024px,
+    // which combined with `mobileSidebarSlot={<OrganizationSwitcher compact />}`
+    // caused the dropdown to reappear inside the mobile sidebar drawer.
+    const hiddenWrappers = container.querySelectorAll('.hidden')
+    for (const wrapper of Array.from(hiddenWrappers)) {
+      expect(wrapper.contains(switcher)).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #1795

## Problem
After PR #1730 moved the Organization switcher out of the sidebar header into the topbar, the dropdown still reappeared inside the sidebar at narrow viewport widths (~ <1024px). This contradicted the design intent — the switcher should remain in the topbar at all widths.

## Root Cause
Two coordinated regressions:

1. `BackendHeaderChrome.tsx` wrapped `LazyOrganizationSwitcher` in `<div className="hidden lg:contents">`, so the topbar control was hidden below the `lg` breakpoint.
2. `(backend)/backend/layout.tsx` (both the app and the create-app template) passed `mobileSidebarSlot={<OrganizationSwitcher compact />}` to `AppShell`, which renders that slot inside the mobile drawer that opens at narrow widths.

Combined, the switcher disappeared from the topbar and reappeared inside the sidebar drawer below `lg`.

## What Changed
- `apps/mercato/src/components/BackendHeaderChrome.tsx` and `packages/create-app/template/src/components/BackendHeaderChrome.tsx`: drop the `hidden lg:contents` wrapper so the topbar shows the switcher at all viewport widths.
- `apps/mercato/src/app/(backend)/backend/layout.tsx` and `packages/create-app/template/src/app/(backend)/backend/layout.tsx`: stop passing `mobileSidebarSlot={<OrganizationSwitcher compact />}` (and remove the now-unused import).
- `AppShell.tsx`'s `mobileSidebarSlot` prop and the `OrganizationSwitcher` `compact` mode are kept for backward compatibility with third-party consumers.

## Tests
- New `apps/mercato/src/components/__tests__/BackendHeaderChrome.test.tsx` mocks the dynamic loaders and asserts the topbar `OrganizationSwitcher` is not rendered inside any element with `class="hidden"`. Verified the test fails before the fix and passes after.
- Existing suites still pass: `@open-mercato/app` (90 tests) and `@open-mercato/ui` (378 tests).
- `yarn turbo run typecheck --filter=@open-mercato/app --filter=@open-mercato/ui` clean.
- `yarn i18n:check-sync` clean (no string changes).

## Backward Compatibility
- No contract surface changes. `AppShell.mobileSidebarSlot` and `OrganizationSwitcher`'s `compact` prop remain available for external consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)