### PR TITLE
feat(cli): add mercato test:bootstrap-tenant for scriptable tenant provisioning

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -74,6 +74,40 @@ yarn generate         # Run generators
 yarn build:packages   # Rebuild with generated files
 ```
 
+## Scriptable Tenant Provisioning (`mercato test:bootstrap-tenant`)
+
+Mints a fully-provisioned tenant — Tenant + Organization + admin User + role
+ACLs + every module's `onTenantCreated` lifecycle hook — against an existing
+OM instance, without sitting in front of the interactive `mercato init` prompts.
+
+```bash
+mercato test:bootstrap-tenant \
+  --slug <slug> \
+  --org-name <name> \
+  --admin-email <email> \
+  --admin-password <password> \
+  [--admin-display-name <name>] \
+  [--with-examples]
+```
+
+Outputs a single JSON object on stdout:
+
+```json
+{ "tenantId": "...", "organizationId": "...", "adminUserId": "...", "adminEmail": "..." }
+```
+
+All four flagged values are required — there are no test-friendly defaults so
+production callers (customer onboarding, disaster recovery, staging seeding,
+sales-engineering demo provisioning) are forced to pass real, deliberate
+values. Slug collisions exit non-zero with `TENANT_SLUG_EXISTS` and never
+silently overwrite or merge into an existing tenant. Banner / progress output
+goes to stderr (or is suppressed via `OM_CLI_QUIET=1`) so consumers can pipe
+the JSON directly into `jq` or downstream scripts.
+
+The subcommand is a thin wrapper around the same internal `setupInitialTenant`
+helper used by `mercato init` and `mercato auth setup`; behaviour parity is
+guaranteed by construction.
+
 ## Module Scaffolding
 
 Each module has an optional `cli.ts` with a default export for module-specific CLI commands. These are auto-discovered and registered in `modules.cli.generated.ts`.

--- a/packages/cli/src/lib/testing/__tests__/bootstrap-tenant.test.ts
+++ b/packages/cli/src/lib/testing/__tests__/bootstrap-tenant.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the scriptable tenant-bootstrap wrapper that backs
+ * `mercato test:bootstrap-tenant`. These tests cover argument parsing,
+ * required-flag validation, slug-collision pre-check, and the JSON output
+ * shape — i.e. the surface that downstream callers (staging-seeding loops,
+ * sales-engineering demo provisioning, customer-onboarding scripts, DR
+ * restores) actually depend on. The full end-to-end path through
+ * `setupInitialTenant` is exercised by the existing CLI integration suite
+ * against a real ephemeral DB.
+ */
+
+// Virtual mocks for the @open-mercato/core / @open-mercato/shared modules that
+// `bootstrap-tenant.ts` lazy-imports — those packages aren't built in the
+// `@open-mercato/cli` test workspace, mirroring the existing `mercato.test.ts`
+// strategy.
+jest.mock(
+  '@open-mercato/core/modules/directory/data/entities',
+  () => ({
+    Tenant: class Tenant {},
+    Organization: class Organization {},
+  }),
+  { virtual: true },
+)
+jest.mock(
+  '@open-mercato/core/modules/auth/lib/setup-app',
+  () => ({
+    setupInitialTenant: jest.fn(),
+  }),
+  { virtual: true },
+)
+jest.mock(
+  '@open-mercato/shared/modules/registry',
+  () => ({
+    getCliModules: jest.fn().mockReturnValue([]),
+  }),
+  { virtual: true },
+)
+jest.mock(
+  '@open-mercato/shared/lib/di/container',
+  () => ({
+    createRequestContainer: jest.fn(),
+  }),
+  { virtual: true },
+)
+
+import {
+  BOOTSTRAP_TENANT_USAGE,
+  BootstrapTenantUsageError,
+  TenantSlugExistsError,
+  bootstrapTenant,
+  parseBootstrapTenantArgs,
+  runBootstrapTenant,
+} from '../bootstrap-tenant'
+
+const REQUIRED_ARGS = [
+  '--slug',
+  'acme',
+  '--org-name',
+  'Acme Corp',
+  '--admin-email',
+  'admin@acme.test',
+  '--admin-password',
+  'TopSecret!2026',
+]
+
+describe('parseBootstrapTenantArgs', () => {
+  it('parses all required flags into a normalized shape', () => {
+    const parsed = parseBootstrapTenantArgs(REQUIRED_ARGS)
+    expect(parsed).toEqual({
+      slug: 'acme',
+      orgName: 'Acme Corp',
+      adminEmail: 'admin@acme.test',
+      adminPassword: 'TopSecret!2026',
+      adminDisplayName: undefined,
+      withExamples: false,
+    })
+  })
+
+  it('accepts the optional --admin-display-name and trims whitespace', () => {
+    const parsed = parseBootstrapTenantArgs([
+      ...REQUIRED_ARGS,
+      '--admin-display-name',
+      '  Director of Operations  ',
+    ])
+    expect(parsed.adminDisplayName).toBe('Director of Operations')
+  })
+
+  it('treats --with-examples as a boolean toggle (off by default, on when present)', () => {
+    expect(parseBootstrapTenantArgs(REQUIRED_ARGS).withExamples).toBe(false)
+    expect(
+      parseBootstrapTenantArgs([...REQUIRED_ARGS, '--with-examples']).withExamples,
+    ).toBe(true)
+  })
+
+  it('supports inline `--key=value` form alongside the space-separated form', () => {
+    const parsed = parseBootstrapTenantArgs([
+      '--slug=acme-2',
+      '--org-name=Acme Two',
+      '--admin-email=admin@acme.test',
+      '--admin-password=TopSecret!2026',
+    ])
+    expect(parsed.slug).toBe('acme-2')
+    expect(parsed.orgName).toBe('Acme Two')
+  })
+
+  it('also accepts the legacy camelCase aliases used elsewhere in the CLI', () => {
+    const parsed = parseBootstrapTenantArgs([
+      '--slug',
+      'acme',
+      '--orgName',
+      'Acme Corp',
+      '--adminEmail',
+      'admin@acme.test',
+      '--adminPassword',
+      'TopSecret!2026',
+    ])
+    expect(parsed.orgName).toBe('Acme Corp')
+    expect(parsed.adminEmail).toBe('admin@acme.test')
+    expect(parsed.adminPassword).toBe('TopSecret!2026')
+  })
+
+  describe('required-flag validation', () => {
+    const requiredFlags: Array<{ remove: string; expect: string }> = [
+      { remove: '--slug', expect: '--slug' },
+      { remove: '--org-name', expect: '--org-name' },
+      { remove: '--admin-email', expect: '--admin-email' },
+      { remove: '--admin-password', expect: '--admin-password' },
+    ]
+
+    for (const { remove, expect: missingFlag } of requiredFlags) {
+      it(`fails with a clear usage error when ${remove} is missing`, () => {
+        const args = [...REQUIRED_ARGS]
+        const idx = args.indexOf(remove)
+        // Drop the flag and its value
+        args.splice(idx, 2)
+        expect(() => parseBootstrapTenantArgs(args)).toThrow(BootstrapTenantUsageError)
+        try {
+          parseBootstrapTenantArgs(args)
+        } catch (err) {
+          expect((err as Error).message).toContain(missingFlag)
+          expect((err as Error).message).toContain(BOOTSTRAP_TENANT_USAGE)
+        }
+      })
+    }
+
+    it('fails when the entire arg list is empty', () => {
+      expect(() => parseBootstrapTenantArgs([])).toThrow(BootstrapTenantUsageError)
+    })
+  })
+})
+
+describe('bootstrapTenant — slug-collision pre-check', () => {
+  it('throws TenantSlugExistsError when an organization with that slug already exists', async () => {
+    const findOne = jest
+      .fn()
+      // Organization lookup hit — slug is taken
+      .mockResolvedValueOnce({ id: 'existing-org', slug: 'acme' })
+    const em = { findOne } as any
+
+    await expect(
+      bootstrapTenant(em, {
+        slug: 'acme',
+        orgName: 'Acme Corp',
+        adminEmail: 'admin@acme.test',
+        adminPassword: 'TopSecret!2026',
+        withExamples: false,
+      }),
+    ).rejects.toBeInstanceOf(TenantSlugExistsError)
+  })
+
+  it('throws TenantSlugExistsError when a tenant synthesized name `${slug} Tenant` already exists', async () => {
+    const findOne = jest
+      .fn()
+      // Organization lookup miss
+      .mockResolvedValueOnce(null)
+      // Tenant lookup hit on synthesized name
+      .mockResolvedValueOnce({ id: 'existing-tenant', name: 'acme Tenant' })
+    const em = { findOne } as any
+
+    await expect(
+      bootstrapTenant(em, {
+        slug: 'acme',
+        orgName: 'Acme Corp',
+        adminEmail: 'admin@acme.test',
+        adminPassword: 'TopSecret!2026',
+        withExamples: false,
+      }),
+    ).rejects.toBeInstanceOf(TenantSlugExistsError)
+  })
+})
+
+describe('runBootstrapTenant — JSON stdout contract', () => {
+  let originalExitCode: number | string | undefined
+  let stdoutSpy: jest.SpyInstance
+  let stderrSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode
+    process.exitCode = undefined
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.exitCode = originalExitCode
+    stdoutSpy.mockRestore()
+    stderrSpy.mockRestore()
+  })
+
+  it('writes a single JSON line to stderr with usage and exits non-zero when args are missing', async () => {
+    await runBootstrapTenant([])
+    expect(process.exitCode).toBe(2)
+    expect(stdoutSpy).not.toHaveBeenCalled()
+    expect(stderrSpy).toHaveBeenCalled()
+    const stderrPayload = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(stderrPayload).toContain('--slug')
+    expect(stderrPayload).toContain(BOOTSTRAP_TENANT_USAGE)
+  })
+})

--- a/packages/cli/src/lib/testing/bootstrap-tenant.ts
+++ b/packages/cli/src/lib/testing/bootstrap-tenant.ts
@@ -1,0 +1,318 @@
+// Scriptable, non-interactive tenant provisioning for Open Mercato instances.
+//
+// This module backs the `mercato test:bootstrap-tenant` subcommand and is the
+// scripting-friendly counterpart of the interactive `mercato init` flow. Both
+// paths funnel through the same internal `setupInitialTenant` helper so a tenant
+// minted here is functionally identical to one minted by `init`: a Tenant row,
+// a primary Organization, the canonical role set + ACLs, an admin User, and one
+// firing of every registered module's `onTenantCreated` lifecycle hook.
+//
+// Real-world callers include staging seeding loops, sales-engineering demo
+// provisioning, customer-onboarding scripts, and disaster-recovery restores —
+// any situation where staff need to mint a fresh tenant against an existing
+// OM instance without sitting in front of the interactive prompts.
+//
+// Output contract: a single JSON object on stdout
+//   { tenantId, organizationId, adminUserId, adminEmail }
+// All diagnostic / banner output goes to stderr or is suppressed via
+// `OM_CLI_QUIET=1` so consumers can pipe the JSON directly into `jq` or a
+// downstream script.
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+export type BootstrapTenantArgs = {
+  slug: string
+  orgName: string
+  adminEmail: string
+  adminPassword: string
+  adminDisplayName?: string
+  withExamples: boolean
+}
+
+export type BootstrapTenantResult = {
+  tenantId: string
+  organizationId: string
+  adminUserId: string
+  adminEmail: string
+}
+
+export class BootstrapTenantUsageError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BootstrapTenantUsageError'
+  }
+}
+
+export class TenantSlugExistsError extends Error {
+  constructor(public readonly slug: string) {
+    super(`TENANT_SLUG_EXISTS: a tenant or organization with slug "${slug}" already exists`)
+    this.name = 'TenantSlugExistsError'
+  }
+}
+
+export const BOOTSTRAP_TENANT_USAGE = `Usage: mercato test:bootstrap-tenant \\
+  --slug <slug> \\
+  --org-name <name> \\
+  --admin-email <email> \\
+  --admin-password <password> \\
+  [--admin-display-name <name>] \\
+  [--with-examples]`
+
+/**
+ * Parse raw CLI args into a validated `BootstrapTenantArgs` shape.
+ *
+ * Validation rules:
+ *   - All four required flags must be provided as non-empty strings.
+ *   - `--with-examples` is a boolean toggle (presence flips it true; default false).
+ *   - `--admin-display-name` is optional; trimmed; absent or empty becomes undefined.
+ *
+ * Throws `BootstrapTenantUsageError` with a clear message on any validation
+ * failure so the subcommand handler can surface it to stderr and exit non-zero
+ * without printing a partial JSON payload.
+ */
+export function parseBootstrapTenantArgs(rest: string[]): BootstrapTenantArgs {
+  const args: Record<string, string | boolean> = {}
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i]
+    if (!token) continue
+    if (!token.startsWith('--')) continue
+    const [rawKey, rawInline] = token.replace(/^--/, '').split('=')
+    if (!rawKey) continue
+    const key = normalizeArgKey(rawKey)
+    if (rawInline !== undefined) {
+      args[key] = rawInline
+      continue
+    }
+    const next = rest[i + 1]
+    if (next !== undefined && !next.startsWith('--')) {
+      args[key] = next
+      i++
+    } else {
+      args[key] = true
+    }
+  }
+
+  const slug = readStringArg(args, 'slug')
+  const orgName = readStringArg(args, 'org-name', 'orgName')
+  const adminEmail = readStringArg(args, 'admin-email', 'adminEmail')
+  const adminPassword = readStringArg(args, 'admin-password', 'adminPassword')
+  const adminDisplayNameRaw = readStringArg(args, 'admin-display-name', 'adminDisplayName')
+  const withExamplesRaw = args['with-examples'] ?? args['withExamples']
+
+  const missing: string[] = []
+  if (!slug) missing.push('--slug')
+  if (!orgName) missing.push('--org-name')
+  if (!adminEmail) missing.push('--admin-email')
+  if (!adminPassword) missing.push('--admin-password')
+  if (missing.length) {
+    throw new BootstrapTenantUsageError(
+      `Missing required flag(s): ${missing.join(', ')}\n\n${BOOTSTRAP_TENANT_USAGE}`,
+    )
+  }
+
+  return {
+    slug: slug!,
+    orgName: orgName!,
+    adminEmail: adminEmail!,
+    adminPassword: adminPassword!,
+    adminDisplayName: adminDisplayNameRaw && adminDisplayNameRaw.trim().length
+      ? adminDisplayNameRaw.trim()
+      : undefined,
+    withExamples: withExamplesRaw === true || withExamplesRaw === 'true' || withExamplesRaw === '1',
+  }
+}
+
+function normalizeArgKey(raw: string): string {
+  // Both kebab-case (`--org-name`) and camelCase (`--orgName`) are accepted to
+  // match the convention the rest of the CLI follows; downstream readers always
+  // look up the kebab form first and fall back to camelCase.
+  return raw
+}
+
+function readStringArg(
+  args: Record<string, string | boolean>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = args[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
+}
+
+/**
+ * Provision a fresh tenant + organization + admin user against the supplied
+ * EntityManager. Wraps the existing `setupInitialTenant` helper used by
+ * `mercato init` and `mercato auth setup` — same code path, no behavioural
+ * forks, no test-only branches. The only differences relative to those callers
+ * are:
+ *
+ *   - A pre-flight slug-collision check that fails loudly instead of merging
+ *     into a foreign tenant.
+ *   - A post-flight write of the supplied `slug` onto the freshly-minted
+ *     organization, so downstream tooling has a stable scriptable handle that
+ *     is independent of the human-friendly `orgName`.
+ *   - Optional `--with-examples` mode that fires every module's `seedExamples`
+ *     hook (mirroring the `mercato init` default-on behaviour, but opt-in here
+ *     so prod customer-onboarding callers don't accidentally seed demo data).
+ */
+export async function bootstrapTenant(
+  em: EntityManager,
+  args: BootstrapTenantArgs,
+  options: { container?: unknown } = {},
+): Promise<BootstrapTenantResult> {
+  const { Tenant, Organization } = await import(
+    '@open-mercato/core/modules/directory/data/entities'
+  )
+  const { setupInitialTenant } = await import(
+    '@open-mercato/core/modules/auth/lib/setup-app'
+  )
+  const { getCliModules } = await import('@open-mercato/shared/modules/registry')
+
+  await assertSlugAvailable(em, args.slug, Tenant, Organization)
+
+  const modules = getCliModules()
+  const result = await setupInitialTenant(em, {
+    orgName: args.orgName,
+    primaryUser: {
+      email: args.adminEmail,
+      password: args.adminPassword,
+      displayName: args.adminDisplayName ?? null,
+      confirm: true,
+    },
+    includeDerivedUsers: false,
+    modules,
+  })
+
+  // setupInitialTenant doesn't accept an org slug; persist it ourselves so the
+  // slug callers passed in becomes a queryable identifier on the org row.
+  await applyOrganizationSlug(em, Organization, result.organizationId, args.slug)
+
+  if (args.withExamples) {
+    const seedCtx = {
+      em,
+      tenantId: result.tenantId,
+      organizationId: result.organizationId,
+      container: options.container,
+    }
+    for (const mod of modules) {
+      if (mod.setup?.seedExamples) {
+        await mod.setup.seedExamples(seedCtx as any)
+      }
+    }
+  }
+
+  const adminSnapshot = pickAdminSnapshot(result.users, args.adminEmail)
+  if (!adminSnapshot) {
+    throw new Error(
+      `BOOTSTRAP_TENANT_FAILED: setupInitialTenant returned no user record matching ${args.adminEmail}`,
+    )
+  }
+
+  return {
+    tenantId: result.tenantId,
+    organizationId: result.organizationId,
+    adminUserId: String(adminSnapshot.user.id),
+    adminEmail: args.adminEmail,
+  }
+}
+
+async function assertSlugAvailable(
+  em: EntityManager,
+  slug: string,
+  TenantCtor: any,
+  OrganizationCtor: any,
+): Promise<void> {
+  // We treat `slug` as a global tenant-identifier from the caller's perspective.
+  // The Tenant entity has no slug column; the Organization entity does (with a
+  // unique-with-tenant constraint). Checking the Organization slug across all
+  // tenants gives the caller-visible "is this slug taken?" semantics they
+  // expect. We additionally guard against the synthesized Tenant.name pattern
+  // (`${slug} Tenant`) so two callers passing the same slug in succession
+  // collide deterministically even in the edge case where the org slug
+  // collision check is somehow bypassed.
+  const existingOrg = await (em as any).findOne(OrganizationCtor, { slug })
+  if (existingOrg) {
+    throw new TenantSlugExistsError(slug)
+  }
+  const synthesizedTenantName = `${slug} Tenant`
+  const existingTenant = await (em as any).findOne(TenantCtor, {
+    name: synthesizedTenantName,
+  })
+  if (existingTenant) {
+    throw new TenantSlugExistsError(slug)
+  }
+}
+
+async function applyOrganizationSlug(
+  em: EntityManager,
+  OrganizationCtor: any,
+  organizationId: string,
+  slug: string,
+): Promise<void> {
+  const org = await (em as any).findOne(OrganizationCtor, { id: organizationId })
+  if (!org) return
+  if (org.slug === slug) return
+  org.slug = slug
+  await (em as any).persist(org).flush()
+}
+
+function pickAdminSnapshot(
+  users: Array<{ user: { id: string; email: string }; roles: string[]; created: boolean }>,
+  adminEmail: string,
+): { user: { id: string; email: string } } | undefined {
+  // Prefer the canonical "primary" user — newly-created superadmin matching the
+  // requested admin email. Fall back to any superadmin in the result set if the
+  // primary lookup misses (e.g. an existing user was reused).
+  const normalizedEmail = adminEmail.toLowerCase()
+  const exact = users.find(
+    (snapshot) =>
+      snapshot.created &&
+      snapshot.roles.includes('superadmin') &&
+      typeof snapshot.user.email === 'string' &&
+      snapshot.user.email.toLowerCase() === normalizedEmail,
+  )
+  if (exact) return exact
+  const anySuperadmin = users.find((snapshot) => snapshot.roles.includes('superadmin'))
+  return anySuperadmin
+}
+
+/**
+ * Subcommand entry point — wired into the `mercato test:bootstrap-tenant`
+ * registration in `mercato.ts`. Parses args, opens a request-scoped DI
+ * container + EM, delegates to `bootstrapTenant`, and prints the result as a
+ * single JSON line on stdout. Sets a non-zero `process.exitCode` on any
+ * failure rather than throwing, so the parent CLI dispatcher reports the error
+ * cleanly without a noisy stack trace.
+ */
+export async function runBootstrapTenant(rest: string[]): Promise<void> {
+  let parsed: BootstrapTenantArgs
+  try {
+    parsed = parseBootstrapTenantArgs(rest)
+  } catch (err) {
+    if (err instanceof BootstrapTenantUsageError) {
+      process.stderr.write(`${err.message}\n`)
+      process.exitCode = 2
+      return
+    }
+    throw err
+  }
+
+  const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as EntityManager
+
+  try {
+    const result = await bootstrapTenant(em, parsed, { container })
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+  } catch (err) {
+    if (err instanceof TenantSlugExistsError) {
+      process.stderr.write(`${err.message}\n`)
+      process.exitCode = 1
+      return
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    process.stderr.write(`BOOTSTRAP_TENANT_FAILED: ${message}\n`)
+    process.exitCode = 1
+  }
+}

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -15,6 +15,8 @@ import { acquireServerStartLock } from './lib/server-start-lock'
 import { createDevEnvReloader, watchDevEnvFiles } from './lib/dev-env-reload'
 // Lazy-imported to avoid pulling in `testcontainers` (devDependency) at startup
 const lazyIntegration = () => import('./lib/testing/integration')
+// Lazy-imported to keep the cold-start surface of unrelated subcommands small
+const lazyBootstrapTenant = () => import('./lib/testing/bootstrap-tenant')
 import type { ChildProcess } from 'node:child_process'
 import path from 'node:path'
 import fs from 'node:fs'
@@ -1207,6 +1209,12 @@ export async function run(argv = process.argv) {
     rest = second !== undefined ? [second, ...remaining] : []
   }
 
+  if (first === 'test:bootstrap-tenant') {
+    modName = 'test'
+    cmdName = 'bootstrap-tenant'
+    rest = second !== undefined ? [second, ...remaining] : []
+  }
+
   if (first === 'test' && second === 'integration') {
     modName = 'test'
     cmdName = 'integration'
@@ -1234,6 +1242,12 @@ export async function run(argv = process.argv) {
   if (first === 'test' && second === 'spec-coverage') {
     modName = 'test'
     cmdName = 'spec-coverage'
+    rest = remaining
+  }
+
+  if (first === 'test' && second === 'bootstrap-tenant') {
+    modName = 'test'
+    cmdName = 'bootstrap-tenant'
     rest = remaining
   }
 
@@ -1973,6 +1987,12 @@ export async function run(argv = process.argv) {
         command: 'spec-coverage',
         run: async (args: string[]) => {
           await (await lazyIntegration()).runIntegrationSpecCoverageReport(args)
+        },
+      },
+      {
+        command: 'bootstrap-tenant',
+        run: async (args: string[]) => {
+          await (await lazyBootstrapTenant()).runBootstrapTenant(args)
         },
       },
     ],


### PR DESCRIPTION
## Motivation

OM staff today have no scriptable, non-interactive way to bootstrap a fully-provisioned tenant (Tenant + Organization + admin User + role ACLs + every module's `onTenantCreated` hook) from the CLI. The available paths each fall short:

- `mercato init` is interactive and assumes a fresh DB.
- `POST /api/directory/tenants` only INSERTs a `Tenant` row + KMS DEK; no org, no user, no lifecycle hooks.
- `mercato auth setup` is in the `auth` namespace, has no JSON-stdout contract, and isn't named for the use case.

Concrete OM-staff scenarios this unblocks:

- **Staging seeding** — `for i in {1..20}; do mercato test:bootstrap-tenant --slug stg-$i ...; done`
- **Demo provisioning** — sales engineering scripts a fresh demo tenant for a customer call, with branded org name + the prospect's email + `--with-examples`
- **Customer onboarding** — ops scripts the initial tenant provisioning when a new enterprise customer signs, instead of clicking through the admin UI
- **Disaster recovery** — re-create a tenant shell from backup metadata when restoring data into a fresh OM instance

## What this PR adds

A new subcommand under the existing `mercato test:` namespace:

```
mercato test:bootstrap-tenant \
  --slug <slug> \
  --org-name <name> \
  --admin-email <email> \
  --admin-password <password> \
  [--admin-display-name <name>] \
  [--with-examples]
```

Outputs a single JSON object on stdout: `{ tenantId, organizationId, adminUserId, adminEmail }`.

Exit code 0 on success; non-zero with `TENANT_SLUG_EXISTS` on slug collision (no silent overwrite); non-zero with `BOOTSTRAP_TENANT_FAILED: <reason>` on any other error.

## Implementation

- New file `packages/cli/src/lib/testing/bootstrap-tenant.ts` exporting `runBootstrapTenant(args)`.
- Subcommand registered alongside `integration`, `ephemeral`, etc. in the `test` module's `cli` array in `packages/cli/src/mercato.ts`, with the matching `test:bootstrap-tenant` shortcut and the long-form `test bootstrap-tenant`.
- Wraps the existing internal `setupInitialTenant` from `@open-mercato/core/modules/auth/lib/setup-app` — same code path `mercato init` and `mercato auth setup` already use. No changes to that helper.
- Pre-flight slug-collision check (Organization slug + synthesized Tenant name) so callers fail loudly instead of silently merging into a foreign tenant.
- `--with-examples` mirrors the `mercato init` example-data behaviour but is opt-in here (default OFF) so prod customer-onboarding callers don't accidentally seed demo data.
- All four flagged values are required — there are no test-friendly defaults so production callers are forced to pass real, deliberate values.
- No new dependencies.

## Test plan

- Unit tests in `packages/cli/src/lib/testing/__tests__/bootstrap-tenant.test.ts` cover argument parsing (required + optional + camelCase aliases + inline `--key=value`), required-flag validation (each required flag missing in turn), the slug-collision pre-check error path (mocked EM), and the JSON-stdout contract on usage error. 13 tests, all passing.
- An end-to-end Playwright-style integration test (calling the built `mercato` binary against a real ephemeral DB) was scoped but skipped to keep the PR small; the wrapper is a thin call into `setupInitialTenant`, which is already exercised end-to-end by the existing `mercato init` integration coverage. Happy to add a CLI-level integration test in a follow-up if reviewers prefer.
- Manually verified: invocation prints clean JSON on stdout, banner suppressed via `OM_CLI_QUIET=1`; missing required flags exit 2 with usage on stderr; slug collision exits 1 with `TENANT_SLUG_EXISTS`.

## Documentation

- New "Scriptable Tenant Provisioning" section in `packages/cli/AGENTS.md` documenting the subcommand surface, output contract, and intended use cases.

## Breaking changes

None. Pure addition. No changes to existing CLI surface, helpers, or schemas.

## Checklist

- [x] Unit tests added (13 tests, all passing)
- [ ] Integration test added (deferred — see Test plan; happy to add if reviewers prefer)
- [x] Documented in `packages/cli/AGENTS.md`
- [x] Manually verified: staging-seeding loop and demo-provisioning invocations from the motivation section
