### PR TITLE
[bug] fix translation manager save flake

### DIFF
--- a/packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts
+++ b/packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts
@@ -123,8 +123,16 @@ test.describe('TC-TRANS-005: Translation Manager Standalone', () => {
 
       const titleInput = page.locator('table input').first()
       await titleInput.fill('Deutscher Titel QA')
+      await expect(titleInput).toHaveValue('Deutscher Titel QA')
 
+      const saveResponsePromise = page.waitForResponse((response) =>
+        response.request().method() === 'PUT'
+        && response.url().includes(`/api/translations/${encodeURIComponent(ENTITY_TYPE)}/${productId}`),
+      )
       await page.getByRole('button', { name: 'Save translations' }).click()
+      const saveResponse = await saveResponsePromise
+      expect(saveResponse.ok()).toBeTruthy()
+      await expect(page.getByText('Translations saved').first()).toBeVisible()
       await expect.poll(async () => {
         const response = await apiRequest(request, 'GET', `/api/translations/${ENTITY_TYPE}/${productId}`, { token: saToken })
         if (!response.ok()) return null

--- a/packages/core/src/modules/translations/components/TranslationManager.tsx
+++ b/packages/core/src/modules/translations/components/TranslationManager.tsx
@@ -67,6 +67,7 @@ export function TranslationManager({
   const [selectedRecordId, setSelectedRecordId] = React.useState(propRecordId ?? '')
   const [activeLocale, setActiveLocale] = React.useState('')
   const [editedTranslations, setEditedTranslations] = React.useState<Record<string, Record<string, string>>>({})
+  const editedTranslationsRef = React.useRef<Record<string, Record<string, string>>>({})
   const [hasUserEdited, setHasUserEdited] = React.useState(false)
 
   const entityType = isEmbedded ? (propEntityType ?? '') : selectedEntityType
@@ -194,7 +195,10 @@ export function TranslationManager({
     lastTranslationSignatureRef.current = sig
 
     if (!translationData?.translations) {
-      if (!hasUserEdited) setEditedTranslations({})
+      if (!hasUserEdited) {
+        editedTranslationsRef.current = {}
+        setEditedTranslations({})
+      }
       return
     }
 
@@ -206,7 +210,10 @@ export function TranslationManager({
         parsed[locale][key] = typeof val === 'string' ? val : ''
       }
     }
-    if (!hasUserEdited) setEditedTranslations(parsed)
+    if (!hasUserEdited) {
+      editedTranslationsRef.current = parsed
+      setEditedTranslations(parsed)
+    }
   }, [translationSignature, translationData, hasUserEdited])
 
   const mutation = useMutation({
@@ -215,7 +222,7 @@ export function TranslationManager({
         throw new Error(t('translations.manager.errors.selectRecord', 'Select an entity and record before saving'))
       }
       const body: Record<string, Record<string, string | null>> = {}
-      for (const [locale, fields] of Object.entries(editedTranslations)) {
+      for (const [locale, fields] of Object.entries(editedTranslationsRef.current)) {
         const localeFields: Record<string, string | null> = {}
         let hasValues = false
         for (const [key, val] of Object.entries(fields)) {
@@ -256,13 +263,15 @@ export function TranslationManager({
 
   const updateFieldValue = (locale: string, fieldKey: string, value: string) => {
     setHasUserEdited(true)
-    setEditedTranslations((prev) => ({
-      ...prev,
+    const next = {
+      ...editedTranslationsRef.current,
       [locale]: {
-        ...prev[locale],
+        ...editedTranslationsRef.current[locale],
         [fieldKey]: value,
       },
-    }))
+    }
+    editedTranslationsRef.current = next
+    setEditedTranslations(next)
   }
 
   const getBaseValue = (fieldKey: string): string => resolveBaseValue(baseValues, fieldKey)


### PR DESCRIPTION
## What changed

- Keep Translation Manager edits mirrored in a synchronous ref so the save payload uses the latest typed value even when React state has not flushed yet.
- Tighten `TC-TRANS-005` so it confirms the input value, waits for the translation `PUT`, and only then polls persisted API state.

## Why

The standalone translation manager integration test could intermittently click Save before the latest input state was visible to the mutation payload builder. In CI this could send an empty/no-op payload, leaving `de.title` missing and causing the API poll to time out.

## Validation

- `yarn exec esbuild packages/core/src/modules/translations/components/TranslationManager.tsx packages/core/src/modules/translations/__integration__/TC-TRANS-005.spec.ts --bundle=false --format=esm --platform=browser --outdir=/tmp/om-esbuild-check --log-level=warning`

Focused Playwright verification was attempted locally, but the recorded ephemeral integration app at `http://127.0.0.1:5001` was stale and not responding.
