### PR TITLE
fix(create-app): make agentic-shared playwright.config.ts ESM-safe

### DIFF
--- a/packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts
+++ b/packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts
@@ -1,9 +1,14 @@
 import { defineConfig } from '@playwright/test'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { discoverIntegrationSpecFiles } from '@open-mercato/cli/lib/testing/integration-discovery'
 
 const captureScreenshots = process.env.PW_CAPTURE_SCREENSHOTS === '1'
 const isGitHubActions = process.env.GITHUB_ACTIONS === 'true'
+// Standalone apps generated from this template declare `"type": "module"`,
+// so the CommonJS `__dirname` is undefined when Playwright loads this config
+// under the Node ESM loader. Reconstruct it from `import.meta.url`.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const projectRoot = path.resolve(__dirname, '..', '..', '..')
 const qaTestResultsRoot = path.join(projectRoot, '.ai', 'qa', 'test-results')
 const normalizePath = (value: string) => value.split(path.sep).join('/')

--- a/packages/create-app/src/setup/tools/shared.test.ts
+++ b/packages/create-app/src/setup/tools/shared.test.ts
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Standalone apps generated from this template declare `"type": "module"` in
+// their package.json (see `packages/create-app/template/package.json.template`),
+// and `generateShared()` copies these template files into them verbatim. Any
+// `.ts` template that references CommonJS-only globals like `__dirname` or
+// `__filename` will crash with `ReferenceError` the moment a Node ESM loader
+// touches it (e.g. Playwright loading the integration config). These tests
+// pin the contract: the templates must be ESM-safe.
+const AGENTIC_SHARED_DIR = join(__dirname, '..', '..', '..', 'agentic', 'shared')
+
+const ESM_INCOMPATIBLE_PATTERNS = [
+  // bare CommonJS globals; ok only when paired with the polyfill below
+  /\b__dirname\b/,
+  /\b__filename\b/,
+  // bare CJS dynamic require — also undefined under ESM
+  /\brequire\s*\(/,
+]
+
+const POLYFILL_PATTERNS = {
+  __dirname: /path\.dirname\s*\(\s*fileURLToPath\s*\(\s*import\.meta\.url\s*\)\s*\)/,
+  __filename: /fileURLToPath\s*\(\s*import\.meta\.url\s*\)/,
+  require: /createRequire\s*\(\s*import\.meta\.url\s*\)/,
+}
+
+// Tracked .ts templates copied into ESM consumers. When new templates are
+// added to `generateShared()`, register them here so this test catches a
+// regression at PR time instead of at customer install time.
+const TRACKED_TEMPLATES = ['ai/qa/tests/playwright.config.ts']
+
+for (const relativePath of TRACKED_TEMPLATES) {
+  test(`agentic/shared template "${relativePath}" is ESM-safe`, () => {
+    const fullPath = join(AGENTIC_SHARED_DIR, relativePath)
+    const source = readFileSync(fullPath, 'utf8')
+
+    if (ESM_INCOMPATIBLE_PATTERNS[0].test(source)) {
+      assert.match(
+        source,
+        POLYFILL_PATTERNS.__dirname,
+        `${relativePath} references __dirname but does not reconstruct it from import.meta.url. ` +
+          `Standalone apps generated from this template are "type": "module"; bare __dirname is undefined under ESM.`,
+      )
+    }
+    if (ESM_INCOMPATIBLE_PATTERNS[1].test(source)) {
+      assert.match(
+        source,
+        POLYFILL_PATTERNS.__filename,
+        `${relativePath} references __filename but does not reconstruct it from import.meta.url.`,
+      )
+    }
+    if (ESM_INCOMPATIBLE_PATTERNS[2].test(source)) {
+      assert.match(
+        source,
+        POLYFILL_PATTERNS.require,
+        `${relativePath} uses require() but does not initialize it via createRequire(import.meta.url).`,
+      )
+    }
+  })
+}


### PR DESCRIPTION
## Problem

Standalone apps generated from `packages/create-app/template/` declare `"type": "module"` in their `package.json`. After `runAgenticSetup()` runs (either via `mercato agentic:init` or as part of the `create-app` bootstrap flow), `<app>/.ai/qa/tests/playwright.config.ts` is overwritten with the version copied from `packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts`. That copy referenced bare `__dirname`, which is undefined under the Node ESM loader, so the next `mercato test:integration` (or any direct `npx playwright test`) crashes:

```
ReferenceError: __dirname is not defined in ES module scope
    at .ai/qa/tests/playwright.config.ts:7:34
    at requireOrImport (node_modules/playwright/lib/transform/transform.js:216:12)
    at loadUserConfig (node_modules/playwright/lib/common/configLoader.js:107:46)
```

Reproduced today on a clean standalone app at `92c8a2e7d7607447750881952f5690b137180cc1` — first `yarn test:integration:ephemeral` worked because the locally-checked-in fix-up shipped in the consuming repo (commit `3d126f2 chore: ... fix __dirname in playwright.config`); the next run crashed because `runAgenticSetup` had clobbered the file with the upstream agentic-shared template.

## Root Cause

Two copies of the same template drifted apart:

| File | `__dirname` polyfill? | Where it ends up |
|---|---|---|
| `packages/create-app/template/.ai/qa/tests/playwright.config.ts` | ✅ Yes | The committed-into-the-template default — fine, never overwritten by setup |
| `packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts` | ❌ No | The version copied by `generateShared()` and `runAgenticSetup()` on every invocation — clobbers the template default |

Both `packages/create-app/src/setup/tools/shared.ts:158` and `packages/cli/src/lib/agentic-setup.ts:186` unconditionally `copyFile()` the agentic-shared version into the target app, so the template's polyfill is silently replaced by the broken agentic-shared copy on every `agentic:init` run.

The agentic-shared copy is otherwise *more* current than the template (carries `.cursor` and `node_modules` in `STATIC_TEST_IGNORES`), so the right fix is to add the polyfill to the agentic-shared file rather than overwrite it with the template version.

## What Changed

- **`packages/create-app/agentic/shared/ai/qa/tests/playwright.config.ts`** — add `import { fileURLToPath } from 'node:url'` and reconstruct `__dirname = path.dirname(fileURLToPath(import.meta.url))`. Three lines + a one-line comment naming the constraint. Everything else (the larger ignores list, defineConfig body) is unchanged.
- **`packages/create-app/src/setup/tools/shared.test.ts`** — new regression-guard test using the existing `node:test` style. Iterates a `TRACKED_TEMPLATES` allowlist and asserts that any template referencing `__dirname`, `__filename`, or `require()` also includes the matching `import.meta.url` polyfill. Adding a new `.ts` template to `generateShared()` without registering it here is fine; adding one that crashes under ESM without registering it here is the caller's bug to fix at PR time.

## Tests

Verified the regression guard catches the broken state and passes on the fix:

```bash
# Against pre-fix state (file reverted via git stash)
$ npx tsx --test packages/create-app/src/setup/tools/shared.test.ts
✖ agentic/shared template "ai/qa/tests/playwright.config.ts" is ESM-safe
  AssertionError [ERR_ASSERTION]: ai/qa/tests/playwright.config.ts references
  __dirname but does not reconstruct it from import.meta.url. Standalone apps
  generated from this template are "type": "module"; bare __dirname is
  undefined under ESM.

# Against the fixed state
$ npx tsx --test packages/create-app/src/setup/tools/shared.test.ts
✔ agentic/shared template "ai/qa/tests/playwright.config.ts" is ESM-safe
ℹ tests 1 ℹ pass 1 ℹ fail 0
```

End-to-end verification on a downstream consumer (the standalone app where the bug was discovered):

```
yarn test:integration:ephemeral  →  14 passed, 1 skipped, 0 failed
  including all 7 WIC-ingestion specs that previously failed via the
  __dirname crash on the second run
```

## Why CI didn't catch this

The upstream's own `yarn test:integration` runs the **monorepo-root** `.ai/qa/tests/playwright.config.ts`, and the **monorepo root** `package.json` does NOT declare `"type": "module"`, so the bare `__dirname` happens to work there. The `agentic/shared` copy is only exercised after `runAgenticSetup` runs on a fresh standalone app — which CI does not do today.

A broader fix would be a separate CI job that bootstraps a fresh app via `create-app`, runs `mercato agentic:init`, then loads the resulting `playwright.config.ts` under ESM (or just `npx playwright test --list`) to catch any future ESM/CJS regression in any agentic-shared template. I kept this PR scoped to the immediate fix plus the file-content regression test; the smoke-job idea is left for a follow-up rather than bundled here.

I also grep-checked every other `.ts`/`.tsx`/`.mjs`/`.cjs` under `packages/*/agentic/shared/` for `__dirname` or `require()` — `playwright.config.ts` is the only file affected.

## Backward Compatibility

- **Template surface**: identical. The same exported `defineConfig({...})` shape, same `STATIC_TEST_IGNORES`, same `outputDir`, same reporter selection. Existing standalone apps that already carry the locally-fixed-up version (e.g. consumers who applied the manual polyfill themselves) will see the next `mercato agentic:init` write a structurally equivalent file.
- **Public API**: no exports added, removed, or renamed. No package version bump needed.
- **Build / dist**: the `node_modules/@open-mercato/cli/dist/agentic/shared/ai/qa/tests/playwright.config.ts` artifact (built from this template) inherits the fix automatically via the existing `build.mjs` copy step.

## Checklist

- [x] This pull request targets `develop`.
- [x] I updated documentation, locales, or generators if the change requires it. — N/A; comment in the template explains the constraint inline.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/`. — Not added: a generated-app smoke job is the right scope for that and is called out under "Why CI didn't catch this" as a follow-up. The file-content regression test in `packages/create-app/src/setup/tools/shared.test.ts` covers the immediate failure mode deterministically.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry. — N/A for a 5-line bug fix in a generated-template file.
