### PR TITLE
fix(ui): popover/select dropdowns visible inside modals (#1836)

### DIFF
--- a/.ai/ds-rules.md
+++ b/.ai/ds-rules.md
@@ -163,15 +163,16 @@ Decision tree — ask "is this a brand moment?":
 |-----------------------|-------|-------|
 | Normal page content | no class / `z-base` | 0 |
 | Sticky header/footer | `z-sticky` | 10 |
-| Dropdown, popover, combobox, select menu | `z-dropdown` | 20 |
+| Inline dropdown rendered in-place (no portal) | `z-dropdown` | 20 |
 | Backdrop behind modal/drawer | `z-overlay` | 30 |
 | Modal, dialog, drawer, side panel | `z-modal` | 40 |
+| Portaled overlay content (popover, select menu, combobox suggestions) | `z-popover` | 45 |
 | Toast / flash message | `z-toast` | 50 |
 | Tooltip | `z-tooltip` | 60 |
 | Global notice bar (cookie banner, system-wide) | `z-banner` | 70 |
 | Always-on-top (dev tools, AI chat, command palette) | `z-top` | 100 |
 
-Tooltip sits above modals (60 > 40) because you may hover a button inside a modal. Tokens defined in `globals.css` as `--z-index-*`. Do NOT add new numeric values — add a token to the scale.
+`z-popover` (45) sits above `z-modal` (40) so dropdowns/selects/popovers opened from inside a modal, drawer, or filter side panel render above the panel rather than behind it. Tooltips stay highest among floating UI (60 > 45) because a tooltip on a button inside a popover must remain visible. Tokens defined in `globals.css` as `--z-index-*`. Do NOT add new numeric values — add a token to the scale.
 
 ## Shadows
 - NEVER use arbitrary shadow values (`shadow-[...]`)

--- a/apps/mercato/src/app/globals.css
+++ b/apps/mercato/src/app/globals.css
@@ -116,6 +116,7 @@ TODO: Fix that latter to have reference by the package names
   --z-index-dropdown: 20;
   --z-index-overlay: 30;
   --z-index-modal: 40;
+  --z-index-popover: 45;
   --z-index-toast: 50;
   --z-index-tooltip: 60;
   --z-index-banner: 70;

--- a/packages/create-app/template/src/app/globals.css
+++ b/packages/create-app/template/src/app/globals.css
@@ -116,6 +116,7 @@ TODO: Fix that latter to have reference by the package names
   --z-index-dropdown: 20;
   --z-index-overlay: 30;
   --z-index-modal: 40;
+  --z-index-popover: 45;
   --z-index-toast: 50;
   --z-index-tooltip: 60;
   --z-index-banner: 70;

--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -242,7 +242,7 @@ export function ComboboxInput({
       />
 
       {showSuggestions && !disabled && (loading || filteredSuggestions.length > 0) && (
-        <div className="absolute z-dropdown w-full mt-1 rounded border bg-popover shadow-lg max-h-48 sm:max-h-60 overflow-auto">
+        <div className="absolute z-popover w-full mt-1 rounded border bg-popover shadow-lg max-h-48 sm:max-h-60 overflow-auto">
           {loading && touched ? (
             <div className="px-3 py-2 text-xs text-muted-foreground">Loading suggestions…</div>
           ) : (

--- a/packages/ui/src/primitives/__tests__/zindex-overlay.test.tsx
+++ b/packages/ui/src/primitives/__tests__/zindex-overlay.test.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react'
+import * as fs from 'fs'
+import * as path from 'path'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { Popover, PopoverContent, PopoverTrigger } from '../popover'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../select'
+import { ComboboxInput } from '../../backend/inputs/ComboboxInput'
+
+const Z_INDEX_BY_TOKEN: Record<string, number> = {
+  'z-base': 0,
+  'z-sticky': 10,
+  'z-dropdown': 20,
+  'z-overlay': 30,
+  'z-modal': 40,
+  'z-popover': 45,
+  'z-toast': 50,
+  'z-tooltip': 60,
+  'z-banner': 70,
+  'z-top': 100,
+}
+
+function findZIndexToken(className: string | undefined): string | null {
+  if (!className) return null
+  const tokens = className.split(/\s+/)
+  for (const token of tokens) {
+    if (token in Z_INDEX_BY_TOKEN) return token
+  }
+  return null
+}
+
+describe('Issue #1836: portaled overlay primitives sit above modals (z-popover > z-modal)', () => {
+  it('PopoverContent renders with z-popover so it is visible inside modals/drawers', async () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>open</PopoverTrigger>
+        <PopoverContent data-testid="popover-content">
+          <span>popover body</span>
+        </PopoverContent>
+      </Popover>,
+    )
+
+    const content = await screen.findByTestId('popover-content')
+    const token = findZIndexToken(content.className)
+    expect(token).toBe('z-popover')
+    expect(Z_INDEX_BY_TOKEN[token!]).toBeGreaterThan(Z_INDEX_BY_TOKEN['z-modal'])
+  })
+
+  it('SelectContent renders with z-popover so dropdowns inside filter overlays are visible', () => {
+    render(
+      <Select defaultOpen>
+        <SelectTrigger>
+          <SelectValue placeholder="pick" />
+        </SelectTrigger>
+        <SelectContent data-testid="select-content">
+          <SelectItem value="a">A</SelectItem>
+          <SelectItem value="b">B</SelectItem>
+        </SelectContent>
+      </Select>,
+    )
+
+    const content = screen.getByTestId('select-content')
+    const token = findZIndexToken(content.className)
+    expect(token).toBe('z-popover')
+    expect(Z_INDEX_BY_TOKEN[token!]).toBeGreaterThan(Z_INDEX_BY_TOKEN['z-modal'])
+  })
+
+  it('ComboboxInput suggestion list renders with z-popover when suggestions are open', () => {
+    const { container } = render(
+      <ComboboxInput
+        value=""
+        onChange={() => {}}
+        suggestions={[{ value: 'alpha', label: 'Alpha' }]}
+      />,
+    )
+
+    const input = container.querySelector('input')
+    expect(input).not.toBeNull()
+    act(() => {
+      fireEvent.focus(input!)
+    })
+    act(() => {
+      fireEvent.change(input!, { target: { value: 'a' } })
+    })
+
+    const suggestions = container.querySelector('[class*="z-popover"]')
+    expect(suggestions).not.toBeNull()
+    const token = findZIndexToken((suggestions as HTMLElement).className)
+    expect(token).toBe('z-popover')
+    expect(Z_INDEX_BY_TOKEN[token!]).toBeGreaterThan(Z_INDEX_BY_TOKEN['z-modal'])
+  })
+
+  it('z-index scale defines --z-index-popover (45) between modal (40) and toast (50) in both globals.css files', () => {
+    const repoRoot = path.resolve(__dirname, '../../../../..')
+    const cssPaths = [
+      path.join(repoRoot, 'apps/mercato/src/app/globals.css'),
+      path.join(repoRoot, 'packages/create-app/template/src/app/globals.css'),
+    ]
+
+    for (const cssPath of cssPaths) {
+      const css = fs.readFileSync(cssPath, 'utf8')
+      const popoverMatch = css.match(/--z-index-popover:\s*(\d+);/)
+      const modalMatch = css.match(/--z-index-modal:\s*(\d+);/)
+      const toastMatch = css.match(/--z-index-toast:\s*(\d+);/)
+
+      expect(popoverMatch).not.toBeNull()
+      expect(modalMatch).not.toBeNull()
+      expect(toastMatch).not.toBeNull()
+
+      const popoverZ = Number(popoverMatch![1])
+      const modalZ = Number(modalMatch![1])
+      const toastZ = Number(toastMatch![1])
+
+      expect(popoverZ).toBeGreaterThan(modalZ)
+      expect(popoverZ).toBeLessThan(toastZ)
+    }
+  })
+})

--- a/packages/ui/src/primitives/popover.tsx
+++ b/packages/ui/src/primitives/popover.tsx
@@ -22,7 +22,7 @@ export const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-tooltip min-w-[280px] rounded-md border bg-popover p-0 text-popover-foreground shadow-md outline-none',
+        'z-popover min-w-[280px] rounded-md border bg-popover p-0 text-popover-foreground shadow-md outline-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',

--- a/packages/ui/src/primitives/select.tsx
+++ b/packages/ui/src/primitives/select.tsx
@@ -81,7 +81,7 @@ const SelectContent = React.forwardRef<
       position={position}
       sideOffset={sideOffset}
       className={cn(
-        'relative z-dropdown min-w-[8rem] overflow-hidden rounded-md border border-input bg-popover text-popover-foreground shadow-md outline-none',
+        'relative z-popover min-w-[8rem] overflow-hidden rounded-md border border-input bg-popover text-popover-foreground shadow-md outline-none',
         'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' && 'w-full min-w-[var(--radix-select-trigger-width)]',
         className


### PR DESCRIPTION
Fixes #1836

## Problem

Filter side-panel dropdowns (Role, Status, Type, etc.) on list pages were rendering but invisible. Clicking the field appeared to do nothing, yet clicking the area below it still selected an option — confirming the dropdown content was in the DOM but hidden behind the filter panel overlay.

## Root Cause

Radix-based primitives portal their content to `<body>`. The DS z-index scale put both `Select` (`z-dropdown` = 20) and `Popover` content below the filter overlay's `z-modal` (40), so dropdowns opened from inside any modal/drawer/filter panel rendered behind it.

PR #1791 had worked around this for `ActivitiesAddNewMenu` by lifting the global `Popover` to `z-tooltip` (60), which fixed that menu but conflated popovers with tooltips in the DS scale and never addressed the `Select` / `ComboboxInput` cases — which is what the filter panel actually uses (`type: 'select'` filters render as `Select`, not `Popover`).

## What Changed

- Added `--z-index-popover: 45` between `--z-index-modal` (40) and `--z-index-toast` (50) in both `apps/mercato/src/app/globals.css` and `packages/create-app/template/src/app/globals.css`.
- Routed portaled overlay content through the new layer:
  - `Popover` (`z-tooltip` → `z-popover`)
  - `Select` (`z-dropdown` → `z-popover`)
  - `ComboboxInput` suggestion list (`z-dropdown` → `z-popover`)
- Updated `.ai/ds-rules.md` to split `z-dropdown` (inline / in-place dropdowns) from `z-popover` (portaled content) and document the modal-aware ordering. Tooltips remain highest among floating UI (60 > 45) so a tooltip on a button inside a popover stays visible.

## Tests

- New `packages/ui/src/primitives/__tests__/zindex-overlay.test.tsx`:
  - `PopoverContent`, `SelectContent`, and `ComboboxInput` suggestion list each render with `z-popover` (and `z-popover > z-modal`).
  - `globals.css` files in both the monorepo app and the standalone template define `--z-index-popover: 45` between `--z-index-modal: 40` and `--z-index-toast: 50`.
  - Verified the test fails when any one primitive regresses to `z-tooltip` / `z-dropdown`.
- Full UI test suite (`@open-mercato/ui`): 382 tests passing.
- `yarn typecheck`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, full `yarn turbo run test --concurrency=1` all green.

## Backward Compatibility

- Additive CSS token (`--z-index-popover`); no contract surface changes (no API/event ID/widget spot/DI key/ACL/schema changes).
- The class names changed on three internal primitives' rendered DOM (`z-tooltip`/`z-dropdown` → `z-popover`). Downstream consumers that override popover styling via `className` keep working — the new token is co-equal in API. A consumer selecting on `.z-tooltip` to find popover content (very unlikely) would need the new selector.

## Test plan

- [x] Open `/backend/staff/team-members`, click **Filters**, click **Role** select → dropdown is visible above the panel
- [x] Same on `/backend/customers/people` and `/backend/catalog/products`
- [x] Combobox-typed filters (e.g. categories on Products) show suggestions above the panel
- [x] Tooltip on a button inside an open popover still renders above the popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)