### PR TITLE
feat(queue): lazy auto-spawn queue workers (#1840)

### DIFF
--- a/.ai/specs/2026-05-07-lazy-auto-spawn-queue-workers.md
+++ b/.ai/specs/2026-05-07-lazy-auto-spawn-queue-workers.md
@@ -519,6 +519,7 @@ None.
 ## Changelog
 ### 2026-05-07
 - Initial comprehensive specification for lazy auto-spawned queue workers.
+- Implementation landed: `packages/cli/src/lib/auto-spawn-workers.ts` (env resolver), `packages/queue/src/pending-probe.ts` (read-only local + async probes), `packages/cli/src/lib/queue-worker-supervisor.ts` (per-queue child supervisor), and wiring in `server dev` / `server start` (`packages/cli/src/mercato.ts`). Lazy mode keys `OM_AUTO_SPAWN_WORKERS_LAZY`, `OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS`, `OM_AUTO_SPAWN_WORKERS_LAZY_RESTART`, and the `OM_AUTO_SPAWN_WORKERS` alias resolve as documented; eager and `AUTO_SPAWN_WORKERS=false` paths are unchanged. Docs updated in `apps/docs/docs/framework/events/queue-workers.mdx` and `apps/docs/docs/appendix/troubleshooting.mdx`.
 
 ### Review - 2026-05-07
 - **Reviewer**: Codex

--- a/apps/docs/docs/appendix/troubleshooting.mdx
+++ b/apps/docs/docs/appendix/troubleshooting.mdx
@@ -43,6 +43,20 @@ The native monorepo dev runtime starts multiple PostgreSQL-backed processes at o
 
 If you continue to hit connection limits, verify that background workers and migrations use the same pool settings, and confirm that your database `max_connections` value comfortably exceeds the aggregate pool size across all applications connecting to it.
 
+## Dev Memory Usage (`🧠 Memory ... RSS`)
+
+The dev runtime prints a `🧠 Memory ... RSS (peak ...)` line that measures the **process-tree RSS** rooted at the app runtime — so the Next.js dev server, the auto-spawned queue workers, and the scheduler are all included in the number. A high idle RSS often reflects per-queue runner overhead rather than Next.js itself.
+
+To shrink idle RSS in development, enable lazy worker auto-spawn:
+
+```bash
+OM_AUTO_SPAWN_WORKERS_LAZY=true yarn dev
+```
+
+In lazy mode the runtime starts a lightweight supervisor that watches each discovered queue for the first ready job and only then spawns `mercato queue worker <queueName>`. Queues that stay idle do not contribute polling timers (local strategy) or BullMQ `Worker`/Redis resources (async strategy) to the process tree. See [Queue Workers — Lazy Worker Auto-Spawn](../framework/events/queue-workers.mdx#lazy-worker-auto-spawn-memory-sensitive-dev) for the env variable reference.
+
+For production deployments, prefer `AUTO_SPAWN_WORKERS=false` plus separately managed worker processes — lazy mode targets memory-sensitive dev and small unified deployments.
+
 ## PostgreSQL auth errors on local setup
 
 If local commands such as `yarn generate`, `yarn db:generate`, or app startup fail with errors like:

--- a/apps/docs/docs/framework/events/queue-workers.mdx
+++ b/apps/docs/docs/framework/events/queue-workers.mdx
@@ -201,6 +201,36 @@ Set to `false` for production deployments where you want to run workers separate
 AUTO_SPAWN_WORKERS=false yarn start
 ```
 
+`OM_AUTO_SPAWN_WORKERS` is an optional Open Mercato-prefixed alias. The legacy `AUTO_SPAWN_WORKERS` always wins when both are set, so existing deployments do not change behavior.
+
+#### Lazy Worker Auto-Spawn (Memory-Sensitive Dev)
+
+The default eager mode starts a single `mercato queue worker --all` process whose runner instantiates a per-queue runtime even when most queues have no jobs. Each runner adds polling timers (local) or BullMQ `Worker` + Redis resources (async) to the process tree, so the dev memory monitor's `Memory ... RSS (peak ...)` line scales with the number of enabled modules rather than actual workload.
+
+Lazy mode replaces `queue worker --all` with a lightweight watcher process. The watcher probes each discovered queue for ready jobs without importing handler code or creating BullMQ workers. The first ready job on a queue triggers `mercato queue worker <queueName>`; queues that never receive jobs stay completely idle.
+
+```bash
+# Enable lazy auto-spawn — default behavior is unchanged for everyone else
+OM_AUTO_SPAWN_WORKERS_LAZY=true yarn dev
+```
+
+Lazy mode env variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OM_AUTO_SPAWN_WORKERS_LAZY` | `false` | Enables the lazy supervisor. Ignored when workers are disabled by `AUTO_SPAWN_WORKERS=false`. |
+| `OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS` | `1000` | Probe interval. Clamped to a minimum of `250`. |
+| `OM_AUTO_SPAWN_WORKERS_LAZY_RESTART` | `true` | Restart a per-queue worker if it exits unexpectedly while jobs remain pending. |
+
+Trade-offs:
+
+- The first job on a cold queue pays one poll cycle plus the worker startup time before it starts processing.
+- Probes are read-only and never invoke handlers. A probe failure (filesystem error, Redis unreachable) is logged at most once per queue per minute and keeps the queue idle until the next successful probe.
+- Lazy mode does not change worker handler contracts. Existing `workers/*.ts` metadata, `runWorker`, and `mercato queue worker <queueName>` continue to work unchanged.
+- Production deployments should still prefer `AUTO_SPAWN_WORKERS=false` plus separately managed worker processes — lazy mode targets memory-sensitive dev and small unified deployments.
+
+The dev runtime's `🧠 Memory ... RSS (peak ...)` line measures the **process-tree RSS** of the app runtime, so any auto-spawned workers and the scheduler are counted in that figure. Lazy mode reduces idle RSS because no per-queue runner exists until a job triggers one. The number rises again as queues become active.
+
 #### Available Scripts
 
 | Script | Description |

--- a/packages/cli/jest.config.cjs
+++ b/packages/cli/jest.config.cjs
@@ -16,6 +16,9 @@ module.exports = {
   },
   moduleNameMapper: {
     '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@open-mercato/queue$': '<rootDir>/../queue/src/index.ts',
+    '^@open-mercato/queue/worker$': '<rootDir>/../queue/src/worker/runner.ts',
+    '^@open-mercato/queue/(.*)$': '<rootDir>/../queue/src/$1',
   },
   transformIgnorePatterns: [
     'node_modules/(?!(@mikro-orm)/)',

--- a/packages/cli/src/__tests__/mercato.test.ts
+++ b/packages/cli/src/__tests__/mercato.test.ts
@@ -619,12 +619,14 @@ describe('generate post-step structural cache purge', () => {
 describe('server dev managed process exits', () => {
   const originalAutoSpawnScheduler = process.env.AUTO_SPAWN_SCHEDULER
   const originalAutoSpawnWorkers = process.env.AUTO_SPAWN_WORKERS
+  const originalLazy = process.env.OM_AUTO_SPAWN_WORKERS_LAZY
 
   beforeEach(() => {
     jest.restoreAllMocks()
     jest.resetModules()
     process.env.AUTO_SPAWN_SCHEDULER = 'false'
     process.env.AUTO_SPAWN_WORKERS = 'true'
+    delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
   })
 
   afterEach(() => {
@@ -633,12 +635,16 @@ describe('server dev managed process exits', () => {
     jest.dontMock('../lib/dev-env-reload')
     jest.dontMock('../lib/generators')
     jest.dontMock('../lib/resolver')
+    jest.dontMock('../lib/queue-worker-supervisor')
     jest.resetModules()
+    delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
   })
 
   afterAll(() => {
     process.env.AUTO_SPAWN_SCHEDULER = originalAutoSpawnScheduler
     process.env.AUTO_SPAWN_WORKERS = originalAutoSpawnWorkers
+    if (originalLazy === undefined) delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
+    else process.env.OM_AUTO_SPAWN_WORKERS_LAZY = originalLazy
   })
 
   it('skips scheduler auto-start when the module is not enabled', async () => {
@@ -730,17 +736,84 @@ describe('server dev managed process exits', () => {
     consoleErrorSpy.mockRestore()
     consoleLogSpy.mockRestore()
   })
+
+  it('starts the lazy worker supervisor instead of `queue worker --all` when OM_AUTO_SPAWN_WORKERS_LAZY=true', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    process.env.OM_AUTO_SPAWN_WORKERS_LAZY = 'true'
+
+    jest.doMock('node:fs', () => {
+      const actual = jest.requireActual('node:fs')
+      return {
+        ...actual,
+        existsSync: jest.fn((candidate: string) =>
+          candidate.includes('next/dist/bin/next') || candidate.includes('@open-mercato/cli/bin/mercato'),
+        ),
+        unlinkSync: jest.fn(),
+      }
+    })
+    jest.doMock('../lib/generators', () => ({
+      generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+    }))
+    jest.doMock('../lib/resolver', () => ({
+      resolveEnvironment: () => ({
+        appDir: '/tmp/test-app',
+        rootDir: '/tmp/test-root',
+      }),
+      createResolver: () => ({}),
+    }))
+
+    const supervisorClose = jest.fn().mockResolvedValue(undefined)
+    const startLazyWorkerSupervisor = jest.fn(() => ({
+      startedQueues: new Set<string>(),
+      getActiveChild: () => undefined,
+      close: supervisorClose,
+      done: Promise.resolve(),
+    }))
+    jest.doMock('../lib/queue-worker-supervisor', () => ({
+      startLazyWorkerSupervisor,
+    }))
+
+    jest.doMock('child_process', () =>
+      buildMockChildProcessModule((args) =>
+        args[0]?.includes('next/dist/bin/next') ? { code: null, signal: 'SIGTERM' } : undefined,
+      ),
+    )
+
+    const mercato = await import('../mercato')
+    mercato.registerCliModules([eventsWorkerFixture as Module])
+
+    const exitCode = await mercato.run(['node', 'mercato', 'server', 'dev'])
+
+    expect(exitCode).toBe(0)
+    expect(startLazyWorkerSupervisor).toHaveBeenCalledTimes(1)
+    const supervisorCall = startLazyWorkerSupervisor.mock.calls[0][0]
+    expect(supervisorCall.workers.map((worker) => worker.queue)).toEqual(['events'])
+    expect(supervisorCall.pollMs).toBe(1000)
+    expect(supervisorCall.restartOnUnexpectedExit).toBe(true)
+    expect(supervisorClose).toHaveBeenCalled()
+
+    const { spawn } = await import('child_process')
+    const allSpawnCalls = (spawn as jest.Mock).mock.calls.map((call) => call[1] as string[])
+    const queueWorkerSpawn = allSpawnCalls.find((args) => args.slice(1).join(' ') === 'queue worker --all')
+    expect(queueWorkerSpawn).toBeUndefined()
+
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
 })
 
 describe('server start managed process exits', () => {
   const originalAutoSpawnScheduler = process.env.AUTO_SPAWN_SCHEDULER
   const originalAutoSpawnWorkers = process.env.AUTO_SPAWN_WORKERS
+  const originalLazy = process.env.OM_AUTO_SPAWN_WORKERS_LAZY
 
   beforeEach(() => {
     jest.restoreAllMocks()
     jest.resetModules()
     process.env.AUTO_SPAWN_SCHEDULER = 'false'
     process.env.AUTO_SPAWN_WORKERS = 'true'
+    delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
   })
 
   afterEach(() => {
@@ -748,12 +821,16 @@ describe('server start managed process exits', () => {
     jest.dontMock('node:fs')
     jest.dontMock('../lib/resolver')
     jest.dontMock('../lib/server-start-lock')
+    jest.dontMock('../lib/queue-worker-supervisor')
     jest.resetModules()
+    delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
   })
 
   afterAll(() => {
     process.env.AUTO_SPAWN_SCHEDULER = originalAutoSpawnScheduler
     process.env.AUTO_SPAWN_WORKERS = originalAutoSpawnWorkers
+    if (originalLazy === undefined) delete process.env.OM_AUTO_SPAWN_WORKERS_LAZY
+    else process.env.OM_AUTO_SPAWN_WORKERS_LAZY = originalLazy
   })
 
   it('skips scheduler auto-start when the module is not enabled', async () => {
@@ -953,6 +1030,65 @@ describe('server start managed process exits', () => {
     )
 
     delete process.env.RESTART_TOKEN
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
+  it('starts the lazy worker supervisor in production server when OM_AUTO_SPAWN_WORKERS_LAZY=true', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    process.env.OM_AUTO_SPAWN_WORKERS_LAZY = 'true'
+
+    jest.doMock('node:fs', () => {
+      const actual = jest.requireActual('node:fs')
+      return {
+        ...actual,
+        existsSync: jest.fn((candidate: string) =>
+          candidate.includes('next/dist/bin/next') || candidate.includes('@open-mercato/cli/bin/mercato'),
+        ),
+      }
+    })
+    jest.doMock('../lib/resolver', () => ({
+      resolveEnvironment: () => ({
+        appDir: '/tmp/test-app',
+        rootDir: '/tmp/test-root',
+      }),
+    }))
+    jest.doMock('../lib/server-start-lock', () => ({
+      acquireServerStartLock: jest.fn(() => ({ release: jest.fn() })),
+    }))
+
+    const supervisorClose = jest.fn().mockResolvedValue(undefined)
+    const startLazyWorkerSupervisor = jest.fn(() => ({
+      startedQueues: new Set<string>(),
+      getActiveChild: () => undefined,
+      close: supervisorClose,
+      done: Promise.resolve(),
+    }))
+    jest.doMock('../lib/queue-worker-supervisor', () => ({
+      startLazyWorkerSupervisor,
+    }))
+
+    jest.doMock('child_process', () =>
+      buildMockChildProcessModule((args) =>
+        args[0]?.includes('next/dist/bin/next') ? { code: null, signal: 'SIGTERM' } : undefined,
+      ),
+    )
+
+    const mercato = await import('../mercato')
+    mercato.registerCliModules([eventsWorkerFixture as Module])
+
+    const exitCode = await mercato.run(['node', 'mercato', 'server', 'start'])
+
+    expect(exitCode).toBe(0)
+    expect(startLazyWorkerSupervisor).toHaveBeenCalledTimes(1)
+    expect(supervisorClose).toHaveBeenCalled()
+
+    const { spawn } = await import('child_process')
+    const allSpawnCalls = (spawn as jest.Mock).mock.calls.map((call) => call[1] as string[])
+    const queueWorkerSpawn = allSpawnCalls.find((args) => args.slice(1).join(' ') === 'queue worker --all')
+    expect(queueWorkerSpawn).toBeUndefined()
+
     consoleErrorSpy.mockRestore()
     consoleLogSpy.mockRestore()
   })

--- a/packages/cli/src/lib/__tests__/auto-spawn-workers.test.ts
+++ b/packages/cli/src/lib/__tests__/auto-spawn-workers.test.ts
@@ -1,0 +1,101 @@
+import {
+  resolveAutoSpawnWorkersMode,
+  resolveLazyPollMs,
+  resolveLazyRestart,
+} from '../auto-spawn-workers'
+
+describe('resolveAutoSpawnWorkersMode', () => {
+  it('defaults to eager when no env is set', () => {
+    expect(resolveAutoSpawnWorkersMode({})).toBe('eager')
+  })
+
+  it('returns off when AUTO_SPAWN_WORKERS=false', () => {
+    expect(resolveAutoSpawnWorkersMode({ AUTO_SPAWN_WORKERS: 'false' })).toBe('off')
+  })
+
+  it('returns off when OM_AUTO_SPAWN_WORKERS=false and legacy unset', () => {
+    expect(resolveAutoSpawnWorkersMode({ OM_AUTO_SPAWN_WORKERS: 'false' })).toBe('off')
+  })
+
+  it('legacy AUTO_SPAWN_WORKERS=true wins over OM_AUTO_SPAWN_WORKERS=false', () => {
+    expect(
+      resolveAutoSpawnWorkersMode({
+        AUTO_SPAWN_WORKERS: 'true',
+        OM_AUTO_SPAWN_WORKERS: 'false',
+      }),
+    ).toBe('eager')
+  })
+
+  it('returns lazy when workers are enabled and OM_AUTO_SPAWN_WORKERS_LAZY=true', () => {
+    expect(
+      resolveAutoSpawnWorkersMode({
+        AUTO_SPAWN_WORKERS: 'true',
+        OM_AUTO_SPAWN_WORKERS_LAZY: 'true',
+      }),
+    ).toBe('lazy')
+  })
+
+  it('lazy is ignored when AUTO_SPAWN_WORKERS=false', () => {
+    expect(
+      resolveAutoSpawnWorkersMode({
+        AUTO_SPAWN_WORKERS: 'false',
+        OM_AUTO_SPAWN_WORKERS_LAZY: 'true',
+      }),
+    ).toBe('off')
+  })
+
+  it('treats invalid AUTO_SPAWN_WORKERS values as default', () => {
+    expect(resolveAutoSpawnWorkersMode({ AUTO_SPAWN_WORKERS: 'maybe' })).toBe('eager')
+  })
+
+  it('falls through OM alias only when legacy is unset', () => {
+    expect(resolveAutoSpawnWorkersMode({ OM_AUTO_SPAWN_WORKERS: 'true' })).toBe('eager')
+    expect(
+      resolveAutoSpawnWorkersMode({
+        OM_AUTO_SPAWN_WORKERS: 'true',
+        OM_AUTO_SPAWN_WORKERS_LAZY: 'true',
+      }),
+    ).toBe('lazy')
+  })
+})
+
+describe('resolveLazyPollMs', () => {
+  it('returns the default when unset', () => {
+    expect(resolveLazyPollMs({})).toBe(1000)
+  })
+
+  it('parses numeric values', () => {
+    expect(resolveLazyPollMs({ OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS: '500' })).toBe(500)
+  })
+
+  it('clamps to the minimum', () => {
+    expect(resolveLazyPollMs({ OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS: '50' })).toBe(250)
+  })
+
+  it('falls back to default for non-numeric', () => {
+    expect(resolveLazyPollMs({ OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS: 'abc' })).toBe(1000)
+  })
+
+  it('falls back to default for non-positive', () => {
+    expect(resolveLazyPollMs({ OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS: '0' })).toBe(1000)
+    expect(resolveLazyPollMs({ OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS: '-100' })).toBe(1000)
+  })
+})
+
+describe('resolveLazyRestart', () => {
+  it('defaults to true when unset', () => {
+    expect(resolveLazyRestart({})).toBe(true)
+  })
+
+  it('returns false when explicitly disabled', () => {
+    expect(resolveLazyRestart({ OM_AUTO_SPAWN_WORKERS_LAZY_RESTART: 'false' })).toBe(false)
+  })
+
+  it('returns true when explicitly enabled', () => {
+    expect(resolveLazyRestart({ OM_AUTO_SPAWN_WORKERS_LAZY_RESTART: 'true' })).toBe(true)
+  })
+
+  it('falls back to default for invalid values', () => {
+    expect(resolveLazyRestart({ OM_AUTO_SPAWN_WORKERS_LAZY_RESTART: 'maybe' })).toBe(true)
+  })
+})

--- a/packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts
+++ b/packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts
@@ -1,0 +1,285 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import type { ModuleWorker } from '@open-mercato/shared/modules/registry'
+import {
+  startLazyWorkerSupervisor,
+  type LazySupervisorProbeFn,
+  type LazySupervisorSpawnFn,
+} from '../queue-worker-supervisor'
+import type {
+  QueuePendingProbeResult,
+  QueueStrategyType,
+} from '@open-mercato/queue'
+
+type FakeChild = ChildProcess & {
+  triggerExit: (code: number | null, signal?: NodeJS.Signals | null) => void
+}
+
+function createFakeChild(): FakeChild {
+  const child = new EventEmitter() as unknown as FakeChild
+  ;(child as any).stdout = null
+  ;(child as any).stderr = null
+  ;(child as any).pid = Math.floor(Math.random() * 100000) + 1
+  ;(child as any).killed = false
+  ;(child as any).exitCode = null
+  ;(child as any).signalCode = null
+  ;(child as any).kill = jest.fn((signal: NodeJS.Signals = 'SIGTERM') => {
+    if ((child as any).killed) return true
+    ;(child as any).killed = true
+    ;(child as any).signalCode = signal
+    process.nextTick(() => child.emit('exit', null, signal))
+    return true
+  })
+  child.triggerExit = (code, signal = null) => {
+    ;(child as any).exitCode = code
+    ;(child as any).signalCode = signal
+    child.emit('exit', code, signal)
+  }
+  return child
+}
+
+const silentLogger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() }
+
+function makeWorker(queue: string, id?: string, concurrency = 1): ModuleWorker {
+  return {
+    id: id ?? `${queue}-worker`,
+    queue,
+    concurrency,
+    handler: jest.fn() as unknown as ModuleWorker['handler'],
+  }
+}
+
+function emptyProbe(queueName: string, strategy: QueueStrategyType): QueuePendingProbeResult {
+  return { queueName, strategy, ready: 0, delayedFuture: 0, active: 0, error: false }
+}
+
+function readyProbe(queueName: string, strategy: QueueStrategyType, ready = 1): QueuePendingProbeResult {
+  return { queueName, strategy, ready, delayedFuture: 0, active: 0, error: false }
+}
+
+async function flushAsync(times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve()
+  }
+}
+
+describe('startLazyWorkerSupervisor', () => {
+  it('does not spawn any worker while every queue is idle', async () => {
+    const spawnFn = jest.fn() as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) =>
+      emptyProbe(queueName, strategy),
+    ) as jest.MockedFunction<LazySupervisorProbeFn>
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events'), makeWorker('emails')],
+      pollMs: 250,
+      restartOnUnexpectedExit: true,
+      strategy: 'local',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(probeFn).toHaveBeenCalled()
+    expect(spawnFn).not.toHaveBeenCalled()
+    expect(handle.startedQueues.size).toBe(0)
+
+    await handle.close()
+  })
+
+  it('spawns only the queue with ready jobs and never duplicates the spawn', async () => {
+    const child = createFakeChild()
+    const spawnFn = jest.fn(() => child) as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) => {
+      if (queueName === 'events') return readyProbe(queueName, strategy)
+      return emptyProbe(queueName, strategy)
+    }) as jest.MockedFunction<LazySupervisorProbeFn>
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events'), makeWorker('emails')],
+      pollMs: 250,
+      restartOnUnexpectedExit: false,
+      strategy: 'local',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+    const [command, args] = spawnFn.mock.calls[0]
+    expect(command).toBe('node')
+    expect(args).toEqual(['/tmp/mercato', 'queue', 'worker', 'events'])
+    expect(handle.startedQueues.has('events')).toBe(true)
+    expect(handle.startedQueues.has('emails')).toBe(false)
+
+    await flushAsync(20)
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+
+    await handle.close()
+  })
+
+  it('does not spawn when probe reports an error', async () => {
+    const spawnFn = jest.fn() as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) => ({
+      queueName,
+      strategy,
+      ready: 0,
+      delayedFuture: 0,
+      active: 0,
+      error: true,
+      errorMessage: 'redis-unreachable',
+    })) as jest.MockedFunction<LazySupervisorProbeFn>
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events')],
+      pollMs: 250,
+      restartOnUnexpectedExit: false,
+      strategy: 'async',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(spawnFn).not.toHaveBeenCalled()
+
+    await handle.close()
+  })
+
+  it('terminates active children on close()', async () => {
+    const child = createFakeChild()
+    const spawnFn = jest.fn(() => child) as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) =>
+      readyProbe(queueName, strategy),
+    ) as jest.MockedFunction<LazySupervisorProbeFn>
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events')],
+      pollMs: 250,
+      restartOnUnexpectedExit: false,
+      strategy: 'local',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+
+    await handle.close()
+    expect((child as any).kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('restarts an unexpectedly exited worker only when jobs remain pending', async () => {
+    const firstChild = createFakeChild()
+    const secondChild = createFakeChild()
+    const spawnFn = jest
+      .fn()
+      .mockImplementationOnce(() => firstChild)
+      .mockImplementationOnce(() => secondChild) as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+
+    let pendingReady = 1
+    const probeFn = jest.fn(async (queueName, strategy) => {
+      if (queueName !== 'events') return emptyProbe(queueName, strategy)
+      return readyProbe(queueName, strategy, pendingReady)
+    }) as jest.MockedFunction<LazySupervisorProbeFn>
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events')],
+      pollMs: 250,
+      restartOnUnexpectedExit: true,
+      strategy: 'local',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+
+    // Worker dies unexpectedly with jobs still pending — supervisor must restart.
+    firstChild.triggerExit(1, null)
+    await flushAsync(40)
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+
+    // Worker dies again, but this time no jobs remain — supervisor must NOT restart.
+    pendingReady = 0
+    secondChild.triggerExit(1, null)
+    await flushAsync(40)
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+
+    await handle.close()
+  })
+
+  it('does not restart on an expected SIGTERM exit', async () => {
+    const child = createFakeChild()
+    const spawnFn = jest.fn(() => child) as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) =>
+      readyProbe(queueName, strategy),
+    ) as jest.MockedFunction<LazySupervisorProbeFn>
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events')],
+      pollMs: 250,
+      restartOnUnexpectedExit: true,
+      strategy: 'local',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+
+    child.triggerExit(null, 'SIGTERM')
+    await flushAsync(40)
+
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+
+    await handle.close()
+  })
+
+  it('handles an empty worker list without crashing', async () => {
+    const spawnFn = jest.fn() as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn() as unknown as jest.MockedFunction<LazySupervisorProbeFn>
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [],
+      pollMs: 250,
+      restartOnUnexpectedExit: true,
+      strategy: 'local',
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(probeFn).not.toHaveBeenCalled()
+    expect(spawnFn).not.toHaveBeenCalled()
+    await handle.close()
+  })
+})

--- a/packages/cli/src/lib/auto-spawn-workers.ts
+++ b/packages/cli/src/lib/auto-spawn-workers.ts
@@ -1,0 +1,39 @@
+import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+
+export type AutoSpawnWorkersMode = 'off' | 'eager' | 'lazy'
+
+export type AutoSpawnEnvSource = Pick<NodeJS.ProcessEnv, string> | Record<string, string | undefined>
+
+const DEFAULT_LAZY_POLL_MS = 1000
+const MIN_LAZY_POLL_MS = 250
+
+export function resolveAutoSpawnWorkersEnabled(env: AutoSpawnEnvSource = process.env): boolean {
+  const legacy = parseBooleanToken(env.AUTO_SPAWN_WORKERS)
+  if (legacy !== null) return legacy
+  const aliased = parseBooleanToken(env.OM_AUTO_SPAWN_WORKERS)
+  if (aliased !== null) return aliased
+  return true
+}
+
+export function resolveAutoSpawnWorkersLazy(env: AutoSpawnEnvSource = process.env): boolean {
+  return parseBooleanToken(env.OM_AUTO_SPAWN_WORKERS_LAZY) === true
+}
+
+export function resolveAutoSpawnWorkersMode(env: AutoSpawnEnvSource = process.env): AutoSpawnWorkersMode {
+  if (!resolveAutoSpawnWorkersEnabled(env)) return 'off'
+  if (resolveAutoSpawnWorkersLazy(env)) return 'lazy'
+  return 'eager'
+}
+
+export function resolveLazyPollMs(env: AutoSpawnEnvSource = process.env): number {
+  const raw = env.OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS
+  if (typeof raw !== 'string' || raw.trim() === '') return DEFAULT_LAZY_POLL_MS
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LAZY_POLL_MS
+  return Math.max(MIN_LAZY_POLL_MS, Math.floor(parsed))
+}
+
+export function resolveLazyRestart(env: AutoSpawnEnvSource = process.env): boolean {
+  const parsed = parseBooleanToken(env.OM_AUTO_SPAWN_WORKERS_LAZY_RESTART)
+  return parsed === null ? true : parsed
+}

--- a/packages/cli/src/lib/queue-worker-supervisor.ts
+++ b/packages/cli/src/lib/queue-worker-supervisor.ts
@@ -1,0 +1,327 @@
+/**
+ * Lazy queue worker supervisor.
+ *
+ * Replaces `mercato queue worker --all` with a lightweight watcher that
+ * starts a per-queue worker process only after the first ready job appears
+ * on that queue. Discovered queues with no jobs stay completely idle.
+ *
+ * Design:
+ *   - Probes every queue on a configurable interval using
+ *     `getQueuePendingProbe()` from `@open-mercato/queue`.
+ *   - The first non-error probe with `ready > 0` triggers `spawn('node', [
+ *     mercatoBin, 'queue', 'worker', queueName ])`.
+ *   - Each spawned child inherits stdio so its logs flow through the
+ *     surrounding dev runtime.
+ *   - On unexpected exit while jobs are still pending, the supervisor
+ *     restarts the worker if `restartOnUnexpectedExit` is enabled.
+ *   - On `close()`, all active children receive SIGTERM and the supervisor
+ *     waits for them to exit before resolving.
+ *
+ * Probes never invoke handlers, never create BullMQ Workers, and never
+ * import generated worker handler modules. The contract is preserved by
+ * `getQueuePendingProbe()`.
+ */
+
+import { spawn as nodeSpawn } from 'node:child_process'
+import type { ChildProcess, SpawnOptions } from 'node:child_process'
+import {
+  getQueuePendingProbe,
+  type QueuePendingProbeResult,
+  type QueueStrategyType,
+} from '@open-mercato/queue'
+import type { ModuleWorker } from '@open-mercato/shared/modules/registry'
+
+export type LazySupervisorSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcess
+
+export type LazySupervisorProbeFn = (
+  queueName: string,
+  strategy: QueueStrategyType,
+) => Promise<QueuePendingProbeResult>
+
+export type LazyWorkerSupervisorOptions = {
+  mercatoBin: string
+  appDir: string
+  runtimeEnv: NodeJS.ProcessEnv
+  workers: ModuleWorker[]
+  pollMs: number
+  restartOnUnexpectedExit: boolean
+  strategy?: QueueStrategyType
+  /** Override for tests. Defaults to `child_process.spawn`. */
+  spawnFn?: LazySupervisorSpawnFn
+  /** Override for tests. Defaults to `getQueuePendingProbe`. */
+  probeFn?: LazySupervisorProbeFn
+  /** Logger override. Defaults to `console`. */
+  logger?: Pick<Console, 'log' | 'warn' | 'error'>
+  onSpawn?: (queueName: string, child: ChildProcess) => void
+  onChildExit?: (
+    queueName: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ) => void
+}
+
+export type LazyWorkerSupervisorHandle = {
+  /** Set of queue names whose worker has started at least once. */
+  readonly startedQueues: ReadonlySet<string>
+  /** Currently running child process per queue (if any). */
+  getActiveChild(queueName: string): ChildProcess | undefined
+  /** Stop polling, kill children, wait for exit. Idempotent. */
+  close(): Promise<void>
+  /** Resolves when the watcher loop has stopped (after `close()`). */
+  done: Promise<void>
+}
+
+type QueueGroup = {
+  queueName: string
+  concurrency: number
+  workerCount: number
+}
+
+function groupWorkersByQueue(workers: ModuleWorker[]): QueueGroup[] {
+  const groups = new Map<string, QueueGroup>()
+  for (const worker of workers) {
+    const existing = groups.get(worker.queue)
+    if (existing) {
+      existing.workerCount += 1
+      if (worker.concurrency > existing.concurrency) {
+        existing.concurrency = worker.concurrency
+      }
+    } else {
+      groups.set(worker.queue, {
+        queueName: worker.queue,
+        concurrency: Math.max(worker.concurrency, 1),
+        workerCount: 1,
+      })
+    }
+  }
+  return [...groups.values()].sort((a, b) => a.queueName.localeCompare(b.queueName))
+}
+
+function resolveStrategyFromEnv(env: NodeJS.ProcessEnv): QueueStrategyType {
+  return env.QUEUE_STRATEGY === 'async' ? 'async' : 'local'
+}
+
+const PROBE_ERROR_LOG_THROTTLE_MS = 60_000
+
+export function startLazyWorkerSupervisor(
+  options: LazyWorkerSupervisorOptions,
+): LazyWorkerSupervisorHandle {
+  const logger = options.logger ?? console
+  const strategy: QueueStrategyType = options.strategy ?? resolveStrategyFromEnv(options.runtimeEnv)
+  const probe: LazySupervisorProbeFn = options.probeFn
+    ?? ((queueName) => getQueuePendingProbe(queueName, strategy))
+  const groups = groupWorkersByQueue(options.workers)
+
+  const startedQueues = new Set<string>()
+  const activeChildren = new Map<string, ChildProcess>()
+  const startingQueues = new Set<string>()
+  const probeErrorLastLoggedAt = new Map<string, number>()
+
+  let stopping = false
+  let pollTimer: ReturnType<typeof setTimeout> | null = null
+  let watchPromiseResolve: (() => void) | null = null
+  const done = new Promise<void>((resolve) => {
+    watchPromiseResolve = resolve
+  })
+
+  if (groups.length === 0) {
+    logger.warn(
+      '[lazy-supervisor] No queues discovered. Idle until queues are registered or run `yarn generate`.',
+    )
+  } else {
+    logger.log(
+      `[lazy-supervisor] Watching ${groups.length} queue(s): ${groups
+        .map((g) => g.queueName)
+        .join(', ')}`,
+    )
+  }
+
+  const spawnFn: LazySupervisorSpawnFn =
+    options.spawnFn ?? ((command, args, opts) => nodeSpawn(command, args as string[], opts))
+
+  function logProbeError(queueName: string, message: string): void {
+    const now = Date.now()
+    const lastAt = probeErrorLastLoggedAt.get(queueName) ?? 0
+    if (now - lastAt < PROBE_ERROR_LOG_THROTTLE_MS) return
+    probeErrorLastLoggedAt.set(queueName, now)
+    logger.warn(`[lazy-supervisor] Probe failed for queue "${queueName}": ${message}`)
+  }
+
+  function spawnQueueWorker(queueName: string): void {
+    if (stopping) return
+    if (activeChildren.has(queueName)) return
+    if (startingQueues.has(queueName)) return
+    startingQueues.add(queueName)
+
+    logger.log(`[lazy-supervisor] Pending job detected — starting worker for queue "${queueName}"`)
+    let child: ChildProcess
+    try {
+      child = spawnFn(
+        'node',
+        [options.mercatoBin, 'queue', 'worker', queueName],
+        {
+          stdio: 'inherit',
+          env: options.runtimeEnv,
+          cwd: options.appDir,
+        },
+      )
+    } catch (err) {
+      startingQueues.delete(queueName)
+      const message = err instanceof Error ? err.message : String(err)
+      logger.error(`[lazy-supervisor] Failed to spawn worker for "${queueName}": ${message}`)
+      return
+    }
+
+    activeChildren.set(queueName, child)
+    startedQueues.add(queueName)
+    startingQueues.delete(queueName)
+    if (options.onSpawn) {
+      try {
+        options.onSpawn(queueName, child)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.warn(`[lazy-supervisor] onSpawn callback threw for "${queueName}": ${message}`)
+      }
+    }
+
+    child.on('exit', (code, signal) => {
+      activeChildren.delete(queueName)
+      if (options.onChildExit) {
+        try {
+          options.onChildExit(queueName, code, signal)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          logger.warn(`[lazy-supervisor] onChildExit callback threw for "${queueName}": ${message}`)
+        }
+      }
+      if (stopping) return
+      const expected = signal === 'SIGTERM' || signal === 'SIGINT'
+      if (expected) return
+      const reason = code !== null ? `code ${code}` : `signal ${signal ?? 'unknown'}`
+      logger.warn(`[lazy-supervisor] Worker for "${queueName}" exited (${reason}).`)
+      if (!options.restartOnUnexpectedExit) return
+      void (async () => {
+        const result = await safeProbe(queueName)
+        if (!result || result.error) return
+        if (result.ready > 0) {
+          logger.warn(`[lazy-supervisor] Restarting worker for "${queueName}" because jobs remain pending.`)
+          spawnQueueWorker(queueName)
+        }
+      })()
+    })
+  }
+
+  async function safeProbe(queueName: string): Promise<QueuePendingProbeResult | null> {
+    try {
+      return await probe(queueName, strategy)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logProbeError(queueName, message)
+      return null
+    }
+  }
+
+  async function tickOnce(): Promise<void> {
+    if (stopping) return
+    if (groups.length === 0) return
+
+    const toCheck = groups.filter((g) => !activeChildren.has(g.queueName) && !startingQueues.has(g.queueName))
+    if (toCheck.length === 0) return
+
+    const probes = await Promise.all(
+      toCheck.map(async (group) => ({
+        group,
+        result: await safeProbe(group.queueName),
+      })),
+    )
+
+    if (stopping) return
+
+    for (const { group, result } of probes) {
+      if (!result) continue
+      if (result.error) {
+        if (result.errorMessage) {
+          logProbeError(group.queueName, result.errorMessage)
+        }
+        continue
+      }
+      if (result.ready > 0) {
+        spawnQueueWorker(group.queueName)
+      }
+    }
+  }
+
+  function scheduleNext(): void {
+    if (stopping) return
+    pollTimer = setTimeout(() => {
+      void (async () => {
+        try {
+          await tickOnce()
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          logger.warn(`[lazy-supervisor] Poll cycle failed: ${message}`)
+        } finally {
+          if (!stopping) scheduleNext()
+        }
+      })()
+    }, options.pollMs)
+    pollTimer.unref?.()
+  }
+
+  // Kick off immediately so the first probe doesn't wait one full poll interval.
+  void (async () => {
+    try {
+      await tickOnce()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn(`[lazy-supervisor] Initial poll failed: ${message}`)
+    } finally {
+      scheduleNext()
+    }
+  })()
+
+  async function close(): Promise<void> {
+    if (stopping) {
+      await done
+      return
+    }
+    stopping = true
+    if (pollTimer) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+
+    const exitWaiters: Promise<void>[] = []
+    for (const [queueName, child] of activeChildren) {
+      exitWaiters.push(
+        new Promise<void>((resolve) => {
+          if (child.exitCode !== null || child.signalCode !== null) return resolve()
+          child.once('exit', () => resolve())
+        }),
+      )
+      try {
+        if (!child.killed) child.kill('SIGTERM')
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.warn(`[lazy-supervisor] Failed to send SIGTERM to "${queueName}": ${message}`)
+      }
+    }
+    await Promise.all(exitWaiters)
+    activeChildren.clear()
+    if (watchPromiseResolve) {
+      watchPromiseResolve()
+      watchPromiseResolve = null
+    }
+  }
+
+  return {
+    startedQueues,
+    getActiveChild: (queueName) => activeChildren.get(queueName),
+    close,
+    done,
+  }
+}

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -9,6 +9,12 @@ import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { getSslConfig } from '@open-mercato/shared/lib/db/ssl'
 import { getRedisUrl, getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import { resolveInitDerivedSecrets } from './lib/init-secrets'
+import {
+  resolveAutoSpawnWorkersMode,
+  resolveLazyPollMs,
+  resolveLazyRestart,
+} from './lib/auto-spawn-workers'
+import { startLazyWorkerSupervisor } from './lib/queue-worker-supervisor'
 import { parseModuleInstallArgs } from './lib/module-install-args'
 import { resolveNextBuildIdCandidate } from './lib/next-build-id'
 import { acquireServerStartLock } from './lib/server-start-lock'
@@ -1660,6 +1666,7 @@ export async function run(argv = process.argv) {
           let didRetryCorruptedTurbopackCache = false
           let stopping = false
           let envChangePromiseResolve: ((result: DevServerRestartResult) => void) | null = null
+          let activeLazySupervisor: ReturnType<typeof startLazyWorkerSupervisor> | null = null
           const envReloader = createDevEnvReloader(appDir, process.env, initialProcessEnvironmentEntries)
 
           function cleanup() {
@@ -1668,6 +1675,9 @@ export async function run(argv = process.argv) {
               if (!proc.killed && proc.exitCode === null && proc.signalCode === null) {
                 proc.kill('SIGTERM')
               }
+            }
+            if (activeLazySupervisor) {
+              void activeLazySupervisor.close().catch(() => undefined)
             }
           }
 
@@ -1683,6 +1693,14 @@ export async function run(argv = process.argv) {
                   })
               )
             )
+            if (activeLazySupervisor) {
+              try {
+                await activeLazySupervisor.close()
+              } catch {
+                // Supervisor close errors should not block dev runtime cleanup.
+              }
+              activeLazySupervisor = null
+            }
             // Safety net: remove Next.js dev lock file in case the child didn't clean up
             const lockFile = path.join(appDir, '.mercato', 'next', 'dev', 'lock')
             try {
@@ -1772,7 +1790,7 @@ export async function run(argv = process.argv) {
             while (!stopping) {
               envReloader.reload()
               const runtimeEnv = buildServerProcessEnvironment(process.env)
-              const autoSpawnWorkers = process.env.AUTO_SPAWN_WORKERS !== 'false'
+              const autoSpawnWorkersMode = resolveAutoSpawnWorkersMode(process.env)
               const autoSpawnScheduler = process.env.AUTO_SPAWN_SCHEDULER !== 'false'
               const queueStrategy = process.env.QUEUE_STRATEGY || 'local'
               const schedulerCommand = lookupModuleCommand(getCliModules(), 'scheduler', 'start')
@@ -1782,10 +1800,21 @@ export async function run(argv = process.argv) {
               ]
 
               // Start workers if enabled
-              if (autoSpawnWorkers) {
-                const discoveredWorkerQueues = [...new Set(getRegisteredCliWorkers().map((worker) => worker.queue))]
+              if (autoSpawnWorkersMode !== 'off') {
+                const discoveredWorkers = getRegisteredCliWorkers()
+                const discoveredWorkerQueues = [...new Set(discoveredWorkers.map((worker) => worker.queue))]
                 if (discoveredWorkerQueues.length === 0) {
                   console.error('[server] AUTO_SPAWN_WORKERS is enabled, but no queues were discovered from CLI modules. Run `yarn generate` and verify `.mercato/generated/modules.cli.generated.ts` contains worker entries. Continuing without auto-spawned workers.')
+                } else if (autoSpawnWorkersMode === 'lazy') {
+                  console.log(`[server] Lazy worker auto-spawn enabled — workers will start on first job (${discoveredWorkerQueues.length} queue(s) watched).`)
+                  activeLazySupervisor = startLazyWorkerSupervisor({
+                    mercatoBin,
+                    appDir,
+                    runtimeEnv,
+                    workers: discoveredWorkers,
+                    pollMs: resolveLazyPollMs(process.env),
+                    restartOnUnexpectedExit: resolveLazyRestart(process.env),
+                  })
                 } else {
                   console.log('[server] Starting workers for all queues...')
                   const workerProcess = spawn('node', [mercatoBin, 'queue', 'worker', '--all'], {
@@ -1843,7 +1872,7 @@ export async function run(argv = process.argv) {
           const nodeModulesBases = Array.from(new Set([env.rootDir, appDir]))
 
           const processes: ChildProcess[] = []
-          const autoSpawnWorkers = process.env.AUTO_SPAWN_WORKERS !== 'false'
+          const autoSpawnWorkersMode = resolveAutoSpawnWorkersMode(process.env)
           const autoSpawnScheduler = process.env.AUTO_SPAWN_SCHEDULER !== 'false'
           const queueStrategy = process.env.QUEUE_STRATEGY || 'local'
           const runtimeEnv = buildServerProcessEnvironment(process.env)
@@ -1851,6 +1880,7 @@ export async function run(argv = process.argv) {
           const serverStartLock = acquireServerStartLock(appDir, {
             port: runtimeEnv.PORT ?? process.env.PORT ?? null,
           })
+          let activeLazySupervisor: ReturnType<typeof startLazyWorkerSupervisor> | null = null
 
           function cleanup() {
             console.log('[server] Shutting down...')
@@ -1858,6 +1888,9 @@ export async function run(argv = process.argv) {
               if (!proc.killed && proc.exitCode === null && proc.signalCode === null) {
                 proc.kill('SIGTERM')
               }
+            }
+            if (activeLazySupervisor) {
+              void activeLazySupervisor.close().catch(() => undefined)
             }
           }
 
@@ -1872,6 +1905,14 @@ export async function run(argv = process.argv) {
                   })
               )
             )
+            if (activeLazySupervisor) {
+              try {
+                await activeLazySupervisor.close()
+              } catch {
+                // Supervisor close errors should not block server shutdown.
+              }
+              activeLazySupervisor = null
+            }
           }
 
           process.on('SIGTERM', cleanup)
@@ -1896,10 +1937,21 @@ export async function run(argv = process.argv) {
             ]
 
             // Start workers if enabled
-            if (autoSpawnWorkers) {
-              const discoveredWorkerQueues = [...new Set(getRegisteredCliWorkers().map((worker) => worker.queue))]
+            if (autoSpawnWorkersMode !== 'off') {
+              const discoveredWorkers = getRegisteredCliWorkers()
+              const discoveredWorkerQueues = [...new Set(discoveredWorkers.map((worker) => worker.queue))]
               if (discoveredWorkerQueues.length === 0) {
                 console.error('[server] AUTO_SPAWN_WORKERS is enabled, but no queues were discovered from CLI modules. Run `yarn generate` and verify `.mercato/generated/modules.cli.generated.ts` contains worker entries. Continuing without auto-spawned workers.')
+              } else if (autoSpawnWorkersMode === 'lazy') {
+                console.log(`[server] Lazy worker auto-spawn enabled — workers will start on first job (${discoveredWorkerQueues.length} queue(s) watched).`)
+                activeLazySupervisor = startLazyWorkerSupervisor({
+                  mercatoBin,
+                  appDir,
+                  runtimeEnv,
+                  workers: discoveredWorkers,
+                  pollMs: resolveLazyPollMs(process.env),
+                  restartOnUnexpectedExit: resolveLazyRestart(process.env),
+                })
               } else {
                 console.log('[server] Starting workers for all queues...')
                 const workerProcess = spawn('node', [mercatoBin, 'queue', 'worker', '--all'], {

--- a/packages/queue/src/__tests__/pending-probe.test.ts
+++ b/packages/queue/src/__tests__/pending-probe.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createQueue } from '../factory'
+import { getQueuePendingProbe } from '../pending-probe'
+
+describe('getQueuePendingProbe — local strategy', () => {
+  const origCwd = process.cwd()
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'queue-probe-test-'))
+    process.chdir(tmp)
+  })
+
+  afterEach(() => {
+    process.chdir(origCwd)
+    try {
+      fs.rmSync(tmp, { recursive: true, force: true })
+    } catch {
+      /* ignore cleanup errors */
+    }
+  })
+
+  it('returns zero when the queue does not exist yet', async () => {
+    const probe = await getQueuePendingProbe('does-not-exist', 'local', { baseDir: tmp })
+    expect(probe.error).toBe(false)
+    expect(probe.ready).toBe(0)
+    expect(probe.delayedFuture).toBe(0)
+  })
+
+  it('counts ready jobs without invoking handlers', async () => {
+    const queue = createQueue<{ value: number }>('probe-queue', 'local', { baseDir: tmp })
+    await queue.enqueue({ value: 1 })
+    await queue.enqueue({ value: 2 })
+    await queue.close()
+
+    const probe = await getQueuePendingProbe('probe-queue', 'local', { baseDir: tmp })
+    expect(probe.error).toBe(false)
+    expect(probe.ready).toBe(2)
+    expect(probe.delayedFuture).toBe(0)
+  })
+
+  it('treats future-delayed jobs as not ready', async () => {
+    const queue = createQueue<{ value: number }>('probe-queue', 'local', { baseDir: tmp })
+    await queue.enqueue({ value: 1 }, { delayMs: 60_000 })
+    await queue.close()
+
+    const probe = await getQueuePendingProbe('probe-queue', 'local', { baseDir: tmp })
+    expect(probe.ready).toBe(0)
+    expect(probe.delayedFuture).toBe(1)
+  })
+
+  it('treats already-elapsed delayed jobs as ready', async () => {
+    const queueDir = path.join(tmp, 'probe-queue')
+    fs.mkdirSync(queueDir, { recursive: true })
+    const past = new Date(Date.now() - 1000).toISOString()
+    fs.writeFileSync(
+      path.join(queueDir, 'queue.json'),
+      JSON.stringify([
+        {
+          id: 'past-job',
+          payload: { value: 1 },
+          createdAt: new Date().toISOString(),
+          availableAt: past,
+        },
+      ]),
+      'utf8',
+    )
+
+    const probe = await getQueuePendingProbe('probe-queue', 'local', { baseDir: tmp })
+    expect(probe.ready).toBe(1)
+    expect(probe.delayedFuture).toBe(0)
+  })
+
+  it('returns a soft error when queue.json is corrupt', async () => {
+    const queueDir = path.join(tmp, 'corrupt-queue')
+    fs.mkdirSync(queueDir, { recursive: true })
+    fs.writeFileSync(path.join(queueDir, 'queue.json'), '{ not valid json', 'utf8')
+
+    const probe = await getQueuePendingProbe('corrupt-queue', 'local', { baseDir: tmp })
+    expect(probe.error).toBe(true)
+    expect(probe.ready).toBe(0)
+  })
+
+  it('does not run the worker handler', async () => {
+    const queue = createQueue<{ value: number }>('handler-check', 'local', { baseDir: tmp })
+    const handler = jest.fn()
+    await queue.enqueue({ value: 1 })
+    await queue.close()
+
+    await getQueuePendingProbe('handler-check', 'local', { baseDir: tmp })
+    expect(handler).not.toHaveBeenCalled()
+  })
+})
+
+describe('getQueuePendingProbe — async strategy', () => {
+  it('reports an error when QUEUE Redis URL is unset and no connection override is provided', async () => {
+    const original = process.env.QUEUE_REDIS_URL
+    const fallback = process.env.REDIS_URL
+    delete process.env.QUEUE_REDIS_URL
+    delete process.env.REDIS_URL
+    try {
+      const probe = await getQueuePendingProbe('no-redis-queue', 'async')
+      // Either bullmq is missing (cached load failed) or Redis URL missing — both surface as error
+      expect(probe.error).toBe(true)
+    } finally {
+      if (original !== undefined) process.env.QUEUE_REDIS_URL = original
+      if (fallback !== undefined) process.env.REDIS_URL = fallback
+    }
+  })
+})

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -26,3 +26,7 @@ export { createQueue, createModuleQueue, resolveQueueStrategy } from './factory'
 // Worker utilities
 export * from './worker/registry'
 export { runWorker, createRoutedHandler } from './worker/runner'
+
+// Lightweight pending-job probes used by the lazy auto-spawn supervisor.
+export { getQueuePendingProbe } from './pending-probe'
+export type { QueuePendingProbeOptions, QueuePendingProbeResult } from './pending-probe'

--- a/packages/queue/src/pending-probe.ts
+++ b/packages/queue/src/pending-probe.ts
@@ -1,0 +1,215 @@
+/**
+ * Lightweight pending-job probe helpers.
+ *
+ * Used by the lazy worker supervisor to detect whether a queue has a
+ * ready-to-process job before spawning a long-lived worker process for it.
+ *
+ * The probes MUST NOT:
+ * - call `queue.process()` or otherwise install handlers
+ * - import any module worker handler code
+ * - create BullMQ `Worker` instances
+ *
+ * Probes are best-effort and fail-soft: a probe error returns "no pending"
+ * so the supervisor can keep polling instead of crashing the runtime.
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import type { QueueStrategyType, RedisConnectionOptions } from './types'
+
+export type QueuePendingProbeOptions = {
+  /** Async strategy: Redis connection override (mirrors `AsyncQueueOptions['connection']`). */
+  connection?: RedisConnectionOptions
+  /** Local strategy: override `QUEUE_BASE_DIR` for test isolation. */
+  baseDir?: string
+}
+
+export type QueuePendingProbeResult = {
+  queueName: string
+  strategy: QueueStrategyType
+  /** Number of jobs ready to process now (no delay or delay already elapsed). */
+  ready: number
+  /** Number of jobs scheduled for the future (still waiting on `availableAt`). */
+  delayedFuture: number
+  /** Number of jobs currently being processed. May be unavailable for some strategies. */
+  active: number
+  /**
+   * True when the probe could not query the underlying storage at all
+   * (filesystem error, Redis unreachable, optional dependency missing, etc.).
+   * The supervisor treats `error: true` as "do not start worker yet".
+   */
+  error: boolean
+  errorMessage?: string
+}
+
+const DEFAULT_LOCAL_QUEUE_BASE_DIR = '.mercato/queue'
+
+const fsp = fs.promises
+
+function emptyResult(queueName: string, strategy: QueueStrategyType): QueuePendingProbeResult {
+  return { queueName, strategy, ready: 0, delayedFuture: 0, active: 0, error: false }
+}
+
+function errorResult(
+  queueName: string,
+  strategy: QueueStrategyType,
+  err: unknown,
+): QueuePendingProbeResult {
+  const message = err instanceof Error ? err.message : String(err)
+  return {
+    queueName,
+    strategy,
+    ready: 0,
+    delayedFuture: 0,
+    active: 0,
+    error: true,
+    errorMessage: message,
+  }
+}
+
+async function probeLocalQueue(
+  queueName: string,
+  options?: QueuePendingProbeOptions,
+): Promise<QueuePendingProbeResult> {
+  const nodeProcess = (globalThis as typeof globalThis & { process?: NodeJS.Process }).process
+  const envBaseDir = nodeProcess?.env?.QUEUE_BASE_DIR
+  const baseDir = options?.baseDir
+    ?? path.resolve(envBaseDir || DEFAULT_LOCAL_QUEUE_BASE_DIR)
+  const queueFile = path.join(baseDir, queueName, 'queue.json')
+
+  let raw: string
+  try {
+    raw = await fsp.readFile(queueFile, 'utf8')
+  } catch (err) {
+    const fsErr = err as NodeJS.ErrnoException
+    if (fsErr?.code === 'ENOENT') {
+      return emptyResult(queueName, 'local')
+    }
+    return errorResult(queueName, 'local', err)
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    return errorResult(queueName, 'local', err)
+  }
+
+  if (!Array.isArray(parsed)) {
+    return emptyResult(queueName, 'local')
+  }
+
+  const now = Date.now()
+  let ready = 0
+  let delayedFuture = 0
+
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== 'object') continue
+    const availableAt = (entry as { availableAt?: unknown }).availableAt
+    if (typeof availableAt !== 'string' || availableAt.length === 0) {
+      ready++
+      continue
+    }
+    const ts = Date.parse(availableAt)
+    if (!Number.isFinite(ts) || ts <= now) {
+      ready++
+    } else {
+      delayedFuture++
+    }
+  }
+
+  return { queueName, strategy: 'local', ready, delayedFuture, active: 0, error: false }
+}
+
+type BullMQModuleShape = {
+  Queue: new <T>(name: string, opts: { connection: RedisConnectionOptions }) => {
+    getJobCounts: (...states: string[]) => Promise<Record<string, number>>
+    close: () => Promise<void>
+  }
+}
+
+let cachedBullMQ: BullMQModuleShape | null | undefined
+
+async function loadBullMQ(): Promise<BullMQModuleShape | null> {
+  if (cachedBullMQ !== undefined) return cachedBullMQ
+  try {
+    cachedBullMQ = (await import('bullmq')) as unknown as BullMQModuleShape
+  } catch {
+    cachedBullMQ = null
+  }
+  return cachedBullMQ
+}
+
+async function probeAsyncQueue(
+  queueName: string,
+  options?: QueuePendingProbeOptions,
+): Promise<QueuePendingProbeResult> {
+  const bullmq = await loadBullMQ()
+  if (!bullmq) {
+    return errorResult(queueName, 'async', new Error('bullmq is not installed'))
+  }
+
+  const { getRedisUrl } = await import('@open-mercato/shared/lib/redis/connection')
+  let connection = options?.connection
+  if (!connection) {
+    const url = getRedisUrl('QUEUE')
+    if (!url) {
+      return errorResult(queueName, 'async', new Error('QUEUE Redis URL is not configured'))
+    }
+    connection = { url }
+  }
+
+  let queue: InstanceType<BullMQModuleShape['Queue']> | null = null
+  try {
+    queue = new bullmq.Queue(queueName, { connection })
+    const counts = await queue.getJobCounts('waiting', 'delayed', 'active')
+    const waiting = counts.waiting ?? 0
+    const delayed = counts.delayed ?? 0
+    const active = counts.active ?? 0
+    return {
+      queueName,
+      strategy: 'async',
+      ready: waiting,
+      delayedFuture: delayed,
+      active,
+      error: false,
+    }
+  } catch (err) {
+    return errorResult(queueName, 'async', err)
+  } finally {
+    if (queue) {
+      try {
+        await queue.close()
+      } catch {
+        /* swallow shutdown errors — probe must not throw on cleanup */
+      }
+    }
+  }
+}
+
+/**
+ * Read-only pending-job probe for a queue.
+ *
+ * `strategy` defaults to the value of `QUEUE_STRATEGY` (via
+ * `resolveQueueStrategy`). The probe never installs handlers and never
+ * starts a BullMQ Worker, so it is safe to call from a lightweight
+ * supervisor process that watches many queues.
+ */
+export async function getQueuePendingProbe(
+  queueName: string,
+  strategy?: QueueStrategyType,
+  options?: QueuePendingProbeOptions,
+): Promise<QueuePendingProbeResult> {
+  const resolvedStrategy: QueueStrategyType = strategy
+    ?? (process.env.QUEUE_STRATEGY === 'async' ? 'async' : 'local')
+
+  if (resolvedStrategy === 'async') {
+    return probeAsyncQueue(queueName, options)
+  }
+  return probeLocalQueue(queueName, options)
+}
+
+/** Reset the cached bullmq module reference. Test-only. */
+export function __resetPendingProbeBullMQCache(): void {
+  cachedBullMQ = undefined
+}


### PR DESCRIPTION
Fixes #1840

## Problem
`AUTO_SPAWN_WORKERS=true` (the default) spawns one long-lived `mercato queue worker --all` process. That process creates a runner — local poll timer or BullMQ `Worker` + Redis resources — for **every** discovered queue, even when most queues are idle. The dev runtime's `🧠 Memory ... RSS (peak ...)` line measures the process tree rooted at the app runtime, so all of this overhead is included in the figure (a key reason for high idle RSS reports like `12.0 GB RSS (peak 20.3 GB)`).

## Root Cause
- `server dev` and `server start` unconditionally spawn `queue worker --all` whenever workers are auto-spawned.
- `queue worker --all` calls `runWorker({ background: true })` per queue, which installs handlers and per-strategy resources up front.
- Handler-level laziness (`createLazyModuleWorker`) defers the *handler module import*, but does nothing about the queue runner itself.

## What Changed
Implements the lazy auto-spawn supervisor described in `.ai/specs/2026-05-07-lazy-auto-spawn-queue-workers.md`.

- **Env resolver** (`packages/cli/src/lib/auto-spawn-workers.ts`) returns `'off' | 'eager' | 'lazy'`. New env knobs:
  - `OM_AUTO_SPAWN_WORKERS` — alias for `AUTO_SPAWN_WORKERS` (legacy wins when both set).
  - `OM_AUTO_SPAWN_WORKERS_LAZY=true` — opts into lazy mode. Default `false`.
  - `OM_AUTO_SPAWN_WORKERS_LAZY_POLL_MS=1000` — probe interval (clamped ≥ 250).
  - `OM_AUTO_SPAWN_WORKERS_LAZY_RESTART=true` — restart per-queue worker on unexpected exit while jobs remain pending.
- **Pending-job probes** (`packages/queue/src/pending-probe.ts`, exported from `@open-mercato/queue`):
  - Local probe parses `.mercato/queue/<name>/queue.json` and splits `ready` vs `delayedFuture` jobs.
  - Async probe uses BullMQ `Queue#getJobCounts('waiting','delayed','active')` and never creates a `Worker`.
  - Probes never invoke handlers; failures return a soft-error result.
- **Lazy supervisor** (`packages/cli/src/lib/queue-worker-supervisor.ts`): polls each idle queue, spawns `node <mercatoBin> queue worker <queueName>` on the first ready job, restarts on unexpected exit when jobs remain, and tears children down on shutdown.
- **CLI wiring** (`packages/cli/src/mercato.ts`): replaces the boolean `AUTO_SPAWN_WORKERS !== 'false'` check in `server dev` and `server start` with `resolveAutoSpawnWorkersMode()`. Eager and `off` paths are unchanged.
- **Docs**: updates `apps/docs/docs/framework/events/queue-workers.mdx` (env reference + trade-offs) and `apps/docs/docs/appendix/troubleshooting.mdx` (memory accounting clarification).

## Backward Compatibility
- No contract surface changed. `ModuleWorker` shape, worker metadata `{ queue, id?, concurrency? }`, `runWorker`, `mercato queue worker --all`, and `mercato queue worker <queueName>` are unchanged.
- New `@open-mercato/queue` exports (`getQueuePendingProbe`, `QueuePendingProbeResult`, `QueuePendingProbeOptions`) are additive.
- Lazy mode is opt-in (`OM_AUTO_SPAWN_WORKERS_LAZY=true`); default behavior is identical to before.

## Tests
- `packages/queue/src/__tests__/pending-probe.test.ts` — local probe (empty/queued/delayed-future/elapsed/corrupt) + async probe error path.
- `packages/cli/src/lib/__tests__/auto-spawn-workers.test.ts` — env precedence, poll-ms clamp, restart flag.
- `packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts` — no-spawn-when-idle, single spawn for ready queue, no duplicate spawn, no spawn on probe error, restart only when jobs remain, no restart on SIGTERM, empty worker list.
- `packages/cli/src/__tests__/mercato.test.ts` — both `server dev` and `server start` invoke the supervisor (and skip `queue worker --all`) when `OM_AUTO_SPAWN_WORKERS_LAZY=true`.

## Validation
- `yarn build:packages` ✅
- `yarn generate` ✅
- `yarn typecheck` ✅ (all 18 packages)
- `yarn i18n:check-sync` ✅
- `yarn workspace @open-mercato/queue test` ✅ (50/50)
- `yarn workspace @open-mercato/cli test` ✅ (851/851)

Two flaky tests (`create-mercato-app` CLI scaffold, `core` SystemStatusPanel) failed only under full-parallel `yarn test` because of resource contention (ETIMEDOUT, async timing); both pass cleanly in isolation and neither is in a code path this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)