### PR TITLE
feat(customers): activity calendars date inheritance and Today button (#1822)

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
@@ -229,13 +229,20 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
     setScheduleDialogOpen(true)
   }, [])
 
-  const handleAddActivity = React.useCallback((kind: 'meeting' | 'call' | 'task' | 'email') => {
+  const handleAddActivity = React.useCallback((kind: 'meeting' | 'call' | 'task' | 'email', selectedDate?: Date) => {
+    let scheduledAt: string | null = null
+    if (selectedDate) {
+      const combined = new Date(selectedDate)
+      const now = new Date()
+      combined.setHours(now.getHours(), now.getMinutes(), 0, 0)
+      scheduledAt = combined.toISOString()
+    }
     setScheduleEditData({
       id: '',
       interactionType: kind,
       title: null,
       body: null,
-      scheduledAt: null,
+      scheduledAt,
       durationMinutes: null,
       location: null,
       allDay: null,

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/__tests__/page.test.tsx
@@ -2,9 +2,14 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import PersonDetailV2Page from '../page'
+
+type ActivitiesCardCapturedProps = { onAddNew: (kind: string, selectedDate?: Date) => void }
+type ScheduleDialogCapturedProps = { editData?: { scheduledAt: string | null } | null; open?: boolean }
+const capturedActivitiesCardProps: { current: ActivitiesCardCapturedProps | null } = { current: null }
+const capturedScheduleDialogProps: { current: ScheduleDialogCapturedProps | null } = { current: null }
 
 const readApiResultOrThrowMock = jest.fn()
 let activeTabParam: string | null = 'changelog'
@@ -124,7 +129,17 @@ jest.mock('../../../../../components/detail/PlannedActivitiesSection', () => ({
 }))
 
 jest.mock('../../../../../components/detail/ScheduleActivityDialog', () => ({
-  ScheduleActivityDialog: () => null,
+  ScheduleActivityDialog: (props: ScheduleDialogCapturedProps) => {
+    capturedScheduleDialogProps.current = props
+    return null
+  },
+}))
+
+jest.mock('../../../../../components/detail/ActivitiesCard', () => ({
+  ActivitiesCard: (props: ActivitiesCardCapturedProps) => {
+    capturedActivitiesCardProps.current = props
+    return <div data-testid="activities-card">activities-card</div>
+  },
 }))
 
 jest.mock('../../../../../components/detail/PersonCompaniesSection', () => ({
@@ -162,5 +177,56 @@ describe('PersonDetailV2Page', () => {
     await waitFor(() => {
       expect(screen.getByText('changelog')).toBeInTheDocument()
     })
+  })
+
+  it('forwards selectedDate from ActivitiesCard.onAddNew into ScheduleActivityDialog.editData.scheduledAt (issue #1822)', async () => {
+    activeTabParam = 'activities'
+    capturedActivitiesCardProps.current = null
+    capturedScheduleDialogProps.current = null
+
+    renderWithProviders(<PersonDetailV2Page params={{ id: 'person-123' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activities-card')).toBeInTheDocument()
+    })
+
+    expect(typeof capturedActivitiesCardProps.current?.onAddNew).toBe('function')
+
+    const selectedDate = new Date(2026, 4, 15) // 15 May 2026 local
+    selectedDate.setHours(0, 0, 0, 0)
+
+    act(() => {
+      capturedActivitiesCardProps.current!.onAddNew('meeting', selectedDate)
+    })
+
+    await waitFor(() => {
+      expect(capturedScheduleDialogProps.current?.open).toBe(true)
+    })
+    expect(capturedScheduleDialogProps.current?.editData?.scheduledAt).toEqual(expect.any(String))
+    const scheduledAt = new Date(capturedScheduleDialogProps.current!.editData!.scheduledAt as string)
+    expect(scheduledAt.getFullYear()).toBe(2026)
+    expect(scheduledAt.getMonth()).toBe(4)
+    expect(scheduledAt.getDate()).toBe(15)
+  })
+
+  it('opens ScheduleActivityDialog with scheduledAt=null when ActivitiesCard.onAddNew is called without a selectedDate', async () => {
+    activeTabParam = 'activities'
+    capturedActivitiesCardProps.current = null
+    capturedScheduleDialogProps.current = null
+
+    renderWithProviders(<PersonDetailV2Page params={{ id: 'person-123' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('activities-card')).toBeInTheDocument()
+    })
+
+    act(() => {
+      capturedActivitiesCardProps.current!.onAddNew('call')
+    })
+
+    await waitFor(() => {
+      expect(capturedScheduleDialogProps.current?.open).toBe(true)
+    })
+    expect(capturedScheduleDialogProps.current?.editData?.scheduledAt).toBeNull()
   })
 })

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
@@ -189,13 +189,20 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
     [injectionContext, runMutation],
   )
 
-  const handleAddActivity = React.useCallback((kind: ActivityKind) => {
+  const handleAddActivity = React.useCallback((kind: ActivityKind, selectedDate?: Date) => {
+    let scheduledAt: string | null = null
+    if (selectedDate) {
+      const combined = new Date(selectedDate)
+      const now = new Date()
+      combined.setHours(now.getHours(), now.getMinutes(), 0, 0)
+      scheduledAt = combined.toISOString()
+    }
     setScheduleEditData({
       id: '',
       interactionType: kind,
       title: null,
       body: null,
-      scheduledAt: null,
+      scheduledAt,
       durationMinutes: null,
       location: null,
       allDay: null,

--- a/packages/core/src/modules/customers/components/detail/ActivitiesCard.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesCard.tsx
@@ -23,7 +23,7 @@ interface ActivitiesCardProps {
    */
   plannedActivities: InteractionSummary[]
   refreshKey?: number
-  onAddNew: (kind: ActivityKind) => void
+  onAddNew: (kind: ActivityKind, selectedDate?: Date) => void
   onEditActivity?: (activity: InteractionSummary) => void
   /**
    * Optional company name for the parent entity. When the planned activity has no `dealTitle`,
@@ -202,7 +202,7 @@ export function ActivitiesCard({
             </span>
           ) : null}
         </div>
-        <ActivitiesAddNewMenu onSelect={onAddNew} />
+        <ActivitiesAddNewMenu onSelect={(kind) => onAddNew(kind, selectedDate)} />
       </div>
 
       <ActivitiesDayStrip

--- a/packages/core/src/modules/customers/components/detail/ActivitiesDayStrip.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesDayStrip.tsx
@@ -7,6 +7,7 @@ import { cn } from '@open-mercato/shared/lib/utils'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { Button } from '@open-mercato/ui/primitives/button'
 import type { InteractionSummary } from './types'
 
 interface ActivitiesDayStripProps {
@@ -273,6 +274,18 @@ export function ActivitiesDayStrip({ entityId, selectedDate, onSelectDate, refre
       return startOfDay(next)
     })
   }, [])
+  const handleToday = React.useCallback(() => {
+    const today = startOfDay(new Date())
+    setAnchor(anchorCenteredOn(today))
+    onSelectDate(today)
+  }, [onSelectDate])
+
+  const todayInWindow = React.useMemo(
+    () => visibleDays.some((day) => isSameDay(day, todayDate)),
+    [visibleDays, todayDate],
+  )
+  const todayIsSelected = isSameDay(selectedDate, todayDate)
+  const todayDisabled = todayInWindow && todayIsSelected
 
   return (
     <div className="flex flex-col gap-2.5 rounded-md px-3.5 py-3 w-full">
@@ -286,6 +299,15 @@ export function ActivitiesDayStrip({ entityId, selectedDate, onSelectDate, refre
           <ChevronLeft className="size-4 text-foreground" />
         </button>
         <span className="flex-1 text-center text-sm font-medium leading-5 text-foreground">{headerLabel}</span>
+        <Button
+          type="button"
+          variant="outline"
+          size="2xs"
+          onClick={handleToday}
+          disabled={todayDisabled}
+        >
+          {t('customers.calendar.today', 'Today')}
+        </Button>
         <button
           type="button"
           onClick={handleHeaderNext}

--- a/packages/core/src/modules/customers/components/detail/ActivityLogTab.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivityLogTab.tsx
@@ -16,7 +16,7 @@ type ActivityLogTabProps = {
   /** @deprecated No longer used after the ActivitiesCard refactor. Kept optional for callers; remove after one minor cycle. */
   onActivityCreated?: () => void
   onScheduleRequested: () => void
-  onAddActivity?: (kind: ActivityKind) => void
+  onAddActivity?: (kind: ActivityKind, selectedDate?: Date) => void
   /** @deprecated No longer used after the ActivitiesCard refactor. Kept optional for callers; remove after one minor cycle. */
   onMarkDone?: (id: string) => void
   onEditActivity: (activity: InteractionSummary) => void
@@ -45,8 +45,8 @@ export function ActivityLogTab({
   useCanonicalInteractions = false,
   entityCompanyName,
 }: ActivityLogTabProps) {
-  const handleAddNew = (kind: ActivityKind) => {
-    if (onAddActivity) onAddActivity(kind)
+  const handleAddNew = (kind: ActivityKind, selectedDate?: Date) => {
+    if (onAddActivity) onAddActivity(kind, selectedDate)
     else onScheduleRequested()
   }
 

--- a/packages/core/src/modules/customers/components/detail/InlineActivityComposer.tsx
+++ b/packages/core/src/modules/customers/components/detail/InlineActivityComposer.tsx
@@ -97,6 +97,16 @@ export function InlineActivityComposer({
     setErrors({})
   }, [])
 
+  const handleCalendarDaySelect = React.useCallback((date: Date) => {
+    setOccurredAt((prev) => {
+      const time = prev && prev.length >= 16 ? prev.slice(11, 16) : new Date().toTimeString().slice(0, 5)
+      const yyyy = date.getFullYear()
+      const mm = String(date.getMonth() + 1).padStart(2, '0')
+      const dd = String(date.getDate()).padStart(2, '0')
+      return `${yyyy}-${mm}-${dd}T${time}`
+    })
+  }, [])
+
   const handleSave = React.useCallback(async () => {
     if (!selectedType) {
       setErrors({ type: t('customers.activityComposer.validation.typeRequired', 'Select an activity type') })
@@ -274,6 +284,7 @@ export function InlineActivityComposer({
               entityId={entityId}
               useCanonicalInteractions={useCanonicalInteractions}
               refreshRef={calendarRefreshRef}
+              onDaySelect={handleCalendarDaySelect}
             />
           </div>
         ) : null}

--- a/packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx
+++ b/packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx
@@ -13,6 +13,7 @@ interface MiniWeekCalendarProps {
   entityId: string
   useCanonicalInteractions?: boolean
   refreshRef?: React.RefObject<(() => void) | null>
+  onDaySelect?: (date: Date) => void
 }
 
 function getWeekDays(baseDate: Date): Date[] {
@@ -60,7 +61,7 @@ function dotColorForType(type: string, isToday: boolean): string {
   return INTERACTION_TYPE_COLORS[type] ?? INTERACTION_TYPE_FALLBACK_COLOR
 }
 
-export function MiniWeekCalendar({ entityId, useCanonicalInteractions = true, refreshRef }: MiniWeekCalendarProps) {
+export function MiniWeekCalendar({ entityId, useCanonicalInteractions = true, refreshRef, onDaySelect }: MiniWeekCalendarProps) {
   const t = useT()
   const today = React.useMemo(() => new Date(), [])
   const [weekOffset, setWeekOffset] = React.useState(0)
@@ -259,6 +260,18 @@ export function MiniWeekCalendar({ entityId, useCanonicalInteractions = true, re
           {monthLabel}
         </div>
         <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="2xs"
+            onClick={() => {
+              setWeekOffset(0)
+              setSelectedDay(null)
+            }}
+            disabled={weekOffset === 0}
+          >
+            {t('customers.calendar.today', 'Today')}
+          </Button>
           <IconButton type="button" variant="ghost" size="xs" onClick={() => setWeekOffset((w) => w - 1)} aria-label={t('customers.calendar.previousWeek', 'Previous week')}>
             <ChevronLeft className="size-3.5" />
           </IconButton>
@@ -290,7 +303,11 @@ export function MiniWeekCalendar({ entityId, useCanonicalInteractions = true, re
               variant="ghost"
               size="sm"
               key={day.toISOString()}
-              onClick={() => setSelectedDay(isSameDay(day, selectedDay ?? today) ? null : day)}
+              onClick={() => {
+                const next = isSameDay(day, selectedDay ?? today) ? null : day
+                setSelectedDay(next)
+                if (next && onDaySelect) onDaySelect(next)
+              }}
               className={cn(
                 'h-auto flex flex-col items-center border-r last:border-r-0 py-3 text-sm transition-colors cursor-pointer rounded-none',
                 isSelected ? 'bg-foreground text-background font-bold' : 'hover:bg-accent/50',

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesCard.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesCard.test.tsx
@@ -2,10 +2,20 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { screen } from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { ActivitiesCard } from '../ActivitiesCard'
 import type { InteractionSummary } from '../types'
+
+type DayStripProps = { selectedDate: Date; onSelectDate: (d: Date) => void }
+const capturedDayStripProps: { current: DayStripProps | null } = { current: null }
+
+jest.mock('../ActivitiesDayStrip', () => ({
+  ActivitiesDayStrip: (props: DayStripProps) => {
+    capturedDayStripProps.current = props
+    return <div data-testid="day-strip">day-strip</div>
+  },
+}))
 
 const readApiResultOrThrowMock = jest.fn()
 
@@ -49,6 +59,7 @@ describe('ActivitiesCard — planned event subtitle fallback', () => {
   beforeEach(() => {
     readApiResultOrThrowMock.mockReset()
     readApiResultOrThrowMock.mockResolvedValue({ items: [] })
+    capturedDayStripProps.current = null
   })
 
   it('uses the company name as subtitle suffix when the activity has no dealTitle', () => {
@@ -92,5 +103,41 @@ describe('ActivitiesCard — planned event subtitle fallback', () => {
     )
     const subtitle = screen.getByText('Email')
     expect(subtitle).toBeInTheDocument()
+  })
+
+  it('forwards the day-strip selectedDate to onAddNew when "+ Add new" is used (issue #1822)', () => {
+    const onAddNew = jest.fn()
+    renderWithProviders(
+      <ActivitiesCard
+        entityId="person-123"
+        plannedActivities={[]}
+        onAddNew={onAddNew}
+      />,
+    )
+
+    // The day strip is mocked above and captured its props on render. Simulate the
+    // user picking a future day by calling onSelectDate from inside the test.
+    const futureDate = new Date()
+    futureDate.setDate(futureDate.getDate() + 5)
+    futureDate.setHours(0, 0, 0, 0)
+    expect(typeof capturedDayStripProps.current?.onSelectDate).toBe('function')
+    act(() => {
+      capturedDayStripProps.current!.onSelectDate(futureDate)
+    })
+
+    // Open the Add new menu and pick "Log call".
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Add new/i }))
+    })
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Log call/i }))
+    })
+
+    expect(onAddNew).toHaveBeenCalledTimes(1)
+    expect(onAddNew.mock.calls[0][0]).toBe('call')
+    const passedDate = onAddNew.mock.calls[0][1] as Date
+    expect(passedDate.getFullYear()).toBe(futureDate.getFullYear())
+    expect(passedDate.getMonth()).toBe(futureDate.getMonth())
+    expect(passedDate.getDate()).toBe(futureDate.getDate())
   })
 })

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesDayStrip.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesDayStrip.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { ActivitiesDayStrip } from '../ActivitiesDayStrip'
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: jest.fn(async () => ({ items: [] })),
+}))
+
+function startOfDay(date: Date): Date {
+  const next = new Date(date)
+  next.setHours(0, 0, 0, 0)
+  return next
+}
+
+describe('ActivitiesDayStrip — Today button (issue #1822)', () => {
+  it('renders Today disabled when today is in the visible window and selected', () => {
+    const today = startOfDay(new Date())
+    renderWithProviders(
+      <ActivitiesDayStrip entityId="person-1" selectedDate={today} onSelectDate={() => {}} events={[]} />,
+    )
+    const todayBtn = screen.getByRole('button', { name: /Today/i })
+    expect(todayBtn).toBeDisabled()
+  })
+
+  it('enables Today after navigating the day window away from today', () => {
+    const today = startOfDay(new Date())
+    renderWithProviders(
+      <ActivitiesDayStrip entityId="person-1" selectedDate={today} onSelectDate={() => {}} events={[]} />,
+    )
+
+    const nextWindow = screen.getByRole('button', { name: /Next days/i })
+    act(() => {
+      fireEvent.click(nextWindow)
+    })
+
+    const todayBtn = screen.getByRole('button', { name: /Today/i })
+    expect(todayBtn).toBeEnabled()
+  })
+
+  it('calls onSelectDate with today when Today is clicked after navigating away', () => {
+    const today = startOfDay(new Date())
+    const onSelectDate = jest.fn()
+    renderWithProviders(
+      <ActivitiesDayStrip entityId="person-1" selectedDate={today} onSelectDate={onSelectDate} events={[]} />,
+    )
+
+    // Navigate forward by one window so Today becomes meaningful.
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Next days/i }))
+    })
+
+    const todayBtn = screen.getByRole('button', { name: /Today/i })
+    act(() => {
+      fireEvent.click(todayBtn)
+    })
+
+    expect(onSelectDate).toHaveBeenCalledTimes(1)
+    const passed = onSelectDate.mock.calls[0][0] as Date
+    expect(passed.getFullYear()).toBe(today.getFullYear())
+    expect(passed.getMonth()).toBe(today.getMonth())
+    expect(passed.getDate()).toBe(today.getDate())
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/__tests__/InlineActivityComposer.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/InlineActivityComposer.test.tsx
@@ -14,14 +14,21 @@ jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
   flash: jest.fn(),
 }))
 
+type MiniWeekCalendarProps = { onDaySelect?: (date: Date) => void }
+const capturedMiniWeekCalendarProps: { current: MiniWeekCalendarProps | null } = { current: null }
+
 jest.mock('../MiniWeekCalendar', () => ({
-  MiniWeekCalendar: () => <div data-testid="mini-week-calendar">mini-week-calendar</div>,
+  MiniWeekCalendar: (props: MiniWeekCalendarProps) => {
+    capturedMiniWeekCalendarProps.current = props
+    return <div data-testid="mini-week-calendar">mini-week-calendar</div>
+  },
 }))
 
 describe('InlineActivityComposer', () => {
   beforeEach(() => {
     localStorage.clear()
     jest.clearAllMocks()
+    capturedMiniWeekCalendarProps.current = null
   })
 
   it('renders a 3-row autosize description textarea with an explicit label', () => {
@@ -88,5 +95,31 @@ describe('InlineActivityComposer', () => {
     // The deal-keyed preference is independent from the company one.
     expect(localStorage.getItem('om:inline-composer:week-preview:deal')).toBeNull()
     expect(screen.getByTestId('mini-week-calendar')).toBeInTheDocument()
+  })
+
+  it('inherits the date from MiniWeekCalendar onDaySelect while preserving the previously-typed time (issue #1822)', () => {
+    renderWithProviders(
+      <InlineActivityComposer entityType="person" entityId="person-1" />,
+    )
+
+    const occurredInput = document.querySelector(
+      'input[type="datetime-local"]',
+    ) as HTMLInputElement
+    expect(occurredInput).toBeInTheDocument()
+
+    // Simulate the user typing a non-default time before picking a day in the calendar.
+    act(() => {
+      fireEvent.change(occurredInput, { target: { value: '2026-05-08T14:30' } })
+    })
+    expect(occurredInput.value).toBe('2026-05-08T14:30')
+
+    // The composer wires its handleCalendarDaySelect into MiniWeekCalendar.onDaySelect.
+    expect(typeof capturedMiniWeekCalendarProps.current?.onDaySelect).toBe('function')
+
+    // Picking May 15 must change only the date portion; the typed 14:30 stays.
+    act(() => {
+      capturedMiniWeekCalendarProps.current!.onDaySelect!(new Date(2026, 4, 15))
+    })
+    expect(occurredInput.value).toBe('2026-05-15T14:30')
   })
 })

--- a/packages/core/src/modules/customers/components/detail/schedule/DateTimeFields.tsx
+++ b/packages/core/src/modules/customers/components/detail/schedule/DateTimeFields.tsx
@@ -57,6 +57,21 @@ export function DateTimeFields({
   setRecurrenceEndDate,
 }: DateTimeFieldsProps) {
   const t = useT()
+  const dateInputRef = React.useRef<HTMLInputElement>(null)
+  const startTimeInputRef = React.useRef<HTMLInputElement>(null)
+
+  const openPicker = React.useCallback((ref: React.RefObject<HTMLInputElement | null>) => (event: React.MouseEvent<HTMLLabelElement>) => {
+    const input = ref.current
+    if (!input || input.disabled) return
+    // Prevent the native input from selecting a segment (e.g. day digit) before
+    // we open the picker — issue #1822 wants a picker on any click in the field.
+    event.preventDefault()
+    try {
+      input.showPicker?.()
+    } catch {
+      input.focus()
+    }
+  }, [])
 
   if (!visible.has('date')) return null
 
@@ -79,14 +94,16 @@ export function DateTimeFields({
             {getFieldLabel(activityType, 'date', t, 'customers.schedule.date', 'Date')}
             <span aria-hidden="true" className="ml-1 text-status-error-foreground">*</span>
           </label>
-          <div
+          <label
+            onClick={openPicker(dateInputRef)}
             className={cn(
-              'flex items-center gap-2 rounded-md border bg-background px-3 py-2.5',
+              'flex cursor-pointer items-center gap-2 rounded-md border bg-background px-3 py-2.5',
               dateMissing ? 'border-status-error-border' : 'border-border',
             )}
           >
             <Calendar className="size-3.5 text-muted-foreground" />
             <input
+              ref={dateInputRef}
               type="date"
               value={date}
               onChange={(e) => setDate(e.target.value)}
@@ -96,7 +113,7 @@ export function DateTimeFields({
               aria-describedby={dateMissing ? dateErrorId : undefined}
               className="flex-1 bg-transparent text-sm text-foreground focus:outline-none"
             />
-          </div>
+          </label>
           {dateMissing ? (
             <p id={dateErrorId} className="text-xs text-status-error-foreground">
               {t('customers.activities.errors.dateRequired', 'Date is required')}
@@ -109,14 +126,17 @@ export function DateTimeFields({
               {getFieldLabel(activityType, 'startTime', t, 'customers.schedule.start', 'Start')}
               <span aria-hidden="true" className="ml-1 text-status-error-foreground">*</span>
             </label>
-            <div
+            <label
+              onClick={openPicker(startTimeInputRef)}
               className={cn(
                 'flex items-center gap-2 rounded-md border bg-background px-3 py-2.5',
+                allDay ? 'cursor-not-allowed' : 'cursor-pointer',
                 timeMissing ? 'border-status-error-border' : 'border-border',
               )}
             >
               <Clock className="size-3.5 text-muted-foreground" />
               <input
+                ref={startTimeInputRef}
                 type="time"
                 value={startTime}
                 onChange={(e) => setStartTime(e.target.value)}
@@ -127,7 +147,7 @@ export function DateTimeFields({
                 aria-describedby={timeMissing ? timeErrorId : undefined}
                 className="flex-1 bg-transparent text-sm text-foreground focus:outline-none disabled:opacity-50"
               />
-            </div>
+            </label>
             {timeMissing ? (
               <p id={timeErrorId} className="text-xs text-status-error-foreground">
                 {t('customers.activities.errors.timeRequired', 'Time is required')}

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -170,6 +170,7 @@
   "customers.calendar.nextWeek": "Nächste Woche",
   "customers.calendar.previousWeek": "Vorherige Woche",
   "customers.calendar.thisWeek": "This week",
+  "customers.calendar.today": "Heute",
   "customers.calendar.tomorrow": "Tomorrow",
   "customers.changelog.actions.assign": "Assign",
   "customers.changelog.actions.create": "Create",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -170,6 +170,7 @@
   "customers.calendar.nextWeek": "Next week",
   "customers.calendar.previousWeek": "Previous week",
   "customers.calendar.thisWeek": "This week",
+  "customers.calendar.today": "Today",
   "customers.calendar.tomorrow": "Tomorrow",
   "customers.changelog.actions.assign": "Assign",
   "customers.changelog.actions.create": "Create",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -170,6 +170,7 @@
   "customers.calendar.nextWeek": "Semana siguiente",
   "customers.calendar.previousWeek": "Semana anterior",
   "customers.calendar.thisWeek": "This week",
+  "customers.calendar.today": "Hoy",
   "customers.calendar.tomorrow": "Tomorrow",
   "customers.changelog.actions.assign": "Assign",
   "customers.changelog.actions.create": "Create",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -170,6 +170,7 @@
   "customers.calendar.nextWeek": "Następny tydzień",
   "customers.calendar.previousWeek": "Poprzedni tydzień",
   "customers.calendar.thisWeek": "Ten tydzień",
+  "customers.calendar.today": "Dzisiaj",
   "customers.calendar.tomorrow": "Tomorrow",
   "customers.changelog.actions.assign": "Przypisanie",
   "customers.changelog.actions.create": "Utworzenie",


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                             
  Implements [#1822](https://github.com/open-mercato/open-mercato/issues/1822) — context-aware date inheritance from activity calendars to the creation modal/composer, plus a "Today" button on the date  
  navigation bar to quickly return to the current day.                                                                                                                                                       
                                                                                                                                                                                                             
  ## Changes                                                                                                                                                                                                 
                                                                                                                                                                                                             
  - `MiniWeekCalendar` (deals page): added `onDaySelect` prop and "Today" button (disabled at `weekOffset === 0`).                                                                                           
  - `InlineActivityComposer`: wires `MiniWeekCalendar.onDaySelect` to update `occurredAt` while preserving the typed time.                                                                                 
  - `ActivitiesDayStrip` (people-v2 / companies-v2): added "Today" button in the month header (disabled when today is selected and visible).
  - `ActivitiesCard`: `onAddNew` now passes the day-strip `selectedDate` so the schedule modal opens pre-filled.                                                                                             
  - `ActivityLogTab`: propagates the new optional `selectedDate` argument.
  - `people-v2/[id]/page.tsx` and `companies-v2/[id]/page.tsx`: `handleAddActivity` combines `selectedDate` with the current local time and seeds `scheduleEditData.scheduledAt`.                            
  - `schedule/DateTimeFields`: full-container click on Date and Start fields opens the native picker via `input.showPicker()` (focus fallback for older browsers).                                           
  - i18n: added `customers.calendar.today` to en, pl, de, es.                                                                                                                                                
  - Tests: extended `InlineActivityComposer`, `ActivitiesCard`, and people-v2 `page` test suites; added new `ActivitiesDayStrip` test.                                                                       
                                                                                                                                                                                                             
  ## Specification                                                                                                                                                                                           
                                                                                                                                                                                                             
  **Does a spec exist for this feature/module?**                                                                                                                                                             
  - [ ] Yes                                                                                                                                                                                                  
  - [ ] No (created a new spec)                                                                                                                                                                              
  - [x] N/A (minor change, no spec needed)                                                                                                                                                                   
                                              
  **Spec file path:**                                                                                                                                                                                        
  The issue references `.ai/specs/SPEC-072-...`, but that spec describes unrelated CRM detail-page enhancements (collapsible groups, multi-role assignment, stage progress bar). This PR follows the issue 
  body literally — it is a small UX improvement and does not warrant its own spec per the "skip for small fixes" rule in `AGENTS.md`.                                                                        
                                          
  ## Testing                                                                                                                                                                                                 
                                                                                                                                                                                                             
  Local CI gate (matches `.github/workflows/ci.yml`):
                                                                                                                                                                                                             
  - `yarn build:packages` — 18/18 packages built                                                                                                                                                           
  - `yarn typecheck` — all packages green                                                                                                                                                                    
  - `yarn test` — 444 suites, 3732 tests pass (+7 new for this PR)
  - `yarn i18n:check-sync` — all 4 locales in sync                                                                                                                                                           
  - `yarn build:app` — Next.js build success                                                                                                                                                               
                                                                                                                                                                                                             
  Manual smoke tests on local dev:                                                                                                                                                                           
                                                                                                                                                                                                             
  - `/backend/customers/people-v2/<id>` — click a day in the strip + "+ Add new" opens the schedule dialog with `scheduledAt` set to the selected date.                                                      
  - `/backend/customers/companies-v2/<id>` — same.                                                                                                                                                           
  - `/backend/customers/deals/<id>` — week preview day click updates the inline composer's `occurredAt` while preserving time; "Schedule" button opens the schedule dialog with the same behavior.           
  - "Today" button disables/enables correctly across all three pages.                                                                                                                                        
  - Click anywhere inside the Date / Start field rectangle in the schedule dialog opens the native picker.                                                                                                 
                                                                                                                                                                                                             
  ## Checklist                                                                                                                                                                                               
                                                                                                                                                                                                             
  - [x] This pull request targets `develop`.                                                                                                                                                                 
  - [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).                                                                                                           
  - [x] I updated documentation, locales, or generators if the change requires it.                                                                                                                           
  - [x] I added or adjusted tests that cover the change.                                                                                                                                                   
  - [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Unit tests cover the three behavioral changes (time preservation, Today button
  state, `onAddNew` payload, page-level `scheduledAt` wiring). No new `.ai/qa/tests/` Playwright scenario added because the change is presentational UX behavior fully covered by unit tests against existing
   data flow; no new API surface or persisted state.
  - [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (see Specification section above).                                                                       
                                                                                                                                                                                                             
  ### Design System Compliance                                                                                                                                                                               
  - [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens                                                                           
  - [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`                                                                                                                     
  - [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A (no new list/data pages)
  - [x] Loading state handled for async pages — N/A (no new async pages)                                                                                                                                     
  - [x] `aria-label` on all icon-only buttons (`<IconButton>`) — Today button has visible text content (no `aria-label` needed); pre-existing icon-only chevrons keep their labels.                          
  - [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — Today button uses the `Button` primitive. Pre-existing raw `<button>` in `ActivitiesDayStrip` chevrons and raw
   `<input>` in `schedule/DateTimeFields` are legacy and out of scope; flagged for a follow-up refactor.                                                                                                     
                                                                                                                                                                                                             
  ## Linked issues                                                                                                                                                                                           
                                                                                                                                                                                                             
  Fixes #1822 