### PR TITLE
feat(dev): optional --database-name override for dev/setup scripts (#1841)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,26 @@ Open **http://localhost:3000/backend** — credentials printed in the terminal.
 
 </details>
 
+#### Running multiple persistent local instances
+
+To keep two long-lived local instances pointing at the same PostgreSQL server (e.g. `client-a` next to a stock `open-mercato`), pass an optional database-name override to `yarn dev`, `yarn dev:greenfield`, or `yarn setup`:
+
+```bash
+# Monorepo: explicit database name; .env update is offered (default yes)
+yarn dev:greenfield --database-name=my_db
+
+# Monorepo: derive database name from the current working directory
+yarn dev --database-name
+
+# Standalone app: same flag, applied to ./.env
+yarn setup --database-name=client_a
+
+# One-off run that does not touch .env (current child process only)
+yarn dev --database-name=review_1720 --no-update-env
+```
+
+Without the flag, behavior is unchanged (no prompt, no `.env` mutation). See the [installation guides](https://docs.openmercato.com/installation/monorepo) and [`yarn setup`](https://docs.openmercato.com/installation/setup) for details.
+
 ---
 
 ### Detailed guides (prerequisites, native services, troubleshooting)

--- a/apps/docs/docs/cli/overview.mdx
+++ b/apps/docs/docs/cli/overview.mdx
@@ -27,6 +27,7 @@ Run `yarn mercato --help` to list modules and `yarn mercato <module> --help` to 
   - `yarn dev:greenfield:classic` – run the greenfield boot flow with raw passthrough output and no splash screen.
   - [`yarn dev:ephemeral`](./dev-ephemeral) – start a dev server on a free port, open browser automatically, and register active instances in `.ai/dev-ephemeral-envs.json`.
   - `yarn dev:ephemeral:classic` – run the ephemeral flow with raw passthrough output and no splash screen.
+  - **Database name override (optional, additive)**: every dev/setup command above accepts `--database-name[=<name>]` to rewrite the database segment of `DATABASE_URL` for the run. Examples: `yarn dev --database-name=client_a` (explicit), `yarn dev --database-name` (derive from `process.cwd()`), `yarn dev --database-name=temp --no-update-env` (current run only). Without the flag, behavior is unchanged. See the monorepo and standalone installation guides for the full walkthrough.
 - **Code Generation**
   - `mercato generate` or `mercato generate all` – run all generators (entity IDs, registry, entities, DI, API client).
   - `mercato generate entity-ids` – generate entity ID mappings.

--- a/apps/docs/docs/customization/standalone-app.mdx
+++ b/apps/docs/docs/customization/standalone-app.mdx
@@ -95,6 +95,16 @@ Useful standalone splash env vars:
 - `OM_DEV_CREATE_GIT_REPO_FLOW=false yarn dev` to hide the GitHub publish panel
 - `OM_ENABLE_CODING_FLOW_FROM_SPLASH=false yarn dev` to hide the coding-tools menu
 
+To run several persistent standalone apps against the same PostgreSQL server, pass `--database-name[=<name>]` to `yarn setup` or `yarn dev`:
+
+```bash
+yarn setup --database-name=client_a   # explicit name; offers to update .env (default yes)
+yarn setup --database-name            # derives name from the current directory
+yarn dev --database-name=temp_run --no-update-env  # only injects DATABASE_URL into this run
+```
+
+Set `OM_DEV_DATABASE_NAME` / `OM_DEV_DATABASE_UPDATE_ENV` for non-interactive automation. Without the flag, `yarn setup` and `yarn dev` keep their current behavior — no prompt, no `.env` mutation.
+
 Navigate to `http://localhost:3000/backend` and sign in with the credentials printed by `yarn initialize`.
 
 ## Test create-mercato-app locally from the monorepo

--- a/apps/docs/docs/installation/monorepo.mdx
+++ b/apps/docs/docs/installation/monorepo.mdx
@@ -530,3 +530,20 @@ yarn dev
 | `yarn dev:classic` | Legacy mode — disables splash, raw output |
 
 Press `d` while `yarn dev` is running to toggle raw log output. If a stage fails, the runner automatically expands and prints the raw error.
+
+### Run multiple persistent local instances against the same PostgreSQL server
+
+`yarn dev`, `yarn dev:greenfield`, and `yarn dev:app` accept an optional `--database-name[=<name>]` flag that rewrites the database segment of `DATABASE_URL` in `apps/mercato/.env`. Without the flag, behavior is unchanged.
+
+```bash
+# explicit name; you'll be asked once whether to persist .env (default yes)
+yarn dev:greenfield --database-name=pricing_v2
+
+# bare flag derives the database name from the current working directory
+yarn dev --database-name
+
+# one-off review run that does not edit .env
+yarn dev --database-name=review_1720 --no-update-env
+```
+
+The override only touches the pathname segment of `DATABASE_URL`, so credentials, host, port, schema (`?schema=…`), and other query parameters are preserved. CI / non-interactive runs default to updating `.env`; pass `--no-update-env` to opt out, or set `OM_DEV_DATABASE_UPDATE_ENV=false`.

--- a/apps/docs/docs/installation/setup.mdx
+++ b/apps/docs/docs/installation/setup.mdx
@@ -101,6 +101,21 @@ Follow these steps after the [prerequisites](./prerequisites) are in place:
    ```
    `yarn dev` starts the compact development runtime. On native local runs it serves a startup splash screen with live progress on `http://localhost:4000` by default, auto-opens that page when possible, and prints the backend URL in the terminal. Once the runtime is ready, continue to `http://localhost:3000/backend` and sign in with the credentials printed by `yarn initialize`.
 
+   To run multiple persistent local instances against the same PostgreSQL server (e.g. one per client repo), pass an optional `--database-name[=<name>]` flag. Without the flag, behavior is unchanged.
+
+   ```bash
+   # explicit name; .env update is offered with default-yes
+   yarn dev:greenfield --database-name=client_a
+
+   # bare flag derives the database name from the current directory
+   yarn dev --database-name
+
+   # one-off run that does not edit .env
+   yarn dev --database-name=client_a --no-update-env
+   ```
+
+   The override only rewrites the database segment of `DATABASE_URL`; credentials, host, port, and query parameters are preserved. CI/non-interactive runs default to updating `.env` — pass `--no-update-env` to opt out.
+
 ## Windows native local development
 
 This is the recommended Windows setup for day-to-day work on the monorepo. Docker Desktop runs the infrastructure services, while Node.js and Yarn run directly on Windows. The full `docker-compose.fullapp.dev.yml` stack remains available for isolated or fully containerized workflows, but on Windows it is usually much slower because a large Node.js monorepo with bind-mounted source files does heavy watched file reads across the Windows/Linux filesystem boundary.

--- a/apps/docs/docs/installation/standalone.mdx
+++ b/apps/docs/docs/installation/standalone.mdx
@@ -121,6 +121,23 @@ yarn dev
 
 Open **http://localhost:3000/backend** and sign in with the credentials printed during setup.
 
+### Run multiple persistent standalone apps against the same PostgreSQL server
+
+`yarn setup`, `yarn dev`, and friends accept an optional `--database-name[=<name>]` flag that rewrites the database segment of `DATABASE_URL` in `./.env`. The flag is fully additive — without it, every script keeps its current behavior.
+
+```bash
+# explicit name; the script asks once whether to update .env (default yes)
+yarn setup --database-name=client_a
+
+# bare flag derives the database name from this app's folder
+yarn setup --database-name
+
+# one-off review run that does not edit .env
+yarn dev --database-name=review_1720 --no-update-env
+```
+
+This makes it easy to run e.g. `client-a/` and `client-b/` side by side against the same PostgreSQL server without manually editing `.env` first. CI / non-interactive runs default to updating `.env`; pass `--no-update-env` (or set `OM_DEV_DATABASE_UPDATE_ENV=false`) to opt out.
+
 ---
 
 ## Add your own modules

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -126,6 +126,19 @@ The standalone dev splash also exposes a GitHub publishing panel after `yarn dev
    yarn setup:reinstall
    ```
 
+   To run several persistent local apps against the same PostgreSQL server, pass an optional database-name override. The flag is purely additive — omitting it preserves existing behavior.
+
+   ```bash
+   # explicit name; .env is updated by default after a confirmation prompt
+   yarn setup --database-name=client_a
+
+   # bare flag derives the database name from the current directory name
+   yarn setup --database-name
+
+   # one-off run that only injects DATABASE_URL into the current child env
+   yarn dev --database-name=review_1720 --no-update-env
+   ```
+
 3. Manual alternative if you want to edit the environment first:
    ```bash
    cp .env.example .env

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -105,6 +105,20 @@ yarn reinstall
 | `OM_DEV_SPLASH_CLAUDE_CODE_PATH` | auto-detect | Optional path override for the Claude Code CLI. |
 | `OM_DEV_SPLASH_CODEX_PATH` | auto-detect | Optional path override for the Codex CLI. |
 | `OM_DEV_AUTO_MIGRATE` | `1` | When set to `1` (default), `yarn dev` runs `yarn db:migrate` once at startup before Next.js boots. Set to `0` to disable. See "Single-shot Database Migrations" below. |
+| `OM_DEV_DATABASE_NAME` | unset | Same as passing `--database-name=<value>` to `yarn dev` / `yarn setup`. CLI flag wins. |
+| `OM_DEV_DATABASE_UPDATE_ENV` | unset | Non-interactive answer for the `.env` update prompt (`true`/`false`). Equivalent to `--update-env` / `--no-update-env`. |
+
+### Persistent Parallel Local Databases
+
+Add `--database-name[=<name>]` to `yarn dev`, `yarn dev:greenfield`, or `yarn setup` to point this app at an isolated PostgreSQL database without manually editing `.env` first. Behavior:
+
+- `yarn dev` (no flag) is unchanged — no prompt, no `.env` mutation.
+- `yarn setup --database-name=client_a` rewrites the `DATABASE_URL` database segment in `./.env` after a confirmation prompt (default yes).
+- `yarn dev --database-name` (bare flag) derives the database name from the current directory.
+- `yarn dev --database-name=review_1720 --no-update-env` injects the rewritten URL into the current child process only and leaves `.env` untouched.
+- Non-interactive runs (`CI=true` or piped stdin) default to updating `.env`; pass `--no-update-env` to opt out.
+
+The override only changes the database segment of `DATABASE_URL`. Credentials, host, port, query strings (`?schema=…`, `?sslmode=…`), and other env variables are preserved verbatim.
 
 ## Infrastructure
 

--- a/packages/create-app/template/scripts/dev-database-url.mjs
+++ b/packages/create-app/template/scripts/dev-database-url.mjs
@@ -1,0 +1,343 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import readline from 'node:readline'
+
+const DATABASE_URL_KEY = 'DATABASE_URL'
+const DATABASE_NAME_FLAG = '--database-name'
+const NO_UPDATE_ENV_FLAG = '--no-update-env'
+const UPDATE_ENV_FLAG = '--update-env'
+const DATABASE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/
+const MAX_DATABASE_NAME_LENGTH = 63
+
+export function collectForwardedSetupFlags(argv) {
+  const out = []
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === DATABASE_NAME_FLAG) {
+      out.push(arg)
+      const next = argv[index + 1]
+      if (typeof next === 'string' && !next.startsWith('-')) {
+        out.push(next)
+        index += 1
+      }
+      continue
+    }
+    if (typeof arg === 'string' && arg.startsWith(`${DATABASE_NAME_FLAG}=`)) {
+      out.push(arg)
+      continue
+    }
+    if (arg === NO_UPDATE_ENV_FLAG || arg === UPDATE_ENV_FLAG) {
+      out.push(arg)
+    }
+  }
+  return out
+}
+
+export function parseDatabaseNameArgs(argv) {
+  const remaining = []
+  let provided = false
+  let rawValue = null
+  let updateEnv = null
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === DATABASE_NAME_FLAG) {
+      provided = true
+      const next = argv[index + 1]
+      if (typeof next === 'string' && !next.startsWith('-')) {
+        rawValue = next
+        index += 1
+      } else {
+        rawValue = null
+      }
+      continue
+    }
+    if (typeof arg === 'string' && arg.startsWith(`${DATABASE_NAME_FLAG}=`)) {
+      provided = true
+      rawValue = arg.slice(DATABASE_NAME_FLAG.length + 1)
+      continue
+    }
+    if (arg === NO_UPDATE_ENV_FLAG) {
+      updateEnv = false
+      continue
+    }
+    if (arg === UPDATE_ENV_FLAG) {
+      updateEnv = true
+      continue
+    }
+    remaining.push(arg)
+  }
+
+  return {
+    provided,
+    rawValue,
+    updateEnv,
+    remainingArgv: remaining,
+  }
+}
+
+export function deriveDatabaseNameFromCwd(cwd) {
+  const basename = path.basename(String(cwd ?? ''))
+  const lower = basename.toLowerCase()
+  const withUnderscores = lower.replace(/[^a-z0-9]+/g, '_')
+  const trimmed = withUnderscores.replace(/^_+|_+$/g, '')
+  if (!trimmed) return 'open_mercato_dev'
+  if (/^[0-9]/.test(trimmed)) return `om_${trimmed}`
+  return trimmed
+}
+
+export function validateDatabaseName(name) {
+  if (typeof name !== 'string') {
+    return { ok: false, reason: 'Database name must be a string.' }
+  }
+  if (name.length === 0) {
+    return { ok: false, reason: 'Database name must not be empty.' }
+  }
+  if (name.length > MAX_DATABASE_NAME_LENGTH) {
+    return {
+      ok: false,
+      reason: `Database name must be ${MAX_DATABASE_NAME_LENGTH} characters or fewer.`,
+    }
+  }
+  if (!DATABASE_NAME_PATTERN.test(name)) {
+    return {
+      ok: false,
+      reason: 'Database name must start with a letter or underscore and contain only letters, digits, underscores, or hyphens.',
+    }
+  }
+  return { ok: true }
+}
+
+export function resolveDatabaseName({ rawValue, cwd }) {
+  const trimmed = typeof rawValue === 'string' ? rawValue.trim() : ''
+  if (!trimmed) {
+    const derived = deriveDatabaseNameFromCwd(cwd)
+    return { name: derived, source: 'cwd' }
+  }
+  return { name: trimmed, source: 'explicit' }
+}
+
+export function rewriteDatabaseUrl(url, databaseName) {
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new Error('DATABASE_URL is empty.')
+  }
+  const parsed = new URL(url)
+  parsed.pathname = `/${encodeURIComponent(databaseName)}`
+  return parsed.toString()
+}
+
+export function updateDatabaseUrlInEnvText(source, databaseName) {
+  const lines = source.split(/\r?\n/)
+  let replaced = false
+  let changed = false
+  let previousValue = null
+  let nextValue = null
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const match = line.match(/^(\s*(?:export\s+)?DATABASE_URL\s*=\s*)(.*)$/)
+    if (!match) continue
+    const prefix = match[1]
+    const rawCurrent = match[2]
+    const { value: currentValue, quote } = stripEnvValueQuotes(rawCurrent)
+    if (replaced) {
+      continue
+    }
+    replaced = true
+    previousValue = currentValue
+    try {
+      nextValue = rewriteDatabaseUrl(currentValue, databaseName)
+    } catch (error) {
+      throw new Error(`Failed to rewrite ${DATABASE_URL_KEY}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    if (nextValue === currentValue) {
+      continue
+    }
+    lines[index] = `${prefix}${quote}${nextValue}${quote}`
+    changed = true
+  }
+
+  if (!replaced) {
+    throw new Error(`No ${DATABASE_URL_KEY} entry found in env file.`)
+  }
+
+  return {
+    text: lines.join('\n'),
+    changed,
+    previousValue,
+    nextValue,
+  }
+}
+
+function stripEnvValueQuotes(rawValue) {
+  if (typeof rawValue !== 'string') return { value: '', quote: '' }
+  const trimmed = rawValue.replace(/\s+#.*$/, '').trim()
+  if (
+    trimmed.length >= 2
+    && (
+      (trimmed.startsWith('"') && trimmed.endsWith('"'))
+      || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    )
+  ) {
+    return { value: trimmed.slice(1, -1), quote: trimmed[0] }
+  }
+  return { value: trimmed, quote: '' }
+}
+
+export function readEnvDatabaseUrl(source) {
+  for (const line of source.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:export\s+)?DATABASE_URL\s*=\s*(.*)$/)
+    if (!match) continue
+    return stripEnvValueQuotes(match[1]).value
+  }
+  return null
+}
+
+export function isNonInteractiveEnvironment({ env, stdinIsTTY }) {
+  if (env && typeof env === 'object') {
+    const ci = String(env.CI ?? '').trim().toLowerCase()
+    if (['1', 'true', 'yes', 'on'].includes(ci)) return true
+  }
+  if (stdinIsTTY === false) return true
+  return false
+}
+
+export function parseUpdateEnvAnswer(answer) {
+  if (typeof answer !== 'string') return null
+  const normalized = answer.trim().toLowerCase()
+  if (normalized === '') return true
+  if (['y', 'yes', '1', 'true'].includes(normalized)) return true
+  if (['n', 'no', '0', 'false'].includes(normalized)) return false
+  return null
+}
+
+async function promptUpdateEnv({ databaseName, input, output }) {
+  if (!input || !output) return true
+  const rl = readline.createInterface({ input, output })
+  try {
+    return await new Promise((resolve) => {
+      rl.question(`[dev] Update .env to use database "${databaseName}"? [Y/n] `, (answer) => {
+        const parsed = parseUpdateEnvAnswer(answer)
+        resolve(parsed === null ? true : parsed)
+      })
+    })
+  } finally {
+    rl.close()
+  }
+}
+
+export function resolveUpdateEnvDecisionFromEnv(env) {
+  if (!env || typeof env !== 'object') return null
+  const raw = env.OM_DEV_DATABASE_UPDATE_ENV
+  if (typeof raw !== 'string') return null
+  const normalized = raw.trim().toLowerCase()
+  if (['', '1', 'true', 'yes', 'on', 'y'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off', 'n'].includes(normalized)) return false
+  return null
+}
+
+export function readDatabaseNameEnvOverride(env) {
+  if (!env || typeof env !== 'object') return null
+  const raw = env.OM_DEV_DATABASE_NAME
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return trimmed
+}
+
+export async function resolveDatabaseNameOverride(options) {
+  const {
+    argv = [],
+    env = {},
+    cwd = process.cwd(),
+    envFilePath,
+    stdin = null,
+    stdout = null,
+    logger = noopLogger(),
+    fsImpl = fs,
+  } = options
+
+  const parsed = parseDatabaseNameArgs(argv)
+  const envOverrideName = readDatabaseNameEnvOverride(env)
+
+  const flagPresent = parsed.provided || envOverrideName !== null
+  if (!flagPresent) {
+    return { applied: false, remainingArgv: parsed.remainingArgv }
+  }
+
+  const rawValue = parsed.provided ? parsed.rawValue : envOverrideName
+  const resolved = resolveDatabaseName({ rawValue, cwd })
+
+  const validation = validateDatabaseName(resolved.name)
+  if (!validation.ok) {
+    throw new Error(`Invalid database name "${resolved.name}": ${validation.reason}`)
+  }
+
+  if (!envFilePath) {
+    throw new Error('Cannot resolve env file path for database-name override.')
+  }
+
+  if (!fsImpl.existsSync(envFilePath)) {
+    throw new Error(`Env file not found at ${envFilePath}. Cannot apply --database-name.`)
+  }
+
+  const envSource = fsImpl.readFileSync(envFilePath, 'utf8')
+  const previousUrl = readEnvDatabaseUrl(envSource)
+  if (!previousUrl) {
+    throw new Error(`Env file ${envFilePath} does not declare ${DATABASE_URL_KEY}.`)
+  }
+
+  const rewritten = updateDatabaseUrlInEnvText(envSource, resolved.name)
+
+  logger.info?.(`[dev] Using database "${resolved.name}" from ${parsed.provided ? '--database-name' : 'OM_DEV_DATABASE_NAME'}.`)
+
+  let updateEnvDecision
+  if (parsed.updateEnv === false) {
+    updateEnvDecision = false
+  } else if (parsed.updateEnv === true) {
+    updateEnvDecision = true
+  } else {
+    const envDecision = resolveUpdateEnvDecisionFromEnv(env)
+    if (envDecision !== null) {
+      updateEnvDecision = envDecision
+    } else if (isNonInteractiveEnvironment({ env, stdinIsTTY: stdin?.isTTY })) {
+      updateEnvDecision = true
+    } else {
+      updateEnvDecision = await promptUpdateEnv({
+        databaseName: resolved.name,
+        input: stdin,
+        output: stdout,
+      })
+    }
+  }
+
+  if (updateEnvDecision) {
+    if (rewritten.changed) {
+      fsImpl.writeFileSync(envFilePath, rewritten.text)
+      logger.info?.(`[dev] Updated ${path.basename(envFilePath)} ${DATABASE_URL_KEY}.`)
+    } else {
+      logger.info?.(`[dev] ${path.basename(envFilePath)} already targets database "${resolved.name}".`)
+    }
+  } else {
+    logger.info?.(`[dev] Leaving ${path.basename(envFilePath)} unchanged; child commands will use database "${resolved.name}" for this run.`)
+  }
+
+  return {
+    applied: true,
+    databaseName: resolved.name,
+    source: resolved.source,
+    envFilePath,
+    previousDatabaseUrl: previousUrl,
+    nextDatabaseUrl: rewritten.nextValue,
+    envFileUpdated: updateEnvDecision && rewritten.changed,
+    envFileWriteSkipped: !updateEnvDecision,
+    childEnv: { [DATABASE_URL_KEY]: rewritten.nextValue },
+    remainingArgv: parsed.remainingArgv,
+  }
+}
+
+function noopLogger() {
+  return { info: () => {}, warn: () => {}, error: () => {} }
+}
+
+export const __DATABASE_URL_KEY__ = DATABASE_URL_KEY

--- a/packages/create-app/template/scripts/dev.mjs
+++ b/packages/create-app/template/scripts/dev.mjs
@@ -30,6 +30,7 @@ import {
   resolveDevBaseUrl,
   resolveSplashUrl as resolveSplashAccessUrl,
 } from './dev-splash-url.mjs'
+import { resolveDatabaseNameOverride } from './dev-database-url.mjs'
 
 function detectDevRuntimeMode() {
   const cwd = process.cwd()
@@ -571,6 +572,39 @@ function ensureStandaloneEnvFile() {
       activity: 'Project files are ready',
     })
   }
+}
+
+function resolveDatabaseEnvFilePath() {
+  return isMonorepo
+    ? path.join(process.cwd(), 'apps', 'mercato', '.env')
+    : path.join(process.cwd(), '.env')
+}
+
+async function applyDatabaseNameOverrideIfRequested() {
+  let result
+  try {
+    result = await resolveDatabaseNameOverride({
+      argv: args,
+      env: process.env,
+      cwd: process.cwd(),
+      envFilePath: resolveDatabaseEnvFilePath(),
+      stdin: process.stdin,
+      stdout: process.stdout,
+      logger: { info: (msg) => console.log(msg) },
+    })
+  } catch (error) {
+    console.error(`❌ ${error instanceof Error ? error.message : String(error)}`)
+    shutdown(1)
+    return null
+  }
+
+  if (result?.applied) {
+    process.env.DATABASE_URL = result.childEnv.DATABASE_URL
+    updateSplashState({
+      activity: `Using database "${result.databaseName}" for this run`,
+    })
+  }
+  return result
 }
 
 function normalizeLocaleToken(value) {
@@ -1613,6 +1647,7 @@ async function runClassicGreenfieldDev() {
 
 async function runStandaloneSetup() {
   ensureStandaloneEnvFile()
+  await applyDatabaseNameOverrideIfRequested()
   if (standaloneLocalRegistryRefresh) {
     await runStage('🧼 Clearing local Open Mercato cache', ['cache', 'clean', '--all'], {
       stageCurrent: 0,
@@ -1639,6 +1674,7 @@ async function runStandaloneSetup() {
 
 async function runClassicStandaloneSetup() {
   ensureStandaloneEnvFile()
+  await applyDatabaseNameOverrideIfRequested()
   if (standaloneLocalRegistryRefresh) {
     await runRawYarnCommand(['cache', 'clean', '--all'])
   }
@@ -1675,6 +1711,7 @@ async function main() {
       await runStandaloneSetup()
       return
     }
+    await applyDatabaseNameOverrideIfRequested()
     if (classic) {
       await runClassicStandaloneDev()
       return
@@ -1698,6 +1735,8 @@ async function main() {
     launchStandaloneDev()
     return
   }
+
+  await applyDatabaseNameOverrideIfRequested()
 
   if (appOnly) {
     launchMonorepoAppDev()

--- a/packages/create-app/template/scripts/setup.mjs
+++ b/packages/create-app/template/scripts/setup.mjs
@@ -1,8 +1,11 @@
 import { spawnSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
+import { collectForwardedSetupFlags } from './dev-database-url.mjs'
 
-const reinstall = process.argv.includes('--reinstall')
-const classic = process.argv.includes('--classic')
+const argv = process.argv.slice(2)
+const reinstall = argv.includes('--reinstall')
+const classic = argv.includes('--classic')
+const forwardedDatabaseFlags = collectForwardedSetupFlags(argv)
 
 if (!existsSync('node_modules/cross-spawn')) {
   const bootstrap = spawnSync('yarn', ['install'], {
@@ -14,7 +17,13 @@ if (!existsSync('node_modules/cross-spawn')) {
 
 const result = spawnSync(
   process.execPath,
-  ['./scripts/dev.mjs', '--setup', ...(reinstall ? ['--reinstall'] : []), ...(classic ? ['--classic'] : [])],
+  [
+    './scripts/dev.mjs',
+    '--setup',
+    ...(reinstall ? ['--reinstall'] : []),
+    ...(classic ? ['--classic'] : []),
+    ...forwardedDatabaseFlags,
+  ],
   {
     stdio: 'inherit',
     shell: process.platform === 'win32',

--- a/scripts/__tests__/dev-database-url.test.mjs
+++ b/scripts/__tests__/dev-database-url.test.mjs
@@ -1,0 +1,484 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  parseDatabaseNameArgs,
+  deriveDatabaseNameFromCwd,
+  validateDatabaseName,
+  resolveDatabaseName,
+  rewriteDatabaseUrl,
+  updateDatabaseUrlInEnvText,
+  readEnvDatabaseUrl,
+  isNonInteractiveEnvironment,
+  parseUpdateEnvAnswer,
+  resolveUpdateEnvDecisionFromEnv,
+  readDatabaseNameEnvOverride,
+  resolveDatabaseNameOverride,
+  collectForwardedSetupFlags,
+} from '../dev-database-url.mjs'
+
+test('parseDatabaseNameArgs: omitted flag preserves argv and reports not-provided', () => {
+  const result = parseDatabaseNameArgs(['--greenfield', '--verbose'])
+  assert.equal(result.provided, false)
+  assert.equal(result.rawValue, null)
+  assert.equal(result.updateEnv, null)
+  assert.deepEqual(result.remainingArgv, ['--greenfield', '--verbose'])
+})
+
+test('parseDatabaseNameArgs: --database-name=value parses explicit value', () => {
+  const result = parseDatabaseNameArgs(['--database-name=client_a', '--verbose'])
+  assert.equal(result.provided, true)
+  assert.equal(result.rawValue, 'client_a')
+  assert.deepEqual(result.remainingArgv, ['--verbose'])
+})
+
+test('parseDatabaseNameArgs: --database-name with following positional value', () => {
+  const result = parseDatabaseNameArgs(['--database-name', 'client_b', '--setup'])
+  assert.equal(result.provided, true)
+  assert.equal(result.rawValue, 'client_b')
+  assert.deepEqual(result.remainingArgv, ['--setup'])
+})
+
+test('parseDatabaseNameArgs: bare --database-name (no value) signals CWD derivation', () => {
+  const result = parseDatabaseNameArgs(['--database-name'])
+  assert.equal(result.provided, true)
+  assert.equal(result.rawValue, null)
+  assert.deepEqual(result.remainingArgv, [])
+})
+
+test('parseDatabaseNameArgs: --database-name= (empty value) also signals CWD derivation', () => {
+  const result = parseDatabaseNameArgs(['--database-name='])
+  assert.equal(result.provided, true)
+  assert.equal(result.rawValue, '')
+})
+
+test('parseDatabaseNameArgs: --database-name does not consume next flag as value', () => {
+  const result = parseDatabaseNameArgs(['--database-name', '--no-update-env'])
+  assert.equal(result.provided, true)
+  assert.equal(result.rawValue, null)
+  assert.equal(result.updateEnv, false)
+})
+
+test('parseDatabaseNameArgs: --no-update-env / --update-env tracked', () => {
+  assert.equal(parseDatabaseNameArgs(['--no-update-env']).updateEnv, false)
+  assert.equal(parseDatabaseNameArgs(['--update-env']).updateEnv, true)
+  assert.equal(parseDatabaseNameArgs([]).updateEnv, null)
+})
+
+test('deriveDatabaseNameFromCwd: lowercases and replaces non-alphanumerics', () => {
+  assert.equal(deriveDatabaseNameFromCwd('/a/b/open-mercato'), 'open_mercato')
+  assert.equal(deriveDatabaseNameFromCwd('/projects/Client-A'), 'client_a')
+  assert.equal(deriveDatabaseNameFromCwd('Client.B App'), 'client_b_app')
+})
+
+test('deriveDatabaseNameFromCwd: trims leading/trailing underscores', () => {
+  assert.equal(deriveDatabaseNameFromCwd('_my-app_'), 'my_app')
+  assert.equal(deriveDatabaseNameFromCwd('--scratch--'), 'scratch')
+})
+
+test('deriveDatabaseNameFromCwd: prefixes om_ when starting with a digit', () => {
+  assert.equal(deriveDatabaseNameFromCwd('/x/2026-redesign'), 'om_2026_redesign')
+  assert.equal(deriveDatabaseNameFromCwd('1stApp'), 'om_1stapp')
+})
+
+test('deriveDatabaseNameFromCwd: falls back to open_mercato_dev for empty/non-alphanumeric', () => {
+  assert.equal(deriveDatabaseNameFromCwd('////'), 'open_mercato_dev')
+  assert.equal(deriveDatabaseNameFromCwd('___'), 'open_mercato_dev')
+  assert.equal(deriveDatabaseNameFromCwd(''), 'open_mercato_dev')
+})
+
+test('validateDatabaseName: accepts allowed names', () => {
+  assert.equal(validateDatabaseName('open_mercato').ok, true)
+  assert.equal(validateDatabaseName('client-a').ok, true)
+  assert.equal(validateDatabaseName('_underscore_first').ok, true)
+  assert.equal(validateDatabaseName('A1_-_2').ok, true)
+})
+
+test('validateDatabaseName: rejects empty, leading-digit, or invalid chars', () => {
+  assert.equal(validateDatabaseName('').ok, false)
+  assert.equal(validateDatabaseName('1bad').ok, false)
+  assert.equal(validateDatabaseName('with space').ok, false)
+  assert.equal(validateDatabaseName('with;semi').ok, false)
+  assert.equal(validateDatabaseName('"quoted"').ok, false)
+})
+
+test('validateDatabaseName: rejects names longer than PostgreSQL identifier limit', () => {
+  assert.equal(validateDatabaseName('a'.repeat(63)).ok, true)
+  assert.equal(validateDatabaseName('a'.repeat(64)).ok, false)
+})
+
+test('resolveDatabaseName: explicit value wins, CWD fallback when empty', () => {
+  assert.deepEqual(
+    resolveDatabaseName({ rawValue: 'client_a', cwd: '/x/y' }),
+    { name: 'client_a', source: 'explicit' },
+  )
+  assert.deepEqual(
+    resolveDatabaseName({ rawValue: '', cwd: '/x/y/open-mercato' }),
+    { name: 'open_mercato', source: 'cwd' },
+  )
+  assert.deepEqual(
+    resolveDatabaseName({ rawValue: null, cwd: '/x/y/client-b' }),
+    { name: 'client_b', source: 'cwd' },
+  )
+  assert.deepEqual(
+    resolveDatabaseName({ rawValue: '   ', cwd: '/x/y/client-c' }),
+    { name: 'client_c', source: 'cwd' },
+  )
+})
+
+test('rewriteDatabaseUrl: replaces only pathname database segment', () => {
+  const url = 'postgres://postgres:postgres@localhost:5432/open-mercato'
+  assert.equal(rewriteDatabaseUrl(url, 'client_a'), 'postgres://postgres:postgres@localhost:5432/client_a')
+})
+
+test('rewriteDatabaseUrl: preserves credentials with reserved characters', () => {
+  const url = 'postgres://user:p%40ss%2Fword@localhost:5432/open-mercato'
+  const rewritten = rewriteDatabaseUrl(url, 'client_a')
+  const parsed = new URL(rewritten)
+  assert.equal(parsed.username, 'user')
+  assert.equal(decodeURIComponent(parsed.password), 'p@ss/word')
+  assert.equal(parsed.pathname, '/client_a')
+})
+
+test('rewriteDatabaseUrl: preserves query string (?schema=custom) and host', () => {
+  const url = 'postgres://postgres:postgres@db.internal:6432/open-mercato?schema=custom&sslmode=require'
+  const rewritten = rewriteDatabaseUrl(url, 'client_a')
+  const parsed = new URL(rewritten)
+  assert.equal(parsed.host, 'db.internal:6432')
+  assert.equal(parsed.pathname, '/client_a')
+  assert.equal(parsed.searchParams.get('schema'), 'custom')
+  assert.equal(parsed.searchParams.get('sslmode'), 'require')
+})
+
+test('rewriteDatabaseUrl: rejects empty input', () => {
+  assert.throws(() => rewriteDatabaseUrl('', 'x'), /empty/i)
+})
+
+test('updateDatabaseUrlInEnvText: rewrites a plain DATABASE_URL line', () => {
+  const source = [
+    '# header',
+    'POSTGRES_USER=postgres',
+    'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato',
+    'JWT_SECRET=abc',
+  ].join('\n')
+  const result = updateDatabaseUrlInEnvText(source, 'client_a')
+  assert.equal(result.changed, true)
+  assert.match(result.text, /^DATABASE_URL=postgres:\/\/postgres:postgres@localhost:5432\/client_a$/m)
+  assert.match(result.text, /JWT_SECRET=abc/)
+})
+
+test('updateDatabaseUrlInEnvText: preserves quotes and trailing comments', () => {
+  const source = 'DATABASE_URL="postgres://u:p@h:5432/db" # comment'
+  const result = updateDatabaseUrlInEnvText(source, 'new_db')
+  assert.match(result.text, /DATABASE_URL="postgres:\/\/u:p@h:5432\/new_db"/)
+})
+
+test('updateDatabaseUrlInEnvText: only rewrites the first DATABASE_URL occurrence', () => {
+  const source = [
+    'DATABASE_URL=postgres://a:b@c:5432/old1',
+    'DATABASE_URL=postgres://a:b@c:5432/old2',
+  ].join('\n')
+  const result = updateDatabaseUrlInEnvText(source, 'new_db')
+  const lines = result.text.split('\n')
+  assert.equal(lines[0], 'DATABASE_URL=postgres://a:b@c:5432/new_db')
+  assert.equal(lines[1], 'DATABASE_URL=postgres://a:b@c:5432/old2')
+})
+
+test('updateDatabaseUrlInEnvText: changed=false when database name already matches', () => {
+  const source = 'DATABASE_URL=postgres://a:b@c:5432/already_set'
+  const result = updateDatabaseUrlInEnvText(source, 'already_set')
+  assert.equal(result.changed, false)
+})
+
+test('updateDatabaseUrlInEnvText: throws when no DATABASE_URL line exists', () => {
+  assert.throws(() => updateDatabaseUrlInEnvText('OTHER=x', 'foo'), /No DATABASE_URL/)
+})
+
+test('readEnvDatabaseUrl: returns the value, stripping quotes', () => {
+  assert.equal(
+    readEnvDatabaseUrl('DATABASE_URL="postgres://x:y@z:5432/a"'),
+    'postgres://x:y@z:5432/a',
+  )
+  assert.equal(
+    readEnvDatabaseUrl('export DATABASE_URL=postgres://x:y@z:5432/a'),
+    'postgres://x:y@z:5432/a',
+  )
+  assert.equal(readEnvDatabaseUrl('OTHER=1'), null)
+})
+
+test('isNonInteractiveEnvironment: detects CI=true and missing TTY', () => {
+  assert.equal(isNonInteractiveEnvironment({ env: { CI: 'true' }, stdinIsTTY: true }), true)
+  assert.equal(isNonInteractiveEnvironment({ env: { CI: '1' }, stdinIsTTY: true }), true)
+  assert.equal(isNonInteractiveEnvironment({ env: {}, stdinIsTTY: false }), true)
+  assert.equal(isNonInteractiveEnvironment({ env: {}, stdinIsTTY: true }), false)
+})
+
+test('parseUpdateEnvAnswer: yes/no aliases and default-yes for empty', () => {
+  assert.equal(parseUpdateEnvAnswer(''), true)
+  assert.equal(parseUpdateEnvAnswer('y'), true)
+  assert.equal(parseUpdateEnvAnswer('Yes'), true)
+  assert.equal(parseUpdateEnvAnswer('1'), true)
+  assert.equal(parseUpdateEnvAnswer('TRUE'), true)
+  assert.equal(parseUpdateEnvAnswer('n'), false)
+  assert.equal(parseUpdateEnvAnswer('No'), false)
+  assert.equal(parseUpdateEnvAnswer('0'), false)
+  assert.equal(parseUpdateEnvAnswer('false'), false)
+  assert.equal(parseUpdateEnvAnswer('maybe'), null)
+})
+
+test('resolveUpdateEnvDecisionFromEnv / readDatabaseNameEnvOverride: env-based defaults', () => {
+  assert.equal(resolveUpdateEnvDecisionFromEnv({ OM_DEV_DATABASE_UPDATE_ENV: 'true' }), true)
+  assert.equal(resolveUpdateEnvDecisionFromEnv({ OM_DEV_DATABASE_UPDATE_ENV: 'no' }), false)
+  assert.equal(resolveUpdateEnvDecisionFromEnv({}), null)
+  assert.equal(readDatabaseNameEnvOverride({ OM_DEV_DATABASE_NAME: 'foo' }), 'foo')
+  assert.equal(readDatabaseNameEnvOverride({ OM_DEV_DATABASE_NAME: '   ' }), null)
+  assert.equal(readDatabaseNameEnvOverride({}), null)
+})
+
+test('resolveDatabaseNameOverride: omitted flag is a no-op', async () => {
+  const result = await resolveDatabaseNameOverride({
+    argv: ['--greenfield'],
+    env: {},
+    cwd: '/tmp/whatever',
+    envFilePath: null,
+  })
+  assert.equal(result.applied, false)
+  assert.deepEqual(result.remainingArgv, ['--greenfield'])
+})
+
+test('resolveDatabaseNameOverride: explicit name updates env file when --update-env', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-'))
+  const envPath = path.join(root, '.env')
+  fs.writeFileSync(
+    envPath,
+    'POSTGRES_USER=postgres\nDATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\nJWT_SECRET=x\n',
+  )
+
+  try {
+    const logs = []
+    const result = await resolveDatabaseNameOverride({
+      argv: ['--database-name=client_a', '--update-env'],
+      env: {},
+      cwd: root,
+      envFilePath: envPath,
+      logger: { info: (msg) => logs.push(msg) },
+    })
+
+    assert.equal(result.applied, true)
+    assert.equal(result.databaseName, 'client_a')
+    assert.equal(result.source, 'explicit')
+    assert.equal(result.envFileUpdated, true)
+    assert.equal(result.envFileWriteSkipped, false)
+    assert.equal(
+      result.childEnv.DATABASE_URL,
+      'postgres://postgres:postgres@localhost:5432/client_a',
+    )
+    const updated = fs.readFileSync(envPath, 'utf8')
+    assert.match(updated, /DATABASE_URL=postgres:\/\/postgres:postgres@localhost:5432\/client_a/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveDatabaseNameOverride: bare --database-name derives from CWD', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-cwd-'))
+  const projectDir = path.join(root, 'Client-Beta')
+  fs.mkdirSync(projectDir, { recursive: true })
+  const envPath = path.join(projectDir, '.env')
+  fs.writeFileSync(envPath, 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\n')
+
+  try {
+    const result = await resolveDatabaseNameOverride({
+      argv: ['--database-name', '--update-env'],
+      env: {},
+      cwd: projectDir,
+      envFilePath: envPath,
+    })
+
+    assert.equal(result.applied, true)
+    assert.equal(result.databaseName, 'client_beta')
+    assert.equal(result.source, 'cwd')
+    assert.equal(result.envFileUpdated, true)
+    assert.equal(
+      result.childEnv.DATABASE_URL,
+      'postgres://postgres:postgres@localhost:5432/client_beta',
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveDatabaseNameOverride: --no-update-env keeps file untouched but injects child env', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-skip-'))
+  const envPath = path.join(root, '.env')
+  const original = 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\n'
+  fs.writeFileSync(envPath, original)
+
+  try {
+    const result = await resolveDatabaseNameOverride({
+      argv: ['--database-name=temp_run', '--no-update-env'],
+      env: {},
+      cwd: root,
+      envFilePath: envPath,
+    })
+
+    assert.equal(result.applied, true)
+    assert.equal(result.envFileUpdated, false)
+    assert.equal(result.envFileWriteSkipped, true)
+    assert.equal(
+      result.childEnv.DATABASE_URL,
+      'postgres://postgres:postgres@localhost:5432/temp_run',
+    )
+    assert.equal(fs.readFileSync(envPath, 'utf8'), original)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveDatabaseNameOverride: non-interactive run defaults to update without prompting', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-ni-'))
+  const envPath = path.join(root, '.env')
+  fs.writeFileSync(envPath, 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\n')
+
+  try {
+    const result = await resolveDatabaseNameOverride({
+      argv: ['--database-name=auto'],
+      env: { CI: 'true' },
+      cwd: root,
+      envFilePath: envPath,
+    })
+
+    assert.equal(result.envFileUpdated, true)
+    assert.match(fs.readFileSync(envPath, 'utf8'), /\/auto/)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveDatabaseNameOverride: invalid explicit name throws and leaves file untouched', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-invalid-'))
+  const envPath = path.join(root, '.env')
+  const original = 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\n'
+  fs.writeFileSync(envPath, original)
+
+  try {
+    await assert.rejects(
+      () => resolveDatabaseNameOverride({
+        argv: ['--database-name=bad name'],
+        env: {},
+        cwd: root,
+        envFilePath: envPath,
+      }),
+      /Invalid database name/,
+    )
+    assert.equal(fs.readFileSync(envPath, 'utf8'), original)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveDatabaseNameOverride: missing env file fails closed without writes', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-noenv-'))
+  try {
+    await assert.rejects(
+      () => resolveDatabaseNameOverride({
+        argv: ['--database-name=any'],
+        env: {},
+        cwd: root,
+        envFilePath: path.join(root, '.env'),
+      }),
+      /Env file not found/,
+    )
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('resolveDatabaseNameOverride: OM_DEV_DATABASE_NAME env var triggers override when CLI flag is absent', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-envvar-'))
+  const envPath = path.join(root, '.env')
+  fs.writeFileSync(envPath, 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\n')
+
+  try {
+    const result = await resolveDatabaseNameOverride({
+      argv: [],
+      env: { OM_DEV_DATABASE_NAME: 'from_env', CI: 'true' },
+      cwd: root,
+      envFilePath: envPath,
+    })
+
+    assert.equal(result.applied, true)
+    assert.equal(result.databaseName, 'from_env')
+    assert.equal(result.envFileUpdated, true)
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('collectForwardedSetupFlags: forwards --database-name=<value> verbatim', () => {
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--reinstall', '--database-name=client_a', '--classic']),
+    ['--database-name=client_a'],
+  )
+})
+
+test('collectForwardedSetupFlags: forwards bare --database-name (no value)', () => {
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--database-name']),
+    ['--database-name'],
+  )
+})
+
+test('collectForwardedSetupFlags: forwards --database-name with positional value', () => {
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--database-name', 'client_b', '--reinstall']),
+    ['--database-name', 'client_b'],
+  )
+})
+
+test('collectForwardedSetupFlags: does not consume next flag as value', () => {
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--database-name', '--no-update-env']),
+    ['--database-name', '--no-update-env'],
+  )
+})
+
+test('collectForwardedSetupFlags: forwards --update-env / --no-update-env', () => {
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--no-update-env']),
+    ['--no-update-env'],
+  )
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--update-env']),
+    ['--update-env'],
+  )
+})
+
+test('collectForwardedSetupFlags: returns empty when none of the flags are present', () => {
+  assert.deepEqual(
+    collectForwardedSetupFlags(['--reinstall', '--classic']),
+    [],
+  )
+})
+
+test('resolveDatabaseNameOverride: CLI flag wins over OM_DEV_DATABASE_NAME', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-db-url-cli-wins-'))
+  const envPath = path.join(root, '.env')
+  fs.writeFileSync(envPath, 'DATABASE_URL=postgres://postgres:postgres@localhost:5432/open-mercato\n')
+
+  try {
+    const result = await resolveDatabaseNameOverride({
+      argv: ['--database-name=cli_wins', '--update-env'],
+      env: { OM_DEV_DATABASE_NAME: 'env_loses' },
+      cwd: root,
+      envFilePath: envPath,
+    })
+
+    assert.equal(result.databaseName, 'cli_wins')
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/scripts/dev-database-url.mjs
+++ b/scripts/dev-database-url.mjs
@@ -1,0 +1,343 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import readline from 'node:readline'
+
+const DATABASE_URL_KEY = 'DATABASE_URL'
+const DATABASE_NAME_FLAG = '--database-name'
+const NO_UPDATE_ENV_FLAG = '--no-update-env'
+const UPDATE_ENV_FLAG = '--update-env'
+const DATABASE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_-]*$/
+const MAX_DATABASE_NAME_LENGTH = 63
+
+export function collectForwardedSetupFlags(argv) {
+  const out = []
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === DATABASE_NAME_FLAG) {
+      out.push(arg)
+      const next = argv[index + 1]
+      if (typeof next === 'string' && !next.startsWith('-')) {
+        out.push(next)
+        index += 1
+      }
+      continue
+    }
+    if (typeof arg === 'string' && arg.startsWith(`${DATABASE_NAME_FLAG}=`)) {
+      out.push(arg)
+      continue
+    }
+    if (arg === NO_UPDATE_ENV_FLAG || arg === UPDATE_ENV_FLAG) {
+      out.push(arg)
+    }
+  }
+  return out
+}
+
+export function parseDatabaseNameArgs(argv) {
+  const remaining = []
+  let provided = false
+  let rawValue = null
+  let updateEnv = null
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === DATABASE_NAME_FLAG) {
+      provided = true
+      const next = argv[index + 1]
+      if (typeof next === 'string' && !next.startsWith('-')) {
+        rawValue = next
+        index += 1
+      } else {
+        rawValue = null
+      }
+      continue
+    }
+    if (typeof arg === 'string' && arg.startsWith(`${DATABASE_NAME_FLAG}=`)) {
+      provided = true
+      rawValue = arg.slice(DATABASE_NAME_FLAG.length + 1)
+      continue
+    }
+    if (arg === NO_UPDATE_ENV_FLAG) {
+      updateEnv = false
+      continue
+    }
+    if (arg === UPDATE_ENV_FLAG) {
+      updateEnv = true
+      continue
+    }
+    remaining.push(arg)
+  }
+
+  return {
+    provided,
+    rawValue,
+    updateEnv,
+    remainingArgv: remaining,
+  }
+}
+
+export function deriveDatabaseNameFromCwd(cwd) {
+  const basename = path.basename(String(cwd ?? ''))
+  const lower = basename.toLowerCase()
+  const withUnderscores = lower.replace(/[^a-z0-9]+/g, '_')
+  const trimmed = withUnderscores.replace(/^_+|_+$/g, '')
+  if (!trimmed) return 'open_mercato_dev'
+  if (/^[0-9]/.test(trimmed)) return `om_${trimmed}`
+  return trimmed
+}
+
+export function validateDatabaseName(name) {
+  if (typeof name !== 'string') {
+    return { ok: false, reason: 'Database name must be a string.' }
+  }
+  if (name.length === 0) {
+    return { ok: false, reason: 'Database name must not be empty.' }
+  }
+  if (name.length > MAX_DATABASE_NAME_LENGTH) {
+    return {
+      ok: false,
+      reason: `Database name must be ${MAX_DATABASE_NAME_LENGTH} characters or fewer.`,
+    }
+  }
+  if (!DATABASE_NAME_PATTERN.test(name)) {
+    return {
+      ok: false,
+      reason: 'Database name must start with a letter or underscore and contain only letters, digits, underscores, or hyphens.',
+    }
+  }
+  return { ok: true }
+}
+
+export function resolveDatabaseName({ rawValue, cwd }) {
+  const trimmed = typeof rawValue === 'string' ? rawValue.trim() : ''
+  if (!trimmed) {
+    const derived = deriveDatabaseNameFromCwd(cwd)
+    return { name: derived, source: 'cwd' }
+  }
+  return { name: trimmed, source: 'explicit' }
+}
+
+export function rewriteDatabaseUrl(url, databaseName) {
+  if (typeof url !== 'string' || url.length === 0) {
+    throw new Error('DATABASE_URL is empty.')
+  }
+  const parsed = new URL(url)
+  parsed.pathname = `/${encodeURIComponent(databaseName)}`
+  return parsed.toString()
+}
+
+export function updateDatabaseUrlInEnvText(source, databaseName) {
+  const lines = source.split(/\r?\n/)
+  let replaced = false
+  let changed = false
+  let previousValue = null
+  let nextValue = null
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]
+    const match = line.match(/^(\s*(?:export\s+)?DATABASE_URL\s*=\s*)(.*)$/)
+    if (!match) continue
+    const prefix = match[1]
+    const rawCurrent = match[2]
+    const { value: currentValue, quote } = stripEnvValueQuotes(rawCurrent)
+    if (replaced) {
+      continue
+    }
+    replaced = true
+    previousValue = currentValue
+    try {
+      nextValue = rewriteDatabaseUrl(currentValue, databaseName)
+    } catch (error) {
+      throw new Error(`Failed to rewrite ${DATABASE_URL_KEY}: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    if (nextValue === currentValue) {
+      continue
+    }
+    lines[index] = `${prefix}${quote}${nextValue}${quote}`
+    changed = true
+  }
+
+  if (!replaced) {
+    throw new Error(`No ${DATABASE_URL_KEY} entry found in env file.`)
+  }
+
+  return {
+    text: lines.join('\n'),
+    changed,
+    previousValue,
+    nextValue,
+  }
+}
+
+function stripEnvValueQuotes(rawValue) {
+  if (typeof rawValue !== 'string') return { value: '', quote: '' }
+  const trimmed = rawValue.replace(/\s+#.*$/, '').trim()
+  if (
+    trimmed.length >= 2
+    && (
+      (trimmed.startsWith('"') && trimmed.endsWith('"'))
+      || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    )
+  ) {
+    return { value: trimmed.slice(1, -1), quote: trimmed[0] }
+  }
+  return { value: trimmed, quote: '' }
+}
+
+export function readEnvDatabaseUrl(source) {
+  for (const line of source.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:export\s+)?DATABASE_URL\s*=\s*(.*)$/)
+    if (!match) continue
+    return stripEnvValueQuotes(match[1]).value
+  }
+  return null
+}
+
+export function isNonInteractiveEnvironment({ env, stdinIsTTY }) {
+  if (env && typeof env === 'object') {
+    const ci = String(env.CI ?? '').trim().toLowerCase()
+    if (['1', 'true', 'yes', 'on'].includes(ci)) return true
+  }
+  if (stdinIsTTY === false) return true
+  return false
+}
+
+export function parseUpdateEnvAnswer(answer) {
+  if (typeof answer !== 'string') return null
+  const normalized = answer.trim().toLowerCase()
+  if (normalized === '') return true
+  if (['y', 'yes', '1', 'true'].includes(normalized)) return true
+  if (['n', 'no', '0', 'false'].includes(normalized)) return false
+  return null
+}
+
+async function promptUpdateEnv({ databaseName, input, output }) {
+  if (!input || !output) return true
+  const rl = readline.createInterface({ input, output })
+  try {
+    return await new Promise((resolve) => {
+      rl.question(`[dev] Update .env to use database "${databaseName}"? [Y/n] `, (answer) => {
+        const parsed = parseUpdateEnvAnswer(answer)
+        resolve(parsed === null ? true : parsed)
+      })
+    })
+  } finally {
+    rl.close()
+  }
+}
+
+export function resolveUpdateEnvDecisionFromEnv(env) {
+  if (!env || typeof env !== 'object') return null
+  const raw = env.OM_DEV_DATABASE_UPDATE_ENV
+  if (typeof raw !== 'string') return null
+  const normalized = raw.trim().toLowerCase()
+  if (['', '1', 'true', 'yes', 'on', 'y'].includes(normalized)) return true
+  if (['0', 'false', 'no', 'off', 'n'].includes(normalized)) return false
+  return null
+}
+
+export function readDatabaseNameEnvOverride(env) {
+  if (!env || typeof env !== 'object') return null
+  const raw = env.OM_DEV_DATABASE_NAME
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  return trimmed
+}
+
+export async function resolveDatabaseNameOverride(options) {
+  const {
+    argv = [],
+    env = {},
+    cwd = process.cwd(),
+    envFilePath,
+    stdin = null,
+    stdout = null,
+    logger = noopLogger(),
+    fsImpl = fs,
+  } = options
+
+  const parsed = parseDatabaseNameArgs(argv)
+  const envOverrideName = readDatabaseNameEnvOverride(env)
+
+  const flagPresent = parsed.provided || envOverrideName !== null
+  if (!flagPresent) {
+    return { applied: false, remainingArgv: parsed.remainingArgv }
+  }
+
+  const rawValue = parsed.provided ? parsed.rawValue : envOverrideName
+  const resolved = resolveDatabaseName({ rawValue, cwd })
+
+  const validation = validateDatabaseName(resolved.name)
+  if (!validation.ok) {
+    throw new Error(`Invalid database name "${resolved.name}": ${validation.reason}`)
+  }
+
+  if (!envFilePath) {
+    throw new Error('Cannot resolve env file path for database-name override.')
+  }
+
+  if (!fsImpl.existsSync(envFilePath)) {
+    throw new Error(`Env file not found at ${envFilePath}. Cannot apply --database-name.`)
+  }
+
+  const envSource = fsImpl.readFileSync(envFilePath, 'utf8')
+  const previousUrl = readEnvDatabaseUrl(envSource)
+  if (!previousUrl) {
+    throw new Error(`Env file ${envFilePath} does not declare ${DATABASE_URL_KEY}.`)
+  }
+
+  const rewritten = updateDatabaseUrlInEnvText(envSource, resolved.name)
+
+  logger.info?.(`[dev] Using database "${resolved.name}" from ${parsed.provided ? '--database-name' : 'OM_DEV_DATABASE_NAME'}.`)
+
+  let updateEnvDecision
+  if (parsed.updateEnv === false) {
+    updateEnvDecision = false
+  } else if (parsed.updateEnv === true) {
+    updateEnvDecision = true
+  } else {
+    const envDecision = resolveUpdateEnvDecisionFromEnv(env)
+    if (envDecision !== null) {
+      updateEnvDecision = envDecision
+    } else if (isNonInteractiveEnvironment({ env, stdinIsTTY: stdin?.isTTY })) {
+      updateEnvDecision = true
+    } else {
+      updateEnvDecision = await promptUpdateEnv({
+        databaseName: resolved.name,
+        input: stdin,
+        output: stdout,
+      })
+    }
+  }
+
+  if (updateEnvDecision) {
+    if (rewritten.changed) {
+      fsImpl.writeFileSync(envFilePath, rewritten.text)
+      logger.info?.(`[dev] Updated ${path.basename(envFilePath)} ${DATABASE_URL_KEY}.`)
+    } else {
+      logger.info?.(`[dev] ${path.basename(envFilePath)} already targets database "${resolved.name}".`)
+    }
+  } else {
+    logger.info?.(`[dev] Leaving ${path.basename(envFilePath)} unchanged; child commands will use database "${resolved.name}" for this run.`)
+  }
+
+  return {
+    applied: true,
+    databaseName: resolved.name,
+    source: resolved.source,
+    envFilePath,
+    previousDatabaseUrl: previousUrl,
+    nextDatabaseUrl: rewritten.nextValue,
+    envFileUpdated: updateEnvDecision && rewritten.changed,
+    envFileWriteSkipped: !updateEnvDecision,
+    childEnv: { [DATABASE_URL_KEY]: rewritten.nextValue },
+    remainingArgv: parsed.remainingArgv,
+  }
+}
+
+function noopLogger() {
+  return { info: () => {}, warn: () => {}, error: () => {} }
+}
+
+export const __DATABASE_URL_KEY__ = DATABASE_URL_KEY

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -30,6 +30,7 @@ import {
   resolveDevBaseUrl,
   resolveSplashUrl as resolveSplashAccessUrl,
 } from './dev-splash-url.mjs'
+import { resolveDatabaseNameOverride } from './dev-database-url.mjs'
 
 function detectDevRuntimeMode() {
   const cwd = process.cwd()
@@ -571,6 +572,39 @@ function ensureStandaloneEnvFile() {
       activity: 'Project files are ready',
     })
   }
+}
+
+function resolveDatabaseEnvFilePath() {
+  return isMonorepo
+    ? path.join(process.cwd(), 'apps', 'mercato', '.env')
+    : path.join(process.cwd(), '.env')
+}
+
+async function applyDatabaseNameOverrideIfRequested() {
+  let result
+  try {
+    result = await resolveDatabaseNameOverride({
+      argv: args,
+      env: process.env,
+      cwd: process.cwd(),
+      envFilePath: resolveDatabaseEnvFilePath(),
+      stdin: process.stdin,
+      stdout: process.stdout,
+      logger: { info: (msg) => console.log(msg) },
+    })
+  } catch (error) {
+    console.error(`❌ ${error instanceof Error ? error.message : String(error)}`)
+    shutdown(1)
+    return null
+  }
+
+  if (result?.applied) {
+    process.env.DATABASE_URL = result.childEnv.DATABASE_URL
+    updateSplashState({
+      activity: `Using database "${result.databaseName}" for this run`,
+    })
+  }
+  return result
 }
 
 function normalizeLocaleToken(value) {
@@ -1613,6 +1647,7 @@ async function runClassicGreenfieldDev() {
 
 async function runStandaloneSetup() {
   ensureStandaloneEnvFile()
+  await applyDatabaseNameOverrideIfRequested()
   if (standaloneLocalRegistryRefresh) {
     await runStage('🧼 Clearing local Open Mercato cache', ['cache', 'clean', '--all'], {
       stageCurrent: 0,
@@ -1639,6 +1674,7 @@ async function runStandaloneSetup() {
 
 async function runClassicStandaloneSetup() {
   ensureStandaloneEnvFile()
+  await applyDatabaseNameOverrideIfRequested()
   if (standaloneLocalRegistryRefresh) {
     await runRawYarnCommand(['cache', 'clean', '--all'])
   }
@@ -1675,6 +1711,7 @@ async function main() {
       await runStandaloneSetup()
       return
     }
+    await applyDatabaseNameOverrideIfRequested()
     if (classic) {
       await runClassicStandaloneDev()
       return
@@ -1698,6 +1735,8 @@ async function main() {
     launchStandaloneDev()
     return
   }
+
+  await applyDatabaseNameOverrideIfRequested()
 
   if (appOnly) {
     launchMonorepoAppDev()

--- a/scripts/template-sync.ts
+++ b/scripts/template-sync.ts
@@ -72,6 +72,11 @@ const EXPLICIT_TEMPLATE_FILE_MAPPINGS = [
     rel: 'scripts/dev-orchestration-log-policy.mjs',
   },
   {
+    sourceFile: path.join(ROOT, 'scripts', 'dev-database-url.mjs'),
+    templateFile: path.join(ROOT, 'packages', 'create-app', 'template', 'scripts', 'dev-database-url.mjs'),
+    rel: 'scripts/dev-database-url.mjs',
+  },
+  {
     sourceFile: path.join(ROOT, 'apps', 'mercato', 'scripts', 'dev.mjs'),
     templateFile: path.join(ROOT, 'packages', 'create-app', 'template', 'scripts', 'dev-runtime.mjs'),
     rel: 'scripts/dev-runtime.mjs',


### PR DESCRIPTION
Fixes #1841

Implements [`.ai/specs/2026-05-07-dev-database-name-override.md`](https://github.com/open-mercato/open-mercato/blob/develop/.ai/specs/2026-05-07-dev-database-name-override.md).

## Problem
Developers running multiple persistent local Open Mercato instances against the same PostgreSQL server have no on-the-spot way to point a dev/setup run at a different database — the only workaround is editing `apps/mercato/.env` (or `./.env`) by hand, which is easy to forget during greenfield bootstrap or standalone setup. `dev:ephemeral` solves throwaway isolation, not long-lived parallel instances.

## What Changed
Adds an optional, additive `--database-name[=<name>]` flag to the shared dev runner used by every quick-start command:

- `yarn dev`, `yarn dev:greenfield`, `yarn dev:app` (monorepo)
- `yarn setup`, `yarn dev`, `yarn setup:classic`, `yarn dev:classic` (standalone)

Behavior matrix:

| Invocation | Effect |
|---|---|
| Flag omitted | **Unchanged** — no prompt, no `.env` mutation. |
| `--database-name=client_a` | Validate and use `client_a`. |
| `--database-name` (bare) / `--database-name=` | Derive the name from the current working directory (`open-mercato` → `open_mercato`, `2026-redesign` → `om_2026_redesign`, etc.). |
| Flag present, interactive | Prompt `Update .env to use database "<name>"? [Y/n]` (default yes). |
| `--no-update-env` | Inject `DATABASE_URL` only into the current child env; leave `.env` untouched. |
| Non-interactive (CI=true / no TTY) | Default to updating `.env` unless `--no-update-env`. |
| `OM_DEV_DATABASE_NAME=<name>` env | Equivalent to passing `--database-name=<name>`; CLI wins. |
| `OM_DEV_DATABASE_UPDATE_ENV=true/false` | Non-interactive answer to the update prompt. |

`DATABASE_URL` is rewritten structurally with `new URL()` — credentials, host, port, and query strings (`?schema=…`, `?sslmode=…`) are preserved.

## Files
- New helper: `scripts/dev-database-url.mjs` (parsing, normalization, validation, env-text rewriting, prompt handling, orchestration). Mirrored byte-identical at `packages/create-app/template/scripts/dev-database-url.mjs` and added to the template-sync registry.
- Wired into both `scripts/dev.mjs` and `packages/create-app/template/scripts/dev.mjs` for monorepo dev/greenfield, standalone setup (after `ensureStandaloneEnvFile`), and standalone dev paths.
- `packages/create-app/template/scripts/setup.mjs` forwards the new flags to `dev.mjs --setup` via the shared `collectForwardedSetupFlags()` helper.
- Documentation updates: root README, `packages/create-app/README.md`, `packages/create-app/template/AGENTS.md`, `apps/docs/docs/installation/{monorepo,standalone,setup}.mdx`, `apps/docs/docs/customization/standalone-app.mdx`, `apps/docs/docs/cli/overview.mdx`.

## Tests
43 new unit tests in `scripts/__tests__/dev-database-url.test.mjs` (run via `yarn test:scripts`):

- argv parsing: explicit value, bare flag, `=value`, next-flag-not-consumed-as-value
- CWD derivation rules (lowercase, run-of-non-alnum→`_`, `om_` prefix for leading digits, `open_mercato_dev` fallback)
- explicit-name validation including the 63-char PostgreSQL identifier limit
- URL rewriting with credentials containing `%40` / `%2F`, hosts with non-default ports, and `?schema=…&sslmode=…`
- env-file rewriting: quoted values, trailing comments, multiple occurrences, idempotent re-application
- non-interactive defaults (CI / no TTY)
- `--update-env` / `--no-update-env` precedence over the prompt
- `OM_DEV_DATABASE_NAME` / `OM_DEV_DATABASE_UPDATE_ENV` precedence
- failure modes: invalid name, missing env file, missing `DATABASE_URL` line
- `setup.mjs` flag forwarding

Validation runs:

- `yarn test:scripts` → **110/110 pass** (37 new + 6 helper-forwarding + existing 67)
- `yarn typecheck` → pass
- `yarn i18n:check-sync` → pass; `yarn i18n:check-usage` → pass (advisory)
- `yarn build:packages` → pass (18/18)
- `yarn workspace @open-mercato/events test` → 31/31 pass
- `yarn workspace @open-mercato/app test` → 91/91 pass
- `yarn workspace create-mercato-app test` → 33/33 pass (in isolation, ~6.4s)

**Note on CI flakiness**: under turbo's parallel `yarn test`, `create-mercato-app#test` intermittently fails with `spawnSync … ETIMEDOUT` (the test harness has a 15-second cold-start cap on `tsx CLI_ENTRY` invocations, which is tight when many workspaces run tests in parallel on a single host). The failing test (`CLI bare scaffold applies explicit crm preset without prompting`) does not exercise any code touched by this PR — neither `setup.mjs` nor the new helper is on its hot path. Running it in isolation passes consistently in ~1.3 s.

## Backward Compatibility
Additive CLI surface only — fully BC. Documented in the spec's *Migration & Compatibility* section:

- No package script renamed or removed.
- No default database name change.
- No env-file mutation when the flag is absent.
- Existing `apps/mercato/.env` / `.env` files remain valid.
- `OM_DEV_DATABASE_NAME` / `OM_DEV_DATABASE_UPDATE_ENV` are new optional inputs with safe defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)