### PR TITLE
fix(ci): skip version commit for existing releases

### DIFF
--- a/.ai/runs/2026-05-07-release-existing-no-version-push.md
+++ b/.ai/runs/2026-05-07-release-existing-no-version-push.md
@@ -51,7 +51,7 @@ Non-goals:
 ### Phase 2: Regression Coverage
 
 - [x] 2.1 Add workflow regression test — 557aac351
-- [ ] 2.2 Run targeted validation
+- [x] 2.2 Run targeted validation — dc582804a
 
 ### Phase 3: Review And PR
 

--- a/.ai/runs/2026-05-07-release-existing-no-version-push.md
+++ b/.ai/runs/2026-05-07-release-existing-no-version-push.md
@@ -55,4 +55,4 @@ Non-goals:
 
 ### Phase 3: Review And PR
 
-- [ ] 3.1 Complete self-review and open PR
+- [x] 3.1 Complete self-review and open PR — a5dc45e8b

--- a/.ai/runs/2026-05-07-release-existing-no-version-push.md
+++ b/.ai/runs/2026-05-07-release-existing-no-version-push.md
@@ -1,0 +1,58 @@
+# Release Existing No Version Push
+
+## Overview
+
+Goal: prevent the release workflow's `existing` mode from creating and pushing a version-change commit, because that mode publishes the version already present in `package.json`.
+
+Scope:
+- `.github/workflows/release.yml`
+- A focused script/workflow regression test under `scripts/__tests__/`
+
+Affected area:
+- GitHub Actions release workflow
+- Release automation behavior for `workflow_dispatch.inputs.bump == existing`
+
+Non-goals:
+- Do not change package publishing behavior.
+- Do not change patch/minor/major release version bump behavior.
+- Do not modify package versions, changelog content, tags, or npm publish scripts.
+
+## Implementation Plan
+
+### Phase 1: Workflow Guard
+
+1. Add an explicit guard to the release workflow so `Commit version changes` exits early when `inputs.bump` is `existing`.
+2. Keep later tag and GitHub Release steps running from the existing version output.
+
+### Phase 2: Regression Coverage
+
+1. Add a small Node test that parses `.github/workflows/release.yml` and verifies the `Commit version changes` step contains the `existing` no-op guard before `git add -A`.
+2. Run the focused script test and targeted syntax validation.
+
+### Phase 3: Review And PR
+
+1. Run targeted checks and a self-review for backward compatibility and workflow scope.
+2. Open a PR against `develop`, apply labels, and post the auto-create-pr summary.
+
+## Risks
+
+- YAML expression placement is easy to get subtly wrong; the guard should run inside the shell step and compare the rendered workflow input string.
+- The workflow still needs to tag and create a GitHub Release in `existing` mode, so only the commit/push step should no-op.
+- Full repository validation may be expensive for a CI-only YAML change; any skipped or blocked full-gate command must be documented in the PR.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Workflow Guard
+
+- [ ] 1.1 Add existing-mode no-op guard to release commit step
+
+### Phase 2: Regression Coverage
+
+- [ ] 2.1 Add workflow regression test
+- [ ] 2.2 Run targeted validation
+
+### Phase 3: Review And PR
+
+- [ ] 3.1 Complete self-review and open PR

--- a/.ai/runs/2026-05-07-release-existing-no-version-push.md
+++ b/.ai/runs/2026-05-07-release-existing-no-version-push.md
@@ -46,7 +46,7 @@ Non-goals:
 
 ### Phase 1: Workflow Guard
 
-- [ ] 1.1 Add existing-mode no-op guard to release commit step
+- [x] 1.1 Add existing-mode no-op guard to release commit step — a1c593136
 
 ### Phase 2: Regression Coverage
 

--- a/.ai/runs/2026-05-07-release-existing-no-version-push.md
+++ b/.ai/runs/2026-05-07-release-existing-no-version-push.md
@@ -50,7 +50,7 @@ Non-goals:
 
 ### Phase 2: Regression Coverage
 
-- [ ] 2.1 Add workflow regression test
+- [x] 2.1 Add workflow regression test — 557aac351
 - [ ] 2.2 Run targeted validation
 
 ### Phase 3: Review And PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,11 @@ jobs:
 
       - name: Commit version changes
         run: |
+          if [ "${{ inputs.bump }}" = "existing" ]; then
+            echo "Existing release mode uses committed versions as-is; skipping version commit"
+            exit 0
+          fi
+
           git add -A
           if git diff --cached --quiet; then
             echo "No release changes to commit"

--- a/scripts/__tests__/release-workflow.test.mjs
+++ b/scripts/__tests__/release-workflow.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const workflowPath = path.resolve('.github/workflows/release.yml')
+
+function extractNamedRunStep(workflow, stepName) {
+  const marker = `- name: ${stepName}`
+  const start = workflow.indexOf(marker)
+  assert.notEqual(start, -1, `Expected workflow to contain step "${stepName}"`)
+
+  const nextStep = workflow.indexOf('\n      - name:', start + marker.length)
+  return workflow.slice(start, nextStep === -1 ? undefined : nextStep)
+}
+
+test('release existing mode skips committing version changes', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8')
+  const commitStep = extractNamedRunStep(workflow, 'Commit version changes')
+
+  const existingGuardIndex = commitStep.indexOf('if [ "${{ inputs.bump }}" = "existing" ]; then')
+  const gitAddIndex = commitStep.indexOf('git add -A')
+
+  assert.notEqual(existingGuardIndex, -1, 'Commit step should guard existing releases')
+  assert.notEqual(gitAddIndex, -1, 'Commit step should keep staging version changes for bump releases')
+  assert.ok(existingGuardIndex < gitAddIndex, 'Existing release guard must run before staging files')
+  assert.match(commitStep, /Existing release mode uses committed versions as-is; skipping version commit/)
+  assert.match(commitStep, /exit 0/)
+})


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-07-release-existing-no-version-push.md
Status: complete

## Goal
- Prevent the release workflow's `existing` mode from committing and pushing version changes, because that mode publishes the version already committed in `package.json`.

## What Changed
- Added an early no-op guard to `.github/workflows/release.yml` so the `Commit version changes` step exits before `git add -A` when `inputs.bump == existing`.
- Added `scripts/__tests__/release-workflow.test.mjs` to assert the guard exists and runs before staging files.

## Tests
- `node --test scripts/__tests__/release-workflow.test.mjs`
- `yarn test:scripts`

## Backward Compatibility
- No contract surface changes. This only changes release workflow behavior for the explicit `existing` dispatch mode.

## Progress
See [Progress section in the plan](.ai/runs/2026-05-07-release-existing-no-version-push.md#progress).
