### PR TITLE
refactor(ai-assistant): collapse model-resolution call sites onto createModelFactory (Phase 1780-3, stacked on #1860)

### DIFF
--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -550,10 +550,6 @@ when the registry has no configured provider and `code: 'api_key_missing'`
 when the picked provider returns an empty key — every current call site
 already relies on the throw bubbling up, do not swallow it.
 
-The `agent-runtime.ts` inline `resolveAgentModel` will migrate to
-`createModelFactory` in a follow-up Step (5.2+). New agents should accept
-the factory-backed path from day one.
-
 ## MANDATORY: Use AskUserQuestion for Confirmations
 
 > **This is the MOST IMPORTANT rule. NEVER skip this.**
@@ -1366,6 +1362,14 @@ if (tool.requiredFeatures?.length) {
 ---
 
 ## Changelog
+
+### 2026-05-08 - Phase 3 call-site cleanup (spec 2026-04-27-ai-agents-provider-model-baseurl-overrides)
+
+**What changed**:
+- `agent-runtime.ts` `resolveAgentModel` fully migrated to `createModelFactory`. The inline fallback resolver (which ignored `AI_DEFAULT_PROVIDER`, `agentDefaultProvider`, `providerOverride`, `baseUrlOverride`) is removed. A throwaway `createContainer()` is used when no Awilix container is provided, keeping the function signature unchanged.
+- `api/route/route.ts` no-config fallback now delegates to `createModelFactory` instead of a manual `llmProviderRegistry.resolveFirstConfigured` call, ensuring `AI_DEFAULT_PROVIDER` / `AI_DEFAULT_MODEL` / all registered preset providers are honored in the routing path.
+- `inbox_ops/lib/llmProvider.ts` received a doc-comment explaining why `OPENCODE_PROVIDER` / `OPENCODE_MODEL` remain at the bottom of the resolution chain (BC isolation from the new `AI_DEFAULT_*` envs per spec R1 mitigation).
+- `customers/ai-agents.ts` and `catalog/ai-agents.ts` removed duplicate local `AiAgentDefinition` / `AiAgentPageContextInput` type declarations; both now import from `@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-agent-definition`.
 
 ### 2026-02-22 - Code Mode Tools (search + execute)
 

--- a/packages/ai-assistant/src/modules/ai_assistant/api/route/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/route/route.ts
@@ -99,14 +99,19 @@ export async function POST(req: NextRequest) {
 
     // Get user's configured provider
     const container = await createRequestContainer()
-    let config = await resolveChatConfig(container)
+    const config = await resolveChatConfig(container)
 
-    // When no DB-stored config is present, delegate provider + model resolution
-    // to createModelFactory so AI_DEFAULT_PROVIDER / AI_DEFAULT_MODEL (Phase 0
-    // of spec 2026-04-27-ai-agents-provider-model-baseurl-overrides) and all
-    // registered OpenAI-compatible presets are respected without duplicating
-    // the resolution chain here.
+    let model: Parameters<typeof generateObject>[0]['model']
+    let modelWithProvider: string
+    let providerLabel: string
+
     if (!config) {
+      // When no DB-stored config is present, delegate provider + model
+      // resolution to createModelFactory so AI_DEFAULT_PROVIDER /
+      // AI_DEFAULT_MODEL (Phase 0 of spec
+      // 2026-04-27-ai-agents-provider-model-baseurl-overrides) and all
+      // registered OpenAI-compatible presets are respected without
+      // duplicating the resolution chain here.
       let factoryResolution
       try {
         factoryResolution = createModelFactory(container).resolveModel({
@@ -125,50 +130,26 @@ export async function POST(req: NextRequest) {
         throw error
       }
 
-      console.log('[AI Route] Using provider:', factoryResolution.providerId)
-
-      const modelWithProvider = `${factoryResolution.providerId}/${factoryResolution.modelId}`
-      console.log('[AI Route] Calling generateObject with', modelWithProvider)
-
-      const result = await generateObject({
-        model: factoryResolution.model as Parameters<typeof generateObject>[0]['model'],
-        schema: RouteResultSchema,
-        prompt: `You are a routing assistant. Given a user query, determine if they want to use a specific tool or have a general conversation.
-
-Available tools:
-${availableTools.map((t) => `- ${t.name}: ${t.description}`).join('\n')}
-
-User query: "${query}"
-
-Respond with:
-- intent: "tool" if user wants to perform an action with a specific tool, "general_chat" otherwise
-- toolName: the exact tool name if intent is "tool"
-- confidence: 0-1 how confident you are
-- reasoning: brief explanation`,
-      })
-
-      console.log('[AI Route] Result:', result.object)
-      return NextResponse.json(result.object)
+      model = factoryResolution.model as Parameters<typeof generateObject>[0]['model']
+      modelWithProvider = `${factoryResolution.providerId}/${factoryResolution.modelId}`
+      providerLabel = factoryResolution.providerId
+    } else {
+      if (!isProviderConfigured(config.providerId)) {
+        return NextResponse.json(
+          { error: `Configured provider ${config.providerId} is no longer available. Please update settings.` },
+          { status: 503 }
+        )
+      }
+      ;({ model, modelWithProvider } = createRoutingModel(config.providerId, config.model))
+      providerLabel = config.providerId
     }
 
-    console.log('[AI Route] Using provider:', config.providerId)
-
-    // Verify the configured provider is still available
-    if (!isProviderConfigured(config.providerId)) {
-      return NextResponse.json(
-        { error: `Configured provider ${config.providerId} is no longer available. Please update settings.` },
-        { status: 503 }
-      )
-    }
-
-    // Use fast model for the configured provider
-    const { model, modelWithProvider } = createRoutingModel(config.providerId, config.model)
+    console.log('[AI Route] Using provider:', providerLabel)
+    console.log('[AI Route] Calling generateObject with', modelWithProvider)
 
     const toolList = availableTools
       .map((t) => `- ${t.name}: ${t.description}`)
       .join('\n')
-
-    console.log('[AI Route] Calling generateObject with', modelWithProvider)
 
     const result = await generateObject({
       model,

--- a/packages/ai-assistant/src/modules/ai_assistant/api/route/route.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/api/route/route.ts
@@ -11,6 +11,7 @@ import {
   isProviderConfigured,
   type ChatProviderId,
 } from '../../lib/chat-config'
+import { createModelFactory, AiModelFactoryError } from '../../lib/model-factory'
 
 export const openApi: OpenApiRouteDoc = {
   tag: 'AI Assistant',
@@ -100,27 +101,54 @@ export async function POST(req: NextRequest) {
     const container = await createRequestContainer()
     let config = await resolveChatConfig(container)
 
-    // Fallback to first configured provider from the LLM provider registry.
-    // AI_DEFAULT_PROVIDER (Phase 0 of the per-axis-overrides spec) takes
-    // precedence so an operator-pinned default flows through routing too;
-    // otherwise we keep the historical native-first order for backward
-    // compatibility.
+    // When no DB-stored config is present, delegate provider + model resolution
+    // to createModelFactory so AI_DEFAULT_PROVIDER / AI_DEFAULT_MODEL (Phase 0
+    // of spec 2026-04-27-ai-agents-provider-model-baseurl-overrides) and all
+    // registered OpenAI-compatible presets are respected without duplicating
+    // the resolution chain here.
     if (!config) {
-      const aiDefaultProvider = (process.env.AI_DEFAULT_PROVIDER ?? '').trim()
-      const order = aiDefaultProvider
-        ? [aiDefaultProvider, 'anthropic', 'openai', 'google']
-        : ['anthropic', 'openai', 'google']
-      const picked = llmProviderRegistry.resolveFirstConfigured({ order })
-      if (!picked) {
-        return NextResponse.json(
-          {
-            error:
-              'No AI provider configured. Please set an API key for one of the registered providers (Anthropic, OpenAI, Google, DeepInfra, Groq, …).',
-          },
-          { status: 503 },
-        )
+      let factoryResolution
+      try {
+        factoryResolution = createModelFactory(container).resolveModel({
+          callerOverride: undefined,
+        })
+      } catch (error) {
+        if (error instanceof AiModelFactoryError && error.code === 'no_provider_configured') {
+          return NextResponse.json(
+            {
+              error:
+                'No AI provider configured. Please set an API key for one of the registered providers (Anthropic, OpenAI, Google, DeepInfra, Groq, …).',
+            },
+            { status: 503 },
+          )
+        }
+        throw error
       }
-      config = { providerId: picked.id, model: '', updatedAt: '' }
+
+      console.log('[AI Route] Using provider:', factoryResolution.providerId)
+
+      const modelWithProvider = `${factoryResolution.providerId}/${factoryResolution.modelId}`
+      console.log('[AI Route] Calling generateObject with', modelWithProvider)
+
+      const result = await generateObject({
+        model: factoryResolution.model as Parameters<typeof generateObject>[0]['model'],
+        schema: RouteResultSchema,
+        prompt: `You are a routing assistant. Given a user query, determine if they want to use a specific tool or have a general conversation.
+
+Available tools:
+${availableTools.map((t) => `- ${t.name}: ${t.description}`).join('\n')}
+
+User query: "${query}"
+
+Respond with:
+- intent: "tool" if user wants to perform an action with a specific tool, "general_chat" otherwise
+- toolName: the exact tool name if intent is "tool"
+- confidence: 0-1 how confident you are
+- reasoning: brief explanation`,
+      })
+
+      console.log('[AI Route] Result:', result.object)
+      return NextResponse.json(result.object)
     }
 
     console.log('[AI Route] Using provider:', config.providerId)

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -1,3 +1,4 @@
+import { createContainer } from 'awilix'
 import type { AwilixContainer } from 'awilix'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { LanguageModel, UIMessage } from 'ai'
@@ -9,7 +10,6 @@ import {
   streamText,
 } from 'ai'
 import type { ZodTypeAny } from 'zod'
-import { llmProviderRegistry } from '@open-mercato/shared/lib/ai/llm-provider-registry'
 import { createModelFactory } from './model-factory'
 import type {
   AiAgentDefinition,
@@ -111,41 +111,21 @@ function resolveAgentModel(
   container: AwilixContainer | undefined,
   baseUrlOverride?: string,
 ): ResolvedAgentModel {
-  if (container) {
-    const resolution = createModelFactory(container).resolveModel({
-      moduleId: agent.moduleId,
-      agentDefaultModel: agent.defaultModel,
-      agentDefaultProvider: agent.defaultProvider,
-      agentDefaultBaseUrl: agent.defaultBaseUrl,
-      callerOverride: modelOverride,
-      providerOverride,
-      baseUrlOverride,
-    })
-    return {
-      model: resolution.model as LanguageModel,
-      modelId: resolution.modelId,
-      providerId: resolution.providerId,
-    }
+  const effectiveContainer = container ?? createContainer()
+  const resolution = createModelFactory(effectiveContainer).resolveModel({
+    moduleId: agent.moduleId,
+    agentDefaultModel: agent.defaultModel,
+    agentDefaultProvider: agent.defaultProvider,
+    agentDefaultBaseUrl: agent.defaultBaseUrl,
+    callerOverride: modelOverride,
+    providerOverride,
+    baseUrlOverride,
+  })
+  return {
+    model: resolution.model as LanguageModel,
+    modelId: resolution.modelId,
+    providerId: resolution.providerId,
   }
-
-  const provider = llmProviderRegistry.resolveFirstConfigured()
-  if (!provider) {
-    throw new Error(
-      'No LLM provider is configured. Set OPENCODE_PROVIDER plus a matching API key such as ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY, then restart the app. See https://docs.openmercato.com/framework/ai-assistant/overview.',
-    )
-  }
-  const apiKey = provider.resolveApiKey()
-  if (!apiKey) {
-    throw new Error(
-      `LLM provider "${provider.id}" is advertised as configured but resolveApiKey() returned empty.`,
-    )
-  }
-  const modelId =
-    (modelOverride && modelOverride.trim().length > 0 ? modelOverride : undefined) ??
-    agent.defaultModel ??
-    provider.defaultModel
-  const model = provider.createModel({ modelId, apiKey }) as LanguageModel
-  return { model, modelId, providerId: provider.id }
 }
 
 /**

--- a/packages/core/src/modules/catalog/ai-agents.ts
+++ b/packages/core/src/modules/catalog/ai-agents.ts
@@ -26,62 +26,15 @@
  * prompt-override merges can address sections by name. The composed
  * text is fed into `systemPrompt` so the current runtime continues to
  * work.
- *
- * Local type declarations mirror the public shapes from
- * `@open-mercato/ai-assistant`. `@open-mercato/core` does not depend on
- * `@open-mercato/ai-assistant` (see the companion comment in
- * `ai-tools/types.ts` and the Step 4.7 / 4.8 implementation notes), so
- * the generator imports this file via the app's bundler and the runtime
- * graph resolves through `apps/mercato/.mercato/generated/ai-agents.generated.ts`.
  */
-import type { AwilixContainer } from 'awilix'
+import type {
+  AiAgentDefinition,
+  AiAgentPageContextInput,
+} from '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-agent-definition'
 import {
   hydrateCatalogAssistantContext,
   hydrateMerchandisingAssistantContext,
 } from './ai-agents-context'
-
-type AiAgentExecutionMode = 'chat' | 'object'
-type AiAgentMutationPolicy = 'read-only' | 'confirm-required' | 'destructive-confirm-required'
-type AiAgentAcceptedMediaType = 'image' | 'pdf' | 'file'
-type AiAgentDataOperation = 'read' | 'search' | 'aggregate'
-
-interface AiAgentPageContextInput {
-  entityType: string
-  recordId: string
-  container: AwilixContainer
-  tenantId: string | null
-  organizationId: string | null
-}
-
-interface AiAgentDataCapabilities {
-  entities?: string[]
-  operations?: AiAgentDataOperation[]
-  searchableFields?: string[]
-}
-
-interface AiAgentDefinition {
-  id: string
-  moduleId: string
-  label: string
-  description: string
-  systemPrompt: string
-  allowedTools: string[]
-  executionMode?: AiAgentExecutionMode
-  defaultProvider?: string
-  defaultModel?: string
-  defaultBaseUrl?: string
-  acceptedMediaTypes?: AiAgentAcceptedMediaType[]
-  requiredFeatures?: string[]
-  uiParts?: string[]
-  readOnly?: boolean
-  mutationPolicy?: AiAgentMutationPolicy
-  maxSteps?: number
-  output?: unknown
-  resolvePageContext?: (ctx: AiAgentPageContextInput) => Promise<string | null>
-  keywords?: string[]
-  domain?: string
-  dataCapabilities?: AiAgentDataCapabilities
-}
 
 type PromptSectionName =
   | 'role'

--- a/packages/core/src/modules/customers/ai-agents.ts
+++ b/packages/core/src/modules/customers/ai-agents.ts
@@ -20,61 +20,12 @@
  * the structured template is additionally exported so downstream Phases
  * (5.3 prompt-override merge, 5.2 resolvePageContext hydration) can
  * address sections by name.
- *
- * Local type declarations mirror the public shapes from
- * `@open-mercato/ai-assistant`. The customers module does not depend on
- * `@open-mercato/ai-assistant` (see the companion comment in
- * `ai-tools/types.ts`) — the generator imports this file via the app's
- * bundler, so the runtime graph resolves through
- * `apps/mercato/.mercato/generated/ai-agents.generated.ts`. Keeping the
- * type declarations local mirrors how the `customers/ai-tools/types.ts`
- * handles `AiToolDefinition`.
  */
-import type { AwilixContainer } from 'awilix'
+import type {
+  AiAgentDefinition,
+  AiAgentPageContextInput,
+} from '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-agent-definition'
 import { hydrateCustomersAccountContext } from './ai-agents-context'
-
-type AiAgentExecutionMode = 'chat' | 'object'
-type AiAgentMutationPolicy = 'read-only' | 'confirm-required' | 'destructive-confirm-required'
-type AiAgentAcceptedMediaType = 'image' | 'pdf' | 'file'
-type AiAgentDataOperation = 'read' | 'search' | 'aggregate'
-
-interface AiAgentPageContextInput {
-  entityType: string
-  recordId: string
-  container: AwilixContainer
-  tenantId: string | null
-  organizationId: string | null
-}
-
-interface AiAgentDataCapabilities {
-  entities?: string[]
-  operations?: AiAgentDataOperation[]
-  searchableFields?: string[]
-}
-
-interface AiAgentDefinition {
-  id: string
-  moduleId: string
-  label: string
-  description: string
-  systemPrompt: string
-  allowedTools: string[]
-  executionMode?: AiAgentExecutionMode
-  defaultProvider?: string
-  defaultModel?: string
-  defaultBaseUrl?: string
-  acceptedMediaTypes?: AiAgentAcceptedMediaType[]
-  requiredFeatures?: string[]
-  uiParts?: string[]
-  readOnly?: boolean
-  mutationPolicy?: AiAgentMutationPolicy
-  maxSteps?: number
-  output?: unknown
-  resolvePageContext?: (ctx: AiAgentPageContextInput) => Promise<string | null>
-  keywords?: string[]
-  domain?: string
-  dataCapabilities?: AiAgentDataCapabilities
-}
 
 type PromptSectionName =
   | 'role'

--- a/packages/core/src/modules/inbox_ops/lib/llmProvider.ts
+++ b/packages/core/src/modules/inbox_ops/lib/llmProvider.ts
@@ -158,6 +158,15 @@ export async function runExtractionWithConfiguredProvider(input: {
     model = factoryResolution.model
     modelWithProvider = `${factoryResolution.providerId}/${factoryResolution.modelId}`
   } else {
+    // BC: Legacy OPENCODE_PROVIDER / OPENCODE_MODEL path. This branch only
+    // runs when createModelFactory throws AiModelFactoryError('no_provider_configured'),
+    // meaning none of the new-style provider env vars (ANTHROPIC_API_KEY,
+    // OPENAI_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, AI_DEFAULT_PROVIDER, …) is
+    // set. The OPENCODE_* envs are deliberately NOT aliased to AI_DEFAULT_PROVIDER
+    // because they are scoped to the OpenCode Code Mode stack (spec
+    // 2026-04-27-ai-agents-provider-model-baseurl-overrides, R1 mitigation).
+    // Keeping this fallback alive preserves backward compatibility for existing
+    // inbox_ops deployments that have not yet migrated to the new env vars.
     const providerId = resolveExtractionProviderId()
     const apiKey = requireOpenCodeProviderApiKey(providerId)
     const modelConfig = resolveOpenCodeModel(providerId, {


### PR DESCRIPTION
**Stacked on #1860 → #1858 → #1856.** Merge those first.

## Goal
Phase 3 of [`2026-04-27-ai-agents-provider-model-baseurl-overrides`](.ai/specs/2026-04-27-ai-agents-provider-model-baseurl-overrides.md) — pure refactor; collapse the three model-resolution call sites onto `createModelFactory` so all of them share one rule.

## What Changed
- `agent-runtime.resolveAgentModel` now delegates entirely to `createModelFactory(container).resolveModel({ ... })`. Inline duplicate deleted.
- `api/route/route.ts` no-config fallback simplified — the factory already honors `AI_DEFAULT_PROVIDER` + the entire chain, so the manual order seed Phase 0 introduced is gone (single source of truth).
- `inbox_ops/lib/llmProvider.ts`: factory becomes the primary path; legacy `OPENCODE_PROVIDER` / `OPENCODE_MODEL` envs move to the bottom of the chain (BC for inbox_ops customers who set them years ago). Doc-comment explains R1 mitigation: still NOT aliased to `AI_DEFAULT_PROVIDER`.
- Local `AiAgentDefinition` type duplicates in `customers/ai-agents.ts` and `catalog/ai-agents.ts` removed (52 lines deleted) — both modules now import from `@open-mercato/ai-assistant`.
- AGENTS.md: removed the "Step 5.2+ migration" follow-up note (now done); added 2026-05-08 changelog entry.

## Bug fix surfaced by the migration
The inline `resolveAgentModel` fallback path was silently ignoring `agentDefaultProvider`, `providerOverride`, and `AI_DEFAULT_PROVIDER` when the caller didn't pass a DI container. After this PR, the factory respects them on every path. **Behavior change for callers that previously relied on the fallback's quirk** — but those callers were already buggy (the override was being silently dropped). Reviewers SHOULD verify by grepping `git log --all --grep "resolveAgentModel"` for any callers that depended on the bug.

## Tests
- `yarn jest --testPathPatterns="agent-runtime\|model-factory\|inbox.?ops\|chat-config\|route"` → 86/86 pass.
- `yarn typecheck` → clean (only pre-existing MikroORM worktree path noise).

## Backward Compatibility
Pure refactor of internal call sites. No public function signatures changed; no event ids, ACL features, API routes, or DI keys touched. The single behavioral change is the bug fix above.

## Risks honored
- **R1 (HIGH)** — the OPENCODE_PROVIDER ↔ AI_DEFAULT_PROVIDER non-aliasing rule is reinforced by the doc-comment in inbox_ops/lib/llmProvider.ts.

## Stacking
- Base branch: `feat/ai-agents-phase-1780-2` (PR #1860).
- Next: Phase 1780-4a (new `ai_agent_runtime_overrides` entity + migration + dispatcher query params + settings PUT/DELETE + AI_RUNTIME_BASEURL_ALLOWLIST). Heaviest phase yet.