### PR TITLE
fix(ui): show variant duplicate-name error inline inside add-variant dialog (#1793)

### DIFF
--- a/packages/ui/src/backend/__tests__/SidebarCustomizationEditor.test.tsx
+++ b/packages/ui/src/backend/__tests__/SidebarCustomizationEditor.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import * as React from 'react'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { SidebarCustomizationEditor } from '../sidebar/SidebarCustomizationEditor'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 
@@ -176,6 +176,86 @@ describe('SidebarCustomizationEditor', () => {
       expect(screen.getByText('Staff')).toBeInTheDocument()
     })
     expect(screen.getByText('Admin')).toBeInTheDocument()
+  })
+
+  it('shows duplicate-name error inline inside the add-variant dialog (not on the page behind it)', async () => {
+    const duplicateMessage = 'A variant with this name already exists. Choose a different name.'
+
+    apiCallMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'POST' && /\/api\/auth\/sidebar\/variants$/.test(url)) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          result: { error: duplicateMessage, code: 'duplicate_name' },
+          response: {},
+          cacheStatus: null,
+        } as ApiCallResult<unknown>)
+      }
+      if (/\/api\/auth\/sidebar\/variants/.test(url)) {
+        return Promise.resolve(okResult({ locale: 'en', variants: [] }))
+      }
+      if (/\/api\/auth\/sidebar\/preferences/.test(url)) {
+        return Promise.resolve(okResult({ canApplyToRoles: false, roles: [] }))
+      }
+      throw new Error(`apiCall mock: no response configured for ${url}`)
+    })
+
+    renderWithProviders(<SidebarCustomizationEditor groups={fakeGroups} />, { dict })
+
+    const openDialogButton = await screen.findByRole('button', { name: /Create new/ })
+    fireEvent.click(openDialogButton)
+
+    const dialog = await screen.findByRole('dialog')
+    const nameInput = within(dialog).getByPlaceholderText('My preferences')
+    fireEvent.change(nameInput, { target: { value: 'My Variant' } })
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /Create variant/ }))
+
+    const dialogAlert = await within(dialog).findByRole('alert')
+    expect(dialogAlert).toHaveTextContent(duplicateMessage)
+    expect(within(dialog).getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+    expect(screen.getAllByText(duplicateMessage)).toHaveLength(1)
+  })
+
+  it('clears the inline dialog error when the user edits the name', async () => {
+    const duplicateMessage = 'A variant with this name already exists. Choose a different name.'
+
+    apiCallMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'POST' && /\/api\/auth\/sidebar\/variants$/.test(url)) {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          result: { error: duplicateMessage, code: 'duplicate_name' },
+          response: {},
+          cacheStatus: null,
+        } as ApiCallResult<unknown>)
+      }
+      if (/\/api\/auth\/sidebar\/variants/.test(url)) {
+        return Promise.resolve(okResult({ locale: 'en', variants: [] }))
+      }
+      if (/\/api\/auth\/sidebar\/preferences/.test(url)) {
+        return Promise.resolve(okResult({ canApplyToRoles: false, roles: [] }))
+      }
+      throw new Error(`apiCall mock: no response configured for ${url}`)
+    })
+
+    renderWithProviders(<SidebarCustomizationEditor groups={fakeGroups} />, { dict })
+
+    const openDialogButton = await screen.findByRole('button', { name: /Create new/ })
+    fireEvent.click(openDialogButton)
+    const dialog = await screen.findByRole('dialog')
+    const nameInput = within(dialog).getByPlaceholderText('My preferences')
+    fireEvent.change(nameInput, { target: { value: 'My Variant' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: /Create variant/ }))
+
+    await within(dialog).findByRole('alert')
+
+    fireEvent.change(nameInput, { target: { value: 'My Variant 2' } })
+
+    expect(within(dialog).queryByRole('alert')).not.toBeInTheDocument()
   })
 
   it('does not render the role-apply target list when canApplyToRoles is false', async () => {

--- a/packages/ui/src/backend/sidebar/SidebarCustomizationEditor.tsx
+++ b/packages/ui/src/backend/sidebar/SidebarCustomizationEditor.tsx
@@ -228,6 +228,7 @@ export function SidebarCustomizationEditor({
   const [canApplyToRoles, setCanApplyToRoles] = React.useState(false)
   const [addDialogOpen, setAddDialogOpen] = React.useState(false)
   const [addDialogName, setAddDialogName] = React.useState('')
+  const [addDialogError, setAddDialogError] = React.useState<string | null>(null)
   const baseSnapshotRef = React.useRef<SidebarGroup[] | null>(null)
   const hasInitializedRef = React.useRef(false)
 
@@ -366,8 +367,11 @@ export function SidebarCustomizationEditor({
     setDirty(true)
   }, [])
 
-  const createNewVariant = React.useCallback(async (proposedName?: string): Promise<boolean> => {
-    if (saving || deleting) return false
+  const createNewVariant = React.useCallback(async (
+    proposedName?: string,
+    options: { suppressPageError?: boolean } = {},
+  ): Promise<{ ok: boolean; error?: string }> => {
+    if (saving || deleting) return { ok: false }
     if (dirty && selectedVariantId !== null) {
       const proceed = await confirmDialog({
         title: t('appShell.sidebarCustomizationSwitchConfirmTitle', 'Discard unsaved changes?'),
@@ -376,10 +380,10 @@ export function SidebarCustomizationEditor({
         cancelText: t('common.cancel', 'Cancel'),
         variant: 'destructive',
       })
-      if (!proceed) return false
+      if (!proceed) return { ok: false }
     }
     setSaving(true)
-    setError(null)
+    if (!options.suppressPageError) setError(null)
     try {
       const baseSnapshot = baseSnapshotRef.current ?? buildBaseSnapshot()
       baseSnapshotRef.current = baseSnapshot
@@ -401,8 +405,9 @@ export function SidebarCustomizationEditor({
         mutationPayload: { name: trimmed.length > 0 ? trimmed : null },
       })
       if (!call.ok) {
-        setError(formatVariantApiError(call, t))
-        return false
+        const message = formatVariantApiError(call, t)
+        if (!options.suppressPageError) setError(message)
+        return { ok: false, error: message }
       }
       const created = call.result?.variant ?? null
       // Trust POST response as authoritative; refetch in background for any side-effects
@@ -424,11 +429,12 @@ export function SidebarCustomizationEditor({
         selectVariantInternal(fresh, nextList)
       }
       flash(t('appShell.sidebarCustomizationVariantCreated', 'Variant created.'), 'success')
-      return true
+      return { ok: true }
     } catch (err) {
       console.error('Failed to create sidebar variant', err)
-      setError(t('appShell.sidebarCustomizationSaveError'))
-      return false
+      const message = t('appShell.sidebarCustomizationSaveError')
+      if (!options.suppressPageError) setError(message)
+      return { ok: false, error: message }
     } finally {
       setSaving(false)
     }
@@ -552,12 +558,16 @@ export function SidebarCustomizationEditor({
   }, [onCanceled])
 
   const submitAddDialog = React.useCallback(async () => {
-    const ok = await createNewVariant(addDialogName)
-    if (ok) {
+    setAddDialogError(null)
+    const result = await createNewVariant(addDialogName, { suppressPageError: true })
+    if (result.ok) {
       setAddDialogOpen(false)
       setAddDialogName('')
+      setAddDialogError(null)
+      return
     }
-  }, [createNewVariant, addDialogName])
+    setAddDialogError(result.error ?? t('appShell.sidebarCustomizationSaveError'))
+  }, [createNewVariant, addDialogName, t])
 
   const sanitizeSettingsPayload = React.useCallback(() => {
     if (!draft || !baseSnapshotRef.current) return null
@@ -857,6 +867,7 @@ export function SidebarCustomizationEditor({
           if (!next) {
             setAddDialogOpen(false)
             setAddDialogName('')
+            setAddDialogError(null)
           }
         }}
       >
@@ -876,7 +887,10 @@ export function SidebarCustomizationEditor({
             <Input
               autoFocus
               value={addDialogName}
-              onChange={(event) => setAddDialogName(event.target.value)}
+              onChange={(event) => {
+                setAddDialogName(event.target.value)
+                if (addDialogError) setAddDialogError(null)
+              }}
               onKeyDown={(event) => {
                 if (event.key === 'Enter' && !event.shiftKey) {
                   event.preventDefault()
@@ -885,7 +899,18 @@ export function SidebarCustomizationEditor({
               }}
               placeholder={t('appShell.sidebarCustomizationVariantNamePlaceholder', 'My preferences')}
               disabled={saving}
+              aria-invalid={addDialogError ? true : undefined}
+              aria-describedby={addDialogError ? 'sidebar-add-variant-error' : undefined}
             />
+            {addDialogError ? (
+              <p
+                id="sidebar-add-variant-error"
+                role="alert"
+                className="text-xs text-destructive"
+              >
+                {addDialogError}
+              </p>
+            ) : null}
           </div>
           <DialogFooter className="mt-2">
             <Button
@@ -894,6 +919,7 @@ export function SidebarCustomizationEditor({
               onClick={() => {
                 setAddDialogOpen(false)
                 setAddDialogName('')
+                setAddDialogError(null)
               }}
               disabled={saving}
             >
@@ -986,6 +1012,7 @@ export function SidebarCustomizationEditor({
                               type="button"
                               onClick={() => {
                                 setAddDialogName('')
+                                setAddDialogError(null)
                                 setAddDialogOpen(true)
                               }}
                               disabled={isBusy}


### PR DESCRIPTION
Fixes #1793

## Problem
On `/backend/sidebar-customization`, attempting to save a new sidebar variant whose name already exists produced the duplicate-name validation error on the **page behind the modal**. The dialog stayed open with no inline feedback, so the user only saw the message after dismissing the dialog — by which point the context was lost.

## Root Cause
`createNewVariant` in `SidebarCustomizationEditor.tsx` reported all save failures through the page-level `setError` state. The page renders that banner above the variant editor, which is occluded by the dialog backdrop while the modal is open. The dialog itself had no inline error surface.

## What Changed
- Add `addDialogError` state and an inline alert below the name input inside the add-variant dialog.
- Mark the input as `aria-invalid` and link the alert via `aria-describedby` when the error is shown.
- Clear the dialog error on user edit, on cancel, on close, and when reopening the dialog.
- `createNewVariant` now returns `{ ok, error? }` and accepts a `suppressPageError` option. `submitAddDialog` opts in so the same message is no longer duplicated behind the dialog.
- All other call sites (none currently) and behavior outside the dialog are unchanged — the page-level banner still serves errors from save flows that originate outside the modal.

## Tests
- New unit test asserts the dialog shows an inline `role="alert"` containing the server message after a 409, the input gets `aria-invalid="true"`, the dialog stays open, and the message is not duplicated on the page behind it.
- New unit test asserts editing the input clears the inline alert.
- Existing `SidebarCustomizationEditor` tests continue to pass (380/380 in the UI workspace).
- `yarn typecheck` ✅, `yarn build:packages` ✅, `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅ (no new keys).

## Backward Compatibility
- No contract surface changes. `createNewVariant` is a closure-scoped helper inside `SidebarCustomizationEditor` and is not exported.
- API route, event IDs, ACL features, DI registrations, and DB schema untouched.