### PR TITLE
fix(ui): restore Settings shortcut in sidebar sticky footer (#1794)

### DIFF
--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { createContext, useContext } from 'react'
 import Link from 'next/link'
 import Image from 'next/image'
-import { ChevronDown, ChevronLeft, Search, X } from 'lucide-react'
+import { ChevronDown, ChevronLeft, Search, Settings, X } from 'lucide-react'
 import { Button } from '../primitives/button'
 import { IconButton } from '../primitives/icon-button'
 import { Input } from '../primitives/input'
@@ -1017,6 +1017,34 @@ function AppShellBody({ productName, logo, email, groups, rightHeaderSlot, child
               context={injectionContext}
             />
           ) : null}
+          {(() => {
+            const settingsHref = '/backend/settings'
+            const isActive = !!pathname && (
+              pathname === settingsHref ||
+              pathname.startsWith(`${settingsHref}/`) ||
+              resolvedSettingsPathPrefixes.some((prefix) => pathname.startsWith(prefix))
+            )
+            const base = compact ? 'w-10 h-10 justify-center' : 'w-full px-3 py-2 gap-2'
+            return (
+              <Link
+                href={settingsHref}
+                className={`relative text-sm font-medium rounded-lg inline-flex items-center ${base} ${
+                  isActive ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted'
+                }`}
+                title={compact ? t('backend.nav.settings', 'Settings') : undefined}
+                data-menu-item-id="backend-sidebar-settings"
+                onClick={() => setMobileOpen(false)}
+              >
+                {isActive ? (
+                  <span aria-hidden className={`absolute ${compact ? 'left-[-20px]' : 'left-[-12px]'} top-2 w-1 h-5 rounded-r bg-foreground`} />
+                ) : null}
+                <span className="flex items-center justify-center shrink-0">
+                  <Settings className="size-4" aria-hidden />
+                </span>
+                {!compact && <span>{t('backend.nav.settings', 'Settings')}</span>}
+              </Link>
+            )
+          })()}
           {shouldRenderSidebarInjectionSpots ? (
             <StatusBadgeInjectionSpot
               spotId={GLOBAL_SIDEBAR_STATUS_BADGES_INJECTION_SPOT_ID}

--- a/packages/ui/src/backend/__tests__/AppShell.test.tsx
+++ b/packages/ui/src/backend/__tests__/AppShell.test.tsx
@@ -384,6 +384,59 @@ describe('AppShell', () => {
     }
   })
 
+  describe('sidebar sticky footer Settings shortcut', () => {
+    const settingsDict = { ...dict, 'backend.nav.settings': 'Settings' }
+
+    it('renders the Settings link inside the main sidebar sticky footer', async () => {
+      mockPathname = '/backend/users'
+
+      renderWithProviders(
+        <AppShell email="demo@example.com" groups={groups}>
+          <div>Page content</div>
+        </AppShell>,
+        { dict: settingsDict },
+      )
+
+      const settingsLink = await screen.findByRole('link', { name: 'Settings' })
+      expect(settingsLink).toHaveAttribute('href', '/backend/settings')
+      expect(settingsLink).toHaveAttribute('data-menu-item-id', 'backend-sidebar-settings')
+    })
+
+    it('marks the Settings link active when the current pathname is a registered settings prefix', async () => {
+      mockPathname = '/backend/entities/user'
+
+      renderWithProviders(
+        <AppShell
+          email="demo@example.com"
+          groups={groups}
+          settingsPathPrefixes={['/backend/entities/user']}
+        >
+          <div>Settings content</div>
+        </AppShell>,
+        { dict: settingsDict },
+      )
+
+      const settingsLink = await screen.findByRole('link', { name: 'Settings' })
+      expect(settingsLink).toHaveClass('bg-muted')
+      expect(settingsLink).toHaveClass('text-foreground')
+    })
+
+    it('keeps the Settings link inactive on non-settings paths', async () => {
+      mockPathname = '/backend/users'
+
+      renderWithProviders(
+        <AppShell email="demo@example.com" groups={groups}>
+          <div>Page content</div>
+        </AppShell>,
+        { dict: settingsDict },
+      )
+
+      const settingsLink = await screen.findByRole('link', { name: 'Settings' })
+      expect(settingsLink).toHaveClass('text-muted-foreground')
+      expect(settingsLink).not.toHaveClass('bg-muted')
+    })
+  })
+
   describe('two-level sidebar (settings/profile mode)', () => {
     it('renders main + section sidebars side-by-side when on a settings path', async () => {
       mockPathname = '/backend/entities/user'


### PR DESCRIPTION
Fixes #1794

## Problem

The reporter expected a visible sticky footer at the bottom of the main sidebar containing a Settings link, the Customize button, and injection spots (per PR #1730's design notes). On the current build the sticky footer renders only the three injection spots — which produce no visible UI on a default install — so the footer area looks empty and Settings is reachable only from the topbar gear icon.

## Root Cause

The carry-forward of the sidebar customization page (#1781) intentionally moved the Customize entry to its own page at `/backend/sidebar-customization` per `.ai/specs/2026-04-27-ds-sidebar-customization-page.md`, but the same diff also dropped the Settings link from the sticky footer. The Settings removal was collateral and not documented in any spec — so the spec at `.ai/specs/2026-04-26-ds-sidebar-restyle.md` still describes the Settings link as part of the footer, while the merged code no longer renders it.

## What Changed

`packages/ui/src/backend/AppShell.tsx`
- Re-add the Settings link inside the sticky footer (between `BACKEND_SIDEBAR_NAV_FOOTER_INJECTION_SPOT_ID` and `GLOBAL_SIDEBAR_STATUS_BADGES_INJECTION_SPOT_ID`, matching the placement described in the restyle spec).
- Use the same 3-state styling as other nav items: `text-muted-foreground hover:bg-muted` default, `bg-muted text-foreground` active, indicator bar at `left-[-20px]` / `left-[-12px]`.
- Active state derives from the same `resolvedSettingsPathPrefixes` resolution used elsewhere in the shell, so any settings descendant route highlights the entry.
- Compact mode (collapsed main sidebar) renders an icon-only link with a `title` tooltip; expanded mode renders icon + label.
- Closes the mobile drawer on click (`setMobileOpen(false)`), matching the behavior of the other nav links.

## Tests

`packages/ui/src/backend/__tests__/AppShell.test.tsx` — three new tests under `describe('sidebar sticky footer Settings shortcut')`:
- renders the Settings link with the expected `href` and `data-menu-item-id`
- marks the link active when the current pathname is a registered settings prefix (asserts `bg-muted` + `text-foreground`)
- keeps the link inactive on non-settings paths (asserts `text-muted-foreground`, no `bg-muted`)

Validation:
- `yarn workspace @open-mercato/ui run test --testPathPatterns=AppShell.test` — 14/14 (3 new)
- `yarn workspace @open-mercato/ui run test` — 381/381
- `yarn workspace @open-mercato/core run test` — 3350/3350
- `yarn typecheck` — 18/18
- `yarn build:packages` — 18/18
- `yarn i18n:check-sync` — 4 locales in sync (`backend.nav.settings` already exists in en/pl/de/es)

## Backward Compatibility

No contract surface changes. The Customize button is intentionally not restored — its move to a dedicated page was a deliberate design decision per `2026-04-27-ds-sidebar-customization-page.md`, and that page remains reachable through Settings → Customization. All injection spot IDs (`backend:sidebar:nav-footer`, `backend:sidebar:footer`, `global:sidebar:status-badges`) and their order are preserved.

## Notes

- A `yarn build:app` failure on `/_global-error/page` (`TypeError: Cannot read properties of null (reading 'useContext')`) is reproducible on a clean `origin/develop` checkout in this worktree and is unrelated to this PR — no code paths the Settings link touches are involved in `/_global-error` prerender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)