### PR TITLE
Fix/rbac privesc promote check

### DIFF
--- a/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
+++ b/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
@@ -50,6 +50,7 @@ const mockDataEngine: MockDataEngine = {
   markOrmEntityChange: jest.fn<void, [QueueEntry | undefined]>(),
   flushOrmEntityChanges: jest.fn<Promise<void>, []>(),
 }
+const mockFindOneWithDecryption = jest.fn()
 const mockRbac: MockRbacService = {
   invalidateUserCache: jest.fn<Promise<void>, [string]>(),
   loadAcl: jest.fn<Promise<MockAcl | null>, [string, { tenantId: string | null; organizationId: string | null }]>(),
@@ -83,6 +84,10 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   })),
 }))
 
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
 jest.mock('../../services/apiKeyService', () => {
   const actual = jest.requireActual('../../services/apiKeyService')
   return {
@@ -106,6 +111,8 @@ describe('API Keys route', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockDataEngine.__queue.length = 0
+    mockFindOneWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockResolvedValue(null)
     mockEm.fork.mockReturnValue(mockEm)
     mockGetAuthFromCookies.mockResolvedValue({
       sub: 'user-1',
@@ -228,7 +235,7 @@ describe('API Keys route', () => {
       isSuperAdmin: false,
       features: ['api_keys.create'],
     })
-    mockEm.findOne.mockImplementation(async (entity: unknown) => {
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
       if (entity === RoleAcl) {
         return {
           isSuperAdmin: false,

--- a/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
+++ b/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 
 import { features } from '../../acl'
+import { RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
 
 const secretFixture = { secret: 'omk_test.secret', prefix: 'omk_testpref' }
 
@@ -21,9 +22,11 @@ interface MockDataEngine {
   flushOrmEntityChanges: jest.Mock<Promise<void>, []>
 }
 
+type MockAcl = { isSuperAdmin: boolean; features?: string[]; organizations?: string[] | null }
+
 interface MockRbacService {
   invalidateUserCache: jest.Mock<Promise<void>, [string]>
-  loadAcl: jest.Mock<Promise<{ isSuperAdmin: boolean } | null>, [string, { tenantId: string | null; organizationId: string | null }]>
+  loadAcl: jest.Mock<Promise<MockAcl | null>, [string, { tenantId: string | null; organizationId: string | null }]>
 }
 
 interface MockContainer {
@@ -49,7 +52,7 @@ const mockDataEngine: MockDataEngine = {
 }
 const mockRbac: MockRbacService = {
   invalidateUserCache: jest.fn<Promise<void>, [string]>(),
-  loadAcl: jest.fn<Promise<{ isSuperAdmin: boolean } | null>, [string, { tenantId: string | null; organizationId: string | null }]>(),
+  loadAcl: jest.fn<Promise<MockAcl | null>, [string, { tenantId: string | null; organizationId: string | null }]>(),
 }
 const mockContainer: MockContainer = {
   resolve: jest.fn((token: string) => {
@@ -218,6 +221,40 @@ describe('API Keys route', () => {
     })
     expect(mockHashApiKey).toHaveBeenCalledWith(secretFixture.secret)
     expect(mockRbac.invalidateUserCache).toHaveBeenCalledWith('api_key:key-1')
+  })
+
+  it('rejects role-backed API keys when the requested role grants features outside the actor ACL', async () => {
+    mockRbac.loadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['api_keys.create'],
+    })
+    mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      if (entity === RoleAcl) {
+        return {
+          isSuperAdmin: false,
+          featuresJson: ['auth.*'],
+          organizationsJson: null,
+          tenantId: '123e4567-e89b-12d3-a456-426614174000',
+        }
+      }
+      return null
+    })
+
+    const res = await postHandler(
+      new Request('http://localhost/api/api_keys/keys', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Escalating key',
+          roles: ['manager'],
+        }),
+      }),
+    )
+    const payload = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(payload.error).toContain('Cannot grant feature wildcard auth.*')
+    expect(mockDataEngine.createOrmEntity).not.toHaveBeenCalled()
   })
 
   it('rejects creation when organization is outside the allowed scope', async () => {

--- a/packages/core/src/modules/api_keys/api/keys/route.ts
+++ b/packages/core/src/modules/api_keys/api/keys/route.ts
@@ -12,6 +12,7 @@ import { generateApiKeySecret, hashApiKey } from '../../services/apiKeyService'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { enforceTenantSelection, resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { assertActorCanGrantRoles } from '@open-mercato/core/modules/auth/lib/grantChecks'
 
 type ApiKeyCrudCtx = CrudCtx & {
   __apiKeySecret?: { secret: string; prefix: string }
@@ -283,6 +284,14 @@ const crud = makeCrudRoute<
         roleEntities.push(role)
         roleIds.push(String(role.id))
       }
+      await assertActorCanGrantRoles({
+        em,
+        rbacService: ctx.container.resolve('rbacService') as RbacService,
+        actorUserId: auth.sub,
+        tenantId: targetTenantId,
+        organizationId: auth.orgId ?? null,
+        roles: roleEntities,
+      })
       scopedCtx.__apiKeyRoles = roleEntities
       scopedCtx.__apiKeyRoleIds = roleIds
 

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1,12 +1,13 @@
 /** @jest-environment node */
 
-import { GET, POST } from '@open-mercato/core/modules/auth/api/users/route'
-import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
+import { GET, POST, PUT } from '@open-mercato/core/modules/auth/api/users/route'
+import { Role, RoleAcl, User } from '@open-mercato/core/modules/auth/data/entities'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 
 const mockGetAuthFromRequest = jest.fn()
 const mockLoadAcl = jest.fn()
 const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
 const mockLoadCustomFieldValues = jest.fn()
 const mockLogCrudAccess = jest.fn()
 
@@ -94,6 +95,7 @@ jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
 }))
 
 jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
@@ -118,6 +120,7 @@ describe('GET /api/auth/users', () => {
     mockEm.findAndCount.mockReset()
     mockEm.getKysely.mockClear()
     mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
     mockLoadCustomFieldValues.mockReset()
     mockLogCrudAccess.mockReset()
     mockContainer.resolve.mockClear()
@@ -140,6 +143,7 @@ describe('GET /api/auth/users', () => {
     mockEm.findOne.mockResolvedValue(null)
     mockEm.findAndCount.mockResolvedValue([[], 0])
     mockFindWithDecryption.mockResolvedValue([])
+    mockFindOneWithDecryption.mockResolvedValue(null)
     mockLoadCustomFieldValues.mockResolvedValue({})
     mockLogCrudAccess.mockResolvedValue(undefined)
   })
@@ -432,7 +436,7 @@ describe('GET /api/auth/users', () => {
       features: ['auth.users.create'],
       organizations: null,
     })
-    mockEm.findOne.mockImplementation(async (entity: unknown) => {
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
       if (entity === Organization) return { id: organizationId, tenant: { id: tenantId } }
       if (entity === Role) return { id: privilegedRoleId, name: 'Tenant Admin', tenantId }
       if (entity === RoleAcl) {
@@ -460,5 +464,41 @@ describe('GET /api/auth/users', () => {
 
     expect(response.status).toBe(403)
     expect(body.error).toContain('Cannot grant feature')
+  })
+
+  test('rejects limited users reassigning an existing user to a privileged role on update', async () => {
+    const userId = '523e4567-e89b-12d3-a456-426614174501'
+    const privilegedRoleId = '323e4567-e89b-12d3-a456-426614174778'
+    mockLoadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.users.edit'],
+      organizations: null,
+    })
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === User) return { id: userId, tenantId, organizationId }
+      if (entity === Role) return { id: privilegedRoleId, name: 'Tenant Admin', tenantId }
+      if (entity === RoleAcl) {
+        return {
+          isSuperAdmin: false,
+          featuresJson: ['api_keys.create'],
+          organizationsJson: null,
+          tenantId,
+        }
+      }
+      return null
+    })
+
+    const response = await PUT(new Request('http://localhost/api/auth/users', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: userId,
+        roles: [privilegedRoleId],
+      }),
+    }))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toContain('Cannot grant feature api_keys.create')
   })
 })

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1,6 +1,8 @@
 /** @jest-environment node */
 
-import { GET } from '@open-mercato/core/modules/auth/api/users/route'
+import { GET, POST } from '@open-mercato/core/modules/auth/api/users/route'
+import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 
 const mockGetAuthFromRequest = jest.fn()
 const mockLoadAcl = jest.fn()
@@ -28,6 +30,7 @@ const mockKysely = { selectFrom: mockSelectFrom }
 
 const mockEm = {
   find: jest.fn(),
+  findOne: jest.fn(),
   findAndCount: jest.fn(),
   getKysely: jest.fn(() => mockKysely),
 }
@@ -48,11 +51,42 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => mockContainer),
 }))
 
+type MockCrudAction = {
+  schema?: { parse: (input: unknown) => Record<string, unknown> }
+  mapInput?: (args: {
+    parsed: Record<string, unknown>
+    raw: Record<string, unknown>
+    ctx: { request: Request }
+  }) => Promise<unknown> | unknown
+  status?: number
+}
+
+async function mockRunCrudAction(action: MockCrudAction | undefined, request: Request): Promise<Response> {
+  try {
+    const raw = await request.json().catch(() => ({})) as Record<string, unknown>
+    const parsed = action?.schema ? action.schema.parse(raw) : raw
+    if (action?.mapInput) await action.mapInput({ parsed, raw, ctx: { request } })
+    return new Response(JSON.stringify({ id: 'created-id' }), {
+      status: action?.status ?? 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  } catch (err) {
+    const httpError = err as { status?: unknown; body?: unknown; message?: string }
+    if (typeof httpError.status === 'number') {
+      return new Response(JSON.stringify(httpError.body ?? { error: httpError.message ?? 'Request failed' }), {
+        status: httpError.status,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    throw err
+  }
+}
+
 jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
-  makeCrudRoute: jest.fn((opts: { metadata: unknown }) => ({
+  makeCrudRoute: jest.fn((opts: { metadata: unknown; actions?: { create?: MockCrudAction; update?: MockCrudAction } }) => ({
     metadata: opts.metadata,
-    POST: jest.fn(),
-    PUT: jest.fn(),
+    POST: jest.fn((request: Request) => mockRunCrudAction(opts.actions?.create, request)),
+    PUT: jest.fn((request: Request) => mockRunCrudAction(opts.actions?.update, request)),
     DELETE: jest.fn(),
   })),
   logCrudAccess: jest.fn((args: unknown) => mockLogCrudAccess(args)),
@@ -80,6 +114,7 @@ describe('GET /api/auth/users', () => {
     mockGetAuthFromRequest.mockReset()
     mockLoadAcl.mockReset()
     mockEm.find.mockReset()
+    mockEm.findOne.mockReset()
     mockEm.findAndCount.mockReset()
     mockEm.getKysely.mockClear()
     mockFindWithDecryption.mockReset()
@@ -102,6 +137,7 @@ describe('GET /api/auth/users', () => {
     })
     mockLoadAcl.mockResolvedValue({ isSuperAdmin: false })
     mockEm.find.mockResolvedValue([])
+    mockEm.findOne.mockResolvedValue(null)
     mockEm.findAndCount.mockResolvedValue([[], 0])
     mockFindWithDecryption.mockResolvedValue([])
     mockLoadCustomFieldValues.mockResolvedValue({})
@@ -387,5 +423,42 @@ describe('GET /api/auth/users', () => {
       { tenantId },
     ]))
     expect(body.isSuperAdmin).toBe(true)
+  })
+
+  test('rejects limited users assigning a role whose ACL grants features outside the actor ACL', async () => {
+    const privilegedRoleId = '323e4567-e89b-12d3-a456-426614174777'
+    mockLoadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.users.create'],
+      organizations: null,
+    })
+    mockEm.findOne.mockImplementation(async (entity: unknown) => {
+      if (entity === Organization) return { id: organizationId, tenant: { id: tenantId } }
+      if (entity === Role) return { id: privilegedRoleId, name: 'Tenant Admin', tenantId }
+      if (entity === RoleAcl) {
+        return {
+          isSuperAdmin: false,
+          featuresJson: ['auth.*'],
+          organizationsJson: null,
+          tenantId,
+        }
+      }
+      return null
+    })
+
+    const response = await POST(new Request('http://localhost/api/auth/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'limited-create@example.com',
+        password: 'StrongSecret123!',
+        organizationId,
+        roles: [privilegedRoleId],
+      }),
+    }))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toContain('Cannot grant feature')
   })
 })

--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -429,6 +429,41 @@ describe('GET /api/auth/users', () => {
     expect(body.isSuperAdmin).toBe(true)
   })
 
+  test('allows assigning a role whose wildcard ACL is covered by actor wildcard ACL', async () => {
+    const employeeRoleId = '323e4567-e89b-12d3-a456-426614174776'
+    mockLoadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.users.create', 'example.*'],
+      organizations: null,
+    })
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === Organization) return { id: organizationId, tenant: { id: tenantId } }
+      if (entity === Role) return { id: employeeRoleId, name: 'employee', tenantId }
+      if (entity === RoleAcl) {
+        return {
+          isSuperAdmin: false,
+          featuresJson: ['example.widgets.*'],
+          organizationsJson: null,
+          tenantId,
+        }
+      }
+      return null
+    })
+
+    const response = await POST(new Request('http://localhost/api/auth/users', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        email: 'employee-create@example.com',
+        password: 'StrongSecret123!',
+        organizationId,
+        roles: [employeeRoleId],
+      }),
+    }))
+
+    expect(response.status).toBe(201)
+  })
+
   test('rejects limited users assigning a role whose ACL grants features outside the actor ACL', async () => {
     const privilegedRoleId = '323e4567-e89b-12d3-a456-426614174777'
     mockLoadAcl.mockResolvedValueOnce({

--- a/packages/core/src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts
+++ b/packages/core/src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts
@@ -214,4 +214,120 @@ describe('role ACL tenant scoping — existence oracle prevention', () => {
     expect(body.error).toContain('Cannot grant feature api_keys.create')
     expect(mockEm.persist).not.toHaveBeenCalled()
   })
+
+  it('PUT rejects superadmin grants from non-superadmin actors', async () => {
+    const role = { id: ROLE_ID, tenantId: ACTOR_TENANT_ID }
+    mockRbacService.loadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.acl.manage'],
+      organizations: null,
+    })
+    mockEm.findOne.mockImplementation(async (ctor: unknown) => {
+      if (ctor === Role) return role
+      if (ctor === RoleAcl) {
+        return {
+          role,
+          tenantId: ACTOR_TENANT_ID,
+          isSuperAdmin: false,
+          featuresJson: ['auth.acl.manage'],
+          organizationsJson: null,
+        }
+      }
+      return null
+    })
+
+    const res = await PUT(
+      new Request('http://localhost/api/auth/roles/acl', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          roleId: ROLE_ID,
+          isSuperAdmin: true,
+          features: ['auth.acl.manage'],
+        }),
+      }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toContain('super admin')
+    expect(mockEm.persist).not.toHaveBeenCalled()
+  })
+
+  it('PUT rejects global wildcard grants from non-superadmin actors', async () => {
+    const role = { id: ROLE_ID, tenantId: ACTOR_TENANT_ID }
+    mockRbacService.loadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.acl.manage'],
+      organizations: null,
+    })
+    mockEm.findOne.mockImplementation(async (ctor: unknown) => {
+      if (ctor === Role) return role
+      if (ctor === RoleAcl) {
+        return {
+          role,
+          tenantId: ACTOR_TENANT_ID,
+          isSuperAdmin: false,
+          featuresJson: ['auth.acl.manage'],
+          organizationsJson: null,
+        }
+      }
+      return null
+    })
+
+    const res = await PUT(
+      new Request('http://localhost/api/auth/roles/acl', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          roleId: ROLE_ID,
+          features: ['*'],
+        }),
+      }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toContain('global wildcard')
+    expect(mockEm.persist).not.toHaveBeenCalled()
+  })
+
+  it('PUT rejects organization grants outside the actor scope', async () => {
+    const role = { id: ROLE_ID, tenantId: ACTOR_TENANT_ID }
+    mockRbacService.loadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.acl.manage'],
+      organizations: ['org-allowed'],
+    })
+    mockEm.findOne.mockImplementation(async (ctor: unknown) => {
+      if (ctor === Role) return role
+      if (ctor === RoleAcl) {
+        return {
+          role,
+          tenantId: ACTOR_TENANT_ID,
+          isSuperAdmin: false,
+          featuresJson: ['auth.acl.manage'],
+          organizationsJson: ['org-allowed'],
+        }
+      }
+      return null
+    })
+
+    const res = await PUT(
+      new Request('http://localhost/api/auth/roles/acl', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          roleId: ROLE_ID,
+          features: ['auth.acl.manage'],
+          organizations: ['org-denied'],
+        }),
+      }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toContain('organization access outside actor scope')
+    expect(mockEm.persist).not.toHaveBeenCalled()
+  })
 })

--- a/packages/core/src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts
+++ b/packages/core/src/modules/auth/api/roles/acl/__tests__/tenant-scoping.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 
-import { Role } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
 import { GET, PUT } from '../route'
 
 const ACTOR_TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
@@ -173,5 +173,45 @@ describe('role ACL tenant scoping — existence oracle prevention', () => {
     )
 
     expect(res.status).toBe(200)
+  })
+
+  it('PUT rejects feature grants outside the actor effective ACL', async () => {
+    const role = { id: ROLE_ID, tenantId: ACTOR_TENANT_ID }
+    mockRbacService.loadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.acl.manage'],
+      organizations: null,
+    })
+    mockEm.findOne.mockImplementation(
+      async (ctor: unknown) => {
+        if (ctor === Role) return role
+        if (ctor === RoleAcl) {
+          return {
+            role,
+            tenantId: ACTOR_TENANT_ID,
+            isSuperAdmin: false,
+            featuresJson: ['auth.acl.manage'],
+            organizationsJson: null,
+          }
+        }
+        return null
+      },
+    )
+
+    const res = await PUT(
+      new Request('http://localhost/api/auth/roles/acl', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          roleId: ROLE_ID,
+          features: ['auth.acl.manage', 'api_keys.create'],
+        }),
+      }),
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(403)
+    expect(body.error).toContain('Cannot grant feature api_keys.create')
+    expect(mockEm.persist).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/auth/api/roles/acl/route.ts
+++ b/packages/core/src/modules/auth/api/roles/acl/route.ts
@@ -4,11 +4,12 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { logCrudAccess } from '@open-mercato/shared/lib/crud/factory'
-import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { RoleAcl, Role } from '@open-mercato/core/modules/auth/data/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { assertActorCanGrantAcl, normalizeGrantFeatureList } from '@open-mercato/core/modules/auth/lib/grantChecks'
 
 type TaggableCache = { deleteByTags?: (tags: string[]) => Promise<void> | void }
 
@@ -132,12 +133,6 @@ export async function PUT(req: Request) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
-  const actorAcl = auth.sub
-    ? await rbacService.loadAcl(auth.sub, { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null })
-    : null
-  const actorIsSuperAdmin = !!actorAcl?.isSuperAdmin
-
-  const requestedFeatures = normalizeFeatureList(parsed.data.features)
   let acl = await em.findOne(RoleAcl, { role, tenantId: targetTenantId })
   if (!acl) {
     acl = em.create(RoleAcl, {
@@ -149,27 +144,35 @@ export async function PUT(req: Request) {
   }
 
   const existingIsSuperAdmin = !!acl.isSuperAdmin
+  const existingFeatures = normalizeGrantFeatureList(acl.featuresJson)
+  const existingOrganizations = normalizeOrganizations(acl.organizationsJson)
   const requestedIsSuperAdmin = parsed.data.isSuperAdmin ?? existingIsSuperAdmin
-  let effectiveIsSuperAdmin = requestedIsSuperAdmin
+  const requestedFeatures = parsed.data.features === undefined
+    ? existingFeatures
+    : normalizeGrantFeatureList(parsed.data.features)
+  const requestedOrganizations = parsed.data.organizations === undefined
+    ? existingOrganizations
+    : normalizeOrganizations(parsed.data.organizations)
 
-  if (!actorIsSuperAdmin) {
-    if (requestedIsSuperAdmin && !existingIsSuperAdmin) {
-      throw forbidden('Only super administrators can mark a role as super admin.')
-    }
-    if (existingIsSuperAdmin && requestedIsSuperAdmin === false) {
-      effectiveIsSuperAdmin = false
-    } else {
-      effectiveIsSuperAdmin = existingIsSuperAdmin
-    }
+  try {
+    await assertActorCanGrantAcl({
+      em,
+      rbacService,
+      actorUserId: auth.sub,
+      tenantId: targetTenantId,
+      organizationId: auth.orgId ?? null,
+      isSuperAdmin: requestedIsSuperAdmin,
+      features: requestedFeatures,
+      organizations: requestedOrganizations,
+    })
+  } catch (err) {
+    if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
+    throw err
   }
 
-  const effectiveFeatures = actorIsSuperAdmin
-    ? requestedFeatures
-    : sanitizeTenantFeatures(requestedFeatures)
-
-  if (parsed.data.organizations !== undefined) acl.organizationsJson = parsed.data.organizations
-  acl.isSuperAdmin = effectiveIsSuperAdmin
-  acl.featuresJson = effectiveFeatures
+  acl.organizationsJson = requestedOrganizations
+  acl.isSuperAdmin = requestedIsSuperAdmin
+  acl.featuresJson = requestedFeatures
   await em.persist(acl).flush()
   
   // Invalidate cache for all users in this tenant since role ACL changed
@@ -184,30 +187,13 @@ export async function PUT(req: Request) {
   
   return NextResponse.json({
     ok: true,
-    sanitized: !actorIsSuperAdmin && (effectiveFeatures.length !== requestedFeatures.length || effectiveIsSuperAdmin !== requestedIsSuperAdmin),
+    sanitized: false,
   })
 }
 
-function normalizeFeatureList(features: unknown): string[] {
-  if (!Array.isArray(features)) return []
-  const dedup = new Set<string>()
-  for (const value of features) {
-    if (typeof value !== 'string') continue
-    const trimmed = value.trim()
-    if (!trimmed) continue
-    dedup.add(trimmed)
-  }
-  return Array.from(dedup)
-}
-
-function sanitizeTenantFeatures(features: string[]): string[] {
-  return features.filter((feature) => !isTenantRestrictedFeature(feature))
-}
-
-function isTenantRestrictedFeature(feature: string): boolean {
-  if (feature === '*' || feature === 'directory.*') return true
-  if (feature.startsWith('directory.tenants')) return true
-  return false
+function normalizeOrganizations(organizations: unknown): string[] | null {
+  if (!Array.isArray(organizations)) return null
+  return normalizeGrantFeatureList(organizations)
 }
 
 export const openApi: OpenApiRouteDoc = {

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -3,16 +3,17 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { logCrudAccess, makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
-import { forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { User, Role, UserRole } from '@open-mercato/core/modules/auth/data/entities'
-import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { Organization, Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import { E } from '#generated/entities.ids.generated'
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { userCrudEvents, userCrudIndexer } from '@open-mercato/core/modules/auth/commands/users'
+import { assertActorCanGrantRoleTokens } from '@open-mercato/core/modules/auth/lib/grantChecks'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
@@ -102,7 +103,7 @@ const crud = makeCrudRoute<CrudInput, CrudInput, Record<string, unknown>>({
       schema: rawBodySchema,
       mapInput: async ({ parsed, ctx }) => {
         if (ctx.request) {
-          await assertCanAssignRoles(ctx.request, parsed.roles)
+          await assertCanAssignRoles(ctx.request, parsed.roles, parsed)
         }
         return parsed
       },
@@ -117,7 +118,7 @@ const crud = makeCrudRoute<CrudInput, CrudInput, Record<string, unknown>>({
       schema: rawBodySchema,
       mapInput: async ({ parsed, ctx }) => {
         if (ctx.request) {
-          await assertCanAssignRoles(ctx.request, parsed.roles)
+          await assertCanAssignRoles(ctx.request, parsed.roles, parsed)
         }
         return parsed
       },
@@ -371,14 +372,10 @@ export async function GET(req: Request) {
 }
 
 export const POST = async (req: Request) => {
-  const body = await req.clone().json().catch(() => ({}))
-  await assertCanAssignRoles(req, body?.roles)
   return crud.POST(req)
 }
 
 export const PUT = async (req: Request) => {
-  const body = await req.clone().json().catch(() => ({}))
-  await assertCanAssignRoles(req, body?.roles)
   return crud.PUT(req)
 }
 
@@ -414,35 +411,41 @@ async function findUserIdsBySearchTokens(
     .filter((id): id is string => typeof id === 'string' && id.length > 0)
 }
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-async function assertCanAssignRoles(req: Request, roles: unknown) {
+async function assertCanAssignRoles(req: Request, roles: unknown, payload: Record<string, unknown>) {
   if (!Array.isArray(roles)) return
-  const values = roles
-    .map((role) => (typeof role === 'string' ? role.trim() : null))
-    .filter((role): role is string => !!role)
-  if (!values.length) return
-
-  let hasSuperAdmin = values.some((v) => v.toLowerCase() === 'superadmin')
-  if (!hasSuperAdmin) {
-    const uuids = values.filter((v) => UUID_RE.test(v))
-    if (uuids.length) {
-      const container = await createRequestContainer()
-      const em = container.resolve('em') as EntityManager
-      const matched = await em.find(Role, { id: { $in: uuids as any } })
-      hasSuperAdmin = matched.some((r) => String(r.name).toLowerCase() === 'superadmin')
-    }
-  }
-  if (!hasSuperAdmin) return
-
   const auth = await getAuthFromRequest(req)
-  if (!auth) throw new Error('Unauthorized')
+  if (!auth?.sub) throw new CrudHttpError(401, { error: 'Unauthorized' })
   const container = await createRequestContainer()
-  const rbac = container.resolve('rbacService') as RbacService
-  const acl = await rbac.loadAcl(auth.sub, { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null })
-  if (!acl?.isSuperAdmin) {
-    throw forbidden('Only super administrators can assign the superadmin role.')
+  const em = container.resolve('em') as EntityManager
+  const tenantId = await resolveTargetTenantIdForRoleGrant(em, payload, auth.tenantId ?? null)
+  await assertActorCanGrantRoleTokens({
+    em,
+    rbacService: container.resolve('rbacService') as RbacService,
+    actorUserId: auth.sub,
+    tenantId,
+    organizationId: auth.orgId ?? null,
+    roleTokens: roles,
+  })
+}
+
+async function resolveTargetTenantIdForRoleGrant(
+  em: EntityManager,
+  payload: Record<string, unknown>,
+  fallbackTenantId: string | null,
+): Promise<string | null> {
+  const organizationId = typeof payload.organizationId === 'string' ? payload.organizationId : null
+  if (organizationId) {
+    const organization = await em.findOne(Organization, { id: organizationId }, { populate: ['tenant'] })
+    return organization?.tenant?.id ? String(organization.tenant.id) : fallbackTenantId
   }
+
+  const userId = typeof payload.id === 'string' ? payload.id : null
+  if (userId) {
+    const user = await em.findOne(User, { id: userId, deletedAt: null })
+    return user?.tenantId ? String(user.tenantId) : fallbackTenantId
+  }
+
+  return fallbackTenantId
 }
 
 export const openApi: OpenApiRouteDoc = {

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -14,7 +14,7 @@ import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fiel
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { userCrudEvents, userCrudIndexer } from '@open-mercato/core/modules/auth/commands/users'
 import { assertActorCanGrantRoleTokens } from '@open-mercato/core/modules/auth/lib/grantChecks'
-import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
@@ -435,13 +435,25 @@ async function resolveTargetTenantIdForRoleGrant(
 ): Promise<string | null> {
   const organizationId = typeof payload.organizationId === 'string' ? payload.organizationId : null
   if (organizationId) {
-    const organization = await em.findOne(Organization, { id: organizationId }, { populate: ['tenant'] })
+    const organization = await findOneWithDecryption(
+      em,
+      Organization,
+      { id: organizationId },
+      { populate: ['tenant'] },
+      { tenantId: null, organizationId },
+    )
     return organization?.tenant?.id ? String(organization.tenant.id) : fallbackTenantId
   }
 
   const userId = typeof payload.id === 'string' ? payload.id : null
   if (userId) {
-    const user = await em.findOne(User, { id: userId, deletedAt: null })
+    const user = await findOneWithDecryption(
+      em,
+      User,
+      { id: userId, deletedAt: null },
+      {},
+      { tenantId: null, organizationId: null },
+    )
     return user?.tenantId ? String(user.tenantId) : fallbackTenantId
   }
 

--- a/packages/core/src/modules/auth/lib/grantChecks.ts
+++ b/packages/core/src/modules/auth/lib/grantChecks.ts
@@ -1,0 +1,220 @@
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import { CrudHttpError, forbidden } from '@open-mercato/shared/lib/crud/errors'
+import { hasFeature } from '@open-mercato/shared/security/features'
+import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+
+type ActorAcl = {
+  isSuperAdmin: boolean
+  features: string[]
+  organizations: string[] | null
+}
+
+type GrantCheckContext = {
+  em: EntityManager
+  rbacService: RbacService
+  actorUserId: string | null | undefined
+  tenantId: string | null | undefined
+  organizationId?: string | null | undefined
+}
+
+type RoleGrantCheckInput = GrantCheckContext & {
+  roles: Role[]
+}
+
+type RoleTokenGrantCheckInput = GrantCheckContext & {
+  roleTokens: unknown
+}
+
+type FeatureGrantCheckInput = GrantCheckContext & {
+  features: unknown
+  isSuperAdmin?: boolean
+  organizations?: string[] | null
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export async function assertActorCanGrantRoleTokens(input: RoleTokenGrantCheckInput): Promise<Role[]> {
+  const tokens = normalizeStringList(input.roleTokens)
+  if (!tokens.length) return []
+
+  const tenantId = normalizeNullableString(input.tenantId)
+  const roles = await resolveRolesForGrant(input.em, tokens, tenantId)
+  await assertActorCanGrantRoles({ ...input, tenantId, roles })
+  return roles
+}
+
+export async function assertActorCanGrantRoles(input: RoleGrantCheckInput): Promise<void> {
+  if (!input.roles.length) return
+
+  const tenantId = normalizeNullableString(input.tenantId)
+  const actorAcl = await loadActorAcl({ ...input, tenantId })
+  if (actorAcl.isSuperAdmin) return
+
+  if (!tenantId) {
+    throw forbidden('Tenant context is required to grant roles.')
+  }
+
+  for (const role of input.roles) {
+    const roleTenantId = normalizeNullableString(role.tenantId)
+    if (roleTenantId !== tenantId) {
+      throw forbidden('Cannot grant a role outside the target tenant.')
+    }
+
+    const acl = await input.em.findOne(RoleAcl, { role, tenantId } as FilterQuery<RoleAcl>)
+    if (!acl) continue
+
+    assertActorCanGrantAclSnapshot(actorAcl, {
+      isSuperAdmin: !!acl.isSuperAdmin,
+      features: normalizeStringList(acl.featuresJson),
+      organizations: normalizeOrganizationList(acl.organizationsJson),
+    })
+  }
+}
+
+export async function assertActorCanGrantAcl(input: FeatureGrantCheckInput): Promise<void> {
+  const actorAcl = await loadActorAcl(input)
+  if (actorAcl.isSuperAdmin) return
+
+  const tenantId = normalizeNullableString(input.tenantId)
+  if (!tenantId) {
+    throw forbidden('Tenant context is required to grant ACL features.')
+  }
+
+  assertActorCanGrantAclSnapshot(actorAcl, {
+    isSuperAdmin: !!input.isSuperAdmin,
+    features: normalizeStringList(input.features),
+    organizations: input.organizations === undefined ? undefined : normalizeOrganizationList(input.organizations),
+  })
+}
+
+export function normalizeGrantFeatureList(features: unknown): string[] {
+  return normalizeStringList(features)
+}
+
+async function loadActorAcl(input: GrantCheckContext): Promise<ActorAcl> {
+  const actorUserId = normalizeNullableString(input.actorUserId)
+  if (!actorUserId) throw forbidden('Not authorized to grant ACL privileges.')
+
+  const acl = await input.rbacService.loadAcl(actorUserId, {
+    tenantId: normalizeNullableString(input.tenantId),
+    organizationId: normalizeNullableString(input.organizationId),
+  })
+
+  return {
+    isSuperAdmin: !!acl?.isSuperAdmin,
+    features: normalizeStringList(acl?.features),
+    organizations: normalizeOrganizationList(acl?.organizations),
+  }
+}
+
+async function resolveRolesForGrant(
+  em: EntityManager,
+  roleTokens: string[],
+  tenantId: string | null,
+): Promise<Role[]> {
+  const roles: Role[] = []
+  const missingRoles: string[] = []
+
+  for (const token of roleTokens) {
+    const role = await resolveRoleForGrant(em, token, tenantId)
+    if (!role) {
+      missingRoles.push(token)
+    } else {
+      roles.push(role)
+    }
+  }
+
+  if (missingRoles.length) {
+    const labels = missingRoles.map((role) => `"${role}"`).join(', ')
+    throw new CrudHttpError(400, { error: `Role(s) not found: ${labels}` })
+  }
+
+  return roles
+}
+
+async function resolveRoleForGrant(
+  em: EntityManager,
+  token: string,
+  tenantId: string | null,
+): Promise<Role | null> {
+  const where: Record<string, unknown> = UUID_RE.test(token)
+    ? { id: token, deletedAt: null }
+    : { name: token, deletedAt: null }
+  if (tenantId) where.tenantId = tenantId
+  return em.findOne(Role, where as FilterQuery<Role>)
+}
+
+function assertActorCanGrantAclSnapshot(
+  actorAcl: ActorAcl,
+  requested: {
+    isSuperAdmin: boolean
+    features: string[]
+    organizations?: string[] | null
+  },
+): void {
+  if (requested.isSuperAdmin) {
+    throw forbidden('Only super administrators can grant super admin access.')
+  }
+
+  for (const feature of requested.features) {
+    if (feature === '*') {
+      throw forbidden('Only super administrators can grant global wildcard access.')
+    }
+    if (isWildcardFeature(feature)) {
+      if (!actorAcl.features.includes(feature)) {
+        throw forbidden(`Cannot grant feature wildcard ${feature}.`)
+      }
+      continue
+    }
+    if (!hasFeature(actorAcl.features.filter((grant) => grant !== '*'), feature)) {
+      throw forbidden(`Cannot grant feature ${feature}.`)
+    }
+  }
+
+  if (requested.organizations !== undefined) {
+    assertActorCanGrantOrganizations(actorAcl.organizations, requested.organizations)
+  }
+}
+
+function assertActorCanGrantOrganizations(
+  actorOrganizations: string[] | null,
+  requestedOrganizations: string[] | null,
+): void {
+  if (actorOrganizations === null || actorOrganizations.includes('__all__')) return
+
+  if (requestedOrganizations === null || requestedOrganizations.includes('__all__')) {
+    throw forbidden('Cannot grant unrestricted organization access.')
+  }
+
+  for (const organizationId of requestedOrganizations) {
+    if (!actorOrganizations.includes(organizationId)) {
+      throw forbidden('Cannot grant organization access outside actor scope.')
+    }
+  }
+}
+
+function normalizeStringList(values: unknown): string[] {
+  if (!Array.isArray(values)) return []
+  const dedup = new Set<string>()
+  for (const value of values) {
+    if (typeof value !== 'string') continue
+    const trimmed = value.trim()
+    if (!trimmed) continue
+    dedup.add(trimmed)
+  }
+  return Array.from(dedup)
+}
+
+function normalizeOrganizationList(values: unknown): string[] | null {
+  if (values === null || values === undefined) return null
+  return normalizeStringList(values)
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function isWildcardFeature(feature: string): boolean {
+  return feature.endsWith('.*')
+}

--- a/packages/core/src/modules/auth/lib/grantChecks.ts
+++ b/packages/core/src/modules/auth/lib/grantChecks.ts
@@ -170,17 +170,18 @@ function assertActorCanGrantAclSnapshot(
     throw forbidden('Only super administrators can grant super admin access.')
   }
 
+  const actorGrantableFeatures = actorAcl.features.filter((grant) => grant !== '*')
   for (const feature of requested.features) {
     if (feature === '*') {
       throw forbidden('Only super administrators can grant global wildcard access.')
     }
     if (isWildcardFeature(feature)) {
-      if (!actorAcl.features.includes(feature)) {
+      if (!hasFeature(actorGrantableFeatures, feature)) {
         throw forbidden(`Cannot grant feature wildcard ${feature}.`)
       }
       continue
     }
-    if (!hasFeature(actorAcl.features.filter((grant) => grant !== '*'), feature)) {
+    if (!hasFeature(actorGrantableFeatures, feature)) {
       throw forbidden(`Cannot grant feature ${feature}.`)
     }
   }

--- a/packages/core/src/modules/auth/lib/grantChecks.ts
+++ b/packages/core/src/modules/auth/lib/grantChecks.ts
@@ -1,6 +1,7 @@
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { CrudHttpError, forbidden } from '@open-mercato/shared/lib/crud/errors'
 import { hasFeature } from '@open-mercato/shared/security/features'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { Role, RoleAcl } from '@open-mercato/core/modules/auth/data/entities'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 
@@ -61,7 +62,13 @@ export async function assertActorCanGrantRoles(input: RoleGrantCheckInput): Prom
       throw forbidden('Cannot grant a role outside the target tenant.')
     }
 
-    const acl = await input.em.findOne(RoleAcl, { role, tenantId } as FilterQuery<RoleAcl>)
+    const acl = await findOneWithDecryption(
+      input.em,
+      RoleAcl,
+      { role, tenantId } as FilterQuery<RoleAcl>,
+      {},
+      { tenantId, organizationId: null },
+    )
     if (!acl) continue
 
     assertActorCanGrantAclSnapshot(actorAcl, {
@@ -142,7 +149,13 @@ async function resolveRoleForGrant(
     ? { id: token, deletedAt: null }
     : { name: token, deletedAt: null }
   if (tenantId) where.tenantId = tenantId
-  return em.findOne(Role, where as FilterQuery<Role>)
+  return findOneWithDecryption(
+    em,
+    Role,
+    where as FilterQuery<Role>,
+    {},
+    { tenantId, organizationId: null },
+  )
 }
 
 function assertActorCanGrantAclSnapshot(


### PR DESCRIPTION
## Summary

  This PR hardens RBAC delegation paths by enforcing explicit promote-checks before
  roles or feature grants are persisted.

  It fixes three related privilege-escalation issues where a non-superadmin actor
  with limited management permissions could delegate permissions beyond their
  intended authority.

  ## Security Issues Fixed

  ### 1. User role assignment allowed unauthorized role grants

  `POST/PUT /api/auth/users` accepted caller-supplied `roles` and persisted them
  after only blocking superadmin role assignment.

  Impact:
  - a limited staff user with user-management permissions could create or update
  another user with a more privileged same-tenant role,
  - authorization was based on role name/id checks instead of the target role’s
  effective ACL.

  Fix:
  - user role assignment now validates the target role ACL before persisting,
  - non-superadmin actors can only grant roles allowed by their delegation policy,
  - unauthorized grants fail closed with `403`.

  ### 2. Role ACL updates used sanitize-and-accept instead of fail-closed promote-
  checks

  `PUT /api/auth/roles/acl` filtered only a small blocklist such as `*` /
  `directory.*`, but allowed other sensitive features to be written.

  Impact:
  - a non-superadmin actor with ACL-management access could persist elevated features
  such as auth/API-key permissions,
  - the route returned success instead of rejecting unauthorized grants.

  Fix:
  - role ACL writes now check requested features against the actor’s grantable
  delegation scope,
  - unauthorized features are rejected with `403`,
  - the route no longer silently sanitizes and accepts unauthorized ACL updates.

  ### 3. API key creation accepted privileged role delegation

  `POST /api/api_keys/keys` accepted caller-supplied `roles` and stored them in
  `rolesJson` without verifying that the actor was allowed to delegate those roles.

  Impact:
  - a limited staff user with API-key creation access could mint role-backed bearer
  credentials with higher privileges,
  - API keys could become a bypass around user role assignment controls.

  Fix:
  - API-key role assignment now uses the same role delegation check as user role
  assignment,
  - non-superadmin actors cannot create API keys with roles outside their delegation
  scope,
  - unauthorized role grants fail with `403`.

  ## Design

  The fix centralizes RBAC delegation checks so all permission-granting paths use the
  same policy.

  Rules enforced:
  - superadmin can manage delegation broadly,
  - non-superadmin actors can only grant roles/features explicitly allowed by their
  delegation scope,
  - role checks inspect the target role’s `RoleAcl`, including `isSuperAdmin` and
  `featuresJson`,
  - authorization never relies on role names,
  - unauthorized grants fail closed with `403`.

  This separates:
  - what an actor can do themselves,
  - what an actor is allowed to delegate to users, roles, or API keys.
  ## Follow-up Proposal: Superadmin-Controlled Delegation Whitelist

  This PR fixes the immediate privilege-escalation paths by enforcing fail-closed
  delegation checks before roles or features are persisted.

  As a follow-up, we recommend introducing a dedicated delegation whitelist
  controlled by superadmin. This would make permission delegation explicit instead of
  deriving it implicitly from management access.

  Proposed model:

  - `effectiveFeatures`: what an actor can do themselves,
  - `grantableFeatures`: what an actor may delegate to users, roles, invitations, and
  API keys.

  Only superadmin should be able to assign or expand `grantableFeatures`.

  Suggested rules:
  - non-superadmin actors may grant only features covered by their
  `grantableFeatures`,
  - `grantableFeatures` must not exceed the actor’s own effective ACL,
  - assigning a role is allowed only if the target role’s `RoleAcl.featuresJson` is
  covered by the actor’s `grantableFeatures`,
  - assigning a role with `isSuperAdmin=true` is always forbidden for non-superadmin
  actors,
  - management permissions such as `auth.acl.manage`, `auth.users.create`, or
  `api_keys.create` should allow access to workflows, but should not imply permission
  to delegate arbitrary roles/features.

  This would allow a tenant admin to create users or API keys while still limiting
  delegation to roles/features explicitly approved by superadmin.