### PR TITLE
feat(auth): add scriptable provisioning flags to `mercato auth setup`

### DIFF
--- a/apps/docs/docs/cli/auth-setup.mdx
+++ b/apps/docs/docs/cli/auth-setup.mdx
@@ -9,10 +9,10 @@ description: Creates a tenant, organization, and seed users with optional derive
 ## Usage
 
 ```bash
-yarn mercato auth setup --orgName "<organization>" --email "<superadmin@email>" --password "<password>" [--roles superadmin,admin,employee] [--skip-password-policy]
+yarn mercato auth setup --orgName "<organization>" --email "<superadmin@email>" --password "<password>" [--orgSlug <slug>] [--roles superadmin,admin,employee] [--skip-password-policy] [--with-examples] [--json]
 ```
 
-Aliases: `--name` for `--orgName`.
+Aliases: `--name` for `--orgName`. `--slug` for `--orgSlug`.
 
 ## Options
 
@@ -21,8 +21,11 @@ Aliases: `--name` for `--orgName`.
 | `--orgName`, `--name` | Organization display name. A tenant named `<orgName> Tenant` is created alongside it. | _(required)_ |
 | `--email` | Primary superadmin email. If the local part is exactly `superadmin`, additional `admin@…` and `employee@…` users are derived automatically. | _(required)_ |
 | `--password` | Password applied to all seeded users. | _(required)_ |
+| `--orgSlug`, `--slug` | Optional global slug persisted on the new organization. Triggers a uniqueness pre-check across tenants and forces a fresh-tenant signal: an existing user with `--email` aborts with a clear error rather than silently reusing the foreign tenant. Format: lowercase, digits, dashes (1–63 chars; cannot start or end with a dash). | _(unset)_ |
 | `--roles` | Comma-separated list of roles to ensure exist before assignment. | `superadmin,admin,employee` |
 | `--skip-password-policy` | Skip password policy validation (useful for demo defaults like `secret`). | off |
+| `--with-examples` | After tenant creation, run every enabled module's `seedExamples` lifecycle hook (mirrors `mercato init`'s opt-out example data, but opt-in here so production callers don't accidentally seed demo data). | off |
+| `--json` | Suppress banners/progress on stdout and emit a single JSON line at the end with `tenantId`, `organizationId`, `adminUserId`, `adminEmail`, and `reusedExistingUser`. Sets `OM_CLI_QUIET=1` automatically and silences `console.log`/`console.info` for the duration so consumers can pipe directly into `jq`. | off |
 
 ## Behavior
 
@@ -59,6 +62,31 @@ Created user admin@acme.dev password: ChangeMe123
 Created user employee@acme.dev password: ChangeMe123
 Setup complete: { tenantId: '...', organizationId: '...' }
 ```
+
+### Scriptable provisioning (`--orgSlug` + `--json`)
+
+For staging seeding loops, sales-engineering demo provisioning, customer onboarding, or DR restores, combine `--orgSlug` with `--json` to get a single-line JSON contract on stdout:
+
+```bash
+TENANT=$(yarn mercato auth setup \
+  --orgName "Acme HQ" \
+  --orgSlug acme-staging-42 \
+  --email admin@acme.test \
+  --password ChangeMe123 \
+  --skip-password-policy \
+  --with-examples \
+  --json)
+
+echo "$TENANT" | jq -r .tenantId
+```
+
+Output:
+
+```json
+{"tenantId":"...","organizationId":"...","adminUserId":"...","adminEmail":"admin@acme.test","reusedExistingUser":false}
+```
+
+When `--orgSlug` collides with an existing organization slug, the command exits 1 and writes `ORG_SLUG_EXISTS: an organization with slug "<slug>" already exists` to stderr instead of clobbering the existing org. When `--orgSlug` is set and `--email` matches an existing user, the command exits 1 with `Setup aborted: user already exists with the provided email.` rather than silently reusing the foreign tenant.
 
 ## Troubleshooting
 

--- a/packages/core/src/modules/auth/AGENTS.md
+++ b/packages/core/src/modules/auth/AGENTS.md
@@ -104,3 +104,15 @@ export const setup: ModuleSetupConfig = {
 ```
 
 When exposing helper endpoints such as `/api/auth/feature-check`, keep wildcard handling normalized for callers. If a consumer bypasses the endpoint and reads raw ACL grants directly, it must apply wildcard-aware matching itself.
+
+## Scriptable Tenant Provisioning
+
+`mercato auth setup` is the scripting-friendly counterpart to interactive `mercato init`. Both call the same `setupInitialTenant` helper, so behaviour is identical for tenant + organization + admin user + role ACLs + `onTenantCreated` lifecycle hooks.
+
+For non-interactive callers (staging seeding, sales-engineering demos, customer onboarding, DR restore), use:
+
+- `--orgSlug <slug>` — persists a global slug on the new organization. Triggers a uniqueness pre-check across all tenants (throws `OrgSlugExistsError` on collision) and forces `failIfUserExists: true` so an existing user with the same email aborts with a clear error rather than silently reusing the foreign tenant.
+- `--with-examples` — runs every enabled module's `seedExamples` after tenant creation. Opt-in here (default off) so production callers don't accidentally seed demo data.
+- `--json` — emits a single JSON line on stdout with `{ tenantId, organizationId, adminUserId, adminEmail, reusedExistingUser }`. Suppresses banner/progress output and silences `console.log`/`console.info` for the duration so consumers can pipe directly into `jq`.
+
+The lib-level option (`SetupInitialTenantOptions.orgSlug`) is available to direct callers of `setupInitialTenant`; the slug pre-check uses `findOneWithDecryption` so it remains correct if `Organization` later gains encrypted fields.

--- a/packages/core/src/modules/auth/__tests__/cli-setup-orgslug.test.ts
+++ b/packages/core/src/modules/auth/__tests__/cli-setup-orgslug.test.ts
@@ -1,0 +1,207 @@
+/** @jest-environment node */
+import { registerModules } from '@open-mercato/shared/lib/modules/registry'
+import { registerCliModules } from '@open-mercato/shared/modules/registry'
+import type { Module } from '@open-mercato/shared/modules/registry'
+import cli from '@open-mercato/core/modules/auth/cli'
+
+const seedExamplesAuth = jest.fn(async () => undefined)
+const seedExamplesCustomers = jest.fn(async () => undefined)
+
+const testModules: Module[] = [
+  { id: 'auth', setup: { defaultRoleFeatures: { admin: ['auth.*'] }, seedExamples: seedExamplesAuth } },
+  { id: 'customers', setup: { defaultRoleFeatures: { admin: ['customers.*'] }, seedExamples: seedExamplesCustomers } },
+  { id: 'directory', setup: { defaultRoleFeatures: { admin: ['directory.*'] } } },
+  { id: 'entities', setup: { defaultRoleFeatures: { admin: ['entities.*'] } } },
+]
+registerModules(testModules)
+registerCliModules(testModules)
+
+const persistedEntities: any[] = []
+const findOne = jest.fn()
+const findOneOrFail = jest.fn(async (_: any, where: any) => ({ id: 'role-' + where.name, name: where.name }))
+const create = jest.fn((entity: any, data: any) => {
+  if (entity?.name === 'Tenant') return { id: 'tenant-1', ...data }
+  if (entity?.name === 'Organization') return { id: 'org-1', ...data }
+  return { ...data }
+})
+const find = jest.fn(async () => [])
+const persist = jest.fn(function persist(this: any, entity: any) {
+  persistedEntities.push(entity)
+  return this
+})
+const flush = jest.fn(async () => {})
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (_: string) => {
+      const baseEm = { findOne, findOneOrFail, create, find, persist, flush }
+      return {
+        ...baseEm,
+        transactional: async (cb: (tem: any) => any) => {
+          const tem = { ...baseEm }
+          return await cb(tem)
+        },
+      }
+    },
+  }),
+}))
+
+const setupCommand = cli.find((c: any) => c.command === 'setup')!
+
+const BASE_ARGS = [
+  '--orgName', 'Acme',
+  '--email', 'root@acme.com',
+  '--password', 'secret',
+  '--skip-password-policy',
+]
+
+describe('mercato auth setup --orgSlug', () => {
+  let stdoutSpy: jest.SpyInstance
+  let stderrSpy: jest.SpyInstance
+  let originalExitCode: number | string | undefined
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    persistedEntities.length = 0
+    originalExitCode = process.exitCode
+    process.exitCode = undefined
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    findOne.mockImplementation(async (Entity: any, where: any) => {
+      const name = (Entity && Entity.name) || ''
+      if (name === 'Role') {
+        if (where?.name === 'superadmin') return { id: 'r-superadmin', name: 'superadmin' }
+        if (where?.name === 'admin') return { id: 'r-admin', name: 'admin' }
+        if (where?.name === 'employee') return { id: 'r-employee', name: 'employee' }
+      }
+      return null
+    })
+  })
+
+  afterEach(() => {
+    process.exitCode = originalExitCode
+    stdoutSpy.mockRestore()
+    stderrSpy.mockRestore()
+  })
+
+  it('rejects invalid slug format with usage error and exit 2', async () => {
+    await setupCommand.run([...BASE_ARGS, '--orgSlug', 'Foo Bar'])
+    expect(process.exitCode).toBe(2)
+    expect(persistedEntities).toHaveLength(0)
+    const stderrPayload = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(stderrPayload).toContain('Invalid --orgSlug')
+  })
+
+  it('throws OrgSlugExistsError when an organization with that slug already exists, exit 1', async () => {
+    findOne.mockImplementation(async (Entity: any, where: any) => {
+      const name = (Entity && Entity.name) || ''
+      if (name === 'Organization' && where?.slug === 'taken') {
+        return { id: 'pre-existing-org', slug: 'taken' }
+      }
+      if (name === 'Role') {
+        if (where?.name === 'superadmin') return { id: 'r-superadmin', name: 'superadmin' }
+      }
+      return null
+    })
+    await setupCommand.run([...BASE_ARGS, '--orgSlug', 'taken', '--json'])
+    expect(process.exitCode).toBe(1)
+    expect(stdoutSpy).not.toHaveBeenCalled()
+    const stderrPayload = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(stderrPayload).toContain('ORG_SLUG_EXISTS')
+    expect(stderrPayload).toContain('taken')
+  })
+
+  it('persists the slug onto the new Organization when no collision', async () => {
+    await setupCommand.run([...BASE_ARGS, '--orgSlug', 'fresh'])
+    const orgPayload = persistedEntities.find((row) => row && row.slug === 'fresh' && row.name === 'Acme')
+    expect(orgPayload).toBeDefined()
+    expect(orgPayload.slug).toBe('fresh')
+  })
+
+  it('emits a single JSON line to stdout in --json mode and suppresses banners', async () => {
+    await setupCommand.run([...BASE_ARGS, '--orgSlug', 'fresh', '--json'])
+    expect(process.exitCode).toBeUndefined()
+    const stdoutWrites = stdoutSpy.mock.calls.map((c) => String(c[0]))
+    expect(stdoutWrites).toHaveLength(1)
+    const payload = JSON.parse(stdoutWrites[0]!.trim())
+    expect(payload).toMatchObject({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      adminEmail: 'root@acme.com',
+      reusedExistingUser: false,
+    })
+    expect(payload.adminUserId === null || typeof payload.adminUserId === 'string').toBe(true)
+    expect(process.env.OM_CLI_QUIET).toBe('1')
+  })
+
+  it('--with-examples invokes each module seedExamples after tenant create', async () => {
+    await setupCommand.run([...BASE_ARGS, '--orgSlug', 'fresh', '--with-examples', '--json'])
+    expect(seedExamplesAuth).toHaveBeenCalledTimes(1)
+    expect(seedExamplesCustomers).toHaveBeenCalledTimes(1)
+    const ctx = seedExamplesAuth.mock.calls[0]![0] as any
+    expect(ctx).toMatchObject({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+    expect(typeof ctx.em).toBe('object')
+    expect(typeof ctx.container).toBe('object')
+  })
+
+  it('treats --orgSlug as a "fresh tenant" signal: existing user with that email aborts with USER_EXISTS, exit 1', async () => {
+    findOne.mockImplementation(async (Entity: any, where: any) => {
+      const name = (Entity && Entity.name) || ''
+      if (name === 'User' && where?.email === 'reused@acme.com') {
+        return {
+          id: 'pre-existing-user',
+          email: 'reused@acme.com',
+          tenantId: 'foreign-tenant',
+          organizationId: 'foreign-org',
+        }
+      }
+      if (name === 'Organization') return null
+      if (name === 'Role') {
+        if (where?.name === 'superadmin') return { id: 'r-superadmin', name: 'superadmin' }
+      }
+      return null
+    })
+    await setupCommand.run([
+      '--orgName', 'Acme',
+      '--email', 'reused@acme.com',
+      '--password', 'secret',
+      '--skip-password-policy',
+      '--orgSlug', 'fresh',
+      '--json',
+    ])
+    expect(process.exitCode).toBe(1)
+    expect(stdoutSpy).not.toHaveBeenCalled()
+    const stderrPayload = stderrSpy.mock.calls.map((c) => String(c[0])).join('')
+    expect(stderrPayload).toContain('user already exists')
+  })
+
+  it('without --orgSlug, retains the legacy reuse behaviour (no failIfUserExists)', async () => {
+    findOne.mockImplementation(async (Entity: any, where: any) => {
+      const name = (Entity && Entity.name) || ''
+      if (name === 'User' && where?.email === 'reused@acme.com') {
+        return {
+          id: 'pre-existing-user',
+          email: 'reused@acme.com',
+          tenantId: 'foreign-tenant',
+          organizationId: 'foreign-org',
+        }
+      }
+      if (name === 'Role') {
+        if (where?.name === 'superadmin') return { id: 'r-superadmin', name: 'superadmin' }
+        if (where?.name === 'admin') return { id: 'r-admin', name: 'admin' }
+        if (where?.name === 'employee') return { id: 'r-employee', name: 'employee' }
+      }
+      return null
+    })
+    await setupCommand.run([
+      '--orgName', 'Acme',
+      '--email', 'reused@acme.com',
+      '--password', 'secret',
+      '--skip-password-policy',
+    ])
+    expect(process.exitCode).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -5,7 +5,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { User, Role, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 import { Tenant, Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { rebuildHierarchyForTenant } from '@open-mercato/core/modules/directory/lib/hierarchy'
-import { ensureRoles, setupInitialTenant, ensureDefaultRoleAcls, ensureCustomRoleAcls } from './lib/setup-app'
+import { ensureRoles, setupInitialTenant, ensureDefaultRoleAcls, ensureCustomRoleAcls, OrgSlugExistsError } from './lib/setup-app'
 import { normalizeTenantId } from './lib/tenantAccess'
 import { computeEmailHash } from './lib/emailHash'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -403,6 +403,8 @@ const addOrganization: ModuleCli = {
   },
 }
 
+const SETUP_USAGE = 'Usage: mercato auth setup --orgName <name> --email <email> --password <password> [--orgSlug <slug>] [--roles superadmin,admin,employee] [--skip-password-policy] [--with-examples] [--json]'
+
 const setupApp: ModuleCli = {
   command: 'setup',
   async run(rest) {
@@ -414,6 +416,17 @@ const setupApp: ModuleCli = {
         : undefined
     const email = typeof args.email === 'string' ? args.email : undefined
     const password = typeof args.password === 'string' ? args.password : undefined
+    const orgSlugRaw = typeof args.orgSlug === 'string'
+      ? args.orgSlug
+      : typeof args.slug === 'string'
+        ? args.slug
+        : undefined
+    const orgSlug = orgSlugRaw && orgSlugRaw.trim().length ? orgSlugRaw.trim() : undefined
+    if (orgSlug !== undefined && !ORG_SLUG_PATTERN.test(orgSlug)) {
+      process.stderr.write(`Invalid --orgSlug: must match ${ORG_SLUG_PATTERN.source} (lowercase, digits, dashes; 1-63 chars; cannot start or end with a dash)\n`)
+      process.exitCode = 2
+      return
+    }
     const rolesCsv = typeof args.roles === 'string'
       ? args.roles.trim()
       : 'superadmin,admin,employee'
@@ -425,28 +438,95 @@ const setupApp: ModuleCli = {
     const skipPasswordPolicy = typeof skipPasswordPolicyRaw === 'boolean'
       ? skipPasswordPolicyRaw
       : parseBooleanToken(typeof skipPasswordPolicyRaw === 'string' ? skipPasswordPolicyRaw : null) ?? false
+    const withExamplesRaw = args['with-examples'] ?? args.withExamples
+    const withExamples = typeof withExamplesRaw === 'boolean'
+      ? withExamplesRaw
+      : parseBooleanToken(typeof withExamplesRaw === 'string' ? withExamplesRaw : null) ?? false
+    const jsonModeRaw = args.json
+    const jsonMode = typeof jsonModeRaw === 'boolean'
+      ? jsonModeRaw
+      : parseBooleanToken(typeof jsonModeRaw === 'string' ? jsonModeRaw : null) ?? false
+    let restoreConsole: (() => void) | null = null
+    if (jsonMode) {
+      // Force quiet mode so module bootstrap / lifecycle hooks cannot pollute
+      // stdout. The JSON contract relies on a single line, so any console.log
+      // from setupInitialTenant or seedExamples would otherwise break the
+      // consumer's `jq` pipe. We additionally rebind console.log/info to a
+      // no-op for the duration of the call because OM_CLI_QUIET is honored
+      // unevenly across module setup hooks.
+      process.env.OM_CLI_QUIET = process.env.OM_CLI_QUIET ?? '1'
+      const originalLog = console.log
+      const originalInfo = console.info
+      console.log = () => undefined
+      console.info = () => undefined
+      restoreConsole = () => {
+        console.log = originalLog
+        console.info = originalInfo
+      }
+    }
     if (!orgName || !email || !password) {
-      console.error('Usage: mercato auth setup --orgName <name> --email <email> --password <password> [--roles superadmin,admin,employee] [--skip-password-policy]')
+      process.stderr.write(`${SETUP_USAGE}\n`)
+      process.exitCode = 2
       return
     }
-    if (!skipPasswordPolicy && !ensurePasswordPolicy(password)) return
-    if (skipPasswordPolicy) {
+    if (!skipPasswordPolicy && !ensurePasswordPolicy(password)) {
+      process.exitCode = 2
+      return
+    }
+    if (skipPasswordPolicy && !jsonMode) {
       console.warn('⚠️  Password policy validation skipped for setup.')
     }
-    const { resolve } = await createRequestContainer()
-    const em = resolve<EntityManager>('em')
+    const container = await createRequestContainer()
+    const em = container.resolve<EntityManager>('em')
     const roleNames = rolesCsv
       ? rolesCsv.split(',').map((s) => s.trim()).filter(Boolean)
       : undefined
 
     try {
+      const modules = getCliModules()
       const result = await setupInitialTenant(em, {
         orgName,
+        orgSlug,
         roleNames,
         primaryUser: { email, password, confirm: true },
         includeDerivedUsers: true,
-        modules: getCliModules(),
+        // When the caller passes an explicit slug, treat it as a "fresh tenant"
+        // signal — silent reuse of an existing user's tenant defeats the point
+        // of slugging the new tenant for downstream tooling.
+        failIfUserExists: orgSlug !== undefined,
+        modules,
       })
+
+      if (withExamples) {
+        const seedCtx = {
+          em,
+          tenantId: result.tenantId,
+          organizationId: result.organizationId,
+          container,
+        }
+        for (const mod of modules) {
+          if (mod.setup?.seedExamples) {
+            await mod.setup.seedExamples(seedCtx as any)
+          }
+        }
+      }
+
+      if (jsonMode) {
+        const adminSnapshot = pickAdminSnapshot(result.users, email)
+        const adminUserId = adminSnapshot && adminSnapshot.user.id != null
+          ? String(adminSnapshot.user.id)
+          : null
+        const payload = {
+          tenantId: result.tenantId,
+          organizationId: result.organizationId,
+          adminUserId,
+          adminEmail: email,
+          reusedExistingUser: result.reusedExistingUser,
+        }
+        if (restoreConsole) restoreConsole()
+        process.stdout.write(`${JSON.stringify(payload)}\n`)
+        return
+      }
 
       if (result.reusedExistingUser) {
         console.log('⚠️  Existing initial user detected during setup.')
@@ -470,13 +550,40 @@ const setupApp: ModuleCli = {
 
       if (env.NODE_ENV !== 'test') console.log('✅ Setup complete:', { tenantId: result.tenantId, organizationId: result.organizationId })
     } catch (err) {
+      if (restoreConsole) restoreConsole()
+      if (err instanceof OrgSlugExistsError) {
+        process.stderr.write(`${err.message}\n`)
+        process.exitCode = 1
+        return
+      }
       if (err instanceof Error && err.message === 'USER_EXISTS') {
-        console.error('Setup aborted: user already exists with the provided email.')
+        process.stderr.write('Setup aborted: user already exists with the provided email.\n')
+        process.exitCode = 1
         return
       }
       throw err
+    } finally {
+      if (restoreConsole) restoreConsole()
     }
   },
+}
+
+const ORG_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+function pickAdminSnapshot(
+  users: Array<{ user: { id: string; email: string }; roles: string[]; created: boolean }>,
+  adminEmail: string,
+): { user: { id: string; email: string } } | undefined {
+  const normalizedEmail = adminEmail.toLowerCase()
+  const exact = users.find(
+    (snapshot) =>
+      snapshot.created &&
+      snapshot.roles.includes('superadmin') &&
+      typeof snapshot.user.email === 'string' &&
+      snapshot.user.email.toLowerCase() === normalizedEmail,
+  )
+  if (exact) return exact
+  return users.find((snapshot) => snapshot.roles.includes('superadmin'))
 }
 
 const listOrganizations: ModuleCli = {

--- a/packages/core/src/modules/auth/lib/setup-app.ts
+++ b/packages/core/src/modules/auth/lib/setup-app.ts
@@ -90,6 +90,20 @@ export type SetupInitialTenantOptions = {
   includeSuperadminRole?: boolean
   /** Optional list of enabled modules. When provided, module setup hooks are called. */
   modules?: Module[]
+  /**
+   * Optional global slug to persist on the new Organization. When set, a
+   * pre-flight uniqueness check across all tenants throws OrgSlugExistsError
+   * on collision so scriptable callers can fail loudly instead of silently
+   * reusing or clobbering an existing organization.
+   */
+  orgSlug?: string
+}
+
+export class OrgSlugExistsError extends Error {
+  constructor(public readonly slug: string) {
+    super(`ORG_SLUG_EXISTS: an organization with slug "${slug}" already exists`)
+    this.name = 'OrgSlugExistsError'
+  }
 }
 
 export type SetupInitialTenantResult = {
@@ -129,6 +143,19 @@ export async function setupInitialTenant(
   const existingUser = await findOneWithDecryption(em, User, { email: mainEmail }, {}, { tenantId: null, organizationId: null })
   if (existingUser && failIfUserExists) {
     throw new Error('USER_EXISTS')
+  }
+
+  if (options.orgSlug) {
+    const slugConflict = await findOneWithDecryption(
+      em,
+      Organization,
+      { slug: options.orgSlug },
+      {},
+      { tenantId: null, organizationId: null },
+    )
+    if (slugConflict) {
+      throw new OrgSlugExistsError(options.orgSlug)
+    }
   }
 
   let tenantId: string | undefined
@@ -206,6 +233,7 @@ export async function setupInitialTenant(
 
       const organization = tem.create(Organization, {
         name: options.orgName,
+        slug: options.orgSlug ?? null,
         tenant,
         isActive: true,
         depth: 0,


### PR DESCRIPTION
Supersedes #1878.

## Summary

#1878 identified a real capability gap: OM staff have no scriptable, non-interactive way to bootstrap a fully-provisioned tenant against an existing instance with a stable slug handle and a JSON contract for downstream tooling. That diagnosis stands.

This PR delivers the same capability as a focused **+392 / −10** delta on `mercato auth setup` instead of #1878's **+4045 / −0** new top-level `test:bootstrap-tenant` namespace. `mercato auth setup` already wraps `setupInitialTenant`, already accepts non-interactive flags, already uses `findOneWithDecryption` correctly. Adding flags here keeps every other caller of `setupInitialTenant` (including `mercato init` and direct programmatic callers) on the same encryption-correct, BC-stable path.

## What's new

- **`--orgSlug <slug>`** (alias `--slug`) — persists a global slug on the new organization. Triggers a `findOneWithDecryption` uniqueness pre-check across all tenants; collisions throw a typed `OrgSlugExistsError` (exit 1, `ORG_SLUG_EXISTS: ...` to stderr). Validated against `^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`. Also forces `failIfUserExists: true` — an explicit slug signals "fresh tenant", so an existing user with the same email aborts loudly instead of silently reusing a foreign tenant.
- **`--with-examples`** — runs every enabled module's `seedExamples` after tenant creation. Opt-in (default off) so production callers do not accidentally seed demo data.
- **`--json`** — emits a single JSON line on stdout `{ tenantId, organizationId, adminUserId, adminEmail, reusedExistingUser }`. Sets `OM_CLI_QUIET=1` and rebinds `console.log`/`console.info` to no-ops for the duration so module lifecycle hooks cannot pollute the contract. Pipe directly into `jq`.

## Why not a new namespace (closing #1878)

#1878 created a `test:bootstrap-tenant` subcommand and ~318-line `bootstrap-tenant.ts` wrapper. Three problems with that path:

1. **Namespace mismatch.** `test:` reads as test infrastructure; #1878's documented audience is **production customer onboarding** and **disaster recovery**.
2. **Encryption-helper bypass.** The wrapper used four `(em as any).findOne` / `(em as any).persist` calls instead of `findOneWithDecryption` / typed `persistAndFlush`. That's the most repeated review comment in the entire repo (PRs #1212, #1213, #1221, #1236, #1248, #1370, #1368). Adding the capability to `auth/cli.ts` — which already imports `findOneWithDecryption` at the top of the file — eliminates the class of error rather than re-introducing it.
3. **Critical bug: silent tenant merge.** The wrapper called `setupInitialTenant` without `failIfUserExists: true`, then unconditionally overwrote the resulting org's slug. On email collision, `applyOrganizationSlug` would clobber a foreign tenant's slug and the JSON output would lie about it being a fresh tenant. The `--orgSlug → failIfUserExists: true` wiring here makes that whole class of bug structurally impossible.

The capability is the same; the surface is smaller, safer, and lives where the convention is already enforced.

## Test plan

- [x] 7 new unit tests in `cli-setup-orgslug.test.ts` (slug-format rejection, slug-collision throw, slug persist on org row, JSON-stdout single-line + banner suppression, `--with-examples` hook invocation, `--orgSlug` + existing user → `USER_EXISTS` exit 1, legacy reuse path intact when `--orgSlug` absent).
- [x] Existing `cli-setup-acl.test.ts` re-runs clean (no regression).
- [x] `tsc --noEmit` clean for `setup-app.ts`, `cli.ts`, and the new test file.
- [ ] Manual smoke: `yarn mercato auth setup --orgName "Acme" --orgSlug acme-1 --email admin@acme.test --password 'ChangeMe!2026' --json | jq .tenantId`

## Backward compatibility

- All additions are optional. `SetupInitialTenantOptions.orgSlug` is `?:`. The new CLI flags default off.
- No DB schema change — `Organization.slug` already exists.
- No event ID, ACL feature, import-path, or signature changes.
- `setupInitialTenant`'s default `failIfUserExists: false` is unchanged; only the CLI sets it to `true` when an explicit `--orgSlug` is provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)