### PR TITLE
fix(core): replace `instanceof CrudHttpError` with `isCrudHttpError()` to fix split-chunk class identity (98 sites, 9 modules)

### DIFF
--- a/packages/core/src/modules/catalog/api/dictionaries/[key]/route.ts
+++ b/packages/core/src/modules/catalog/api/dictionaries/[key]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
 const KEY_ALIASES: Record<string, string[]> = {
@@ -62,7 +62,7 @@ export async function GET(
       })),
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[catalog.dictionaries.GET] Unexpected error', err)

--- a/packages/core/src/modules/customers/api/activities/route.ts
+++ b/packages/core/src/modules/customers/api/activities/route.ts
@@ -8,7 +8,7 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
   runCrudMutationGuardAfterSuccess,
@@ -449,7 +449,7 @@ export async function GET(request: Request): Promise<Response> {
       }),
     )
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {
@@ -543,7 +543,7 @@ export async function POST(request: Request): Promise<Response> {
       ),
     )
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {
@@ -620,7 +620,7 @@ export async function PUT(request: Request): Promise<Response> {
 
     return withAdapterHeaders(NextResponse.json({ ok: true }))
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {
@@ -682,7 +682,7 @@ export async function DELETE(request: Request): Promise<Response> {
     }
     return withAdapterHeaders(NextResponse.json({ ok: true }))
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/customers/api/assignable-staff/route.ts
+++ b/packages/core/src/modules/customers/api/assignable-staff/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
@@ -213,7 +213,7 @@ export async function GET(request: Request) {
       pageSize: query.pageSize,
     })
   } catch (error) {
-    if (error instanceof CrudHttpError) {
+    if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
     }
     if (error instanceof z.ZodError) {

--- a/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -201,7 +201,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       totalPages,
     })
   } catch (error) {
-    if (error instanceof CrudHttpError) {
+    if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
     }
     console.error('[customers.companies.people.GET]', error)

--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveWidgetScope, type WidgetScopeContext } from '../utils'
 import { resolveCustomerInteractionFeatureFlags } from '../../../../lib/interactionFeatureFlags'
 import { CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE } from '../../../../lib/interactionCompatibility'
@@ -127,7 +127,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ items })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.widgets.todos failed', err)

--- a/packages/core/src/modules/customers/api/dashboard/widgets/new-customers/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/new-customers/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { CustomerEntity, type CustomerEntityKind } from '../../../../data/entities'
 import { resolveWidgetScope, type WidgetScopeContext } from '../utils'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -80,7 +80,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ items })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.widgets.newCustomers failed', err)

--- a/packages/core/src/modules/customers/api/dashboard/widgets/new-deals/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/new-deals/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { CustomerDeal } from '../../../../data/entities'
 import { resolveWidgetScope, type WidgetScopeContext } from '../utils'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -75,7 +75,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ items })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.widgets.newDeals failed', err)

--- a/packages/core/src/modules/customers/api/dashboard/widgets/next-interactions/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/next-interactions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { CustomerEntity } from '../../../../data/entities'
 import type { FilterQuery } from '@mikro-orm/core'
 import { resolveWidgetScope, type WidgetScopeContext } from '../utils'
@@ -89,7 +89,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ items, now: now.toISOString() })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.widgets.nextInteractions failed', err)

--- a/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -163,7 +163,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       totalPages,
     })
   } catch (error) {
-    if (error instanceof CrudHttpError) {
+    if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
     }
     console.error('[customers.deals.companies.GET]', error)

--- a/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -142,7 +142,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       totalPages,
     })
   } catch (error) {
-    if (error instanceof CrudHttpError) {
+    if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
     }
     console.error('[customers.deals.people.GET]', error)

--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandExecuteResult } from '@open-mercato/shared/lib/commands/types'
@@ -81,7 +81,7 @@ export async function PATCH(req: Request, ctx: { params?: { kind?: string; id?: 
         ctx: routeContext.ctx,
       })) as CommandExecuteResult<{ entryId: string; changed: boolean }>
     } catch (err) {
-      if (err instanceof CrudHttpError) {
+      if (isCrudHttpError(err)) {
         if (err.status === 404) {
           throw new CrudHttpError(404, { error: routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found') })
         }
@@ -169,7 +169,7 @@ export async function PATCH(req: Request, ctx: { params?: { kind?: string; id?: 
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()
@@ -214,10 +214,10 @@ export async function DELETE(req: Request, ctx: { params?: { kind?: string; id?:
         ctx: routeContext.ctx,
       })) as CommandExecuteResult<{ entryId: string }>
     } catch (err) {
-      if (err instanceof CrudHttpError && err.status === 404) {
+      if (isCrudHttpError(err) && err.status === 404) {
         throw new CrudHttpError(404, { error: routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found') })
       }
-      if (err instanceof CrudHttpError && err.status === 409 && (err.body as Record<string, unknown> | undefined)?.code === 'role_type_in_use') {
+      if (isCrudHttpError(err) && err.status === 409 && (err.body as Record<string, unknown> | undefined)?.code === 'role_type_in_use') {
         const usageCount = Number((err.body as Record<string, unknown> | undefined)?.usageCount ?? 0)
         throw new CrudHttpError(409, {
           ...(err.body as Record<string, unknown> | undefined),
@@ -270,7 +270,7 @@ export async function DELETE(req: Request, ctx: { params?: { kind?: string; id?:
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { CommandExecuteResult } from '@open-mercato/shared/lib/commands/types'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
@@ -190,7 +190,7 @@ export async function GET(req: Request, ctx: { params?: { kind?: string } }) {
 
     return NextResponse.json(responseBody)
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()
@@ -289,7 +289,7 @@ export async function POST(req: Request, ctx: { params?: { kind?: string } }) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/customers/api/dictionaries/currency/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/currency/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
 export const metadata = {
@@ -62,7 +62,7 @@ export async function GET(req: Request) {
       })),
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers.currencyDictionary.GET] Unexpected error', err)

--- a/packages/core/src/modules/customers/api/dictionaries/kind-settings/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/kind-settings/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { TableNotFoundException } from '@mikro-orm/core'
 import { CustomerDictionaryKindSetting } from '../../../data/entities'
 import { resolveDictionaryRouteContext } from '../context'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -79,7 +79,7 @@ export async function GET(req: Request) {
     if (isMissingKindSettingsTable(err)) {
       return NextResponse.json({ items: [] })
     }
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/dictionaries/kind-settings.GET]', err)
@@ -180,7 +180,7 @@ export async function PATCH(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/dictionaries/kind-settings.PATCH]', err)

--- a/packages/core/src/modules/customers/api/entity-roles-factory.ts
+++ b/packages/core/src/modules/customers/api/entity-roles-factory.ts
@@ -4,7 +4,7 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
@@ -318,7 +318,7 @@ export function createEntityRolesHandlers(entityType: EntityType) {
         })),
       })
     } catch (err) {
-      if (err instanceof CrudHttpError) return NextResponse.json(err.body, { status: err.status })
+      if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
       if (err instanceof z.ZodError) return buildValidationErrorResponse(err, translate)
       console.error(`${logPrefix}.get failed`, err)
       return NextResponse.json({ error: translate('customers.errors.failed_to_load_roles', 'Failed to load roles') }, { status: 500 })
@@ -375,7 +375,7 @@ export function createEntityRolesHandlers(entityType: EntityType) {
         { resourceKind, resourceId: entityId },
       )
     } catch (err) {
-      if (err instanceof CrudHttpError) return NextResponse.json(err.body, { status: err.status })
+      if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
       if (err instanceof z.ZodError) return buildValidationErrorResponse(err, translate)
       console.error(`${logPrefix}.post failed`, err)
       return NextResponse.json({ error: translate('customers.errors.failed_to_assign_role', 'Failed to assign role') }, { status: 500 })
@@ -433,7 +433,7 @@ export function createEntityRolesHandlers(entityType: EntityType) {
         { resourceKind, resourceId: entityId },
       )
     } catch (err) {
-      if (err instanceof CrudHttpError) return NextResponse.json(err.body, { status: err.status })
+      if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
       if (err instanceof z.ZodError) return buildValidationErrorResponse(err, translate)
       console.error(`${logPrefix}.put failed`, err)
       return NextResponse.json({ error: translate('customers.errors.failed_to_update_role', 'Failed to update role') }, { status: 500 })
@@ -489,7 +489,7 @@ export function createEntityRolesHandlers(entityType: EntityType) {
         { resourceKind, resourceId: entityId },
       )
     } catch (err) {
-      if (err instanceof CrudHttpError) return NextResponse.json(err.body, { status: err.status })
+      if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
       if (err instanceof z.ZodError) return buildValidationErrorResponse(err, translate)
       console.error(`${logPrefix}.delete failed`, err)
       return NextResponse.json({ error: translate('customers.errors.failed_to_delete_role', 'Failed to delete role') }, { status: 500 })

--- a/packages/core/src/modules/customers/api/interactions/cancel/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/cancel/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { interactionCancelSchema, type InteractionCancelInput } from '../../../data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
       { resourceKind: 'customers.interaction', resourceId: parsed.id },
     )
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/customers/api/interactions/complete/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/complete/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { interactionCompleteSchema, type InteractionCompleteInput } from '../../../data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
       { resourceKind: 'customers.interaction', resourceId: parsed.id },
     )
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/customers/api/interactions/conflicts/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/conflicts/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { sql } from 'kysely'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -190,7 +190,7 @@ export async function GET(req: Request) {
       result: { hasConflicts: conflicts.length > 0, conflicts },
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/interactions/conflicts] GET failed', err)

--- a/packages/core/src/modules/customers/api/interactions/counts/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/counts/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { sql } from 'kysely'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -106,7 +106,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ ok: true, result: { ...counts, total } })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/interactions/counts] GET failed', err)

--- a/packages/core/src/modules/customers/api/interactions/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { sql } from 'kysely'
 import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import { normalizeCustomFieldResponse } from '@open-mercato/shared/lib/custom-fields/normalize'
 import { applyResponseEnrichers } from '@open-mercato/shared/lib/crud/enricher-runner'
@@ -543,7 +543,7 @@ export async function GET(req: Request) {
       nextCursor,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/customers/api/interactions/tasks/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
@@ -108,7 +108,7 @@ export async function GET(request: Request): Promise<Response> {
       totalPages: paged.totalPages,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/customers/api/labels/assign/route.ts
+++ b/packages/core/src/modules/customers/api/labels/assign/route.ts
@@ -4,7 +4,7 @@ import { labelAssignCommandSchema, labelAssignmentSchema, type LabelAssignComman
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -168,7 +168,7 @@ export async function POST(req: Request) {
       const migrationError = await createMissingCustomerLabelTablesError()
       return NextResponse.json(migrationError.body, { status: migrationError.status })
     }
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/labels/assign.POST]', err)

--- a/packages/core/src/modules/customers/api/labels/route.ts
+++ b/packages/core/src/modules/customers/api/labels/route.ts
@@ -5,7 +5,7 @@ import { labelCreateCommandSchema, labelCreateSchema, type LabelCreateCommandInp
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -139,7 +139,7 @@ export async function GET(req: Request) {
     if (isMissingCustomerLabelTable(err)) {
       return NextResponse.json({ items: [], assignedIds: [] })
     }
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/labels.GET]', err)
@@ -256,7 +256,7 @@ export async function POST(req: Request) {
       const migrationError = await createMissingCustomerLabelTablesError()
       return NextResponse.json(migrationError.body, { status: migrationError.status })
     }
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/labels.POST]', err)

--- a/packages/core/src/modules/customers/api/labels/unassign/route.ts
+++ b/packages/core/src/modules/customers/api/labels/unassign/route.ts
@@ -4,7 +4,7 @@ import { labelUnassignCommandSchema, labelAssignmentSchema, type LabelUnassignCo
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -168,7 +168,7 @@ export async function POST(req: Request) {
       const migrationError = await createMissingCustomerLabelTablesError()
       return NextResponse.json(migrationError.body, { status: migrationError.status })
     }
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/labels/unassign.POST]', err)

--- a/packages/core/src/modules/customers/api/people/[id]/companies/[linkId]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/[linkId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import {
   runCrudMutationGuardAfterSuccess,
   validateCrudMutationGuard,
@@ -225,7 +225,7 @@ export async function PATCH(req: Request, ctx: { params?: { id?: string; linkId?
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     return NextResponse.json({ error: translate('customers.errors.internal', 'Internal server error') }, { status: 500 })
@@ -323,7 +323,7 @@ export async function DELETE(req: Request, ctx: { params?: { id?: string; linkId
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     return NextResponse.json({ error: translate('customers.errors.internal', 'Internal server error') }, { status: 500 })

--- a/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -380,7 +380,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       totalPages,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[customers/people/[id]/companies/enriched] GET failed', err)

--- a/packages/core/src/modules/customers/api/people/[id]/companies/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import {
   runCrudMutationGuardAfterSuccess,
   validateCrudMutationGuard,
@@ -91,7 +91,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
     }))
     return NextResponse.json({ items })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     return NextResponse.json({ error: translate('customers.errors.internal', 'Internal server error') }, { status: 500 })
@@ -207,7 +207,7 @@ export async function POST(req: Request, ctx: { params?: { id?: string } }) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     return NextResponse.json({ error: translate('customers.errors.internal', 'Internal server error') }, { status: 500 })

--- a/packages/core/src/modules/customers/api/pipeline-stages/reorder/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/reorder/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { pipelineStageReorderSchema, type PipelineStageReorderInput } from '../../../data/validators'
 import { withScopedPayload } from '../../utils'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
@@ -40,7 +40,7 @@ export async function POST(req: Request) {
     )
     return NextResponse.json({ ok: true })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipeline-stages.reorder failed', err)

--- a/packages/core/src/modules/customers/api/pipeline-stages/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/route.ts
@@ -16,7 +16,7 @@ import {
 } from '../../data/validators'
 import { withScopedPayload } from '../utils'
 import { ensureDictionaryEntry } from '../../commands/shared'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -106,7 +106,7 @@ export async function GET(req: Request) {
     })
     return NextResponse.json({ items, total: items.length })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipeline-stages GET failed', err)
@@ -143,7 +143,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipeline-stages POST failed', err)
@@ -180,7 +180,7 @@ export async function PUT(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipeline-stages PUT failed', err)
@@ -202,7 +202,7 @@ export async function DELETE(req: Request) {
     )
     return NextResponse.json({ ok: true })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipeline-stages DELETE failed', err)

--- a/packages/core/src/modules/customers/api/pipelines/route.ts
+++ b/packages/core/src/modules/customers/api/pipelines/route.ts
@@ -15,7 +15,7 @@ import {
   type PipelineDeleteInput,
 } from '../../data/validators'
 import { withScopedPayload } from '../utils'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -74,7 +74,7 @@ export async function GET(req: Request) {
     }))
     return NextResponse.json({ items, total: items.length })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipelines GET failed', err)
@@ -111,7 +111,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipelines POST failed', err)
@@ -148,7 +148,7 @@ export async function PUT(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipelines PUT failed', err)
@@ -170,7 +170,7 @@ export async function DELETE(req: Request) {
     )
     return NextResponse.json({ ok: true })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('customers.pipelines DELETE failed', err)

--- a/packages/core/src/modules/customers/api/settings/address-format/route.ts
+++ b/packages/core/src/modules/customers/api/settings/address-format/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { customerSettingsUpsertSchema, type CustomerSettingsUpsertInput } from '../../../data/validators'
 import { loadCustomerSettings } from '../../../commands/settings'
 import type { CustomerAddressFormat } from '../../../data/entities'
@@ -67,7 +67,7 @@ export async function GET(req: Request) {
       addressFormat: record?.addressFormat ?? 'line_first',
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()
@@ -93,7 +93,7 @@ export async function PUT(req: Request) {
       addressFormat: result?.addressFormat ?? input.addressFormat,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/customers/api/tags/assign/route.ts
+++ b/packages/core/src/modules/customers/api/tags/assign/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { tagAssignmentSchema, type TagAssignmentInput } from '../../../data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { withScopedPayload } from '../../utils'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/customers/api/tags/unassign/route.ts
+++ b/packages/core/src/modules/customers/api/tags/unassign/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { tagAssignmentSchema, type TagAssignmentInput } from '../../../data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { withScopedPayload } from '../../utils'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/customers/api/todos/route.ts
+++ b/packages/core/src/modules/customers/api/todos/route.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
@@ -303,7 +303,7 @@ export async function GET(request: Request): Promise<Response> {
       }),
     )
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {
@@ -403,7 +403,7 @@ export async function POST(request: Request): Promise<Response> {
       ),
     )
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {
@@ -494,7 +494,7 @@ export async function PUT(request: Request): Promise<Response> {
 
     return withAdapterHeaders(NextResponse.json({ ok: true }))
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {
@@ -568,7 +568,7 @@ export async function DELETE(request: Request): Promise<Response> {
 
     return withAdapterHeaders(NextResponse.json({ ok: true }))
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return withAdapterHeaders(NextResponse.json(err.body, { status: err.status }))
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/[entryId]/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/[entryId]/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
 import { updateDictionaryEntrySchema } from '@open-mercato/core/modules/dictionaries/data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -122,7 +122,7 @@ export async function PATCH(req: Request, ctx: { params?: { dictionaryId?: strin
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id/entries/:entryId.PATCH] Unexpected error', err)
@@ -161,7 +161,7 @@ export async function DELETE(req: Request, ctx: { params?: { dictionaryId?: stri
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id/entries/:entryId.DELETE] Unexpected error', err)

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/reorder/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/reorder/route.ts
@@ -7,7 +7,7 @@ import {
   reorderDictionaryEntriesSchema,
   type ReorderDictionaryEntriesCommandInput,
 } from '@open-mercato/core/modules/dictionaries/data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
@@ -124,7 +124,7 @@ export async function POST(req: Request, ctx: { params?: { dictionaryId?: string
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id/entries/reorder.POST] Unexpected error', err)

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { Dictionary, DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
 import { createDictionaryEntrySchema } from '@open-mercato/core/modules/dictionaries/data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -88,7 +88,7 @@ export async function GET(req: Request, ctx: { params?: { dictionaryId?: string 
       })),
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id/entries.GET] Unexpected error', err)
@@ -152,7 +152,7 @@ export async function POST(req: Request, ctx: { params?: { dictionaryId?: string
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id/entries.POST] Unexpected error', err)

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/set-default/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/entries/set-default/route.ts
@@ -7,7 +7,7 @@ import {
   setDefaultDictionaryEntrySchema,
   type SetDefaultDictionaryEntryCommandInput,
 } from '@open-mercato/core/modules/dictionaries/data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
@@ -124,7 +124,7 @@ export async function POST(req: Request, ctx: { params?: { dictionaryId?: string
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id/entries/set-default.POST] Unexpected error', err)

--- a/packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts
+++ b/packages/core/src/modules/dictionaries/api/[dictionaryId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { Dictionary } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   dictionariesErrorSchema,
@@ -83,7 +83,7 @@ export async function GET(req: Request, ctx: { params?: { dictionaryId?: string 
       updatedAt: dictionary.updatedAt,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id.GET] Unexpected error', err)
@@ -157,7 +157,7 @@ export async function PATCH(req: Request, ctx: { params?: { dictionaryId?: strin
       updatedAt: dictionary.updatedAt,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id.PATCH] Unexpected error', err)
@@ -181,7 +181,7 @@ export async function DELETE(req: Request, ctx: { params?: { dictionaryId?: stri
 
     return NextResponse.json({ ok: true })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries/:id.DELETE] Unexpected error', err)

--- a/packages/core/src/modules/dictionaries/api/route.ts
+++ b/packages/core/src/modules/dictionaries/api/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { Dictionary } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { resolveDictionariesRouteContext } from '@open-mercato/core/modules/dictionaries/api/context'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   dictionariesErrorSchema,
@@ -55,7 +55,7 @@ export async function GET(req: Request) {
       })),
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries.GET] Unexpected error', err)
@@ -108,7 +108,7 @@ export async function POST(req: Request) {
       updatedAt: dictionary.updatedAt,
     }, { status: 201 })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[dictionaries.POST] Unexpected error', err)

--- a/packages/core/src/modules/feature_toggles/api/overrides/route.ts
+++ b/packages/core/src/modules/feature_toggles/api/overrides/route.ts
@@ -5,7 +5,7 @@ import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import { getOverrides } from '../../lib/queries'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { logCrudAccess } from '@open-mercato/shared/lib/crud/factory'
 import { buildContext } from '../../lib/utils'
 import { resolveFeatureCheckContext } from "@open-mercato/core/modules/directory/utils/organizationScope"
@@ -120,7 +120,7 @@ export async function PUT(req: Request) {
 
     return response
   } catch (error) {
-    if (error instanceof CrudHttpError) {
+    if (isCrudHttpError(error)) {
       return NextResponse.json(error.body, { status: error.status })
     }
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/packages/core/src/modules/planner/api/availability-date-specific.ts
+++ b/packages/core/src/modules/planner/api/availability-date-specific.ts
@@ -6,7 +6,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { plannerAvailabilityDateSpecificReplaceSchema } from '../data/validators'
@@ -112,7 +112,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/planner/api/availability-weekly.ts
+++ b/packages/core/src/modules/planner/api/availability-weekly.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { plannerAvailabilityWeeklyReplaceSchema } from '../data/validators'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
@@ -74,7 +74,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/resources/api/resources/tags/assign/route.ts
+++ b/packages/core/src/modules/resources/api/resources/tags/assign/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/resources/api/resources/tags/unassign/route.ts
+++ b/packages/core/src/modules/resources/api/resources/tags/unassign/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/api/document-history/route.ts
+++ b/packages/core/src/modules/sales/api/document-history/route.ts
@@ -5,7 +5,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { NextResponse } from 'next/server'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { ActionLog } from '@open-mercato/core/modules/audit_logs/data/entities'
@@ -127,7 +127,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({ items, nextCursor })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('sales.document-history.get failed', err)

--- a/packages/core/src/modules/sales/api/document-numbers/route.ts
+++ b/packages/core/src/modules/sales/api/document-numbers/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { documentNumberRequestSchema } from '../../data/validators'
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
       sequence: result.sequence,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { LockMode } from '@mikro-orm/core'
@@ -182,7 +182,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ orderId, orderNumber })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/api/quotes/convert/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/convert/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   bridgeLegacyGuard,
@@ -169,7 +169,7 @@ export async function POST(req: Request) {
 
     return jsonResponse
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createRequestContainer } from "@open-mercato/shared/lib/di/container";
 import { resolveTranslations } from "@open-mercato/shared/lib/i18n/server";
-import { CrudHttpError } from "@open-mercato/shared/lib/crud/errors";
+import { CrudHttpError, isCrudHttpError } from "@open-mercato/shared/lib/crud/errors";
 import type { OpenApiRouteDoc } from "@open-mercato/shared/lib/openapi";
 import type { EntityManager } from "@mikro-orm/postgresql";
 import { findOneWithDecryption, findWithDecryption } from "@open-mercato/shared/lib/encryption/find";
@@ -138,7 +138,7 @@ export async function GET(req: Request, ctx: { params: { token: string } }) {
       isExpired,
     });
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status });
     }
     const { translate } = await resolveTranslations();

--- a/packages/core/src/modules/sales/api/quotes/send/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/send/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations, detectLocale } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   bridgeLegacyGuard,
@@ -225,7 +225,7 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ ok: true })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/api/returns/[id]/route.ts
+++ b/packages/core/src/modules/sales/api/returns/[id]/route.ts
@@ -6,7 +6,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SalesReturn, SalesReturnLine } from '../../../data/entities'
 
@@ -99,7 +99,7 @@ export async function GET(req: Request, ctx: { params: { id: string } }) {
       })),
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('sales.returns.get failed', err)

--- a/packages/core/src/modules/sales/api/settings/document-numbers/route.ts
+++ b/packages/core/src/modules/sales/api/settings/document-numbers/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { salesSettingsUpsertSchema, type SalesSettingsUpsertInput } from '../../../data/validators'
 import { loadSalesSettings } from '../../../commands/settings'
@@ -79,7 +79,7 @@ export async function GET(req: Request) {
       tokens: DOCUMENT_NUMBER_TOKENS,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()
@@ -120,7 +120,7 @@ export async function PUT(req: Request) {
       tokens: DOCUMENT_NUMBER_TOKENS,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/api/settings/order-editing/route.ts
+++ b/packages/core/src/modules/sales/api/settings/order-editing/route.ts
@@ -6,7 +6,7 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { salesEditingSettingsSchema, salesSettingsUpsertSchema } from '../../../data/validators'
 import { loadSalesSettings } from '../../../commands/settings'
@@ -99,7 +99,7 @@ export async function GET(req: Request) {
       orderStatuses,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()
@@ -139,7 +139,7 @@ export async function PUT(req: Request) {
       orderStatuses,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/sales/widgets/dashboard/makeDashboardWidgetRoute.ts
+++ b/packages/core/src/modules/sales/widgets/dashboard/makeDashboardWidgetRoute.ts
@@ -6,7 +6,7 @@ import type { CacheStrategy } from '@open-mercato/cache'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { runWithCacheTenant } from '@open-mercato/cache'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { findAndCountWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveDateRange } from '@open-mercato/ui/backend/date-range'
 import type { DatePeriodOption } from '../../api/dashboard/widgets/helpers'
@@ -204,7 +204,7 @@ export function makeDashboardWidgetRoute<TEntity extends object, TItem extends R
 
       return NextResponse.json(response)
     } catch (err) {
-      if (err instanceof CrudHttpError) {
+      if (isCrudHttpError(err)) {
         return NextResponse.json(err.body, { status: err.status })
       }
       console.error(`${config.errorPrefix} failed`, err)

--- a/packages/core/src/modules/staff/api/leave-requests/accept/route.ts
+++ b/packages/core/src/modules/staff/api/leave-requests/accept/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/staff/api/leave-requests/reject/route.ts
+++ b/packages/core/src/modules/staff/api/leave-requests/reject/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -61,7 +61,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/staff/api/team-members/self/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/self/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -77,7 +77,7 @@ export async function GET(req: Request) {
       },
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) return NextResponse.json(err.body, { status: err.status })
+    if (isCrudHttpError(err)) return NextResponse.json(err.body, { status: err.status })
     console.error('staff.teamMembers.self.load failed', err)
     return NextResponse.json({ member: null })
   }
@@ -136,7 +136,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/staff/api/team-members/tags/assign/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/tags/assign/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/staff/api/team-members/tags/unassign/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/tags/unassign/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -64,7 +64,7 @@ export async function POST(req: Request) {
     }
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/translations/api/[entityType]/[entityId]/route.ts
+++ b/packages/core/src/modules/translations/api/[entityType]/[entityId]/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { sql } from 'kysely'
 import { resolveTranslationsRouteContext, requireTranslationFeatures } from '@open-mercato/core/modules/translations/api/context'
 import { translationBodySchema, entityTypeParamSchema, entityIdParamSchema } from '@open-mercato/core/modules/translations/data/validators'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -49,7 +49,7 @@ export async function GET(req: Request, ctx: { params?: { entityType?: string; e
       updatedAt: row.updated_at,
     })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {
@@ -122,7 +122,7 @@ export async function PUT(req: Request, ctx: { params?: { entityType?: string; e
 
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {
@@ -179,7 +179,7 @@ export async function DELETE(req: Request, ctx: { params?: { entityType?: string
 
     return response
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {

--- a/packages/core/src/modules/translations/api/get/locales.ts
+++ b/packages/core/src/modules/translations/api/get/locales.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslationsRouteContext } from '@open-mercato/core/modules/translations/api/context'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { locales as defaultLocales } from '@open-mercato/shared/lib/i18n/config'
 import type { ModuleConfigService } from '@open-mercato/core/modules/configs/lib/module-config-service'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -22,7 +22,7 @@ async function GET(req: Request) {
 
     return NextResponse.json({ locales: Array.isArray(locales) ? locales : [...defaultLocales] })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     console.error('[translations/locales.GET] Unexpected error', err)

--- a/packages/core/src/modules/translations/api/put/locales.ts
+++ b/packages/core/src/modules/translations/api/put/locales.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslationsRouteContext } from '@open-mercato/core/modules/translations/api/context'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { isValidIso639 } from '@open-mercato/shared/lib/i18n/iso639'
 import type { ModuleConfigService } from '@open-mercato/core/modules/configs/lib/module-config-service'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -28,7 +28,7 @@ async function PUT(req: Request) {
 
     return NextResponse.json({ locales: uniqueLocales })
   } catch (err) {
-    if (err instanceof CrudHttpError) {
+    if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
     if (err instanceof z.ZodError) {


### PR DESCRIPTION
## Summary

Replace every `err instanceof CrudHttpError` catch-side guard inside `@open-mercato/core` modules with the symbol-based `isCrudHttpError(err)` helper that already lives at `packages/shared/src/lib/crud/errors.ts`. The helper exists specifically to survive bundle/module duplication; `instanceof` does not.

- 9 modules affected: `catalog`, `customers`, `dictionaries`, `feature_toggles`, `planner`, `resources`, `sales`, `staff`, `translations`.
- 63 distinct files.
- 98 catch-site occurrences swept.
- 0 service-side / `throw new CrudHttpError(...)` sites changed. The constructor stays; only catch-time identity tests move from `instanceof` to `isCrudHttpError`.

## Why this matters — the dual-load bug

`CrudHttpError` is exported from `@open-mercato/shared`. At runtime it can be loaded through more than one resolved path:

1. The route handler's bundle resolves `@open-mercato/shared/lib/crud/errors` directly.
2. A service / command / DI registrar imported earlier in the request lifecycle resolves the same module through a different chunk (Turbopack production builds, dynamic `import()` from a different package, jest module isolation, enterprise plugins, etc.).

When the two resolutions produce two distinct class objects, `err instanceof CrudHttpError` returns `false` even though the thrown value is structurally a `CrudHttpError`. The catch falls through to the generic 500 / silent fallback branch. This is the same family of bug solved years ago for `Symbol.hasInstance` based registries (`globalThis` DI registrars, `Symbol.for(...)` markers).

The shared package already encodes the fix:

```typescript
// packages/shared/src/lib/crud/errors.ts
const CRUD_HTTP_ERROR_MARKER = Symbol.for('@open-mercato/CrudHttpError')

export class CrudHttpError extends Error {
  readonly [CRUD_HTTP_ERROR_MARKER] = true
  // ...
}

export function isCrudHttpError(err: unknown): err is CrudHttpError {
  return !!err && typeof err === 'object'
    && (err as Record<symbol, unknown>)[CRUD_HTTP_ERROR_MARKER] === true
}
```

The marker uses `Symbol.for(...)` so it is unified across module duplicates. `isCrudHttpError(err)` is a strict superset of the `instanceof` check: any value the `instanceof` branch accepted will also pass `isCrudHttpError`. The reverse is not true — that is precisely the bug.

## Why jest does not catch this

Jest's CJS module loader collapses both `from` paths to a single instance, so `instanceof` succeeds in unit tests. The break only manifests in:

- Next.js / Turbopack production builds with split chunks.
- Apps that consume `@open-mercato/core` as a published artifact while also loading enterprise / plugin packages that ship their own copy of `@open-mercato/shared` (or a path-mapped alias resolves them differently).
- Workers / SSE handlers that lazy-import via dynamic `import()`.

A reasonable proxy in CI is the production-build integration test described in the verification plan below.

## Why this matters — privacy / invariant breakage in downstream apps

In a downstream PRM standalone app (PR #19), this exact pattern broke a privacy invariant: a `RfpVisibilityNotFoundError` (a `CrudHttpError(404)` raised by the visibility service) was meant to silent-404 unauthorized RFP detail probes so attackers could not distinguish "exists but hidden" from "does not exist". Under the production build, the catch at the API boundary used `err instanceof CrudHttpError`, the marker class identity differed, the catch fell through, and the route returned a 500 with stack-trace-derived hints that leaked the existence of the resource. That PR fixed it locally by switching to `isCrudHttpError(...)`. This sweep makes that fix apply to every catch site upstream so other apps building on the same primitives do not have to rediscover the same trap.

Across `@open-mercato/core` this guard is wired into 98 catch handlers across 9 modules. Most are benign (you would see a 500 instead of the intended 4xx body), but **any catch handler that gates a security or privacy decision on the type test is potentially affected**, and there is no good reason to leave the landmine in place when the symbol-based guard is already canonical.

## Precedent

`packages/core/src/modules/auth/api/profile/route.ts` already does it the right way (line 9 imports `isCrudHttpError`; line 193 uses it in the `catch`). The pattern is already considered canonical in core — this PR finishes the job for the remaining catch sites.

## Out of scope (separate follow-ups)

A cross-module audit also flagged 4 other module-specific error classes that have the same dual-load risk but each needs its own `is<Class>Error` helper authored and exported alongside the class:

- `ShipmentCancelNotAllowedError` (`shipping_carriers`)
- `UnauthorizedError` (`inbox_ops`, ~6 catch sites)
- `WidgetDataValidationError` (`dashboards`)
- `ExecutionError` (`inbox_ops`, ~2 sites)

These are intentionally **not bundled** into this PR. Each requires (a) adding a `Symbol.for(...)` marker to the class, (b) exporting a sibling type-guard, (c) sweeping the call sites. Recommend tracking them as separate issues / PRs so this PR stays mechanical and reviewable.

## Notable edge cases preserved by the codemod

- **Status-conditional guards** (`customers/api/dictionaries/[kind]/[id]/route.ts`) — multiple sites guard on `instanceof CrudHttpError && err.status === 404`. The new guard narrows to `CrudHttpError` via the `err is CrudHttpError` predicate, so `err.status` access remains type-safe.
- **`withAdapterHeaders`-wrapped responses** in `customers/api/activities/route.ts` — wrapper sits outside the guarded branch; only the predicate changes.
- **Single-line guard** in `staff/api/team-members/self/route.ts:80` — preserved as a single-line form.
- **Variable named `error`** (vs `err`) in `feature_toggles/api/overrides/route.ts` and a few other deals/people/companies routes — codemod handles either identifier.
- **`sales/widgets/dashboard/makeDashboardWidgetRoute.ts:207`** is a **factory** that produces dashboard widget routes; fixing it propagates to every dashboard widget built through it.
- **`sales/api/quotes/public/[token]/route.ts:141`** is the **public, unauthenticated** quote-view route — same hazard pattern the downstream PRM PR fixed for `RfpVisibilityNotFoundError`.

## Backwards compatibility

Behavioural: none. The guard accepts every value the previous guard accepted plus values the previous guard would have wrongly rejected. No public API changes. No type changes. No dependency changes. `CrudHttpError` is **kept** in each import alongside the new `isCrudHttpError` because most files also `throw new CrudHttpError(...)` from validation paths.

## Test plan

- [x] Codemod is mechanical and idempotent — running it a second time produces 0 changes.
- [x] `yarn build:packages` succeeds.
- [x] `yarn turbo run typecheck --filter=@open-mercato/shared --filter=@open-mercato/core` succeeds.
- [x] `yarn turbo run test --filter=@open-mercato/shared --filter=@open-mercato/core` succeeds (existing jest unit tests for each touched route still pass — the guard is a strict superset of the existing `instanceof` predicate).
- [ ] Recommended follow-up: add a unit test that constructs a `CrudHttpError` whose prototype reference is **not** the one currently in scope (simulate dual-load via `Object.setPrototypeOf` or by re-requiring the module under a modified `require.cache`) and confirm both `instanceof` returns `false` and `isCrudHttpError` returns `true`. This locks in the regression.
- [ ] Recommended follow-up: a Playwright test against `next build && next start` that hits one route per touched module and asserts the 4xx body shape (not a 500). Real-world repro of the bug.
- [ ] Recommended follow-up: an ESLint `no-restricted-syntax` rule preventing regression. Suggested rule body:

  ```js
  'no-restricted-syntax': [
    'error',
    {
      selector: "BinaryExpression[operator='instanceof'][right.name='CrudHttpError']",
      message: "Use isCrudHttpError(err). instanceof is unsafe across split chunks.",
    },
  ]
  ```

  (Recommend landing the lint rule as a separate PR after this one merges so the rule does not block the codemod itself.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
