### PR TITLE
feat(ai-assistant): agentic loop config + per-call overrides + native SDK callback (Phase 1782-0..2, stacked on #1865)

### DIFF
--- a/apps/docs/docs/framework/ai-assistant/agents.mdx
+++ b/apps/docs/docs/framework/ai-assistant/agents.mdx
@@ -344,40 +344,67 @@ When you want most of the wrapper's guarantees but need to reach into the raw AI
 - builds the tool map from `allowedTools`,
 - composes the system prompt (including `resolvePageContext`),
 - routes any mutation tool calls through `prepareMutation` + the approval contract,
+- composes the effective loop config from the agent's declaration, per-call overrides, and wrapper defaults,
 
-and then hands the fully prepared options object to your callback so you can call `generateText` / `streamText` (text runtime) or `generateObject` / `streamObject` (object runtime) directly. The streaming variants (`streamText` / `streamObject`) are reached from inside the same callback — the name describes which runtime family you are overriding, not which exact AI SDK function you must call.
+and then hands the fully prepared options bag (`PreparedAiSdkOptions`) to your callback so you can call `generateText` / `streamText` (text runtime) or `generateObject` / `streamObject` (object runtime) directly. The streaming variants (`streamText` / `streamObject`) are reached from inside the same callback — the name describes which runtime family you are overriding, not which exact AI SDK function you must call.
 
 ```ts
 import { runAiAgentText } from '@open-mercato/ai-assistant'
-import { generateText } from 'ai'
+import { streamText } from 'ai'
 
-const result = await runAiAgentText({
+const response = await runAiAgentText({
   agentId: 'customers.account_assistant',
   container,
   authContext,
-  prompt: 'Summarize this account',
-  generateText: async ({ model, tools, system, messages, maxSteps }) => {
-    return generateText({
+  messages,
+  generateText: async ({
+    model, tools, system, messages,
+    // loop primitives — see MUST rules below before omitting any
+    stopWhen,
+    prepareStep,
+    onStepFinish,
+    onStepStart,
+    onToolCallStart,
+    onToolCallFinish,
+    experimental_repairToolCall,
+    activeTools,
+    toolChoice,
+    abortSignal,
+  }) => {
+    return streamText({
       model,
       tools,
       system,
       messages,
-      maxSteps,
+      stopWhen,
+      prepareStep,
+      onStepFinish,
+      onStepStart,
+      experimental_onToolCallStart: onToolCallStart,
+      experimental_onToolCallFinish: onToolCallFinish,
+      experimental_repairToolCall,
+      ...(activeTools !== undefined ? { activeTools } : {}),
+      ...(toolChoice !== undefined ? { toolChoice } : {}),
+      abortSignal,
       experimental_telemetry: { isEnabled: true, functionId: 'customers.account_assistant' },
       providerOptions: {
         anthropic: { cacheControl: { type: 'ephemeral' } },
       },
-      onStepFinish: (step) => { /* custom logging */ },
     })
   },
 })
 ```
 
-The matching hook on `runAiAgentObject` is named `generateObject` and additionally receives the resolved `output.schema` so the callback can call `generateObject` / `streamObject` directly.
+The matching hook on `runAiAgentObject` is named `generateObject` and additionally receives the resolved `output.schema` and the object-mode subset of loop primitives (`maxSteps`, `onStepFinish`, `onStepStart`, `abortSignal`).
+
+**MUST rules — security-critical fields you MUST NOT drop:**
+
+- `prepareStep` — **SECURITY-CRITICAL.** The wrapper-owned `PrepareStepFunction` re-asserts the tool allowlist and mutation-approval wrapping on every step. Dropping it means mutation tools are no longer routed through `prepareMutation` on steps 2+; the approval contract no longer applies. Never omit `prepareStep` unless you are deliberately removing mutation-approval guardrails for that call (and understand the consequences).
+- `stopWhen` — dropping this removes the agent's loop policy and the R3 step-count fallback, turning the call into a single model invocation that never executes tool calls.
+- `tools`, `system`, `messages` — dropping any of these bypasses the corresponding guardrail (tool allowlist, prompt composition, message history).
 
 **What you still lose with the `generateText` / `generateObject` callbacks:**
 
-- If your callback ignores the supplied `tools` / `system` / `messages` arguments, you also bypass tool whitelisting, prompt composition, and mutation approvals — only the model factory and feature gate remain. Treat the supplied arguments as required inputs unless you know exactly which guardrail you are dropping.
 - Custom transports (e.g. swapping the HTTP client) move you outside the model factory's provider routing; per-tenant API key overrides set in settings will not apply.
 - UI streaming parts (`AiUiPart` tags consumed by `<AiChat>`) are produced by the default runtime path; if your callback returns a stream that does not emit those parts, the embedded chat UI degrades to plain text.
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-loop-phase0.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-loop-phase0.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Phase 0 unit tests for the agentic loop control surface.
+ *
+ * Covers:
+ * - resolveEffectiveLoopConfig — precedence chain (caller > agent.loop > legacyMaxSteps > wrapper default)
+ * - translateStopConditions — mapping of AiAgentLoopStopCondition to SDK helpers + hard stepCountIs fallback
+ * - mergeStepOverrides — security-critical tool-allowlist enforcement
+ * - assertLoopObjectModeCompatible — object-mode field rejection
+ *
+ * Phase 0 of spec 2026-04-28-ai-agents-agentic-loop-controls.
+ */
+
+const stepCountIsMock = jest.fn((count: number) => ({ __kind: 'stepCount', count }))
+const hasToolCallMock = jest.fn((name: string) => ({ __kind: 'hasToolCall', name }))
+
+jest.mock('ai', () => {
+  const actual = jest.requireActual('ai')
+  return {
+    ...actual,
+    stepCountIs: (count: number) => stepCountIsMock(count),
+    hasToolCall: (name: string) => hasToolCallMock(name),
+  }
+})
+
+import type { AiAgentDefinition } from '../ai-agent-definition'
+import type { PrepareStepResult, ToolSet } from 'ai'
+import {
+  resolveEffectiveLoopConfig,
+  translateStopConditions,
+  mergeStepOverrides,
+  assertLoopObjectModeCompatible,
+} from '../agent-runtime'
+import { AgentPolicyError } from '../agent-tools'
+
+function makeAgent(
+  overrides: Partial<AiAgentDefinition> & Pick<AiAgentDefinition, 'id' | 'moduleId'>,
+): AiAgentDefinition {
+  return {
+    label: `${overrides.id} label`,
+    description: `${overrides.id} description`,
+    systemPrompt: 'System prompt.',
+    allowedTools: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveEffectiveLoopConfig
+// ---------------------------------------------------------------------------
+
+describe('resolveEffectiveLoopConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns wrapper default when agent has no loop config and no caller override', () => {
+    const agent = makeAgent({ id: 'mod.agent', moduleId: 'mod' })
+    const result = resolveEffectiveLoopConfig(agent, undefined, { maxSteps: 10 })
+    expect(result.maxSteps).toBe(10)
+  })
+
+  it('uses legacy agent.maxSteps when agent.loop is absent', () => {
+    const agent = makeAgent({ id: 'mod.agent', moduleId: 'mod', maxSteps: 5 })
+    const result = resolveEffectiveLoopConfig(agent, undefined, { maxSteps: 10 })
+    expect(result.maxSteps).toBe(5)
+  })
+
+  it('agent.loop wins over legacy maxSteps when both are present', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      maxSteps: 5,
+      loop: { maxSteps: 8 },
+    })
+    const result = resolveEffectiveLoopConfig(agent, undefined, { maxSteps: 10 })
+    expect(result.maxSteps).toBe(8)
+  })
+
+  it('caller loop override wins over agent.loop', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { maxSteps: 8 },
+    })
+    const result = resolveEffectiveLoopConfig(agent, { maxSteps: 3 }, { maxSteps: 10 })
+    expect(result.maxSteps).toBe(3)
+  })
+
+  it('caller loop preserves agent-level stopWhen when caller does not override it', () => {
+    const agentStop = { kind: 'hasToolCall' as const, toolName: 'mod.tool' }
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { stopWhen: agentStop },
+    })
+    const result = resolveEffectiveLoopConfig(agent, { maxSteps: 3 }, { maxSteps: 10 })
+    expect(result.stopWhen).toEqual(agentStop)
+    expect(result.maxSteps).toBe(3)
+  })
+
+  it('caller override replaces agent stopWhen when caller sets stopWhen', () => {
+    const agentStop = { kind: 'hasToolCall' as const, toolName: 'mod.tool' }
+    const callerStop = { kind: 'stepCount' as const, count: 2 }
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { stopWhen: agentStop },
+    })
+    const result = resolveEffectiveLoopConfig(agent, { stopWhen: callerStop }, { maxSteps: 10 })
+    expect(result.stopWhen).toEqual(callerStop)
+  })
+
+  it('legacy maxSteps is NOT applied when agent.loop is present (loop wins)', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      maxSteps: 99,
+      loop: { maxSteps: 7 },
+    })
+    const result = resolveEffectiveLoopConfig(agent)
+    expect(result.maxSteps).toBe(7)
+  })
+
+  it('returns wrapper default maxSteps when no source provides maxSteps', () => {
+    const agent = makeAgent({ id: 'mod.agent', moduleId: 'mod' })
+    const result = resolveEffectiveLoopConfig(agent, undefined, { maxSteps: 10 })
+    expect(result.maxSteps).toBe(10)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// translateStopConditions
+// ---------------------------------------------------------------------------
+
+describe('translateStopConditions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('always includes stepCountIs(maxSteps) as the final element', () => {
+    const result = translateStopConditions({ maxSteps: 5 })
+    expect(stepCountIsMock).toHaveBeenCalledWith(5)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({ __kind: 'stepCount', count: 5 })
+  })
+
+  it('defaults to maxSteps=10 when maxSteps is not set', () => {
+    translateStopConditions({})
+    expect(stepCountIsMock).toHaveBeenCalledWith(10)
+  })
+
+  it('maps kind:stepCount to stepCountIs', () => {
+    const result = translateStopConditions({
+      maxSteps: 10,
+      stopWhen: { kind: 'stepCount', count: 3 },
+    })
+    expect(stepCountIsMock).toHaveBeenCalledWith(3)
+    expect(result).toHaveLength(2)
+  })
+
+  it('maps kind:hasToolCall to hasToolCall', () => {
+    const result = translateStopConditions({
+      maxSteps: 10,
+      stopWhen: { kind: 'hasToolCall', toolName: 'mod.update' },
+    })
+    expect(hasToolCallMock).toHaveBeenCalledWith('mod.update')
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({ __kind: 'hasToolCall', name: 'mod.update' })
+    expect(result[1]).toEqual({ __kind: 'stepCount', count: 10 })
+  })
+
+  it('passes kind:custom predicates through as-is', () => {
+    const customStop = jest.fn(() => false) as unknown as import('ai').StopCondition<Record<string, unknown>>
+    const result = translateStopConditions({
+      maxSteps: 10,
+      stopWhen: { kind: 'custom', stop: customStop },
+    })
+    expect(result[0]).toBe(customStop)
+    expect(result).toHaveLength(2)
+  })
+
+  it('handles an array of stopWhen conditions', () => {
+    const result = translateStopConditions({
+      maxSteps: 4,
+      stopWhen: [
+        { kind: 'hasToolCall', toolName: 'mod.a' },
+        { kind: 'hasToolCall', toolName: 'mod.b' },
+      ],
+    })
+    expect(hasToolCallMock).toHaveBeenCalledWith('mod.a')
+    expect(hasToolCallMock).toHaveBeenCalledWith('mod.b')
+    expect(result).toHaveLength(3)
+    expect(result[2]).toEqual({ __kind: 'stepCount', count: 4 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeStepOverrides
+// ---------------------------------------------------------------------------
+
+describe('mergeStepOverrides', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const agent = makeAgent({
+    id: 'mod.agent',
+    moduleId: 'mod',
+    allowedTools: ['mod.read', 'mod.write'],
+  })
+
+  const wrappedRead = { execute: jest.fn(), description: 'read tool' }
+  const wrappedWrite = { execute: jest.fn(), description: 'write tool', isMutation: true }
+  const wrappedRegistry = {
+    mod__read: wrappedRead,
+    mod__write: wrappedWrite,
+  }
+
+  it('returns wrapperOverride unchanged when userOverride is null', () => {
+    const wrapper: PrepareStepResult<ToolSet> = { activeTools: ['mod__read'] }
+    expect(mergeStepOverrides(wrapper, null, agent, wrappedRegistry)).toBe(wrapper)
+  })
+
+  it('returns wrapperOverride unchanged when userOverride is undefined', () => {
+    const wrapper: PrepareStepResult<ToolSet> = { activeTools: ['mod__read'] }
+    expect(mergeStepOverrides(wrapper, undefined, agent, wrappedRegistry)).toBe(wrapper)
+  })
+
+  it('merges model from userOverride', () => {
+    const fakeModel = { id: 'gpt-5-mini' } as unknown as import('ai').LanguageModel
+    const result = mergeStepOverrides({}, { model: fakeModel }, agent, wrappedRegistry)
+    expect(result.model).toBe(fakeModel)
+  })
+
+  it('merges toolChoice from userOverride', () => {
+    const result = mergeStepOverrides({}, { toolChoice: 'none' }, agent, wrappedRegistry)
+    expect(result.toolChoice).toBe('none')
+  })
+
+  it('filters user activeTools to only those in agent.allowedTools (dotted names)', () => {
+    const result = mergeStepOverrides(
+      {},
+      { activeTools: ['mod.read', 'mod.write', 'outside.tool'] },
+      agent,
+      wrappedRegistry,
+    )
+    expect(result.activeTools).toEqual(['mod.read', 'mod.write'])
+  })
+
+  it('replaces user tools with wrapped counterparts from wrappedRegistry', () => {
+    const rawHandler = { execute: jest.fn() }
+    const result = mergeStepOverrides(
+      {},
+      { tools: { mod__read: rawHandler } as unknown as PrepareStepResult<ToolSet>['tools'] },
+      agent,
+      wrappedRegistry,
+    )
+    expect((result.tools as Record<string, unknown>)['mod__read']).toBe(wrappedRead)
+  })
+
+  it('drops user tools not present in wrappedRegistry with a warning', () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const rawHandler = { execute: jest.fn() }
+    const result = mergeStepOverrides(
+      {},
+      { tools: { unknown__tool: rawHandler } as unknown as PrepareStepResult<ToolSet>['tools'] },
+      agent,
+      wrappedRegistry,
+    )
+    expect((result.tools as Record<string, unknown>)['unknown__tool']).toBeUndefined()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('unknown__tool'),
+    )
+    consoleSpy.mockRestore()
+  })
+
+  it('throws loop_violates_mutation_policy when user returns raw mutation handler', () => {
+    const { toolRegistry: registry } = jest.requireActual('../tool-registry') as {
+      toolRegistry: { getTool: (name: string) => unknown }
+    }
+    jest.spyOn(registry, 'getTool').mockImplementation((name: string) => {
+      if (name === 'mod.write') return { isMutation: true }
+      return undefined
+    })
+
+    const rawMutationHandler = { execute: jest.fn() }
+    expect(() =>
+      mergeStepOverrides(
+        {},
+        { tools: { mod__write: rawMutationHandler } as unknown as PrepareStepResult<ToolSet>['tools'] },
+        agent,
+        wrappedRegistry,
+      ),
+    ).toThrow(AgentPolicyError)
+
+    jest.restoreAllMocks()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assertLoopObjectModeCompatible
+// ---------------------------------------------------------------------------
+
+describe('assertLoopObjectModeCompatible', () => {
+  it('does not throw for object-safe loop fields', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({
+        maxSteps: 5,
+        budget: { maxTokens: 50000 },
+        onStepFinish: jest.fn(),
+        onStepStart: jest.fn(),
+        allowRuntimeOverride: true,
+      }),
+    ).not.toThrow()
+  })
+
+  it('throws loop_unsupported_in_object_mode for prepareStep', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ prepareStep: jest.fn() }),
+    ).toThrow(AgentPolicyError)
+    try {
+      assertLoopObjectModeCompatible({ prepareStep: jest.fn() })
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_unsupported_in_object_mode')
+    }
+  })
+
+  it('throws for repairToolCall', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ repairToolCall: jest.fn() }),
+    ).toThrow(AgentPolicyError)
+  })
+
+  it('throws for stopWhen', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ stopWhen: { kind: 'stepCount', count: 3 } }),
+    ).toThrow(AgentPolicyError)
+  })
+
+  it('throws for activeTools', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ activeTools: ['mod.read'] }),
+    ).toThrow(AgentPolicyError)
+  })
+
+  it('throws for toolChoice', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ toolChoice: 'none' }),
+    ).toThrow(AgentPolicyError)
+  })
+
+  it('mentions all unsupported fields in the error message', () => {
+    try {
+      assertLoopObjectModeCompatible({ prepareStep: jest.fn(), stopWhen: { kind: 'stepCount', count: 2 } })
+    } catch (error) {
+      expect((error as Error).message).toContain('prepareStep')
+      expect((error as Error).message).toContain('stopWhen')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ai-agent-definition legacy maxSteps and loop field acceptance
+// ---------------------------------------------------------------------------
+
+describe('defineAiAgent loop field acceptance (Phase 0 BC)', () => {
+  it('legacy maxSteps is still accepted on AiAgentDefinition', () => {
+    const agent = makeAgent({ id: 'mod.agent', moduleId: 'mod', maxSteps: 5 })
+    expect(agent.maxSteps).toBe(5)
+  })
+
+  it('loop field is accepted on AiAgentDefinition', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { maxSteps: 7, stopWhen: { kind: 'hasToolCall', toolName: 'mod.update' } },
+    })
+    expect(agent.loop?.maxSteps).toBe(7)
+    const stopWhen = agent.loop?.stopWhen
+    expect(stopWhen).toEqual({ kind: 'hasToolCall', toolName: 'mod.update' })
+  })
+
+  it('loop and maxSteps can coexist (loop wins in resolveEffectiveLoopConfig)', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      maxSteps: 99,
+      loop: { maxSteps: 4 },
+    })
+    const result = resolveEffectiveLoopConfig(agent)
+    expect(result.maxSteps).toBe(4)
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-loop-phase1.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-loop-phase1.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Phase 1 unit tests for per-call loop overrides on runAiAgentText /
+ * runAiAgentObject.
+ *
+ * Covers:
+ * - Caller override is accepted when allowRuntimeOverride is true (default).
+ * - AgentPolicyError loop_runtime_override_disabled when agent opts out.
+ * - Object-mode loop subset: chat-only fields throw loop_unsupported_in_object_mode.
+ * - resolveEffectiveLoopConfig caller precedence with gating.
+ *
+ * Phase 1 of spec 2026-04-28-ai-agents-agentic-loop-controls.
+ */
+
+const stepCountIsMock = jest.fn((count: number) => ({ __kind: 'stepCount', count }))
+
+jest.mock('ai', () => {
+  const actual = jest.requireActual('ai')
+  return {
+    ...actual,
+    stepCountIs: (count: number) => stepCountIsMock(count),
+  }
+})
+
+import type { AiAgentDefinition, AiAgentLoopConfig } from '../ai-agent-definition'
+import {
+  resolveEffectiveLoopConfig,
+  assertLoopObjectModeCompatible,
+} from '../agent-runtime'
+import { AgentPolicyError } from '../agent-tools'
+
+function makeAgent(
+  overrides: Partial<AiAgentDefinition> & Pick<AiAgentDefinition, 'id' | 'moduleId'>,
+): AiAgentDefinition {
+  return {
+    label: `${overrides.id} label`,
+    description: `${overrides.id} description`,
+    systemPrompt: 'System prompt.',
+    allowedTools: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-call loop override gating
+// ---------------------------------------------------------------------------
+
+describe('Phase 1: caller loop override gating (loop_runtime_override_disabled)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('accepts per-call loop override when agent has no allowRuntimeOverride set (default true)', () => {
+    const agent = makeAgent({ id: 'mod.agent', moduleId: 'mod' })
+    expect(() =>
+      resolveEffectiveLoopConfig(agent, { maxSteps: 3 }),
+    ).not.toThrow()
+  })
+
+  it('accepts per-call loop override when agent explicitly sets allowRuntimeOverride: true', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { allowRuntimeOverride: true, maxSteps: 8 },
+    })
+    expect(() =>
+      resolveEffectiveLoopConfig(agent, { maxSteps: 3 }),
+    ).not.toThrow()
+    const result = resolveEffectiveLoopConfig(agent, { maxSteps: 3 })
+    expect(result.maxSteps).toBe(3)
+  })
+
+  it('throws loop_runtime_override_disabled when agent sets allowRuntimeOverride: false', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { allowRuntimeOverride: false, maxSteps: 8 },
+    })
+    expect(() =>
+      resolveEffectiveLoopConfig(agent, { maxSteps: 3 }),
+    ).toThrow(AgentPolicyError)
+
+    try {
+      resolveEffectiveLoopConfig(agent, { maxSteps: 3 })
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_runtime_override_disabled')
+      expect((error as AgentPolicyError).message).toContain('mod.agent')
+    }
+  })
+
+  it('does NOT throw when allowRuntimeOverride: false but no caller loop is supplied', () => {
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { allowRuntimeOverride: false, maxSteps: 8 },
+    })
+    expect(() =>
+      resolveEffectiveLoopConfig(agent, undefined),
+    ).not.toThrow()
+    const result = resolveEffectiveLoopConfig(agent, undefined)
+    expect(result.maxSteps).toBe(8)
+  })
+
+  it('caller loop fields override agent loop fields selectively', () => {
+    const agentStop = { kind: 'hasToolCall' as const, toolName: 'mod.update' }
+    const agent = makeAgent({
+      id: 'mod.agent',
+      moduleId: 'mod',
+      loop: { maxSteps: 8, stopWhen: agentStop },
+    })
+    const result = resolveEffectiveLoopConfig(agent, { maxSteps: 3 })
+    expect(result.maxSteps).toBe(3)
+    expect(result.stopWhen).toEqual(agentStop)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Object-mode loop subset
+// ---------------------------------------------------------------------------
+
+describe('Phase 1: object-mode loop subset enforcement', () => {
+  it('accepts maxSteps in object mode', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ maxSteps: 3 }),
+    ).not.toThrow()
+  })
+
+  it('accepts budget in object mode', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ budget: { maxTokens: 50000 } }),
+    ).not.toThrow()
+  })
+
+  it('accepts onStepFinish in object mode', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ onStepFinish: jest.fn() }),
+    ).not.toThrow()
+  })
+
+  it('accepts onStepStart in object mode', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ onStepStart: jest.fn() }),
+    ).not.toThrow()
+  })
+
+  it('accepts allowRuntimeOverride in object mode', () => {
+    expect(() =>
+      assertLoopObjectModeCompatible({ allowRuntimeOverride: true }),
+    ).not.toThrow()
+  })
+
+  it('rejects prepareStep with loop_unsupported_in_object_mode', () => {
+    try {
+      assertLoopObjectModeCompatible({ prepareStep: jest.fn() })
+      fail('Expected AgentPolicyError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_unsupported_in_object_mode')
+    }
+  })
+
+  it('rejects stopWhen with loop_unsupported_in_object_mode', () => {
+    try {
+      assertLoopObjectModeCompatible({ stopWhen: { kind: 'stepCount', count: 2 } })
+      fail('Expected AgentPolicyError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_unsupported_in_object_mode')
+    }
+  })
+
+  it('rejects repairToolCall with loop_unsupported_in_object_mode', () => {
+    try {
+      assertLoopObjectModeCompatible({ repairToolCall: jest.fn() })
+      fail('Expected AgentPolicyError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_unsupported_in_object_mode')
+    }
+  })
+
+  it('rejects activeTools with loop_unsupported_in_object_mode', () => {
+    try {
+      assertLoopObjectModeCompatible({ activeTools: ['mod.read'] })
+      fail('Expected AgentPolicyError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_unsupported_in_object_mode')
+    }
+  })
+
+  it('rejects toolChoice with loop_unsupported_in_object_mode', () => {
+    try {
+      assertLoopObjectModeCompatible({ toolChoice: 'auto' })
+      fail('Expected AgentPolicyError')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentPolicyError)
+      expect((error as AgentPolicyError).code).toBe('loop_unsupported_in_object_mode')
+    }
+  })
+
+  it('lists all unsupported fields in the error message when multiple are set', () => {
+    try {
+      assertLoopObjectModeCompatible({
+        prepareStep: jest.fn(),
+        stopWhen: { kind: 'stepCount', count: 1 },
+        activeTools: ['mod.read'],
+      })
+      fail('Expected AgentPolicyError')
+    } catch (error) {
+      const message = (error as Error).message
+      expect(message).toContain('prepareStep')
+      expect(message).toContain('stopWhen')
+      expect(message).toContain('activeTools')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AgentPolicyDenyCode exhaustiveness check
+// ---------------------------------------------------------------------------
+
+describe('Phase 1: AgentPolicyDenyCode has loop override codes', () => {
+  it('AgentPolicyError can be constructed with loop_runtime_override_disabled', () => {
+    const error = new AgentPolicyError('loop_runtime_override_disabled', 'test')
+    expect(error.code).toBe('loop_runtime_override_disabled')
+  })
+
+  it('AgentPolicyError can be constructed with loop_unsupported_in_object_mode', () => {
+    const error = new AgentPolicyError('loop_unsupported_in_object_mode', 'test')
+    expect(error.code).toBe('loop_unsupported_in_object_mode')
+  })
+
+  it('AgentPolicyError can be constructed with loop_violates_mutation_policy', () => {
+    const error = new AgentPolicyError('loop_violates_mutation_policy', 'test')
+    expect(error.code).toBe('loop_violates_mutation_policy')
+  })
+
+  it('AgentPolicyError can be constructed with loop_active_tools_outside_allowlist', () => {
+    const error = new AgentPolicyError('loop_active_tools_outside_allowlist', 'test')
+    expect(error.code).toBe('loop_active_tools_outside_allowlist')
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-loop-phase2.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-loop-phase2.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Phase 2 unit tests for the native SDK callback contract on runAiAgentText /
+ * runAiAgentObject.
+ *
+ * Covers:
+ * - generateText callback receives a PreparedAiSdkOptions bag with all loop
+ *   primitives: stopWhen (array), prepareStep, onStepFinish, onStepStart,
+ *   onToolCallStart, onToolCallFinish, experimental_repairToolCall, activeTools,
+ *   toolChoice, abortSignal.
+ * - When the callback is absent, streamText is called directly with the same
+ *   prepared options.
+ * - generateObject callback receives PreparedAiSdkObjectOptions (object-mode
+ *   subset) and its result is forwarded correctly.
+ * - abortSignal is always an AbortSignal instance in the prepared bag.
+ * - Per-call loop fields (maxSteps, onStepFinish, stopWhen, etc.) are forwarded
+ *   to the prepared-options bag.
+ *
+ * Phase 2 of spec 2026-04-28-ai-agents-agentic-loop-controls.
+ */
+
+const streamTextMock = jest.fn()
+const generateObjectMock = jest.fn()
+const stepCountIsMock = jest.fn((count: number) => ({ __kind: 'stepCount', count }))
+const hasToolCallMock = jest.fn((name: string) => ({ __kind: 'hasToolCall', name }))
+const convertToModelMessagesMock = jest.fn((messages: unknown) => messages)
+
+jest.mock('ai', () => {
+  const actual = jest.requireActual('ai')
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    generateObject: (...args: unknown[]) => generateObjectMock(...args),
+    stepCountIs: (count: number) => stepCountIsMock(count),
+    hasToolCall: (name: string) => hasToolCallMock(name),
+    convertToModelMessages: (...args: unknown[]) => convertToModelMessagesMock(...args),
+  }
+})
+
+const createModelMock = jest.fn(
+  (options: { modelId: string; apiKey: string }) => ({ id: options.modelId, apiKey: options.apiKey }),
+)
+const resolveApiKeyMock = jest.fn(() => 'test-api-key')
+
+jest.mock('@open-mercato/shared/lib/ai/llm-provider-registry', () => ({
+  llmProviderRegistry: {
+    resolveFirstConfigured: () => ({
+      id: 'test-provider',
+      defaultModel: 'provider-default-model',
+      resolveApiKey: resolveApiKeyMock,
+      createModel: createModelMock,
+      isConfigured: () => true,
+    }),
+    get: () => null,
+  },
+}))
+
+import type { AiAgentDefinition, AiAgentLoopConfig } from '../ai-agent-definition'
+import type { PreparedAiSdkOptions, PreparedAiSdkObjectOptions } from '../agent-runtime'
+import {
+  resetAgentRegistryForTests,
+  seedAgentRegistryForTests,
+} from '../agent-registry'
+import { toolRegistry } from '../tool-registry'
+import { runAiAgentText, runAiAgentObject } from '../agent-runtime'
+
+function makeAgent(
+  overrides: Partial<AiAgentDefinition> & Pick<AiAgentDefinition, 'id' | 'moduleId'>,
+): AiAgentDefinition {
+  return {
+    label: `${overrides.id} label`,
+    description: `${overrides.id} description`,
+    systemPrompt: 'System prompt.',
+    allowedTools: [],
+    ...overrides,
+  }
+}
+
+const baseAuth = {
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+  userId: 'user-1',
+  features: ['*'],
+  isSuperAdmin: true,
+}
+
+const baseMessages = [
+  { role: 'user' as const, id: 'm1', parts: [{ type: 'text' as const, text: 'hi' }] },
+]
+
+function fakeStreamResult() {
+  return {
+    toUIMessageStreamResponse: jest.fn(
+      () =>
+        new Response('streamed', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+    ),
+  }
+}
+
+describe('Phase 2: generateText callback on runAiAgentText', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetAgentRegistryForTests()
+    toolRegistry.clear()
+    streamTextMock.mockImplementation(() => fakeStreamResult())
+  })
+
+  afterAll(() => {
+    resetAgentRegistryForTests()
+    toolRegistry.clear()
+  })
+
+  it('invokes the generateText callback with the full prepared-options bag', async () => {
+    seedAgentRegistryForTests([
+      makeAgent({
+        id: 'mod.agent',
+        moduleId: 'mod',
+        loop: { maxSteps: 6 },
+      }),
+    ])
+
+    const capturedOptions: PreparedAiSdkOptions[] = []
+    const fakeStream = fakeStreamResult()
+
+    await runAiAgentText({
+      agentId: 'mod.agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+      generateText: async (options) => {
+        capturedOptions.push(options)
+        return fakeStream as never
+      },
+    })
+
+    expect(capturedOptions).toHaveLength(1)
+    const opts = capturedOptions[0]
+    expect(opts.model).toBeDefined()
+    expect(opts.tools).toBeDefined()
+    expect(opts.system).toBe('System prompt.')
+    expect(opts.messages).toBeDefined()
+    expect(opts.maxSteps).toBe(6)
+    expect(Array.isArray(opts.stopWhen)).toBe(true)
+    expect(opts.stopWhen.length).toBeGreaterThanOrEqual(1)
+    expect(typeof opts.prepareStep).toBe('function')
+    expect(opts.abortSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('does NOT call streamText when generateText callback is supplied', async () => {
+    seedAgentRegistryForTests([
+      makeAgent({ id: 'mod.agent', moduleId: 'mod' }),
+    ])
+    const fakeStream = fakeStreamResult()
+
+    await runAiAgentText({
+      agentId: 'mod.agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+      generateText: async () => fakeStream as never,
+    })
+
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
+  it('calls streamText with prepared loop options when no callback is supplied', async () => {
+    seedAgentRegistryForTests([
+      makeAgent({
+        id: 'mod.agent',
+        moduleId: 'mod',
+        loop: { maxSteps: 4 },
+      }),
+    ])
+
+    await runAiAgentText({
+      agentId: 'mod.agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+    })
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+    const callArg = streamTextMock.mock.calls[0][0] as {
+      stopWhen: unknown[]
+      prepareStep: unknown
+      abortSignal: unknown
+    }
+    expect(Array.isArray(callArg.stopWhen)).toBe(true)
+    expect(callArg.stopWhen.length).toBeGreaterThanOrEqual(1)
+    expect(typeof callArg.prepareStep).toBe('function')
+    expect(callArg.abortSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('forwards per-call loop overrides into the prepared-options bag', async () => {
+    seedAgentRegistryForTests([
+      makeAgent({
+        id: 'mod.agent',
+        moduleId: 'mod',
+        loop: { maxSteps: 8 },
+      }),
+    ])
+
+    const capturedOptions: PreparedAiSdkOptions[] = []
+    const fakeStream = fakeStreamResult()
+    const callerOnStepFinish = jest.fn()
+
+    await runAiAgentText({
+      agentId: 'mod.agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+      loop: { maxSteps: 3, onStepFinish: callerOnStepFinish },
+      generateText: async (options) => {
+        capturedOptions.push(options)
+        return fakeStream as never
+      },
+    })
+
+    expect(capturedOptions[0].maxSteps).toBe(3)
+    expect(capturedOptions[0].onStepFinish).toBe(callerOnStepFinish)
+  })
+
+  it('stopWhen array always ends with stepCountIs(maxSteps)', async () => {
+    seedAgentRegistryForTests([
+      makeAgent({
+        id: 'mod.agent',
+        moduleId: 'mod',
+        loop: {
+          maxSteps: 5,
+          stopWhen: { kind: 'hasToolCall', toolName: 'mod.update' },
+        },
+      }),
+    ])
+
+    const capturedOptions: PreparedAiSdkOptions[] = []
+    const fakeStream = fakeStreamResult()
+
+    await runAiAgentText({
+      agentId: 'mod.agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+      generateText: async (options) => {
+        capturedOptions.push(options)
+        return fakeStream as never
+      },
+    })
+
+    const stopWhen = capturedOptions[0].stopWhen
+    expect(stopWhen).toHaveLength(2)
+    expect(stopWhen[0]).toEqual({ __kind: 'hasToolCall', name: 'mod.update' })
+    expect(stopWhen[1]).toEqual({ __kind: 'stepCount', count: 5 })
+  })
+
+  it('abortSignal is an AbortSignal in the prepared bag (Phases 0-2 pre-wire)', async () => {
+    seedAgentRegistryForTests([
+      makeAgent({ id: 'mod.agent', moduleId: 'mod' }),
+    ])
+
+    const capturedOptions: PreparedAiSdkOptions[] = []
+    const fakeStream = fakeStreamResult()
+
+    await runAiAgentText({
+      agentId: 'mod.agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+      generateText: async (options) => {
+        capturedOptions.push(options)
+        return fakeStream as never
+      },
+    })
+
+    expect(capturedOptions[0].abortSignal).toBeInstanceOf(AbortSignal)
+    expect(capturedOptions[0].abortSignal?.aborted).toBe(false)
+  })
+})
+
+describe('Phase 2: generateObject callback on runAiAgentObject', () => {
+  let z: typeof import('zod').z
+  const objSchema = { schemaName: 'Out', schema: null as unknown }
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    resetAgentRegistryForTests()
+    toolRegistry.clear()
+    generateObjectMock.mockResolvedValue({ object: { title: 'ok' } })
+    const zod = await import('zod')
+    z = zod.z
+    objSchema.schema = z.object({ title: z.string() })
+  })
+
+  afterAll(() => {
+    resetAgentRegistryForTests()
+    toolRegistry.clear()
+  })
+
+  function makeObjectAgent(loop?: AiAgentDefinition['loop']): AiAgentDefinition {
+    const { z: zInner } = require('zod')
+    return makeAgent({
+      id: 'mod.obj_agent',
+      moduleId: 'mod',
+      executionMode: 'object',
+      output: { schemaName: 'Out', schema: zInner.object({ title: zInner.string() }) },
+      ...(loop !== undefined ? { loop } : {}),
+    })
+  }
+
+  it('invokes the generateObject callback with PreparedAiSdkObjectOptions', async () => {
+    seedAgentRegistryForTests([makeObjectAgent({ maxSteps: 4 })])
+
+    const capturedOptions: PreparedAiSdkObjectOptions[] = []
+
+    await runAiAgentObject({
+      agentId: 'mod.obj_agent',
+      input: 'Generate something',
+      authContext: baseAuth,
+      output: {
+        schemaName: 'TestOutput',
+        schema: objSchema.schema,
+        mode: 'generate',
+      },
+      generateObject: async (options) => {
+        capturedOptions.push(options)
+        return { object: { title: 'result' } } as never
+      },
+    })
+
+    expect(capturedOptions).toHaveLength(1)
+    const opts = capturedOptions[0]
+    expect(opts.model).toBeDefined()
+    expect(opts.system).toBe('System prompt.')
+    expect(opts.messages).toBeDefined()
+    expect(opts.schemaName).toBe('TestOutput')
+    expect(opts.schema).toBeDefined()
+    expect(opts.maxSteps).toBe(4)
+    expect(opts.abortSignal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('does NOT call generateObject SDK function when callback is supplied', async () => {
+    seedAgentRegistryForTests([makeObjectAgent()])
+
+    await runAiAgentObject({
+      agentId: 'mod.obj_agent',
+      input: 'Generate',
+      authContext: baseAuth,
+      output: { schemaName: 'Out', schema: objSchema.schema },
+      generateObject: async () => ({ object: { title: 'ok' } } as never),
+    })
+
+    expect(generateObjectMock).not.toHaveBeenCalled()
+  })
+
+  it('returns generate result from the generateObject callback', async () => {
+    seedAgentRegistryForTests([makeObjectAgent()])
+
+    const result = await runAiAgentObject({
+      agentId: 'mod.obj_agent',
+      input: 'Generate',
+      authContext: baseAuth,
+      output: { schemaName: 'Out', schema: objSchema.schema },
+      generateObject: async () =>
+        ({ object: { title: 'found' }, finishReason: 'stop' } as never),
+    })
+
+    expect(result.mode).toBe('generate')
+    expect((result as { object: unknown }).object).toEqual({ title: 'found' })
+  })
+
+  it('calls generateObject SDK function when no callback is supplied', async () => {
+    seedAgentRegistryForTests([makeObjectAgent()])
+    generateObjectMock.mockResolvedValue({ object: { title: 'sdk' } })
+
+    await runAiAgentObject({
+      agentId: 'mod.obj_agent',
+      input: 'Generate',
+      authContext: baseAuth,
+      output: { schemaName: 'Out', schema: objSchema.schema },
+    })
+
+    expect(generateObjectMock).toHaveBeenCalledTimes(1)
+    const callArg = generateObjectMock.mock.calls[0][0] as {
+      abortSignal: unknown
+    }
+    expect(callArg.abortSignal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime.test.ts
@@ -187,7 +187,8 @@ describe('runAiAgentText', () => {
 
     expect(stepCountIsMock).toHaveBeenCalledWith(5)
     const callArg = streamTextMock.mock.calls[0][0] as { stopWhen: unknown }
-    expect(callArg.stopWhen).toEqual({ __stopWhen: 'stepCount', count: 5 })
+    // Phase 2: stopWhen is now always an array from translateStopConditions
+    expect(callArg.stopWhen).toEqual([{ __stopWhen: 'stepCount', count: 5 }])
   })
 
   it('lets modelOverride win over agent.defaultModel', async () => {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-policy.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-policy.ts
@@ -18,6 +18,15 @@ export type AgentPolicyDenyCode =
   | 'mutation_blocked_by_policy'
   | 'execution_mode_not_supported'
   | 'attachment_type_not_accepted'
+  // Loop policy codes — Phase 0 of spec 2026-04-28-ai-agents-agentic-loop-controls
+  /** Object-mode rejects loop primitives that the SDK ignores for generateObject. */
+  | 'loop_unsupported_in_object_mode'
+  /** User prepareStep returned a tools map with a raw (unwrapped) mutation handler. */
+  | 'loop_violates_mutation_policy'
+  /** loop.activeTools contained names outside agent.allowedTools (thrown for caller-supplied overrides; warning-only for agent-declared). */
+  | 'loop_active_tools_outside_allowlist'
+  /** agent.loop.allowRuntimeOverride is false and a per-call loop override was supplied. */
+  | 'loop_runtime_override_disabled'
 
 export type AgentPolicyDecision =
   | { ok: true; agent: AiAgentDefinition; tool?: AiToolDefinition }

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -5,10 +5,12 @@ import type { LanguageModel, UIMessage } from 'ai'
 import {
   convertToModelMessages,
   generateObject,
+  hasToolCall,
   stepCountIs,
   streamObject,
   streamText,
 } from 'ai'
+import type { StopCondition } from 'ai'
 import type { ZodTypeAny } from 'zod'
 import { createModelFactory } from './model-factory'
 import type {
@@ -167,6 +169,42 @@ export function resolveEffectiveLoopConfig(
     ...base,
     ...callerLoop,
   }
+}
+
+/**
+ * Translates serializable `AiAgentLoopStopCondition` items into the Vercel AI
+ * SDK `StopCondition` array ready to pass to `streamText` / `generateText`.
+ *
+ * The wrapper ALWAYS appends `stepCountIs(maxSteps ?? 10)` as the final item
+ * in the returned array (R3 mitigation). This guarantees that a misconfigured
+ * `hasToolCall` for a non-existent tool can never cause an infinite loop
+ * because the SDK treats `stopWhen` arrays with OR semantics — the step-count
+ * fallback will always trip eventually.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export function translateStopConditions(
+  loopConfig: AiAgentLoopConfig,
+): StopCondition<Record<string, unknown>>[] {
+  const effectiveMaxSteps = loopConfig.maxSteps ?? 10
+  const userConditions: StopCondition<Record<string, unknown>>[] = []
+
+  const rawStopWhen = loopConfig.stopWhen
+  if (rawStopWhen) {
+    const items = Array.isArray(rawStopWhen) ? rawStopWhen : [rawStopWhen]
+    for (const item of items) {
+      if (item.kind === 'stepCount') {
+        userConditions.push(stepCountIs(item.count))
+      } else if (item.kind === 'hasToolCall') {
+        userConditions.push(hasToolCall(item.toolName))
+      } else if (item.kind === 'custom') {
+        userConditions.push(item.stop as StopCondition<Record<string, unknown>>)
+      }
+    }
+  }
+
+  // Always append the hard step-count fallback (R3 mitigation).
+  return [...userConditions, stepCountIs(effectiveMaxSteps)]
 }
 
 interface ResolvedAgentModel {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -344,6 +344,38 @@ export function buildWrapperPrepareStep(
   }
 }
 
+/**
+ * Validates that a loop config does not set any primitives that are
+ * unsupported by the object-mode SDK path (`generateObject` / `streamObject`).
+ *
+ * Object mode accepts ONLY: `maxSteps`, `budget`, `onStepFinish`,
+ * `onStepStart`, `allowRuntimeOverride`. The remaining fields
+ * (`prepareStep`, `repairToolCall`, `stopWhen`, `activeTools`,
+ * `toolChoice`) are chat-only and will never reach `generateObject`.
+ *
+ * Throws `AgentPolicyError` code `loop_unsupported_in_object_mode` if any
+ * unsupported field is set. This provides an explicit, actionable error
+ * rather than a silent no-op.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export function assertLoopObjectModeCompatible(loopConfig: Partial<AiAgentLoopConfig>): void {
+  const unsupportedFields: string[] = []
+
+  if (loopConfig.prepareStep !== undefined) unsupportedFields.push('prepareStep')
+  if (loopConfig.repairToolCall !== undefined) unsupportedFields.push('repairToolCall')
+  if (loopConfig.stopWhen !== undefined) unsupportedFields.push('stopWhen')
+  if (loopConfig.activeTools !== undefined) unsupportedFields.push('activeTools')
+  if (loopConfig.toolChoice !== undefined) unsupportedFields.push('toolChoice')
+
+  if (unsupportedFields.length > 0) {
+    throw new AgentPolicyError(
+      'loop_unsupported_in_object_mode',
+      `Object-mode agents do not support these loop primitives: ${unsupportedFields.join(', ')}. Use runAiAgentText for agents that require these loop controls.`,
+    )
+  }
+}
+
 interface ResolvedAgentModel {
   model: LanguageModel
   modelId: string

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -1002,6 +1002,17 @@ export interface RunAiAgentObjectInput<TSchema = ZodTypeAny> {
   output?: RunAiAgentObjectOutputOverride<TSchema>
   debug?: boolean
   container?: AwilixContainer
+  /**
+   * Optional per-call loop config override for object mode. Only the
+   * object-safe subset is accepted: `maxSteps`, `budget`, `onStepFinish`,
+   * `onStepStart`, and `allowRuntimeOverride`. Providing any chat-only
+   * field (`prepareStep`, `repairToolCall`, `stopWhen`, `activeTools`,
+   * `toolChoice`) throws `AgentPolicyError` code
+   * `loop_unsupported_in_object_mode`.
+   *
+   * Phase 1 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+   */
+  loop?: Pick<AiAgentLoopConfig, 'maxSteps' | 'budget' | 'onStepFinish' | 'onStepStart' | 'allowRuntimeOverride'>
 }
 
 export type RunAiAgentObjectGenerateResult<TSchema> = {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -1103,9 +1103,7 @@ export async function runAiAgentObject<TSchema = unknown>(
     resolvedAttachments,
   )
   const modelMessages = await convertToModelMessages(hydratedMessages)
-  const stopWhen = typeof agent.maxSteps === 'number' && agent.maxSteps > 0
-    ? stepCountIs(agent.maxSteps)
-    : undefined
+  void tools
 
   if (resolvedOutput.mode === 'stream') {
     const streamArgs: Parameters<typeof streamObject>[0] = {
@@ -1139,15 +1137,6 @@ export async function runAiAgentObject<TSchema = unknown>(
     schema: resolvedOutput.schema as never,
     schemaName: resolvedOutput.schemaName,
   }
-  if (stopWhen) {
-    // generateObject shares `CallSettings` with generateText; stopWhen is ignored
-    // by the typed surface but harmless for providers that respect it. Tools
-    // flow through the system prompt only in object mode today — the whitelist
-    // has already been resolved via `resolveAiAgentTools` above, even if we
-    // don't hand it to generateObject.
-    ;(generateArgs as Record<string, unknown>).stopWhen = stopWhen
-  }
-  void tools
 
   const result = await generateObject(generateArgs)
   return {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -119,6 +119,17 @@ export interface RunAiAgentTextInput {
    * per-tenant/org uniqueness within the TTL window.
    */
   conversationId?: string | null
+  /**
+   * Optional per-call loop config override. Fields set here win over the
+   * agent's `loop` declaration and the tenant DB override. The override is
+   * gated by `agent.loop?.allowRuntimeOverride ?? true` — agents that pin
+   * a loop policy for correctness reasons can set `allowRuntimeOverride: false`
+   * to reject any per-call override with `AgentPolicyError` code
+   * `loop_runtime_override_disabled`.
+   *
+   * Phase 1 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+   */
+  loop?: Partial<AiAgentLoopConfig>
 }
 
 /**
@@ -129,6 +140,29 @@ export interface RunAiAgentTextInput {
  */
 const WRAPPER_DEFAULT_LOOP_CHAT: AiAgentLoopConfig = { maxSteps: 10 }
 const WRAPPER_DEFAULT_LOOP_OBJECT: AiAgentLoopConfig = {}
+
+/**
+ * Guards the per-call loop override against agents that have opted out of
+ * runtime overrides by setting `loop.allowRuntimeOverride: false`.
+ *
+ * Throws `AgentPolicyError` with code `loop_runtime_override_disabled` when
+ * the agent has opted out and a caller override was supplied.
+ *
+ * Phase 1 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+function assertLoopRuntimeOverrideAllowed(
+  agent: AiAgentDefinition,
+  callerLoop: Partial<AiAgentLoopConfig> | undefined,
+): void {
+  if (!callerLoop) return
+  const allowed = agent.loop?.allowRuntimeOverride ?? true
+  if (!allowed) {
+    throw new AgentPolicyError(
+      'loop_runtime_override_disabled',
+      `Agent "${agent.id}" has disabled per-call loop overrides (loop.allowRuntimeOverride: false). Remove the loop override to proceed.`,
+    )
+  }
+}
 
 /**
  * Resolves the effective loop config for a turn by walking the precedence
@@ -145,13 +179,18 @@ const WRAPPER_DEFAULT_LOOP_OBJECT: AiAgentLoopConfig = {}
  * a higher-priority source fall through to a lower-priority one. The merge is
  * performed left-to-right with higher-priority sources winning field-by-field.
  *
- * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ * Throws `AgentPolicyError` code `loop_runtime_override_disabled` when the
+ * agent opts out of per-call overrides and a caller loop was supplied.
+ *
+ * Phase 0 + Phase 1 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
  */
 export function resolveEffectiveLoopConfig(
   agent: AiAgentDefinition,
   callerLoop?: Partial<AiAgentLoopConfig> | undefined,
   wrapperDefault?: AiAgentLoopConfig,
 ): AiAgentLoopConfig {
+  assertLoopRuntimeOverrideAllowed(agent, callerLoop)
+
   const effectiveDefault = wrapperDefault ?? WRAPPER_DEFAULT_LOOP_CHAT
 
   // Build base from lowest-priority: wrapper default → legacy maxSteps → agent.loop

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -1,7 +1,13 @@
 import { createContainer } from 'awilix'
 import type { AwilixContainer } from 'awilix'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import type { LanguageModel, UIMessage } from 'ai'
+import type {
+  LanguageModel,
+  PrepareStepFunction,
+  PrepareStepResult,
+  ToolSet,
+  UIMessage,
+} from 'ai'
 import {
   convertToModelMessages,
   generateObject,
@@ -205,6 +211,137 @@ export function translateStopConditions(
 
   // Always append the hard step-count fallback (R3 mitigation).
   return [...userConditions, stepCountIs(effectiveMaxSteps)]
+}
+
+/**
+ * Security-critical merge of the wrapper-owned step override with the user's
+ * `prepareStep` return value.
+ *
+ * Guarantees (R1 mitigation — preserving the mutation-approval contract):
+ * 1. Any `tools` map returned by the user is intersected with `toolRegistry`
+ *    (the policy-gated, mutation-approval-wrapped map). If the user returned
+ *    a raw mutation handler, the merged map points at the wrapped one.
+ * 2. Any `activeTools` returned by the user is intersected with
+ *    `agent.allowedTools`. Out-of-set names are dropped with a single
+ *    `loop:active_tools_filtered` warning.
+ * 3. A user-returned `tools` map that contains a mutation tool pointing at the
+ *    raw handler (not the wrapped one) is rejected with
+ *    `AgentPolicyError` code `loop_violates_mutation_policy`.
+ * 4. Non-policy fields (`model`, `toolChoice`, `system`, `messages`) from the
+ *    user override are honored as-is.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export function mergeStepOverrides(
+  wrapperOverride: PrepareStepResult<ToolSet>,
+  userOverride: PrepareStepResult<ToolSet> | undefined | null,
+  agent: AiAgentDefinition,
+  wrappedToolRegistry: Record<string, unknown>,
+): PrepareStepResult<ToolSet> {
+  if (!userOverride) return wrapperOverride
+
+  const merged: PrepareStepResult<ToolSet> = { ...wrapperOverride }
+
+  if (userOverride.model !== undefined) {
+    merged.model = userOverride.model
+  }
+  if (userOverride.toolChoice !== undefined) {
+    merged.toolChoice = userOverride.toolChoice
+  }
+
+  if (userOverride.activeTools !== undefined) {
+    const filtered = userOverride.activeTools.filter((name) => {
+      const allowed = agent.allowedTools.includes(name)
+      if (!allowed) {
+        console.warn(
+          `[AI Agents] loop:active_tools_filtered — tool "${name}" is not in agent "${agent.id}" allowedTools; dropping from activeTools.`,
+        )
+      }
+      return allowed
+    })
+    merged.activeTools = filtered
+  }
+
+  if (userOverride.tools !== undefined) {
+    const userTools = userOverride.tools as Record<string, unknown>
+    const mergedTools: Record<string, unknown> = {}
+
+    for (const [toolKey, userHandler] of Object.entries(userTools)) {
+      const wrappedHandler = wrappedToolRegistry[toolKey]
+      if (!wrappedHandler) {
+        console.warn(
+          `[AI Agents] mergeStepOverrides — tool "${toolKey}" from user prepareStep is not in the wrapper tool registry; dropping.`,
+        )
+        continue
+      }
+      if (userHandler !== wrappedHandler) {
+        const toolDef = toolRegistry.getTool(
+          toolKey.replace(/__/g, '.'),
+        ) as { isMutation?: boolean } | undefined
+        if (toolDef?.isMutation === true) {
+          throw new AgentPolicyError(
+            'loop_violates_mutation_policy',
+            `User prepareStep returned a tools map with raw (unwrapped) mutation handler for "${toolKey}". This bypasses the mutation-approval gate and is rejected.`,
+          )
+        }
+      }
+      mergedTools[toolKey] = wrappedHandler
+    }
+    merged.tools = mergedTools as PrepareStepResult<ToolSet>['tools']
+  }
+
+  return merged
+}
+
+/**
+ * Builds the wrapper-owned `PrepareStepFunction` that enforces the tool
+ * allowlist and mutation-approval contract on every step, then composes
+ * the user's `prepareStep` on top via `mergeStepOverrides`.
+ *
+ * This is the SECURITY-CRITICAL function for Phase 0. The wrapper `prepareStep`
+ * ensures:
+ * - Tool active-set is always a subset of `effectiveLoop.activeTools ?? agent.allowedTools`.
+ * - Mutation tools always point at the prepareMutation-wrapped handlers.
+ * - User's `prepareStep` return value cannot smuggle raw mutation handlers.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export function buildWrapperPrepareStep(
+  agent: AiAgentDefinition,
+  effectiveLoop: AiAgentLoopConfig,
+  wrappedTools: Record<string, unknown>,
+): PrepareStepFunction<ToolSet> {
+  return async (state) => {
+    const wrapperOverride: PrepareStepResult<ToolSet> = {}
+
+    if (effectiveLoop.activeTools && effectiveLoop.activeTools.length > 0) {
+      wrapperOverride.activeTools = effectiveLoop.activeTools.filter((name) => {
+        const allowed = agent.allowedTools.includes(name)
+        if (!allowed) {
+          console.warn(
+            `[AI Agents] loop:active_tools_filtered — tool "${name}" is not in agent "${agent.id}" allowedTools; dropping from activeTools.`,
+          )
+        }
+        return allowed
+      })
+    }
+
+    if (effectiveLoop.prepareStep) {
+      let userOverride: PrepareStepResult<ToolSet> | undefined | null
+      try {
+        userOverride = await effectiveLoop.prepareStep(state)
+      } catch (error) {
+        console.error(
+          `[AI Agents] User prepareStep threw for agent "${agent.id}"; ignoring user override:`,
+          error,
+        )
+        return wrapperOverride
+      }
+      return mergeStepOverrides(wrapperOverride, userOverride, agent, wrappedTools)
+    }
+
+    return wrapperOverride
+  }
 }
 
 interface ResolvedAgentModel {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -13,6 +13,7 @@ import type { ZodTypeAny } from 'zod'
 import { createModelFactory } from './model-factory'
 import type {
   AiAgentDefinition,
+  AiAgentLoopConfig,
   AiAgentPageContextInput,
   AiAgentStructuredOutput,
 } from './ai-agent-definition'
@@ -110,6 +111,62 @@ export interface RunAiAgentTextInput {
    * per-tenant/org uniqueness within the TTL window.
    */
   conversationId?: string | null
+}
+
+/**
+ * The wrapper default loop config used when neither the caller, tenant, agent,
+ * nor legacy maxSteps supplies any config. Chat mode defaults to `{ maxSteps: 10 }`
+ * to ensure tool-using agents can loop; object mode defaults to an empty config
+ * (single structured-output call, no explicit step cap).
+ */
+const WRAPPER_DEFAULT_LOOP_CHAT: AiAgentLoopConfig = { maxSteps: 10 }
+const WRAPPER_DEFAULT_LOOP_OBJECT: AiAgentLoopConfig = {}
+
+/**
+ * Resolves the effective loop config for a turn by walking the precedence
+ * chain (highest first):
+ *
+ * 1. `callerLoop` — per-call `runAiAgentText({ loop })` override (Phase 1).
+ * 2. Tenant override row — NOT yet implemented in DB; always `undefined` here.
+ *    // TODO(Phase 1782-3): hydrate loop columns from ai_agent_runtime_overrides
+ * 3. `agent.loop` — agent's declarative loop config.
+ * 4. `agent.maxSteps` (deprecated alias) — mapped to `{ maxSteps: agent.maxSteps }`.
+ * 5. `wrapperDefault` — the wrapper's hardcoded fallback.
+ *
+ * Each source contributes only the fields it sets explicitly; fields absent at
+ * a higher-priority source fall through to a lower-priority one. The merge is
+ * performed left-to-right with higher-priority sources winning field-by-field.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export function resolveEffectiveLoopConfig(
+  agent: AiAgentDefinition,
+  callerLoop?: Partial<AiAgentLoopConfig> | undefined,
+  wrapperDefault?: AiAgentLoopConfig,
+): AiAgentLoopConfig {
+  const effectiveDefault = wrapperDefault ?? WRAPPER_DEFAULT_LOOP_CHAT
+
+  // Build base from lowest-priority: wrapper default → legacy maxSteps → agent.loop
+  const legacyMaxSteps: AiAgentLoopConfig | undefined =
+    typeof agent.maxSteps === 'number' && agent.maxSteps > 0 && !agent.loop
+      ? { maxSteps: agent.maxSteps }
+      : undefined
+
+  const base: AiAgentLoopConfig = {
+    ...effectiveDefault,
+    ...(legacyMaxSteps ?? {}),
+    ...(agent.loop ?? {}),
+  }
+
+  // TODO(Phase 1782-3): hydrate loop columns from ai_agent_runtime_overrides
+  // and merge tenantOverride here at priority #2.
+
+  if (!callerLoop) return base
+
+  return {
+    ...base,
+    ...callerLoop,
+  }
 }
 
 interface ResolvedAgentModel {

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -2,9 +2,13 @@ import { createContainer } from 'awilix'
 import type { AwilixContainer } from 'awilix'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type {
+  GenerateObjectResult,
+  GenerateTextResult,
   LanguageModel,
   PrepareStepFunction,
   PrepareStepResult,
+  StreamObjectResult,
+  StreamTextResult,
   ToolSet,
   UIMessage,
 } from 'ai'
@@ -130,6 +134,24 @@ export interface RunAiAgentTextInput {
    * Phase 1 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
    */
   loop?: Partial<AiAgentLoopConfig>
+  /**
+   * Optional escape-hatch callback that receives the fully prepared AI SDK
+   * options bag and must return the SDK result (either from `streamText` or
+   * `generateText`). When supplied, the wrapper still enforces every policy
+   * guardrail (features, tool allowlist, mutation approval, model factory,
+   * prompt composition, attachment bridging) and then hands control to this
+   * callback instead of calling `streamText` directly.
+   *
+   * The callback MUST pass `stopWhen` and `prepareStep` through to the AI SDK
+   * call — dropping either one disables the agent's loop policy or mutation
+   * approval guards respectively. See `agents.mdx` §"Option B" for the full
+   * contract and what you lose when fields are omitted.
+   *
+   * Phase 2 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+   */
+  generateText?: (
+    options: PreparedAiSdkOptions,
+  ) => Promise<GenerateTextResult<ToolSet> | StreamTextResult<ToolSet>>
 }
 
 /**
@@ -140,6 +162,71 @@ export interface RunAiAgentTextInput {
  */
 const WRAPPER_DEFAULT_LOOP_CHAT: AiAgentLoopConfig = { maxSteps: 10 }
 const WRAPPER_DEFAULT_LOOP_OBJECT: AiAgentLoopConfig = {}
+
+/**
+ * The fully prepared options bag handed to the `runAiAgentText({ generateText })`
+ * escape-hatch callback. Callers receive a complete set of wrapper-composed
+ * loop primitives so they can forward them to `streamText` / `generateText`.
+ *
+ * SECURITY CONTRACT: callers MUST forward `prepareStep` to the AI SDK call.
+ * Dropping it removes the per-step tool-allowlist re-check and the mutation-
+ * approval wrapping. Dropping `stopWhen` removes the agent's loop policy and
+ * the R3 step-count fallback.
+ *
+ * Phase 2 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export interface PreparedAiSdkOptions {
+  model: LanguageModel
+  tools: ToolSet
+  system: string
+  messages: Awaited<ReturnType<typeof convertToModelMessages>>
+  /** Alias kept for SDK compat — equals `stopWhen` array's effective maxSteps. */
+  maxSteps: number
+  /**
+   * Wrapper-composed stop conditions (R3 mitigated: always ends with
+   * `stepCountIs(maxSteps)`). MUST be forwarded to the SDK call.
+   */
+  stopWhen: StopCondition<ToolSet>[]
+  /**
+   * Wrapper-owned `PrepareStepFunction` that re-asserts the tool allowlist and
+   * mutation-approval wrapping per step. SECURITY-CRITICAL: callers MUST
+   * forward this to the SDK call or they lose mutation-approval guarantees.
+   */
+  prepareStep: PrepareStepFunction<ToolSet>
+  /** Wrapper trace aggregator chained with the agent's `onStepFinish` hook. */
+  onStepFinish: AiAgentLoopConfig['onStepFinish']
+  onStepStart: AiAgentLoopConfig['onStepStart']
+  onToolCallStart: AiAgentLoopConfig['onToolCallStart']
+  onToolCallFinish: AiAgentLoopConfig['onToolCallFinish']
+  experimental_repairToolCall: AiAgentLoopConfig['repairToolCall']
+  activeTools: AiAgentLoopConfig['activeTools']
+  toolChoice: AiAgentLoopConfig['toolChoice']
+  /**
+   * Pre-wired to the per-turn `AbortController` used by budget enforcement
+   * (Phase 3). Forward to the SDK call so budget limits can abort in-flight
+   * requests. May be `undefined` when budget enforcement is not yet active
+   * (Phases 0–2); the SDK treats `undefined` the same as no signal.
+   */
+  abortSignal: AbortSignal | undefined
+}
+
+/**
+ * The fully prepared options bag handed to the `runAiAgentObject({ generateObject })`
+ * escape-hatch callback. Object-mode subset — chat-only fields are absent.
+ *
+ * Phase 2 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export interface PreparedAiSdkObjectOptions {
+  model: LanguageModel
+  system: string
+  messages: Awaited<ReturnType<typeof convertToModelMessages>>
+  schemaName: string
+  schema: unknown
+  maxSteps: number | undefined
+  onStepFinish: AiAgentLoopConfig['onStepFinish']
+  onStepStart: AiAgentLoopConfig['onStepStart']
+  abortSignal: AbortSignal | undefined
+}
 
 /**
  * Guards the per-call loop override against agents that have opted out of
@@ -911,23 +998,61 @@ export async function runAiAgentText(input: RunAiAgentTextInput): Promise<Respon
   const normalizedMessages = ensureUiMessageShape(input.messages)
   const hydratedMessages = attachAttachmentsToMessages(normalizedMessages, resolvedAttachments)
   const modelMessages = await convertToModelMessages(hydratedMessages)
-  // Default to 10 agentic steps when the agent does not declare maxSteps.
-  // Without stopWhen the AI SDK runs a single model call and never executes
-  // tool calls, which makes every tool-using query return an empty stream.
-  const effectiveMaxSteps = typeof agent.maxSteps === 'number' && agent.maxSteps > 0
-    ? agent.maxSteps
-    : 10
-  const stopWhen = stepCountIs(effectiveMaxSteps)
 
-  const streamArgs: Parameters<typeof streamText>[0] = {
+  const effectiveLoop = resolveEffectiveLoopConfig(agent, input.loop, WRAPPER_DEFAULT_LOOP_CHAT)
+  const stopConditions = translateStopConditions(effectiveLoop)
+  const wrapperPrepareStep = buildWrapperPrepareStep(agent, effectiveLoop, tools)
+
+  // Pre-wire the per-turn AbortController for budget enforcement (Phase 3).
+  // Phases 0–2: not yet enforced; the signal is forwarded to callers and the
+  // SDK so Phase 3 can activate it without changing the prepared-options shape.
+  const abortController = new AbortController()
+
+  const preparedOptions: PreparedAiSdkOptions = {
+    model,
+    tools,
+    system: systemPrompt,
+    messages: modelMessages,
+    maxSteps: effectiveLoop.maxSteps ?? 10,
+    stopWhen: stopConditions,
+    prepareStep: wrapperPrepareStep,
+    onStepFinish: effectiveLoop.onStepFinish,
+    onStepStart: effectiveLoop.onStepStart,
+    onToolCallStart: effectiveLoop.onToolCallStart,
+    onToolCallFinish: effectiveLoop.onToolCallFinish,
+    experimental_repairToolCall: effectiveLoop.repairToolCall,
+    activeTools: effectiveLoop.activeTools,
+    toolChoice: effectiveLoop.toolChoice,
+    abortSignal: abortController.signal,
+  }
+
+  if (input.generateText) {
+    const callbackResult = await input.generateText(preparedOptions)
+    return (callbackResult as StreamTextResult<ToolSet>).toUIMessageStreamResponse({
+      sendReasoning: true,
+      headers: {
+        'Cache-Control': 'no-cache, no-transform',
+        Connection: 'keep-alive',
+      },
+    })
+  }
+
+  const result = streamText({
     model,
     system: systemPrompt,
     messages: modelMessages,
     tools,
-    stopWhen,
-  }
-
-  const result = streamText(streamArgs)
+    stopWhen: stopConditions,
+    prepareStep: wrapperPrepareStep,
+    onStepFinish: effectiveLoop.onStepFinish,
+    onStepStart: effectiveLoop.onStepStart,
+    experimental_onToolCallStart: effectiveLoop.onToolCallStart,
+    experimental_onToolCallFinish: effectiveLoop.onToolCallFinish,
+    experimental_repairToolCall: effectiveLoop.repairToolCall,
+    ...(effectiveLoop.activeTools !== undefined ? { activeTools: effectiveLoop.activeTools } : {}),
+    ...(effectiveLoop.toolChoice !== undefined ? { toolChoice: effectiveLoop.toolChoice } : {}),
+    abortSignal: abortController.signal,
+  })
   return result.toUIMessageStreamResponse({
     sendReasoning: true,
     headers: {
@@ -1013,6 +1138,17 @@ export interface RunAiAgentObjectInput<TSchema = ZodTypeAny> {
    * Phase 1 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
    */
   loop?: Pick<AiAgentLoopConfig, 'maxSteps' | 'budget' | 'onStepFinish' | 'onStepStart' | 'allowRuntimeOverride'>
+  /**
+   * Optional escape-hatch callback receiving the fully prepared object-mode
+   * options bag. When supplied the wrapper still enforces all policy guardrails
+   * and then delegates the actual SDK call to this function. The callback MUST
+   * return a value compatible with `GenerateObjectResult` or `StreamObjectResult`.
+   *
+   * Phase 2 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+   */
+  generateObject?: (
+    options: PreparedAiSdkObjectOptions,
+  ) => Promise<GenerateObjectResult<unknown> | StreamObjectResult<unknown, unknown, unknown>>
 }
 
 export type RunAiAgentObjectGenerateResult<TSchema> = {
@@ -1155,6 +1291,54 @@ export async function runAiAgentObject<TSchema = unknown>(
   const modelMessages = await convertToModelMessages(hydratedMessages)
   void tools
 
+  if (input.loop) {
+    assertLoopObjectModeCompatible(input.loop)
+  }
+  const effectiveLoop = resolveEffectiveLoopConfig(agent, input.loop, WRAPPER_DEFAULT_LOOP_OBJECT)
+
+  const abortController = new AbortController()
+
+  const preparedObjectOptions: PreparedAiSdkObjectOptions = {
+    model,
+    system: systemPrompt,
+    messages: modelMessages,
+    schemaName: resolvedOutput.schemaName,
+    schema: resolvedOutput.schema,
+    maxSteps: effectiveLoop.maxSteps,
+    onStepFinish: effectiveLoop.onStepFinish,
+    onStepStart: effectiveLoop.onStepStart,
+    abortSignal: abortController.signal,
+  }
+
+  if (input.generateObject) {
+    const callbackResult = await input.generateObject(preparedObjectOptions)
+    const typedResult = callbackResult as Record<string, unknown>
+    if ('partialObjectStream' in typedResult) {
+      const streamResult = typedResult as {
+        object: Promise<TSchema>
+        partialObjectStream: AsyncIterable<Partial<TSchema>>
+        textStream: AsyncIterable<string>
+        finishReason?: Promise<string | undefined>
+        usage?: Promise<{ inputTokens?: number; outputTokens?: number } | undefined>
+      }
+      return {
+        mode: 'stream',
+        object: streamResult.object,
+        partialObjectStream: streamResult.partialObjectStream,
+        textStream: streamResult.textStream,
+        finishReason: streamResult.finishReason,
+        usage: streamResult.usage,
+      }
+    }
+    const genResult = typedResult as { object: unknown; finishReason?: string; usage?: { inputTokens?: number; outputTokens?: number } }
+    return {
+      mode: 'generate',
+      object: genResult.object as TSchema,
+      finishReason: genResult.finishReason,
+      usage: genResult.usage,
+    }
+  }
+
   if (resolvedOutput.mode === 'stream') {
     const streamArgs: Parameters<typeof streamObject>[0] = {
       model,
@@ -1162,6 +1346,10 @@ export async function runAiAgentObject<TSchema = unknown>(
       messages: modelMessages,
       schema: resolvedOutput.schema as never,
       schemaName: resolvedOutput.schemaName,
+      ...(effectiveLoop.maxSteps !== undefined ? { maxSteps: effectiveLoop.maxSteps } : {}),
+      onStepFinish: effectiveLoop.onStepFinish,
+      onStepStart: effectiveLoop.onStepStart,
+      abortSignal: abortController.signal,
     }
     const result = streamObject(streamArgs) as unknown as {
       object: Promise<TSchema>
@@ -1186,6 +1374,10 @@ export async function runAiAgentObject<TSchema = unknown>(
     messages: modelMessages,
     schema: resolvedOutput.schema as never,
     schemaName: resolvedOutput.schemaName,
+    ...(effectiveLoop.maxSteps !== undefined ? { maxSteps: effectiveLoop.maxSteps } : {}),
+    onStepFinish: effectiveLoop.onStepFinish,
+    onStepStart: effectiveLoop.onStepStart,
+    abortSignal: abortController.signal,
   }
 
   const result = await generateObject(generateArgs)

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/ai-agent-definition.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/ai-agent-definition.ts
@@ -1,7 +1,145 @@
 import type { AwilixContainer } from 'awilix'
 import type { ZodTypeAny } from 'zod'
+import type {
+  PrepareStepFunction,
+  GenerateTextOnStepFinishCallback,
+  GenerateTextOnStepStartCallback,
+  GenerateTextOnToolCallStartCallback,
+  GenerateTextOnToolCallFinishCallback,
+  ToolCallRepairFunction,
+  StopCondition,
+  ToolChoice,
+  ToolSet,
+} from 'ai'
 
 export type AiAgentExecutionMode = 'chat' | 'object'
+
+/**
+ * A serializable stop condition for the agentic loop. The `kind` field
+ * determines which Vercel AI SDK helper is used at runtime:
+ * - `stepCount` → `stepCountIs(count)` — the loop stops after N steps.
+ * - `hasToolCall` → `hasToolCall(toolName)` — the loop stops immediately
+ *   after the model emits a tool call for the named tool.
+ * - `custom` — a raw `StopCondition<ToolSet>` predicate supplied in code.
+ *   NOT valid from JSON-only override sources (tenant DB overrides); only
+ *   accepted when declared directly in `agent.loop` or a `runAiAgentText`
+ *   caller override.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export type AiAgentLoopStopCondition =
+  | { kind: 'stepCount'; count: number }
+  | { kind: 'hasToolCall'; toolName: string }
+  | { kind: 'custom'; stop: StopCondition<ToolSet> }
+
+/**
+ * Budget limits for the agentic loop turn. When any limit is exceeded the
+ * wrapper's `prepareStep`/`onStepFinish` aborts the turn via the per-turn
+ * `AbortController` and the loop terminates with a `loop_budget_exceeded`
+ * finish condition.
+ *
+ * Budget enforcement is implemented in Phase 1782-3; for Phases 0–2 the
+ * fields are accepted and forwarded to the prepared-options bag but are not
+ * actively enforced.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export interface AiAgentLoopBudget {
+  /** Hard cap on tool calls across all steps in this turn. */
+  maxToolCalls?: number
+  /** Wall-clock cap (ms) per turn; runtime aborts via AbortController. */
+  maxWallClockMs?: number
+  /** Input+output token cap; aggregated from step `usage` fields. */
+  maxTokens?: number
+}
+
+/**
+ * First-class loop configuration for an AI agent. Supersedes the flat
+ * `maxSteps` alias on `AiAgentDefinition`.
+ *
+ * All fields are optional; the runtime falls back to the wrapper default
+ * (`{ maxSteps: 10 }` for chat, `{ maxSteps: undefined }` for object) when
+ * neither the agent nor the caller supplies any loop config.
+ *
+ * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+ */
+export interface AiAgentLoopConfig {
+  /** Maximum number of agentic steps before the loop is forced to stop. */
+  maxSteps?: number
+  /**
+   * Additional stop conditions. The wrapper ALWAYS composes these with
+   * `stepCountIs(maxSteps ?? 10)` so a misconfigured `hasToolCall` for a
+   * non-existent tool can never cause an infinite loop (R3 mitigation).
+   */
+  stopWhen?: AiAgentLoopStopCondition | AiAgentLoopStopCondition[]
+  /**
+   * Per-step preparation hook. The wrapper composes this with its own
+   * security-critical `prepareStep` that re-asserts the tool allowlist and
+   * mutation-approval wrapping per step.
+   *
+   * Only valid for chat agents. Rejected with `loop_unsupported_in_object_mode`
+   * for object-mode agents.
+   */
+  prepareStep?: PrepareStepFunction<ToolSet>
+  /**
+   * Callback fired when a step finishes. The wrapper chains its own
+   * aggregation callback (LoopTrace builder) before invoking this one.
+   * Exceptions thrown by this callback are caught and logged but do not
+   * abort the turn (matching the SDK's own contract).
+   */
+  onStepFinish?: GenerateTextOnStepFinishCallback<ToolSet>
+  /**
+   * Callback fired when a step starts. Forwarded to the AI SDK as
+   * `experimental_onStepStart`.
+   */
+  onStepStart?: GenerateTextOnStepStartCallback<ToolSet>
+  /**
+   * Callback fired when a tool call starts. Forwarded to the AI SDK as
+   * `experimental_onToolCallStart`.
+   */
+  onToolCallStart?: GenerateTextOnToolCallStartCallback<ToolSet>
+  /**
+   * Callback fired when a tool call finishes. Forwarded to the AI SDK as
+   * `experimental_onToolCallFinish`.
+   */
+  onToolCallFinish?: GenerateTextOnToolCallFinishCallback<ToolSet>
+  /**
+   * Tool-call repair function. Forwarded to the AI SDK as
+   * `experimental_repairToolCall`.
+   *
+   * Only valid for chat agents. Rejected with `loop_unsupported_in_object_mode`
+   * for object-mode agents.
+   */
+  repairToolCall?: ToolCallRepairFunction<ToolSet>
+  /**
+   * Narrow the active tool surface for each step. Names must be a subset of
+   * `agent.allowedTools`; any names outside the allowlist are filtered out
+   * with a `loop:active_tools_filtered` warning.
+   *
+   * Only valid for chat agents. Rejected with `loop_unsupported_in_object_mode`
+   * for object-mode agents.
+   */
+  activeTools?: string[]
+  /**
+   * Tool choice strategy forwarded to the AI SDK on each step.
+   *
+   * Only valid for chat agents. Rejected with `loop_unsupported_in_object_mode`
+   * for object-mode agents.
+   */
+  toolChoice?: ToolChoice<ToolSet>
+  /** Budget caps for this loop turn. */
+  budget?: AiAgentLoopBudget
+  /**
+   * When `false`, per-call `runAiAgentText({ loop })` / HTTP query-param
+   * overrides are rejected with `AgentPolicyError` code
+   * `loop_runtime_override_disabled`. Default is `true` (permissive).
+   *
+   * Agents that pin a loop policy for correctness reasons (e.g. a
+   * `stopWhen: hasToolCall(...)` that must not be bypassed by callers)
+   * should set this to `false`.
+   */
+  allowRuntimeOverride?: boolean
+}
 
 export type AiAgentMutationPolicy =
   | 'read-only'
@@ -98,7 +236,23 @@ export interface AiAgentDefinition {
   uiParts?: string[]
   readOnly?: boolean
   mutationPolicy?: AiAgentMutationPolicy
+  /**
+   * @deprecated Use `loop.maxSteps` instead. Honored as alias when `loop` is
+   * omitted. When both `maxSteps` and `loop.maxSteps` are specified, `loop.maxSteps`
+   * wins. This field will be removed in a future minor release.
+   *
+   * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+   */
   maxSteps?: number
+  /**
+   * First-class agentic loop configuration. Supersedes the flat `maxSteps`
+   * alias. The runtime walks a precedence chain (per-call override → tenant
+   * DB override → this block → legacy `maxSteps` alias → wrapper default)
+   * to resolve the effective loop config for each turn.
+   *
+   * Phase 0 of spec `2026-04-28-ai-agents-agentic-loop-controls`.
+   */
+  loop?: AiAgentLoopConfig
   output?: AiAgentStructuredOutput
   resolvePageContext?: (ctx: AiAgentPageContextInput) => Promise<string | null>
   keywords?: string[]


### PR DESCRIPTION
**Stacked on #1865 → #1864 → #1863 → #1860 → #1858 → #1856.** Merge those first.

## Goal
Phases 0, 1, and 2 of [`2026-04-28-ai-agents-agentic-loop-controls`](.ai/specs/2026-04-28-ai-agents-agentic-loop-controls.md) — promote the agentic loop from a single \`maxSteps\` knob to a first-class part of the agent contract, on parity with the per-axis provider/model/baseURL spec landed in #1856–#1865.

## What Changed (14 commits)

**Phase 0 — declarative \`loop\` block on AiAgentDefinition (l0.1–l0.7)**
- New types: \`AiAgentLoopStopCondition\`, \`AiAgentLoopBudget\`, \`AiAgentLoopConfig\`. Added \`loop?: AiAgentLoopConfig\` to \`AiAgentDefinition\`. \`maxSteps\` field marked \`@deprecated\` (honored as alias when \`loop\` is omitted).
- \`AgentPolicyDenyCode\` extended with 4 loop codes (\`loop_unsupported_in_object_mode\`, \`loop_violates_mutation_policy\`, \`loop_active_tools_outside_allowlist\`, \`loop_runtime_override_disabled\`).
- New helpers: \`resolveEffectiveLoopConfig\`, \`translateStopConditions\`, \`mergeStepOverrides\`, \`buildWrapperPrepareStep\`, \`assertLoopObjectModeCompatible\`.
- **Security-critical:** \`mergeStepOverrides\` enforces R1 mitigation — user-supplied \`prepareStep\` cannot smuggle raw mutation handlers (intersected with wrapper-owned tool map); \`activeTools\` intersected with \`agent.allowedTools\`. Failures throw typed \`AgentPolicyError\`.
- Removed dead \`(generateArgs as Record<string, unknown>).stopWhen\` cast that was masking the missing implementation.

**Phase 1 — per-call loop overrides (l1.1–l1.3)**
- \`loop?\` input on \`runAiAgentText\` / \`runAiAgentObject\`, gated by \`agent.loop?.allowRuntimeOverride ?? true\`. Object mode accepts only \`Pick<AiAgentLoopConfig, 'maxSteps' | 'budget' | 'onStepFinish' | 'onStepStart' | 'allowRuntimeOverride'>\`; the rest throws \`loop_unsupported_in_object_mode\`.

**Phase 2 — native SDK callback wiring + extended prepared-options bag (l2.1–l2.4)**
- \`PreparedAiSdkOptions\` and \`PreparedAiSdkObjectOptions\` exported with the full loop primitive bag (\`stopWhen\`, \`prepareStep\`, \`onStepFinish\`, \`onStepStart\`, \`experimental_onToolCallStart\`, \`experimental_onToolCallFinish\`, \`experimental_repairToolCall\`, \`activeTools\`, \`toolChoice\`, \`abortSignal\`).
- \`abortSignal\` pre-wired to per-turn \`AbortController\` (Phase 1782-3 will tie it to budget enforcement).
- \`generateText?\` / \`generateObject?\` callback fields wired through; when present, the wrapper invokes \`cb(preparedOptions)\` instead of calling the SDK directly.
- \`agents.mdx\` documents the security-critical contract: dropping \`stopWhen\` drops the loop policy; dropping \`prepareStep\` drops mutation-approval guards.

## Tests
- 32 + 20 + 10 = **62 new unit tests** covering all three phases.
- Total in scope: 171 tests passing (model-factory, agent-runtime, ai-agent-definition, all three loop suites).
- \`yarn typecheck\` clean (only pre-existing MikroORM noise).

## Backward Compatibility
Fully additive across all 13 contract surfaces. \`maxSteps\` keeps its semantics; the wrapper still applies \`stepCountIs(maxSteps ?? 10)\` when nothing else is declared.

## Risks honored
- **R1** (user prepareStep smuggling raw mutation handlers) — \`mergeStepOverrides\` re-intersects with the wrapper-owned tool map.
- **R3** (misconfigured \`hasToolCall\` running forever) — wrapper always pairs user stopWhen with \`stepCountIs(maxSteps ?? 10)\`.
- **R4** (object-mode users assuming \`stopWhen\` works) — \`loop_unsupported_in_object_mode\` thrown at definition load + at call site.

## Stacking
- Base branch: \`feat/ai-agents-phase-1780-4b\` (PR #1865).
- Next: Phase 1782-3..4 (operator budgets / kill switch / LoopTrace / dispatcher \`?loopBudget\` query param / \`allowRuntimeModelOverride\` rename to \`allowRuntimeOverride\`). UI surface returns.