### PR TITLE
docs(release): draft 0.6.0 changelog and version bump

### DIFF
--- a/.ai/runs/2026-05-06-changelog-0.6.0.md
+++ b/.ai/runs/2026-05-06-changelog-0.6.0.md
@@ -62,4 +62,4 @@ Prepare the Open Mercato 0.6.0 release metadata by updating the changelog with m
 
 - [x] 3.1 Re-read release-prep diff — 5288bf261
 - [x] 3.2 Run release-prep validation — 5288bf261
-- [ ] 3.3 Open PR and post summary
+- [x] 3.3 Open PR and post summary — PR #1814

--- a/.ai/runs/2026-05-06-changelog-0.6.0.md
+++ b/.ai/runs/2026-05-06-changelog-0.6.0.md
@@ -1,0 +1,65 @@
+# Release 0.6.0 Changelog And Version Bump
+
+## Goal
+
+Prepare the Open Mercato 0.6.0 release metadata by updating the changelog with merged `develop` PRs since 0.5.0 and bumping workspace package versions to `0.6.0`.
+
+## Scope
+
+- Update `CHANGELOG.md` for release `0.6.0 (2026-05-06)`.
+- Preserve original contributor credit for carry-forward/superseded PRs.
+- Bump workspace `package.json` `version` fields from `0.5.0`/current workspace versions to `0.6.0`.
+- Do not change runtime code, generated module artifacts, migrations, or application behavior.
+
+## External References
+
+- `.ai/skills/auto-update-changelog/SKILL.md` — adopted release-window, categorization, contributor-credit, and reporting rules. Extended scope only because the user explicitly requested package version bumps in the same release-prep PR.
+
+## Implementation Plan
+
+### Phase 1: Release Window And Draft
+
+1. Resolve the release window from the top numbered `CHANGELOG.md` heading: `2026-04-21` through `2026-05-06`.
+2. Enumerate merged PRs targeting `develop`, excluding prior release/changelog-only PRs.
+3. Detect carry-forward/supersede credit paths and resolve original authors.
+4. Draft the `0.6.0` changelog entry and reset `# Unreleased` to an empty placeholder.
+
+### Phase 2: Version Bump
+
+1. Update workspace package manifest `version` fields to `0.6.0`.
+2. Leave fixture package manifests alone.
+3. Confirm lockfile workspace entries do not need a manual version update.
+
+### Phase 3: Verification And PR
+
+1. Re-read the diff for scope.
+2. Run docs/release-prep validation appropriate for manifest-only and changelog changes.
+3. Push the branch, open a PR against `develop`, apply `review`, `documentation`, and `skip-qa` labels, and post the run summary.
+
+## Risks
+
+- The git tag boundary is stale (`v0.4.10`); the user explicitly requested `0.6.0`, so this run uses the current changelog release heading (`0.5.0` on `2026-04-21`) as the boundary.
+- Changelog entries are machine-drafted and should get human editorial review before release.
+- Version bumps are metadata-only, but package publishing relies on every workspace manifest staying aligned.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Release Window And Draft
+
+- [ ] 1.1 Resolve release window
+- [ ] 1.2 Enumerate merged develop PRs
+- [ ] 1.3 Resolve carry-forward credits
+- [ ] 1.4 Draft changelog entry
+
+### Phase 2: Version Bump
+
+- [ ] 2.1 Update workspace package versions
+- [ ] 2.2 Confirm lockfile version handling
+
+### Phase 3: Verification And PR
+
+- [ ] 3.1 Re-read release-prep diff
+- [ ] 3.2 Run release-prep validation
+- [ ] 3.3 Open PR and post summary

--- a/.ai/runs/2026-05-06-changelog-0.6.0.md
+++ b/.ai/runs/2026-05-06-changelog-0.6.0.md
@@ -48,18 +48,18 @@ Prepare the Open Mercato 0.6.0 release metadata by updating the changelog with m
 
 ### Phase 1: Release Window And Draft
 
-- [ ] 1.1 Resolve release window
-- [ ] 1.2 Enumerate merged develop PRs
-- [ ] 1.3 Resolve carry-forward credits
-- [ ] 1.4 Draft changelog entry
+- [x] 1.1 Resolve release window — 5288bf261
+- [x] 1.2 Enumerate merged develop PRs — 5288bf261
+- [x] 1.3 Resolve carry-forward credits — 5288bf261
+- [x] 1.4 Draft changelog entry — 5288bf261
 
 ### Phase 2: Version Bump
 
-- [ ] 2.1 Update workspace package versions
-- [ ] 2.2 Confirm lockfile version handling
+- [x] 2.1 Update workspace package versions — 5288bf261
+- [x] 2.2 Confirm lockfile version handling — 5288bf261
 
 ### Phase 3: Verification And PR
 
-- [ ] 3.1 Re-read release-prep diff
-- [ ] 3.2 Run release-prep validation
+- [x] 3.1 Re-read release-prep diff — 5288bf261
+- [x] 3.2 Run release-prep validation — 5288bf261
 - [ ] 3.3 Open PR and post summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: AI agents now have a unified runtime and approval flow, MikroORM has moved to v7/Kysely, CRM and navigation screens received another major usability pass, and release engineering now carries forward contributor credits for superseded PRs.
 
 ## ✨ Features
-
 - ✨ Realtime messages. (#1590) *(@Sawarz)*
 - ✨ CRM details screens revamp. (#1618) *(@haxiorz)*
 - ✨ Starter preset. (#1670) *(@dominikpalatynski)*
@@ -29,11 +28,14 @@ Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: 
 - ✨ AI framework unification + testing subagents flow with better agent-to-human communication. (#1593) *(@pkarw)*
 
 ## 🔒 Security
-
 - 🔒 Atomic password change + audit event for customer_accounts. (#1692) *(@pkarw)*
+- 🔒 Add tenant encryption map for inbox_ops module. (#1688) *(@WH173-P0NY)*
+- 🔒 Revoke customer sessions on self-service password change. (#1686) *(@WH173-P0NY)*
+- 🔒 Harden reset origin checks and require password confirmation. (#1729) *(@MStaniaszek1998)*
+- 🔒 Pin outbound webhook DNS to defeat rebinding (SSRF). (#1735) *(@pat-lewczuk)*
+- 🔒 Gate sidebar customization behind auth.sidebar.manage (#1792). (#1802) *(@pkarw)*
 
 ## 🐛 Fixes
-
 - 🐛 Parallelize entity defs, search availability, and dictionary resolution (#1404). (#1614) *(@pkarw)*
 - 🐛 Accept edit form payload and embed triggers in definition (#1586). (#1601) *(@pkarw)*
 - 🐛 Link seeded deals to pipeline + prevent doc number increment on type switch. (#1609) *(@vloneskorpion)*
@@ -54,9 +56,7 @@ Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: 
 - 🔄 V7 generated cache recovery. (#1672) *(@pkarw)*
 - 🔧 Restore recipient access to inbox and detail pages (#1633). (#1639) *(@pkarw)*
 - 📦 Hide example links in lean starters. (#1684) *(@pkarw)*
-- 🔐 Add tenant encryption map for inbox_ops module. (#1688) *(@WH173-P0NY)*
 - 🔄 Scope bulk-delete cache invalidation to worker tenant (fixes #1677). (#1687) *(@marcinwadon)*
-- 🔐 Revoke customer sessions on self-service password change. (#1686) *(@WH173-P0NY)*
 - 🐳 Extend QA Dokploy slots and adapt Docker provider API. (#1683) *(@dominikpalatynski)*
 - 📦 Update the create-app template copy path. (#1675) *(@dominikpalatynski)*
 - 🐛 Use search_tokens for users list search on encrypted email (#1666). (#1674) *(@pkarw)*
@@ -64,10 +64,8 @@ Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: 
 - 🐛 Normalize interaction & deal customValues via shared response helper. (#1680) *(@pkarw)*
 - 🔧 Update Docker ignore test exclusions and retain runtime helpers. (#1695) *(@dominikpalatynski)*
 - 🐛 CRM issues resolution (fixes #1657). (#1700) *(@haxiorz)*
-- 🔐 Harden reset origin checks and require password confirmation. (#1729) *(@MStaniaszek1998)*
 - 🐛 Disable rate limiting under OM_INTEGRATION_TEST. (#1673) *(@jtomaszewski)*
 - 🔧 Skip ratelimit_probe path when module is absent (standalone scaffold). (#1756) *(@pat-lewczuk)*
-- 🔐 Pin outbound webhook DNS to defeat rebinding (SSRF). (#1735) *(@pat-lewczuk)*
 - 🐛 CRM fixes 2 (fixes #1711). (#1743) *(@haxiorz)*
 - 🔧 Unblock standalone CI under zod 4.4.x + capture app log. (#1764) *(@pat-lewczuk)*
 - 💰 Fix company v2 currency collapse. (#1753) *(@dominikpalatynski)*
@@ -84,11 +82,9 @@ Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: 
 - 🐛 [Custom Fields] Deleted custom fields still appear in API response after removal from entity definition (#1749). (#1760) *(@pat-lewczuk)*
 - 🔐 [Customer Portal] Password reset link leads to 404 — reset page does not exist at generated URL (#1740). (#1758) *(@pat-lewczuk)*
 - 🔧 Remove explicit NODE_ENV from env files to silence Next.js warning. (#1728) *(@pkarw)*
-- 🔐 Gate sidebar customization behind auth.sidebar.manage (#1792). (#1802) *(@pkarw)*
 - 🐛 Keep organization switcher in topbar at all viewport widths (#1795). (#1798) *(@pkarw)*
 
 ## 🛠️ Improvements
-
 - 🛠️ Memoize Tabs context value to prevent consumer re-renders (#1409). (#1610) *(@pkarw)*
 - 🛠️ Lazy-load heavy libraries for schedule, markdown, and API docs (#1408). (#1615) *(@pkarw)*
 - 🛠️ Eliminate N+1 queries in user listing and role validation (#1398). (#1613) *(@pkarw)*
@@ -101,7 +97,6 @@ Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: 
 - 🛠️ Migrate Dependabot PRs #1724 + #1723 to develop. (#1775) *(@pkarw)*
 
 ## 📝 Specs & Documentation
-
 - 📝 Add local development walkthrough (#1435). (#1611) *(@pkarw)*
 - 📝 Add Hall of Fame for Agentic Hackathon winners. (#1646) *(@pat-lewczuk)*
 - 📝 Reassign authors on review and fix handoffs. (#1644) *(@pkarw)*
@@ -111,7 +106,6 @@ Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: 
 - 📝 Telemetry package with pluggable OTEL backend. (#1747) *(@jtomaszewski)*
 
 ## 👥 Contributors
-
 - @pkarw
 - @vloneskorpion
 - @jtomaszewski

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,131 @@
 # Unreleased
 
 ## Highlights
-**AI Framework Unification** 🧠 (#1593) — single contract for agent-oriented surfaces across the platform, from typed agent definitions to mutation approval. Implements the full [`2026-04-11-unified-ai-tooling-and-subagents`](.ai/specs/implemented/2026-04-11-unified-ai-tooling-and-subagents.md) spec (Phases 0–3). OpenCode Code Mode stays unchanged — the new framework runs alongside it.
+<!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
+
+---
+
+# 0.6.0 (2026-05-06)
+
+## Highlights
+Open Mercato `0.6.0` turns the post-0.5.0 work into a broader platform release: AI agents now have a unified runtime and approval flow, MikroORM has moved to v7/Kysely, CRM and navigation screens received another major usability pass, and release engineering now carries forward contributor credits for superseded PRs.
 
 ## ✨ Features
 
-### 🧠 AI agent runtime
-- `AiAgentDefinition` + `defineAiTool()`, `ai-agents.generated.ts` discovery, `agent-registry.ts` loader, runtime policy gate, and `POST /api/ai_assistant/ai/chat?agent=<module>.<agent>` dispatcher route. (#1593) *(@peter)*
+- ✨ Realtime messages. (#1590) *(@Sawarz)*
+- ✨ CRM details screens revamp. (#1618) *(@haxiorz)*
+- ✨ Starter preset. (#1670) *(@dominikpalatynski)*
+- ✨ UI-driven e2e tests + trigger cache invalidation. (#1689) *(@jtomaszewski)*
+- ✨ Accept { cause } option in CrudHttpError constructor (supersedes #1691). (#1694) *(@jtomaszewski, via @pkarw)*
+- ✨ Add `mercato auth sync-role-acls` CLI for re-applying default role features. (#1699) *(@MStaniaszek1998)*
+- ✨ Add inbox bulk actions. (#1685) *(@dominikpalatynski)*
+- ✨ Route metadata + standalone auto-skills + agent guardrails. (#1650) *(@pkarw)*
+- ✨ Make AppShell and PortalShell logo configurable. (#1725) *(@jtomaszewski)*
+- ✨ DS Foundation v2: form primitives + Tooltip + sweep migrations (clean replay). (#1739) *(@zielivia)*
+- ✨ Sidebar customization page with variants, DnD, and cross-locale support (supersedes #1730). (#1781) *(@zielivia, via @pkarw)*
+- ✨ Two-level sidebar — settings/profile alongside collapsed main. (#1790) *(@zielivia)*
+- ✨ CRM activity new UI. (#1791) *(@haxiorz)*
+- ✨ Introduce optional module orchestration and improve CLI errors. (#1698) *(@dominikpalatynski)*
+- ✨ AI framework unification + testing subagents flow with better agent-to-human communication. (#1593) *(@pkarw)*
 
-### 🧰 AI SDK helpers
-- `createAiAgentTransport`, `resolveAiAgentTools`, `runAiAgentText`, `runAiAgentObject` plus chat-mode / object-mode parity tests. (#1593) *(@peter)*
+## 🔒 Security
 
-### 📎 Attachment bridge
-- Typed resolved-attachment parts (`bytes` / `signed-url` / `text` / `metadata-only`), UI-part contract, and structured prompt-composition primitives. (#1593) *(@peter)*
+- 🔒 Atomic password change + audit event for customer_accounts. (#1692) *(@pkarw)*
 
-### 🧩 Tool packs
-- General (`search.*`, `attachments.*`, `meta.*`), customers, and catalog packs plus D18 merchandising read + AI-authoring tools. (#1593) *(@peter)*
+## 🐛 Fixes
 
-### 🛍️ D18 merchandising demo
-- `catalog.merchandising_assistant` with selection-aware `pageContext`; four bulk-edit use cases flow through `bulk_update_products` with single `[Confirm All]` approval, per-record `catalog.product.updated` events, DataTable refresh via DOM bridge, and `partialSuccess` handling. (#1593) *(@peter)*
-
-### 🎛️ Playground + settings UI
-- `<AiChat>` component, backend playground (`/backend/config/ai-assistant/playground`), and agent settings page (`/backend/config/ai-assistant/agents`) with versioned prompt overrides and feature-gated `mutationPolicy`. (#1593) *(@peter)*
-
-### 🛡️ Mutation approval gate (D16)
-- New additive table `ai_pending_actions` with three routes (`GET`/`confirm`/`cancel`), `prepareMutation` runtime wrapper, four new UI parts, typed `ai.action.{confirmed,cancelled,expired}` events, cleanup worker, and the first mutation-capable agent flow (`customers.account_assistant`). (#1593) *(@peter)*
+- 🐛 Parallelize entity defs, search availability, and dictionary resolution (#1404). (#1614) *(@pkarw)*
+- 🐛 Accept edit form payload and embed triggers in definition (#1586). (#1601) *(@pkarw)*
+- 🐛 Link seeded deals to pipeline + prevent doc number increment on type switch. (#1609) *(@vloneskorpion)*
+- 🐛 Prevent column truncation on definitions list. (#1623) *(@jtomaszewski)*
+- 💰 Load Stripe.js only on payment pages and update CSP (#1606). (#1608) *(@pkarw)*
+- 🐛 Move layout above [...slug] to stop navigation remount (#1083). (#1612) *(@pkarw)*
+- 🔐 Extend PII encryption maps + use decryption helpers in auth (#1413). (#1581) *(@pkarw)*
+- 🐛 Hide messages topbar icon when backing module is disabled. (#1567) *(@jtomaszewski)*
+- 🌍 Restore Jest module resolution and reduce false-positive unused i18n keys. (#1616) *(@pkarw)*
+- 🐛 Use `yarn mercato db` commands in codex enforcement rules. (#1630) *(@pat-lewczuk)*
+- 💰 [Business Logic] Shipment remains editable after full return and completed payment — missing state guards (#1624). (#1628) *(@pat-lewczuk)*
+- 🐛 Customer portal review fixes. (#1629) *(@pat-lewczuk)*
+- 🔄 Refresh inbox cache on unread events (#1634). (#1638) *(@pkarw)*
+- 🐛 Hide UI and gate APIs when backing module is disabled (supersedes #1636). (#1641) *(@jtomaszewski, via @pkarw)*
+- 🔐 Resolve CALL_API roles from the instance initiator. (#1643) *(@pkarw)*
+- 🔐 Use security email URL helper in signup. (#1642) *(@pkarw)*
+- 🐛 Eliminate race condition causing truncated dist files. (#1667) *(@staskolukasz)*
+- 🔄 V7 generated cache recovery. (#1672) *(@pkarw)*
+- 🔧 Restore recipient access to inbox and detail pages (#1633). (#1639) *(@pkarw)*
+- 📦 Hide example links in lean starters. (#1684) *(@pkarw)*
+- 🔐 Add tenant encryption map for inbox_ops module. (#1688) *(@WH173-P0NY)*
+- 🔄 Scope bulk-delete cache invalidation to worker tenant (fixes #1677). (#1687) *(@marcinwadon)*
+- 🔐 Revoke customer sessions on self-service password change. (#1686) *(@WH173-P0NY)*
+- 🐳 Extend QA Dokploy slots and adapt Docker provider API. (#1683) *(@dominikpalatynski)*
+- 📦 Update the create-app template copy path. (#1675) *(@dominikpalatynski)*
+- 🐛 Use search_tokens for users list search on encrypted email (#1666). (#1674) *(@pkarw)*
+- 🔄 Move default file-backed cache paths under .mercato. (#1682) *(@pkarw)*
+- 🐛 Normalize interaction & deal customValues via shared response helper. (#1680) *(@pkarw)*
+- 🔧 Update Docker ignore test exclusions and retain runtime helpers. (#1695) *(@dominikpalatynski)*
+- 🐛 CRM issues resolution (fixes #1657). (#1700) *(@haxiorz)*
+- 🔐 Harden reset origin checks and require password confirmation. (#1729) *(@MStaniaszek1998)*
+- 🐛 Disable rate limiting under OM_INTEGRATION_TEST. (#1673) *(@jtomaszewski)*
+- 🔧 Skip ratelimit_probe path when module is absent (standalone scaffold). (#1756) *(@pat-lewczuk)*
+- 🔐 Pin outbound webhook DNS to defeat rebinding (SSRF). (#1735) *(@pat-lewczuk)*
+- 🐛 CRM fixes 2 (fixes #1711). (#1743) *(@haxiorz)*
+- 🔧 Unblock standalone CI under zod 4.4.x + capture app log. (#1764) *(@pat-lewczuk)*
+- 💰 Fix company v2 currency collapse. (#1753) *(@dominikpalatynski)*
+- 🔐 Expand auth users search to organizations and roles. (#1752) *(@dominikpalatynski)*
+- 🐛 Resolve owning module from registry, not feature-id prefix. (#1768) *(@pat-lewczuk)*
+- 🔐 Fix portal signup activation messaging. (#1754) *(@dominikpalatynski)*
+- 🐛 Devsplash respects configured base URL across all variants. (#1726) *(@pkarw)*
+- 🔧 Align MikroORM entity migration guidance. (#1710) *(@pkarw)*
+- 🐛 Anchor storage/ and data/ ignore patterns to repo root. (#1697) *(@Kamyyylo)*
+- 🐛 Prevent duplicate sends from composer (#1631). (#1640) *(@pkarw)*
+- 🔧 Use OM_SEARCH_MIN_LEN env var for search query minimum length (supersedes #1761). (#1773) *(@haxiorz, via @pkarw)*
+- 🐛 Fix numeric-string display names and collapsed-rail icon focus (supersedes #1766). (#1772) *(@haxiorz, via @pkarw)*
+- 💰 [Forms] Native browser "Leave site?" dialog appears when submitting Create User or Create Payment Link forms (#1733). (#1759) *(@pat-lewczuk)*
+- 🐛 [Custom Fields] Deleted custom fields still appear in API response after removal from entity definition (#1749). (#1760) *(@pat-lewczuk)*
+- 🔐 [Customer Portal] Password reset link leads to 404 — reset page does not exist at generated URL (#1740). (#1758) *(@pat-lewczuk)*
+- 🔧 Remove explicit NODE_ENV from env files to silence Next.js warning. (#1728) *(@pkarw)*
+- 🔐 Gate sidebar customization behind auth.sidebar.manage (#1792). (#1802) *(@pkarw)*
+- 🐛 Keep organization switcher in topbar at all viewport widths (#1795). (#1798) *(@pkarw)*
 
 ## 🛠️ Improvements
 
-- Shared model factory extracted from `inbox_ops/lib/llmProvider.ts` with caller-override / `<MODULE>_AI_MODEL` env / agent-default / provider-default resolution; original API preserved via a thin shim (no call-site churn). New env var `AI_PENDING_ACTION_TTL_SECONDS` (default `900`). (#1593) *(@peter)*
+- 🛠️ Memoize Tabs context value to prevent consumer re-renders (#1409). (#1610) *(@pkarw)*
+- 🛠️ Lazy-load heavy libraries for schedule, markdown, and API docs (#1408). (#1615) *(@pkarw)*
+- 🛠️ Eliminate N+1 queries in user listing and role validation (#1398). (#1613) *(@pkarw)*
+- 🛠️ Migrate deprecated Notice usages to Alert. (#1649) *(@pkarw)*
+- 🛠️ MikroORM v7, use Kysely. (#1513) *(@staskolukasz)*
+- 🛠️ DS foundation v1. (#1708) *(@zielivia)*
+- 🛠️ Document v2 form primitives + new tokens. (#1707) *(@zielivia)*
+- 🛠️ Update README.md. (#1765) *(@pat-lewczuk)*
+- 🛠️ Add priority labels (low/medium/high/extreme). (#1785) *(@pkarw)*
+- 🛠️ Migrate Dependabot PRs #1724 + #1723 to develop. (#1775) *(@pkarw)*
 
 ## 📝 Specs & Documentation
 
-- Spec moved to [`.ai/specs/implemented/2026-04-11-unified-ai-tooling-and-subagents.md`](.ai/specs/implemented/2026-04-11-unified-ai-tooling-and-subagents.md) (history preserved via `git mv`); AI Assistant `AGENTS.md` gains an **Upgrading / Operator rollout notes** section with env vars, new tables, cleanup worker registration, and OpenCode coexistence guidance. (#1593) *(@peter)*
+- 📝 Add local development walkthrough (#1435). (#1611) *(@pkarw)*
+- 📝 Add Hall of Fame for Agentic Hackathon winners. (#1646) *(@pat-lewczuk)*
+- 📝 Reassign authors on review and fix handoffs. (#1644) *(@pkarw)*
+- 📝 Make vector auto-indexing opt-in by default. (#1679) *(@pkarw)*
+- 📝 Add CRM call transcriptions + Zoom + tl;dv adapter specs. (#1645) *(@matgren)*
+- 📝 Push notifications and devices modules. (#1746) *(@jtomaszewski)*
+- 📝 Telemetry package with pluggable OTEL backend. (#1747) *(@jtomaszewski)*
 
 ## 👥 Contributors
 
-- @peter
+- @pkarw
+- @vloneskorpion
+- @jtomaszewski
+- @Sawarz
+- @pat-lewczuk
+- @haxiorz
+- @staskolukasz
+- @dominikpalatynski
+- @matgren
+- @WH173-P0NY
+- @marcinwadon
+- @MStaniaszek1998
+- @zielivia
+- @Kamyyylo
 
 ---
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-mercato-docs",
-  "version": "0.3.6",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "docusaurus start",

--- a/apps/mercato/package.json
+++ b/apps/mercato/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/app",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-mercato",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
   "engines": {

--- a/packages/ai-assistant/package.json
+++ b/packages/ai-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/ai-assistant",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "engines": {
     "node": ">=22.0.0"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/cache",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Multi-strategy cache service with tag-based invalidation support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/checkout",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/content",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mercato-app",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "description": "Create a new Open Mercato application",
   "main": "./dist/index.js",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/enterprise",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/events",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/gateway-stripe/package.json
+++ b/packages/gateway-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/gateway-stripe",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/onboarding",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/queue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Multi-strategy job queue with local and BullMQ support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/scheduler",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Database-managed scheduled jobs with admin UI",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/search",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/shared",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {
@@ -92,7 +92,7 @@
     "@mikro-orm/core": "^7.0.13",
     "@mikro-orm/decorators": "^7.0.13",
     "@mikro-orm/postgresql": "^7.0.13",
-    "@open-mercato/cache": "0.5.0",
+    "@open-mercato/cache": "0.6.0",
     "dotenv": "^17.4.2",
     "rate-limiter-flexible": "^11.0.1",
     "reflect-metadata": "^0.2.2",

--- a/packages/sync-akeneo/package.json
+++ b/packages/sync-akeneo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/sync-akeneo",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/ui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/webhooks",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Webhooks module for Open Mercato — Standard Webhooks compliant outbound/inbound delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6389,7 +6389,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@open-mercato/cache@npm:0.5.0, @open-mercato/cache@workspace:*, @open-mercato/cache@workspace:packages/cache":
+"@open-mercato/cache@npm:0.6.0, @open-mercato/cache@workspace:*, @open-mercato/cache@workspace:packages/cache":
   version: 0.0.0-use.local
   resolution: "@open-mercato/cache@workspace:packages/cache"
   dependencies:
@@ -6649,7 +6649,7 @@ __metadata:
     "@mikro-orm/core": "npm:^7.0.13"
     "@mikro-orm/decorators": "npm:^7.0.13"
     "@mikro-orm/postgresql": "npm:^7.0.13"
-    "@open-mercato/cache": "npm:0.5.0"
+    "@open-mercato/cache": "npm:0.6.0"
     "@types/jest": "npm:^30.0.0"
     "@types/sanitize-html": "npm:^2.16.1"
     dotenv: "npm:^17.4.2"


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-06-changelog-0.6.0.md
Status: complete

## Goal
- Prepare Open Mercato `0.6.0` release metadata with a changelog entry and aligned workspace package versions.

## External References
- `.ai/skills/auto-update-changelog/SKILL.md` — adopted the release-window, categorization, contributor-credit, and reporting rules; extended scope only because the user explicitly requested package version bumps.

## What Changed
- Reset `# Unreleased` to an empty placeholder and added `# 0.6.0 (2026-05-06)` covering 85 merged `develop` PRs since `0.5.0`.
- Preserved carry-forward credits for superseded PRs: #1641/#1636, #1694/#1691, #1781/#1730, #1773/#1761, and #1772/#1766.
- Bumped workspace package manifest versions to `0.6.0` and updated the `@open-mercato/cache` manifest/lockfile release reference from `0.5.0` to `0.6.0`.

## Tests
- `yarn install --immutable` — passes with existing peer-dependency warnings.
- `yarn check:dep-versions` — passes.
- `git diff --check` — passes.
- Node validation: workspace package `version` fields are `0.6.0` except the fixture package; changelog release heading and carry-forward credits are present.

## Backward Compatibility
- No runtime code or public contract surface changes. This is release metadata plus package version alignment.

## Progress
See [Progress section in the plan](.ai/runs/2026-05-06-changelog-0.6.0.md#progress).
