### PR TITLE
chore(ci): unique snapshot versions on canary reruns (split from #1852)

### DIFF
--- a/.ai/specs/implemented/2026-03-21-open-mercato-develop-snapshot-release.md
+++ b/.ai/specs/implemented/2026-03-21-open-mercato-develop-snapshot-release.md
@@ -131,19 +131,20 @@ Develop snapshots MUST be unique per run.
 Recommended format:
 
 ```text
-<next-stable-version>-develop.<github_run_number>.<short_sha>
+<next-stable-version>-develop.<github_run_number>.<github_run_attempt>.<short_sha>
 ```
 
 Example:
 
 ```text
-0.4.9-develop.1523.a1b2c3d4
+0.4.9-develop.1523.1.a1b2c3d4
 ```
 
 Rules:
 
 - the base version SHOULD be derived from the current stable package version and incremented to the next patch line
 - the version MUST include enough build identity to remain unique
+- GitHub reruns MUST include the workflow attempt so a rerun never republishes an immutable npm version
 - the version string MUST remain valid semver
 
 ### 3. Dist-tag Behavior

--- a/scripts/lib/__tests__/snapshot-release.test.mjs
+++ b/scripts/lib/__tests__/snapshot-release.test.mjs
@@ -36,6 +36,18 @@ test('buildSnapshotVersion keeps numeric-only identifiers semver-safe', () => {
   assert.equal(version, '0.4.9-develop.n001523.g0123456789')
 })
 
+test('buildSnapshotVersion includes the workflow attempt when provided', () => {
+  const version = buildSnapshotVersion({
+    currentVersion: '0.6.0',
+    channel: 'canary',
+    buildId: '3130',
+    buildAttempt: '2',
+    commitSha: '7277430535',
+  })
+
+  assert.equal(version, '0.6.1-canary.3130.2.g7277430535')
+})
+
 test('resolveSnapshotPublishConfig maps develop pushes to the develop tag', () => {
   const config = resolveSnapshotPublishConfig({
     eventName: 'push',

--- a/scripts/lib/snapshot-release.mjs
+++ b/scripts/lib/snapshot-release.mjs
@@ -42,13 +42,18 @@ export function getNextPatchVersion(currentVersion) {
   return `${major}.${minor}.${patch + 1}`
 }
 
-export function buildSnapshotVersion({ currentVersion, channel, buildId, commitSha }) {
+export function buildSnapshotVersion({ currentVersion, channel, buildId, buildAttempt, commitSha }) {
   const nextVersion = getNextPatchVersion(currentVersion)
   const normalizedChannel = normalizePrereleaseIdentifier(channel, 'snapshot')
   const normalizedBuildId = normalizePrereleaseIdentifier(buildId, '0')
+  const normalizedBuildAttempt =
+    buildAttempt == null || String(buildAttempt).trim() === ''
+      ? ''
+      : normalizePrereleaseIdentifier(buildAttempt, '1')
   const normalizedCommitSha = normalizePrereleaseIdentifier(commitSha, 'local', { prefixIfNumeric: 'g' })
+  const buildIdentity = normalizedBuildAttempt ? `${normalizedBuildId}.${normalizedBuildAttempt}` : normalizedBuildId
 
-  return `${nextVersion}-${normalizedChannel}.${normalizedBuildId}.${normalizedCommitSha}`
+  return `${nextVersion}-${normalizedChannel}.${buildIdentity}.${normalizedCommitSha}`
 }
 
 export function resolveSnapshotPublishConfig({ eventName, refName }) {
@@ -116,6 +121,7 @@ function runCli() {
       currentVersion: requireOption(options, 'current-version'),
       channel: requireOption(options, 'channel'),
       buildId: requireOption(options, 'build-id'),
+      buildAttempt: options['build-attempt'] ?? '',
       commitSha: requireOption(options, 'commit-sha'),
     })
 

--- a/scripts/release-snapshot.sh
+++ b/scripts/release-snapshot.sh
@@ -50,6 +50,7 @@ fi
 
 COMMIT_HASH=$(git rev-parse --short=10 HEAD)
 BUILD_ID="${GITHUB_RUN_NUMBER:-$(date -u +%s)}"
+BUILD_ATTEMPT="${GITHUB_RUN_ATTEMPT:-}"
 
 if [ "${CI:-}" != "true" ]; then
   echo "==> Syncing create-app template from apps/mercato/src..."
@@ -59,11 +60,20 @@ else
 fi
 
 CURRENT_VERSION=$(jq -r '.version' packages/shared/package.json)
-SNAPSHOT_VERSION=$(node scripts/lib/snapshot-release.mjs version \
-  --current-version "$CURRENT_VERSION" \
-  --channel "$CHANNEL" \
-  --build-id "$BUILD_ID" \
-  --commit-sha "$COMMIT_HASH")
+VERSION_ARGS=(
+  version
+  --current-version "$CURRENT_VERSION"
+  --channel "$CHANNEL"
+  --build-id "$BUILD_ID"
+)
+
+if [ -n "$BUILD_ATTEMPT" ]; then
+  VERSION_ARGS+=(--build-attempt "$BUILD_ATTEMPT")
+fi
+
+VERSION_ARGS+=(--commit-sha "$COMMIT_HASH")
+
+SNAPSHOT_VERSION=$(node scripts/lib/snapshot-release.mjs "${VERSION_ARGS[@]}")
 
 echo "==> Setting version to ${SNAPSHOT_VERSION}..."
 yarn workspaces foreach -A --no-private version "$SNAPSHOT_VERSION"


### PR DESCRIPTION
## Summary

Carved out of #1852 so the CI/release-snapshot fix can be merged independently of the AiChat behavioral fix that ships in #1852. The original PR will be updated to revert the files in this PR; the AiChat unmount fix stays on #1852.

When a GitHub Actions canary release run was retried (e.g. transient npm/registry failure), the snapshot version string only included the workflow run number — so the second attempt tried to publish the same npm version and failed. Including the run **attempt** in the prerelease identifier keeps reruns publishable.

## Changes

- `scripts/lib/snapshot-release.mjs` — accept `--build-attempt` and append it to the prerelease identifier when present.
- `scripts/release-snapshot.sh` — forward `GITHUB_RUN_ATTEMPT` to the version CLI.
- `scripts/lib/__tests__/snapshot-release.test.mjs` — cover the rerun-aware version string (`0.6.1-canary.3130.2.g7277430535`).
- `.ai/specs/implemented/2026-03-21-open-mercato-develop-snapshot-release.md` — document the new identifier shape.

## Why split

PR #1852 was a small AiChat regression fix that picked up an unrelated CI change. Splitting lets us:

- Merge this CI fix immediately to unblock canary release reruns.
- Keep #1852 focused on the AiChat behavior fix so QA only has to exercise the assistant unmount path.

## Merge order

This PR should be merged **before** #1852 so the canary release infra is in a known-good state.

## Test plan

- [x] `node --test scripts/lib/__tests__/snapshot-release.test.mjs` passes (new "buildSnapshotVersion includes the workflow attempt" assertion).
- [ ] Next canary release run (`develop` push) produces version `0.X.Y-develop.<run>.g<sha>` (no attempt suffix).
- [ ] Manual rerun of the canary workflow produces `0.X.Y-develop.<run>.<attempt>.g<sha>` and publishes successfully.