### PR TITLE
feat(crud): centralize custom-fields response normalization (#1769)

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -361,9 +361,29 @@ Always reference generated ids (`E.<module>.<entity>`) so system entities stay a
 
 ### Helpers
 
-- **Shared helpers**: `splitCustomFieldPayload`, `normalizeCustomFieldValues`, `normalizeCustomFieldResponse` from `@open-mercato/shared`
+- **Shared helpers**: `splitCustomFieldPayload`, `normalizeCustomFieldValues`, `normalizeCustomFieldResponse`, `applyCustomFieldsNormalization` from `@open-mercato/shared`
 - **Form collection**: `collectCustomFieldValues()` from `@open-mercato/ui/backend/utils/customFieldValues`
 - **Command undo**: capture custom field snapshots in `before`/`after` payloads (`snapshot.custom`), restore via `buildCustomFieldResetMap(before.custom, after.custom)`
+
+### Response Shape
+
+`makeCrudRoute` already extracts custom field values into `customValues` (bare keys, e.g. `{ priority: 3 }`) and `customFields` (definition array) when `list.decorateCustomFields` is configured.
+
+To opt into the canonical single-source response shape (no top-level `cf_*`/`cf:*` redundancy — the standardization requested in #1769), set `stripPrefixedKeys: true`:
+
+```typescript
+list: {
+  // ...
+  decorateCustomFields: {
+    entityIds: E.example.todo,
+    stripPrefixedKeys: true,
+  },
+}
+```
+
+For non-CRUD routes (custom detail GETs, ad-hoc handlers), call `applyCustomFieldsNormalization(record, decorated, { stripPrefixedKeys: true })` to get the same shape.
+
+The flag is opt-in to keep the existing wire format stable for callers that read `cf_*` from the top level — turn it on for new modules and migrate existing modules deliberately, with a deprecation note for any external consumer that still reads the prefixed keys.
 
 ### DSL Helpers
 

--- a/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/custom-fields.test.ts
@@ -1,4 +1,5 @@
 import {
+  applyCustomFieldsNormalization,
   buildCustomFieldFiltersFromQuery,
   decorateRecordWithCustomFields,
   extractAllCustomFieldEntries,
@@ -295,6 +296,62 @@ describe('decorateRecordWithCustomFields', () => {
     expect(result.customValues).toEqual({ priority: 5, severity: 'high' })
     expect(result.customFields.map((entry) => entry.key)).toEqual(['priority', 'severity'])
     expect(result.customFields.find((entry) => entry.key === 'my_test_key')).toBeUndefined()
+  })
+})
+
+describe('applyCustomFieldsNormalization', () => {
+  const definitionIndex: CustomFieldDefinitionIndex = new Map([
+    [
+      'priority',
+      [
+        {
+          key: 'priority',
+          label: 'Priority',
+          kind: 'integer',
+          multi: false,
+          organizationId: null,
+          tenantId: null,
+          priority: 0,
+          updatedAt: 1,
+        },
+      ],
+    ],
+  ])
+
+  it('preserves cf_* keys by default for backward compatibility', () => {
+    const record = { id: 'r-1', name: 'Item', cf_priority: 5, 'cf:priority': 5 }
+    const decorated = decorateRecordWithCustomFields(record, definitionIndex, {})
+    const result = applyCustomFieldsNormalization(record, decorated)
+
+    expect(result.id).toBe('r-1')
+    expect(result.cf_priority).toBe(5)
+    expect(result['cf:priority']).toBe(5)
+    expect(result.customValues).toEqual({ priority: 5 })
+    expect(Array.isArray(result.customFields)).toBe(true)
+    expect((result.customFields as any[])[0]).toMatchObject({ key: 'priority', value: 5 })
+  })
+
+  it('strips cf_* and cf:* keys when stripPrefixedKeys is enabled (issue #1769)', () => {
+    const record = { id: 'r-1', name: 'Item', cf_priority: 5, 'cf:priority': 5 }
+    const decorated = decorateRecordWithCustomFields(record, definitionIndex, {})
+    const result = applyCustomFieldsNormalization(record, decorated, { stripPrefixedKeys: true })
+
+    expect(result.id).toBe('r-1')
+    expect(result.name).toBe('Item')
+    expect('cf_priority' in result).toBe(false)
+    expect('cf:priority' in result).toBe(false)
+    expect(result.customValues).toEqual({ priority: 5 })
+    expect(Array.isArray(result.customFields)).toBe(true)
+  })
+
+  it('emits null customValues when no active definitions match', () => {
+    const record = { id: 'r-1', cf_unknown: 'leftover' }
+    const decorated = decorateRecordWithCustomFields(record, new Map(), {})
+    const result = applyCustomFieldsNormalization(record, decorated, { stripPrefixedKeys: true })
+
+    expect(result.customValues).toBeNull()
+    expect(result.customFields).toEqual([])
+    expect('cf_unknown' in result).toBe(false)
   })
 })
 

--- a/packages/shared/src/lib/crud/custom-fields.ts
+++ b/packages/shared/src/lib/crud/custom-fields.ts
@@ -406,6 +406,32 @@ export async function loadCustomFieldDefinitionIndex(opts: {
   return index
 }
 
+export type ApplyCustomFieldsNormalizationOptions = {
+  /**
+   * When true, removes raw `cf_*` and `cf:*` keys from the record once they
+   * have been extracted into `customValues` / `customFields`. Produces a single
+   * canonical response shape (issue #1769). Defaults to `false` to preserve the
+   * existing wire format for callers that read `cf_*` from the top level.
+   */
+  stripPrefixedKeys?: boolean
+}
+
+export function applyCustomFieldsNormalization(
+  record: Record<string, unknown>,
+  decorated: CustomFieldDisplayPayload,
+  options: ApplyCustomFieldsNormalizationOptions = {},
+): Record<string, unknown> {
+  const stripPrefixedKeys = options.stripPrefixedKeys === true
+  const base: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(record)) {
+    if (stripPrefixedKeys && (key.startsWith('cf_') || key.startsWith('cf:'))) continue
+    base[key] = value
+  }
+  base.customValues = decorated.customValues
+  base.customFields = decorated.customFields
+  return base
+}
+
 export function decorateRecordWithCustomFields(
   record: Record<string, unknown>,
   definitions: CustomFieldDefinitionIndex,

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -30,6 +30,7 @@ import {
   extractCustomFieldValuesFromPayload,
   extractAllCustomFieldEntries,
   decorateRecordWithCustomFields,
+  applyCustomFieldsNormalization,
   loadCustomFieldDefinitionIndex,
 } from './custom-fields'
 import { serializeExport, normalizeExportFormat, defaultExportFilename, ensureColumns, type CrudExportFormat, type PreparedExport } from './exporters'
@@ -162,6 +163,14 @@ export type CustomFieldsConfig =
 export type CrudListCustomFieldDecorator = {
   entityIds: EntityId | EntityId[]
   resolveContext?: (item: any, ctx: CrudCtx) => { organizationId?: string | null; tenantId?: string | null }
+  /**
+   * When true, the factory removes raw `cf_*` and `cf:*` keys from each list
+   * item after extracting them into `customValues` / `customFields`. Recommended
+   * for new modules — produces the single canonical response shape requested in
+   * #1769. Defaults to `false` so existing callers that read `cf_*` from the
+   * top level keep working until they migrate.
+   */
+  stripPrefixedKeys?: boolean
 }
 
 export type ListConfig<TList> = {
@@ -921,12 +930,9 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
           organizationId: organizationId ?? null,
           tenantId: tenantId ?? null,
         })
-        const output = {
-          ...item,
-          customValues: decorated.customValues,
-          customFields: decorated.customFields,
-        }
-        return output
+        return applyCustomFieldsNormalization(item, decorated, {
+          stripPrefixedKeys: listCustomFieldDecorator.stripPrefixedKeys === true,
+        })
       })
       cfProfiler.mark('decorate_complete', { itemCount: decoratedItems.length })
       endProfile({


### PR DESCRIPTION
Fixes #1769

## Problem

The CRUD factory and module-level routes emit custom field values in three places at once:
- top-level `cf_*` keys spread from the raw record
- a `customValues` map keyed by bare field name
- a `customFields` array of definition entries

Issue #1769 calls this the \"tri-state\" data flow and asks for a global mechanism that produces one canonical, predictable response shape — without making each module re-implement the same normalization by hand.

## Root Cause

`makeCrudRoute`'s list decoration always merges `...item, customValues, customFields`. The `cf_*` keys live on the raw record, so they survive the spread even though the same data is already present (in normalized form) inside `customValues` / `customFields`. Routes that bypass `decorateCustomFields` get no normalization at all.

## What Changed

- Added `applyCustomFieldsNormalization(record, decorated, { stripPrefixedKeys? })` in `@open-mercato/shared/lib/crud/custom-fields`. Single helper that any handler — CRUD or hand-rolled — can use to produce the canonical shape.
- Added `stripPrefixedKeys?: boolean` to `CrudListCustomFieldDecorator`. When `true`, the factory drops the redundant `cf_*` / `cf:*` keys from each list item; when `false` (default), the existing wire format is preserved byte-for-byte.
- Routed `makeCrudRoute`'s list decoration through the new helper so the behavior is centralized in one place going forward.
- Documented the flag and the helper in `packages/core/AGENTS.md` so module authors know how to opt into the standardized shape for new modules.

## Tests

- `packages/shared/src/lib/crud/__tests__/custom-fields.test.ts` adds three cases covering the helper:
  - default behavior preserves `cf_*` keys for backward compatibility
  - `stripPrefixedKeys: true` removes `cf_*` and `cf:*` keys while keeping `customValues` / `customFields`
  - records without active definitions still produce the expected empty payload
- All 16 tests in the file pass; the full workspace suite (3,350 tests across 19 packages) passes.

## Validation

- ✅ \`yarn typecheck\` — all 18 packages
- ✅ \`yarn test\` — 3,350/3,350
- ✅ \`yarn i18n:check-sync\` and \`yarn i18n:check-usage\`
- ✅ \`yarn build:packages\` and \`yarn generate\`
- ⚠️ \`yarn build:app\` — fails on this branch **and** on \`origin/develop\` with the same \`Module not found: ../../../../../../generated/entities.ids.generated.js\` turbopack errors. Pre-existing, unrelated to this change.

## Backward Compatibility

Strictly additive. The opt-in flag defaults to \`false\`, the existing public types only gain optional fields, and a new helper is exported from an existing module path. No frozen surface (events, ACL ids, route URLs, DB schema, DI names, generated contracts) is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)