### PR TITLE
fix(sales): enforce return adjustment sign in calculations and validators (#1705)

### DIFF
--- a/packages/core/src/modules/sales/api/order-adjustments/route.ts
+++ b/packages/core/src/modules/sales/api/order-adjustments/route.ts
@@ -3,7 +3,10 @@ import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { SalesOrderAdjustment } from '../../data/entities'
-import { orderAdjustmentCreateSchema } from '../../data/validators'
+import {
+  enforceReturnAdjustmentSign,
+  orderAdjustmentCreateSchema,
+} from '../../data/validators'
 import { createPagedListResponseSchema, createSalesCrudOpenApi, defaultOkResponseSchema } from '../openapi'
 import { withScopedPayload } from '../utils'
 import { E } from '#generated/entities.ids.generated'
@@ -29,7 +32,9 @@ const routeMetadata = {
   DELETE: { requireAuth: true, requireFeatures: ['sales.orders.manage'] },
 }
 
-const upsertSchema = orderAdjustmentCreateSchema.extend({ id: z.string().uuid().optional() })
+const upsertSchema = orderAdjustmentCreateSchema
+  .extend({ id: z.string().uuid().optional() })
+  .superRefine(enforceReturnAdjustmentSign)
 
 const deleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/api/quote-adjustments/route.ts
+++ b/packages/core/src/modules/sales/api/quote-adjustments/route.ts
@@ -3,7 +3,10 @@ import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { SalesQuoteAdjustment } from '../../data/entities'
-import { quoteAdjustmentCreateSchema } from '../../data/validators'
+import {
+  enforceReturnAdjustmentSign,
+  quoteAdjustmentCreateSchema,
+} from '../../data/validators'
 import { createPagedListResponseSchema, createSalesCrudOpenApi, defaultOkResponseSchema } from '../openapi'
 import { withScopedPayload } from '../utils'
 import { E } from '#generated/entities.ids.generated'
@@ -29,7 +32,9 @@ const routeMetadata = {
   DELETE: { requireAuth: true, requireFeatures: ['sales.quotes.manage'] },
 }
 
-const upsertSchema = quoteAdjustmentCreateSchema.extend({ id: z.string().uuid().optional() })
+const upsertSchema = quoteAdjustmentCreateSchema
+  .extend({ id: z.string().uuid().optional() })
+  .superRefine(enforceReturnAdjustmentSign)
 
 const deleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -66,6 +66,7 @@ import {
   CustomerPersonProfile,
 } from "../../customers/data/entities";
 import {
+  enforceReturnAdjustmentSign,
   quoteCreateSchema,
   quoteLineCreateSchema,
   quoteAdjustmentCreateSchema,
@@ -6299,18 +6300,22 @@ const quoteLineDeleteSchema = z.object({
   quoteId: z.string().uuid(),
 });
 
-const orderAdjustmentUpsertSchema = orderAdjustmentCreateSchema.extend({
-  id: z.string().uuid().optional(),
-});
+const orderAdjustmentUpsertSchema = orderAdjustmentCreateSchema
+  .extend({
+    id: z.string().uuid().optional(),
+  })
+  .superRefine(enforceReturnAdjustmentSign);
 
 const orderAdjustmentDeleteSchema = z.object({
   id: z.string().uuid(),
   orderId: z.string().uuid(),
 });
 
-const quoteAdjustmentUpsertSchema = quoteAdjustmentCreateSchema.extend({
-  id: z.string().uuid().optional(),
-});
+const quoteAdjustmentUpsertSchema = quoteAdjustmentCreateSchema
+  .extend({
+    id: z.string().uuid().optional(),
+  })
+  .superRefine(enforceReturnAdjustmentSign);
 
 const quoteAdjustmentDeleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod'
+import {
+  RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
+  RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
+  enforceReturnAdjustmentSign,
+  orderAdjustmentCreateSchema,
+  quoteAdjustmentCreateSchema,
+} from '../validators'
+
+const SCOPE = {
+  organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  tenantId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+}
+
+const ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const QUOTE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+
+const orderUpsertSchema = orderAdjustmentCreateSchema
+  .extend({ id: z.string().uuid().optional() })
+  .superRefine(enforceReturnAdjustmentSign)
+
+const quoteUpsertSchema = quoteAdjustmentCreateSchema
+  .extend({ id: z.string().uuid().optional() })
+  .superRefine(enforceReturnAdjustmentSign)
+
+describe('enforceReturnAdjustmentSign — order adjustments', () => {
+  const base = {
+    ...SCOPE,
+    orderId: ORDER_ID,
+    scope: 'order' as const,
+    currencyCode: 'USD',
+  }
+
+  it('rejects positive amountNet for kind="return"', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: 1,
+      amountGross: 1,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE)
+      expect(messages).toContain(RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE)
+    }
+  })
+
+  it('rejects positive-only amountGross for kind="return"', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: -1,
+      amountGross: 1,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE)
+      expect(messages).not.toContain(RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE)
+    }
+  })
+
+  it('accepts negative amounts for kind="return"', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: -12,
+      amountGross: -12,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts zero amounts for kind="return"', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: 0,
+      amountGross: 0,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts positive amounts for non-return adjustments', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'surcharge',
+      amountNet: 5,
+      amountGross: 5,
+    })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('enforceReturnAdjustmentSign — quote adjustments', () => {
+  const base = {
+    ...SCOPE,
+    quoteId: QUOTE_ID,
+    scope: 'order' as const,
+    currencyCode: 'USD',
+  }
+
+  it('rejects positive amountNet for kind="return" on quote adjustments', () => {
+    const result = quoteUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: 1,
+      amountGross: 1,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE)
+    }
+  })
+
+  it('accepts negative amounts for kind="return" on quote adjustments', () => {
+    const result = quoteUpsertSchema.safeParse({
+      ...base,
+      kind: 'return',
+      amountNet: -7.5,
+      amountGross: -7.5,
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -419,6 +419,41 @@ export const quoteLineUpdateSchema = z
   })
   .merge(quoteLineCreateSchema.partial())
 
+// A `return` adjustment must never increase the grand total. The calculation
+// engine is defensively normalized to negative, but the API edge also rejects
+// positive amounts so bad input is caught before it reaches storage. See #1705.
+export const RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE =
+  'Return adjustments must use a non-positive amountNet (returns reduce the total).'
+export const RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE =
+  'Return adjustments must use a non-positive amountGross (returns reduce the total).'
+
+type AdjustmentSignInput = {
+  kind?: string
+  amountNet?: number
+  amountGross?: number
+}
+
+export const enforceReturnAdjustmentSign = (
+  value: AdjustmentSignInput,
+  ctx: z.RefinementCtx
+) => {
+  if (value.kind !== 'return') return
+  if (typeof value.amountNet === 'number' && value.amountNet > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
+      path: ['amountNet'],
+    })
+  }
+  if (typeof value.amountGross === 'number' && value.amountGross > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
+      path: ['amountGross'],
+    })
+  }
+}
+
 export const orderAdjustmentCreateSchema = scoped.extend({
   orderId: uuid(),
   orderLineId: uuid().optional(),

--- a/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
@@ -208,6 +208,38 @@ describe('calculateDocumentTotals', () => {
     }
   })
 
+  it('treats positive return amounts as negative so they never inflate the grand total (issue #1705)', async () => {
+    const lines: SalesLineSnapshot[] = [
+      {
+        kind: 'product',
+        quantity: 1,
+        currencyCode: 'USD',
+        unitPriceNet: 1,
+        taxRate: 0,
+      },
+    ]
+    const adjustments: SalesAdjustmentDraft[] = [
+      {
+        scope: 'order',
+        kind: 'return',
+        amountNet: 1,
+        amountGross: 1,
+        currencyCode: 'USD',
+      },
+    ]
+
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments,
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.totals.grandTotalGrossAmount).toBeLessThanOrEqual(1)
+    expect(result.totals.grandTotalGrossAmount).toBeCloseTo(0, 4)
+    expect(result.totals.subtotalNetAmount).toBeCloseTo(0, 4)
+  })
+
   it('reduces grand total for line-scoped return (credit) adjustments', async () => {
     const lines: SalesLineSnapshot[] = [
       {

--- a/packages/core/src/modules/sales/lib/calculations.ts
+++ b/packages/core/src/modules/sales/lib/calculations.ts
@@ -190,13 +190,17 @@ function buildBaseDocumentResult(params: {
     }
   }
 
-  // Line-scoped and any other return (credit) adjustments reduce grand total
+  // Line-scoped and any other return (credit) adjustments reduce grand total.
+  // Sign is normalized to negative regardless of the stored sign so a positive
+  // amountNet / amountGross can never inflate totals (issue #1705).
   for (const adj of resolvedAdjustments) {
     if (adj.kind !== 'return') continue
     const net = toNumber(adj.amountNet, toNumber(adj.amountGross))
     const gross = toNumber(adj.amountGross, net)
-    subtotalNet = Math.max(subtotalNet + net, 0)
-    subtotalGross = Math.max(subtotalGross + gross, 0)
+    const netDelta = -Math.abs(net)
+    const grossDelta = -Math.abs(gross)
+    subtotalNet = Math.max(subtotalNet + netDelta, 0)
+    subtotalGross = Math.max(subtotalGross + grossDelta, 0)
   }
 
   const grandTotalNet = round(subtotalNet)


### PR DESCRIPTION
Fixes #1705

## Problem
- A `return` order/quote adjustment is contractually a credit (negative `amountNet` per `packages/core/src/modules/sales/AGENTS.md`).
- Neither the Zod validator nor the calculation engine enforced the sign rule. POSTing a positive `amountNet`/`amountGross` to `/api/sales/order-adjustments` inflated the grand total instead of reducing it (e.g. an order of `1.00` with a `return` adjustment of `+1` became `2.00`).
- Same shape existed for quote adjustments.

## Root Cause
- `packages/core/src/modules/sales/data/validators.ts` — `orderAdjustmentCreateSchema` / `quoteAdjustmentCreateSchema` accepted any decimal regardless of `kind`.
- `packages/core/src/modules/sales/lib/calculations.ts:194-200` — return loop did `subtotalNet = max(subtotalNet + net, 0)` with the signed input, so a positive `net` increased totals.

## What Changed
Defense in depth — fix at both layers so any path (direct API, MCP, future bulk paths, legacy data) stays sign-correct:

1. **`lib/calculations.ts`** — return adjustment amounts are now normalized to `-Math.abs(net)` / `-Math.abs(gross)` before being applied. A positive amount can no longer inflate the total under any circumstances.
2. **`data/validators.ts`** — exports a new `enforceReturnAdjustmentSign` superRefine helper. Applied to all four adjustment-mutation upsert schemas:
   - `api/order-adjustments/route.ts` upsertSchema
   - `api/quote-adjustments/route.ts` upsertSchema
   - `commands/documents.ts` `orderAdjustmentUpsertSchema` + `quoteAdjustmentUpsertSchema`
   The base `*CreateSchema` exports stay as `ZodObject` so existing `.extend()` / `.partial()` / `.omit()` consumers are not broken.

## Tests
- `lib/__tests__/calculations.test.ts` — new regression test reproducing the exact issue payload (`amountNet: 1, amountGross: 1` with `kind: 'return'`) and asserting the grand total is no longer inflated.
- `data/__tests__/validators.adjustment-sign.test.ts` — new file covering: positive net rejected, positive gross rejected, negative/zero accepted, non-return adjustments unaffected, both order and quote variants.
- All 14 targeted tests pass; pre-existing unrelated test-runner module-resolution failures (`@open-mercato/cache` jest mapping) are unchanged from `develop`.
- `yarn typecheck`: 18/18 packages green.

## Backward Compatibility
- No public type, signature, import path, event ID, widget spot ID, ACL feature, API route, or DB schema change.
- New export `enforceReturnAdjustmentSign` is additive; existing schema exports retain their `ZodObject` shape so all `.extend()` / `.partial()` / `.omit()` callers continue to compile.
- Behavior change for adjustment mutation: positive `amountNet`/`amountGross` on `kind: 'return'` is now rejected at the API edge. The official `sales.return.create` command always emits negative amounts, so this only affects callers that were posting bad data (which previously produced an incorrect grand total).