### PR TITLE
feat(ai-assistant): baseURL overrides + OpenRouter/LM Studio presets (Phase 1780-2, stacked on #1858)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-adapters-google.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/llm-adapters-google.test.ts
@@ -68,4 +68,22 @@ describe('GoogleAdapter', () => {
     expect(model).toBeDefined()
     expect(model).not.toBeNull()
   })
+
+  it('createModel forwards baseURL to createGoogleGenerativeAI without throwing', () => {
+    const model = adapter.createModel({
+      apiKey: 'AIza-test',
+      modelId: 'gemini-3-flash',
+      baseURL: 'https://generativelanguage-proxy.example.com/v1beta',
+    })
+    expect(model).toBeDefined()
+    expect(model).not.toBeNull()
+  })
+
+  it('createModel without baseURL still works (Google API default)', () => {
+    const model = adapter.createModel({
+      apiKey: 'AIza-test',
+      modelId: 'gemini-3-flash',
+    })
+    expect(model).toBeDefined()
+  })
 })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/model-factory.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/model-factory.test.ts
@@ -455,6 +455,130 @@ describe('createModelFactory', () => {
       expect(resolution.source).toBe('agent_default')
     })
   })
+
+  describe('Phase 2 — agentDefaultBaseUrl, <MODULE>_AI_BASE_URL, baseUrlOverride', () => {
+    function makeBaseUrlProviderWithSpy(): {
+      provider: FakeProvider
+      createModel: jest.Mock<unknown, [{ modelId: string; apiKey: string; baseURL?: string }]>
+    } {
+      const createModel = jest.fn(
+        (options: { modelId: string; apiKey: string; baseURL?: string }) => ({
+          kind: 'fake-model',
+          ...options,
+        }),
+      ) as jest.Mock<unknown, [{ modelId: string; apiKey: string; baseURL?: string }]>
+      const provider = makeProvider({
+        createModel: createModel as unknown as FakeProvider['createModel'],
+      })
+      return { provider, createModel }
+    }
+
+    it('omits baseURL from AiModelResolution when no caller-side source applies', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider))
+      const resolution = factory.resolveModel({})
+      expect(resolution.baseURL).toBeUndefined()
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: undefined }),
+      )
+    })
+
+    it('forwards agentDefaultBaseUrl to provider.createModel and surfaces it on AiModelResolution', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider))
+      const resolution = factory.resolveModel({
+        agentDefaultBaseUrl: 'https://agent.example.com/v1',
+      })
+      expect(resolution.baseURL).toBe('https://agent.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://agent.example.com/v1' }),
+      )
+    })
+
+    it('<MODULE>_AI_BASE_URL env beats agentDefaultBaseUrl for the baseURL axis', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const env = { CATALOG_AI_BASE_URL: 'https://catalog-env.example.com/v1' }
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider, env))
+      const resolution = factory.resolveModel({
+        moduleId: 'catalog',
+        agentDefaultBaseUrl: 'https://agent.example.com/v1',
+      })
+      expect(resolution.baseURL).toBe('https://catalog-env.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://catalog-env.example.com/v1' }),
+      )
+    })
+
+    it('baseUrlOverride beats <MODULE>_AI_BASE_URL env and agentDefaultBaseUrl', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const env = { CATALOG_AI_BASE_URL: 'https://catalog-env.example.com/v1' }
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider, env))
+      const resolution = factory.resolveModel({
+        moduleId: 'catalog',
+        agentDefaultBaseUrl: 'https://agent.example.com/v1',
+        baseUrlOverride: 'https://caller.example.com/v1',
+      })
+      expect(resolution.baseURL).toBe('https://caller.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://caller.example.com/v1' }),
+      )
+    })
+
+    it('uppercases moduleId when deriving the <MODULE>_AI_BASE_URL env var name', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const env = { INBOX_OPS_AI_BASE_URL: 'https://inbox-env.example.com/v1' }
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider, env))
+      const resolution = factory.resolveModel({ moduleId: 'inbox_ops' })
+      expect(resolution.baseURL).toBe('https://inbox-env.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://inbox-env.example.com/v1' }),
+      )
+    })
+
+    it('treats empty baseUrlOverride as "no override" and falls through to env', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const env = { CATALOG_AI_BASE_URL: 'https://catalog-env.example.com/v1' }
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider, env))
+      const resolution = factory.resolveModel({
+        moduleId: 'catalog',
+        baseUrlOverride: '   ',
+      })
+      expect(resolution.baseURL).toBe('https://catalog-env.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://catalog-env.example.com/v1' }),
+      )
+    })
+
+    it('skips <MODULE>_AI_BASE_URL lookup when moduleId is undefined', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const env = { CATALOG_AI_BASE_URL: 'https://catalog-env.example.com/v1' }
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider, env))
+      const resolution = factory.resolveModel({
+        agentDefaultBaseUrl: 'https://agent.example.com/v1',
+      } satisfies AiModelFactoryInput)
+      expect(resolution.baseURL).toBe('https://agent.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://agent.example.com/v1' }),
+      )
+    })
+
+    it('baseURL axis is independent of model + provider axes (composes with caller_override)', () => {
+      const { provider, createModel } = makeBaseUrlProviderWithSpy()
+      const factory = createModelFactory(fakeContainer, makeFactoryDeps(provider))
+      const resolution = factory.resolveModel({
+        callerOverride: 'caller-model',
+        baseUrlOverride: 'https://caller.example.com/v1',
+      })
+      expect(resolution.source).toBe('caller_override')
+      expect(resolution.modelId).toBe('caller-model')
+      expect(resolution.baseURL).toBe('https://caller.example.com/v1')
+      expect(createModel).toHaveBeenCalledWith({
+        modelId: 'caller-model',
+        apiKey: 'test-api-key',
+        baseURL: 'https://caller.example.com/v1',
+      })
+    })
+  })
 })
 
 describe('parseSlashShorthand', () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/ai-agent-definition.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/ai-agent-definition.ts
@@ -72,10 +72,12 @@ export interface AiAgentDefinition {
   defaultModel?: string
   /**
    * Optional base URL this agent prefers for its chosen provider.
-   * Sits between `<MODULE>_AI_BASE_URL` (step 6) and the preset env override
-   * (`baseURLEnvKeys`) in the resolution chain. Only honoured by adapters that
-   * support baseURL (Anthropic Messages-protocol relays, all OpenAI-compatible
-   * adapters, Google via @ai-sdk/google ≥3.0).
+   * Sits between the `<MODULE>_AI_BASE_URL` env (step 2 of the public 5-step
+   * baseURL hierarchy) and the preset env override (`baseURLEnvKeys`, step 4).
+   * Only honoured by adapters that support baseURL (Anthropic Messages-
+   * protocol relays, all OpenAI-compatible adapters, Google via
+   * @ai-sdk/google ≥3.0). See `packages/ai-assistant/AGENTS.md` →
+   * "baseURL override hierarchy" for the full numbered chain.
    *
    * Phase 2 of spec `2026-04-27-ai-agents-provider-model-baseurl-overrides`.
    */

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/model-factory.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/model-factory.ts
@@ -88,8 +88,9 @@ export interface AiModelFactoryInput {
   /**
    * Agent-level default provider, typically `AiAgentDefinition.defaultProvider`.
    * Named provider id; falls through transparently when the named provider is
-   * registered-but-unconfigured. Sits between `<MODULE>_AI_PROVIDER` (step 4)
-   * and the global `AI_DEFAULT_PROVIDER` (step 6) in the resolution chain.
+   * registered-but-unconfigured. Sits between `<MODULE>_AI_PROVIDER` and the
+   * global `AI_DEFAULT_PROVIDER` in the provider-axis seed list above
+   * (lines 31-39).
    *
    * Phase 1 of spec `2026-04-27-ai-agents-provider-model-baseurl-overrides`.
    */


### PR DESCRIPTION
**Stacked on #1858 → #1856.** Merge those first.

## Goal
Phase 2 of [`2026-04-27-ai-agents-provider-model-baseurl-overrides`](.ai/specs/2026-04-27-ai-agents-provider-model-baseurl-overrides.md) — close the baseURL gap so OpenRouter, LM Studio, vLLM, self-hosted Anthropic relays, and Gemini proxies all work without forking adapters.

## What Changed
- `baseURLEnvKeys` added to OPENAI / DEEPINFRA / GROQ / TOGETHER / FIREWORKS presets — operators can now point any of them at OpenRouter / LiteLLM / a relay without setting a different preset.
- New built-in `OPENROUTER_PRESET` (`https://openrouter.ai/api/v1`) and `LM_STUDIO_PRESET` (`http://localhost:1234/v1`, empty `defaultModel` so the local API auto-detects).
- Anthropic adapter forwards `baseURL` to `createAnthropic` with a doc-comment that scopes it to Anthropic Messages-protocol relays only (R3 mitigation: doesn't work for OpenAI-format gateways).
- Google adapter forwards `baseURL` — `@ai-sdk/google` v3.0.64 supports it (verified type def quote in subagent report).
- `AiAgentDefinition.defaultBaseUrl?: string` (canonical type + customers/catalog local copies).
- baseURL axis in `model-factory.ts`: `baseUrlOverride` → `<MODULE>_AI_BASE_URL` → `agentDefaultBaseUrl` → preset env override → preset default. Resolved baseURL surfaces in `AiModelResolution.baseURL`.
- `runAiAgentText`/`runAiAgentObject`: new `baseUrlOverride?: string` input (programmatic only — HTTP query-param + `AI_RUNTIME_BASEURL_ALLOWLIST` are deferred to Phase 4a per R6).
- Adapter tests: 31 OpenAI-side + 9 Anthropic-side cases covering env override beats default, per-call beats env, OpenRouter / LM Studio configured-state + create-model paths.
- `.env.example` files + AGENTS.md updated with the new envs and the baseURL column.

## Tests
- `yarn jest --testPathPatterns="llm-adapters\|model-factory"` → 98 passed.
- `yarn typecheck` → zero errors in `@open-mercato/ai-assistant` (only the pre-existing MikroORM worktree path-collision noise that Phase 0/1 also reported).

## Backward Compatibility
Additive across all 13 contract surfaces. New optional fields, new exported presets, new env vars. No frozen surface changed; no migrations.

## Risks honored
- **R3** — Anthropic baseURL doc-comment scopes it to Messages-protocol relays only.
- **R6** — `baseUrlOverride` is programmatic-only here; the HTTP `baseUrl` query-param + allowlist arrive in Phase 4a.

## Stacking
- Base branch: `feat/ai-agents-phase-1780-1` (PR #1858).
- After #1856 + #1858 merge, GitHub retargets this PR's base to `develop`.
- Next: Phase 1780-3 (call-site cleanup — pure refactor, no new behavior).