### PR TITLE
fix(auth): gate sidebar customization behind auth.sidebar.manage (#1792)

### DIFF
--- a/apps/docs/docs/user-guide/perspectives-and-sidebar.mdx
+++ b/apps/docs/docs/user-guide/perspectives-and-sidebar.mdx
@@ -36,11 +36,13 @@ Role perspectives can coexist with personal ones: users may adopt the role basel
 
 ![Sidebar customization with renamed groups and hidden links](/screenshots/open-mercato-sidebar-customization.png)
 
-1. Open the backend (`/backend`) and click **Customize sidebar** at the bottom of the navigation.
+Sidebar customization is gated by the `auth.sidebar.manage` feature. Users without that feature do not see the **Customize sidebar** entry in the Settings sidebar and are denied (`403`) on the underlying preferences and variants APIs. Role presets configured by users with the feature still cascade to members the next time they sign in.
+
+1. Open the backend (`/backend`) and navigate to **Settings → Customize sidebar**.
 2. Drag groups to reorder sections, rename the entries that matter, and hide rarely used links. Changes preview instantly on the right.
 3. Save to persist the layout for your account. Preferences are stored per locale and tenant/organization combination.
 
-To broadcast the layout to roles, pick **Share with roles** before saving. This requires the `auth.sidebar.manage` feature. Role presets cascade to members the next time they sign in; personal overrides remain available for power users who need their own tweaks.
+To broadcast the layout to roles, pick **Share with roles** before saving — the same `auth.sidebar.manage` feature controls both personal customization and role apply.
 
 ## Tips & troubleshooting
 

--- a/packages/core/src/modules/auth/api/__tests__/sidebar-preferences.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/sidebar-preferences.test.ts
@@ -1,0 +1,80 @@
+/** @jest-environment node */
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({ locale: 'en' }),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({ resolve: () => null }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/services/sidebarPreferencesService', () => ({
+  loadRoleSidebarPreferences: jest.fn(),
+  loadSidebarPreference: jest.fn(),
+  saveRoleSidebarPreference: jest.fn(),
+  saveSidebarPreference: jest.fn(),
+  createSidebarVariant: jest.fn(),
+  listSidebarVariants: jest.fn(),
+  deleteSidebarVariant: jest.fn(),
+  loadSidebarVariant: jest.fn(),
+  updateSidebarVariant: jest.fn(),
+}))
+
+type MethodMeta = { requireAuth?: boolean; requireFeatures?: string[] }
+
+describe('sidebar preferences/variants gating (issue #1792)', () => {
+  it('preferences PUT requires auth.sidebar.manage', async () => {
+    const mod = await import('@open-mercato/core/modules/auth/api/sidebar/preferences/route')
+    const metadata = mod.metadata as Record<string, MethodMeta>
+    expect(metadata.PUT.requireAuth).toBe(true)
+    expect(metadata.PUT.requireFeatures).toEqual(['auth.sidebar.manage'])
+  })
+
+  it('preferences DELETE requires auth.sidebar.manage', async () => {
+    const mod = await import('@open-mercato/core/modules/auth/api/sidebar/preferences/route')
+    const metadata = mod.metadata as Record<string, MethodMeta>
+    expect(metadata.DELETE.requireAuth).toBe(true)
+    expect(metadata.DELETE.requireFeatures).toEqual(['auth.sidebar.manage'])
+  })
+
+  it('preferences GET stays open to authenticated users (no manage feature required)', async () => {
+    const mod = await import('@open-mercato/core/modules/auth/api/sidebar/preferences/route')
+    const metadata = mod.metadata as Record<string, MethodMeta>
+    expect(metadata.GET.requireAuth).toBe(true)
+    expect(metadata.GET.requireFeatures).toBeUndefined()
+  })
+
+  it('variants POST requires auth.sidebar.manage', async () => {
+    const mod = await import('@open-mercato/core/modules/auth/api/sidebar/variants/route')
+    const metadata = mod.metadata as Record<string, MethodMeta>
+    expect(metadata.POST.requireAuth).toBe(true)
+    expect(metadata.POST.requireFeatures).toEqual(['auth.sidebar.manage'])
+  })
+
+  it('variants [id] PUT and DELETE require auth.sidebar.manage', async () => {
+    const mod = await import('@open-mercato/core/modules/auth/api/sidebar/variants/[id]/route')
+    const metadata = mod.metadata as Record<string, MethodMeta>
+    expect(metadata.PUT.requireAuth).toBe(true)
+    expect(metadata.PUT.requireFeatures).toEqual(['auth.sidebar.manage'])
+    expect(metadata.DELETE.requireAuth).toBe(true)
+    expect(metadata.DELETE.requireFeatures).toEqual(['auth.sidebar.manage'])
+  })
+})
+
+describe('sidebar customization page metadata (issue #1792)', () => {
+  it('declares requireFeatures: [auth.sidebar.manage]', async () => {
+    const mod = await import('@open-mercato/core/modules/auth/backend/sidebar-customization/page.meta')
+    const metadata = mod.metadata as { requireAuth?: boolean; requireFeatures?: string[] }
+    expect(metadata.requireAuth).toBe(true)
+    expect(metadata.requireFeatures).toEqual(['auth.sidebar.manage'])
+  })
+})

--- a/packages/core/src/modules/auth/api/sidebar/preferences/route.ts
+++ b/packages/core/src/modules/auth/api/sidebar/preferences/route.ts
@@ -21,8 +21,8 @@ import { z } from 'zod'
 
 export const metadata = {
   GET: { requireAuth: true },
-  PUT: { requireAuth: true },
-  DELETE: { requireAuth: true },
+  PUT: { requireAuth: true, requireFeatures: ['auth.sidebar.manage'] },
+  DELETE: { requireAuth: true, requireFeatures: ['auth.sidebar.manage'] },
 }
 
 const sidebarSettingsSchema = z.object({

--- a/packages/core/src/modules/auth/api/sidebar/variants/[id]/route.ts
+++ b/packages/core/src/modules/auth/api/sidebar/variants/[id]/route.ts
@@ -19,8 +19,8 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
 export const metadata = {
   GET: { requireAuth: true },
-  PUT: { requireAuth: true },
-  DELETE: { requireAuth: true },
+  PUT: { requireAuth: true, requireFeatures: ['auth.sidebar.manage'] },
+  DELETE: { requireAuth: true, requireFeatures: ['auth.sidebar.manage'] },
 }
 
 const variantResponseSchema = z.object({

--- a/packages/core/src/modules/auth/api/sidebar/variants/route.ts
+++ b/packages/core/src/modules/auth/api/sidebar/variants/route.ts
@@ -18,7 +18,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
 export const metadata = {
   GET: { requireAuth: true },
-  POST: { requireAuth: true },
+  POST: { requireAuth: true, requireFeatures: ['auth.sidebar.manage'] },
 }
 
 const variantListResponseSchema = z.object({

--- a/packages/core/src/modules/auth/backend/sidebar-customization/page.meta.ts
+++ b/packages/core/src/modules/auth/backend/sidebar-customization/page.meta.ts
@@ -9,16 +9,9 @@ const sidebarCustomizeIcon = React.createElement(
   React.createElement('path', { d: 'M17.5 14v7' }),
 )
 
-// Page is reachable by any authenticated user — every staff user has
-// always been able to customize their PERSONAL sidebar (the variants /
-// preferences APIs gate only role-application via `auth.sidebar.manage`).
-// Inside the editor, the "Apply to roles" card and role variants picker are
-// already conditionally hidden via `canApplyToRoles` (server-checked against
-// `auth.sidebar.manage`), so non-admins see only the personal-scope flow,
-// matching the pre-PR inline-editor behavior. Restricting the whole page
-// to `auth.sidebar.manage` would be a stealth regression for non-admins.
 export const metadata = {
   requireAuth: true,
+  requireFeatures: ['auth.sidebar.manage'],
   pageTitle: 'Customize sidebar',
   pageTitleKey: 'appShell.customizeSidebar',
   pageGroup: 'Customization',


### PR DESCRIPTION
Fixes #1792

## Problem
Users with the **Employee** role (which does not carry `auth.sidebar.manage`) could navigate to `/backend/sidebar-customization` and use the full editor. The page metadata explicitly opted out of the feature gate, so any authenticated user could `PUT`/`DELETE` `/api/auth/sidebar/preferences` and create/edit/delete sidebar variants via `/api/auth/sidebar/variants`.

## Root Cause
The PR that introduced the dedicated customization page (#1781) intentionally left `requireFeatures` off the page metadata, reasoning that personal-scope customization had historically been open to all authenticated users. RBAC was only enforced for the **role-apply** step inside the editor, leaving personal preference writes wide open.

## What Changed
- Add `requireFeatures: ['auth.sidebar.manage']` to:
  - `packages/core/src/modules/auth/backend/sidebar-customization/page.meta.ts` (page route + Settings sidebar visibility)
  - `PUT` and `DELETE` on `/api/auth/sidebar/preferences`
  - `POST` on `/api/auth/sidebar/variants`
  - `PUT` and `DELETE` on `/api/auth/sidebar/variants/[id]`
- `GET` endpoints stay open to authenticated users so existing personal preferences continue to load.
- Drop the page-meta comment justifying the previous open-by-default stance.
- Update the user-guide docs to describe the new contract.

## Tests
- New `packages/core/src/modules/auth/api/__tests__/sidebar-preferences.test.ts` asserts the feature gate on every mutating sidebar route + the page metadata.
- Targeted runs:
  - `yarn workspace @open-mercato/core jest --testPathPatterns=sidebar` → 12 passed
  - `yarn workspace @open-mercato/ui jest` → 378 passed
  - `yarn typecheck` → all 18 packages clean
  - `yarn i18n:check-sync` → in sync

## Backward Compatibility
- API contract: `PUT`/`DELETE` on the affected routes now return `403` (with `requiredFeatures: ['auth.sidebar.manage']`) for users without the feature. Previously they accepted personal-scope writes. This is the intended fix — it closes the privilege-escalation path called out in the PR review for #1730 and matches the feature title "Manage sidebar presets".
- Page route: `/backend/sidebar-customization` returns `403` for users without the feature. Settings sidebar entry is filtered server-side via the existing `featureChecker`.
- Default role mapping: `admin: ['auth.*']` already covers `auth.sidebar.manage`, so admins keep access. Employee, by design, does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)