### PR TITLE
fix(ui): resolve pre-populated ComboboxInput values to labels without interaction

### DIFF
--- a/apps/docs/docs/framework/extensibility/current-surfaces.mdx
+++ b/apps/docs/docs/framework/extensibility/current-surfaces.mdx
@@ -84,7 +84,7 @@ Below is the current-state inventory of extension surfaces in Open Mercato.
 | Reactive notification handlers | Add `notifications.handlers.ts` and export `notificationHandlers`; react via `useNotificationEffect` | [Notifications](/framework/modules/notifications), [Widget injection](/framework/widget-injection) |
 | Message types | Add `message-types.ts` in your module | [Messages system](/framework/modules/messages) |
 | Message object types | Add `message-objects.ts` for attachable domain objects | [Messages system](/framework/modules/messages) |
-| Payment/shipping providers | Register `registerPaymentProvider` / `registerShippingProvider` | [Shipping & payment providers](/framework/modules/sales-providers), [Sales calculations](/framework/modules/sales-calculations) |
+| Payment/shipping providers | Register `registerPaymentProvider` / `registerShippingProvider` | [Shipping & payment providers](/framework/modules/sales-providers), [Sales calculations](/framework/modules/sales/calculations) |
 | Currency providers | Add custom rate provider implementations | [Currencies module](/framework/modules/currencies) |
 | Workflow integrations | Add custom workflow activities/signals/subscribers | [Workflows extending](/framework/workflows/extending) |
 | Integration registry (UMES L) | Use `registerIntegration()` for typed integration definitions | [Integration enhancements](/framework/extensibility/integration-enhancements), [Data extensibility](/framework/database/data-extensibility) |

--- a/packages/ui/src/backend/CrudForm.tsx
+++ b/packages/ui/src/backend/CrudForm.tsx
@@ -216,6 +216,13 @@ export type CrudBuiltinField = CrudFieldBase & {
   suggestions?: string[]
   // for combobox fields; allow custom values or restrict to suggestions only
   allowCustomValues?: boolean
+  // for combobox fields; hydrate the option map up front so a pre-selected value
+  // (typically an FK whose row is not on the first page of `loadOptions`) renders
+  // its label without requiring the user to focus the field
+  seedOptions?: CrudFieldOption[]
+  // for combobox fields; resolve a pre-selected value to its display label when it
+  // is not covered by `options`/`seedOptions`/`loadOptions` results (may be async)
+  resolveLabel?: (value: string) => string | Promise<string>
   // for text/textarea fields; HTML maxLength + (textarea only) char counter when showCount=true
   maxLength?: number
   // for textarea fields; show character counter (requires maxLength)
@@ -4077,6 +4084,12 @@ const FieldControl = React.memo(function FieldControlImpl({
               ? builtin.suggestions
               : options.map((opt) => ({ value: opt.value, label: opt.label }))
           }
+          seedOptions={
+            builtin?.seedOptions
+              ? builtin.seedOptions.map((opt) => ({ value: opt.value, label: opt.label }))
+              : undefined
+          }
+          resolveLabel={builtin?.resolveLabel}
           loadSuggestions={
             typeof builtin?.loadOptions === 'function'
               ? async (query?: string) => {

--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -14,8 +14,15 @@ export type ComboboxInputProps = {
   onChange: (next: string) => void
   placeholder?: string
   suggestions?: Array<string | ComboboxOption>
+  // Options to hydrate the option map up front (typically the linked entity's
+  // display fields, already present in a record-detail payload). Merged with
+  // `suggestions` so a pre-selected value renders its label without interaction.
+  seedOptions?: ComboboxOption[]
   loadSuggestions?: (query?: string) => Promise<Array<string | ComboboxOption>>
-  resolveLabel?: (value: string) => string
+  // Eagerly resolve a pre-selected `value` to a human label when it is not
+  // covered by `suggestions`/`seedOptions`/`loadSuggestions` results. Runs once
+  // per value, before any user interaction. May be sync or async.
+  resolveLabel?: (value: string) => string | Promise<string>
   resolveDescription?: (value: string) => string | null | undefined
   autoFocus?: boolean
   disabled?: boolean
@@ -47,6 +54,7 @@ export function ComboboxInput({
   onChange,
   placeholder,
   suggestions,
+  seedOptions,
   loadSuggestions,
   resolveLabel,
   resolveDescription,
@@ -56,6 +64,7 @@ export function ComboboxInput({
 }: ComboboxInputProps) {
   const [input, setInput] = React.useState('')
   const [asyncOptions, setAsyncOptions] = React.useState<ComboboxOption[]>([])
+  const [resolvedOptions, setResolvedOptions] = React.useState<ComboboxOption[]>([])
   const [loading, setLoading] = React.useState(false)
   const [touched, setTouched] = React.useState(false)
   const [showSuggestions, setShowSuggestions] = React.useState(false)
@@ -63,29 +72,46 @@ export function ComboboxInput({
   const inputRef = React.useRef<HTMLInputElement>(null)
   const suppressOpenOnFocusRef = React.useRef(Boolean(autoFocus && !disabled))
 
-  const staticOptions = React.useMemo(() => normalizeOptions(suggestions), [suggestions])
+  const staticOptions = React.useMemo(
+    () => normalizeOptions([...(seedOptions ?? []), ...(suggestions ?? [])]),
+    [seedOptions, suggestions]
+  )
+
+  // Options whose label is genuinely known (not a self-mapping `value === label`
+  // placeholder). Used to decide whether eager resolution still needs to run.
+  const knownLabelValues = React.useMemo(() => {
+    const set = new Set<string>()
+    for (const option of [...staticOptions, ...asyncOptions, ...resolvedOptions]) {
+      if (option.label && option.label !== option.value) set.add(option.value)
+    }
+    return set
+  }, [staticOptions, asyncOptions, resolvedOptions])
 
   const optionMap = React.useMemo(() => {
     const map = new Map<string, ComboboxOption>()
     const register = (option: ComboboxOption) => {
-      if (!map.has(option.value)) {
+      const existing = map.get(option.value)
+      // Prefer an entry that carries a real label over a self-mapping placeholder.
+      if (!existing || (existing.label === existing.value && option.label !== option.value)) {
         map.set(option.value, option)
       }
     }
     staticOptions.forEach(register)
     asyncOptions.forEach(register)
+    resolvedOptions.forEach(register)
     if (value) {
       const existing = map.get(value)
       if (!existing) {
+        const sync = typeof resolveLabel === 'function' ? resolveLabel(value) : undefined
         map.set(value, {
           value,
-          label: resolveLabel?.(value) ?? value,
+          label: typeof sync === 'string' && sync ? sync : value,
           description: resolveDescription?.(value) ?? null,
         })
       }
     }
     return map
-  }, [asyncOptions, resolveDescription, resolveLabel, staticOptions, value])
+  }, [asyncOptions, resolvedOptions, resolveDescription, resolveLabel, staticOptions, value])
 
   const availableOptions = React.useMemo(() => {
     return Array.from(optionMap.values())
@@ -122,7 +148,47 @@ export function ComboboxInput({
     }
   }, [disabled, input, loadSuggestions, touched])
 
-  // Sync input with value when value changes externally and input is not focused
+  // Eagerly resolve a pre-selected value to its label without requiring the user
+  // to focus the field. Runs once per value when it is not already covered.
+  const eagerResolveLabel = typeof resolveLabel === 'function' ? resolveLabel : undefined
+  React.useEffect(() => {
+    if (!value || disabled) return
+    if (knownLabelValues.has(value)) return
+    let cancelled = false
+    const apply = (label?: string | null, description?: string | null) => {
+      const clean = typeof label === 'string' ? label.trim() : ''
+      if (cancelled || !clean || clean === value) return
+      setResolvedOptions((prev) => {
+        if (prev.some((option) => option.value === value && option.label === clean)) return prev
+        return [...prev.filter((option) => option.value !== value), { value, label: clean, description: description ?? null }]
+      })
+    }
+    if (eagerResolveLabel) {
+      Promise.resolve()
+        .then(() => eagerResolveLabel(value))
+        .then((label) => apply(label, resolveDescription?.(value)))
+        .catch(() => {})
+      return () => { cancelled = true }
+    }
+    // Fallback: pull the first page of async suggestions so a remount that lost
+    // its option cache can still recover the label without user interaction.
+    if (loadSuggestions) {
+      setLoading(true)
+      Promise.resolve()
+        .then(() => loadSuggestions())
+        .then((items) => {
+          if (cancelled) return
+          const normalized = normalizeOptions(items)
+          setAsyncOptions(normalized)
+        })
+        .catch(() => {})
+        .finally(() => { if (!cancelled) setLoading(false) })
+    }
+    return () => { cancelled = true }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, disabled, knownLabelValues, eagerResolveLabel, loadSuggestions])
+
+  // Sync input with value when value changes externally and input is not focused.
   React.useEffect(() => {
     if (document.activeElement !== inputRef.current) {
       const option = optionMap.get(value)
@@ -165,10 +231,16 @@ export function ComboboxInput({
         return
       }
       if (!allowCustomValues) {
-        // Revert to current value if custom values not allowed
-        const currentOption = optionMap.get(value)
-        setInput(currentOption?.label ?? value ?? '')
+        // Revert to the current value's label — but only if we actually know it.
+        // Baking the raw value back in while eager resolution is still pending
+        // would freeze a placeholder (e.g. a UUID) into the visible input.
         setShowSuggestions(false)
+        const currentOption = optionMap.get(value)
+        if (currentOption && currentOption.label !== currentOption.value) {
+          setInput(currentOption.label)
+        } else if (!value) {
+          setInput('')
+        }
         return
       }
       selectValue(raw)

--- a/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react'
+import { act, render, fireEvent, waitFor } from '@testing-library/react'
+import { ComboboxInput } from '../ComboboxInput'
+
+function getInput(container: HTMLElement): HTMLInputElement {
+  const el = container.querySelector('input')
+  if (!el) throw new Error('input not found')
+  return el as HTMLInputElement
+}
+
+describe('ComboboxInput — eager label resolution', () => {
+  it('renders the raw value when nothing can resolve it', () => {
+    const { container } = render(<ComboboxInput value="uuid-123" onChange={() => {}} />)
+    expect(getInput(container).value).toBe('uuid-123')
+  })
+
+  it('hydrates the label from seedOptions without any interaction', () => {
+    const { container } = render(
+      <ComboboxInput
+        value="uuid-123"
+        onChange={() => {}}
+        seedOptions={[{ value: 'uuid-123', label: 'Acme Corp' }]}
+      />,
+    )
+    expect(getInput(container).value).toBe('Acme Corp')
+  })
+
+  it('resolves the label via resolveLabel (async) on mount', async () => {
+    const resolveLabel = jest.fn(async (value: string) => `Resolved ${value}`)
+    const { container } = render(
+      <ComboboxInput value="uuid-123" onChange={() => {}} resolveLabel={resolveLabel} />,
+    )
+    // before the promise resolves, falls back to the raw value
+    expect(getInput(container).value).toBe('uuid-123')
+    await waitFor(() => expect(getInput(container).value).toBe('Resolved uuid-123'))
+    expect(resolveLabel).toHaveBeenCalledWith('uuid-123')
+  })
+
+  it('resolves the label via a synchronous resolveLabel', () => {
+    const { container } = render(
+      <ComboboxInput
+        value="uuid-123"
+        onChange={() => {}}
+        resolveLabel={(value) => (value === 'uuid-123' ? 'Sync Label' : value)}
+      />,
+    )
+    expect(getInput(container).value).toBe('Sync Label')
+  })
+
+  it('does not call resolveLabel when the value is already covered by suggestions', () => {
+    const resolveLabel = jest.fn(() => 'should-not-be-used')
+    render(
+      <ComboboxInput
+        value="uuid-123"
+        onChange={() => {}}
+        suggestions={[{ value: 'uuid-123', label: 'Already Known' }]}
+        resolveLabel={resolveLabel}
+      />,
+    )
+    expect(resolveLabel).not.toHaveBeenCalled()
+  })
+
+  it('falls back to loadSuggestions() (no query) when resolveLabel is absent', async () => {
+    const loadSuggestions = jest.fn(async () => [{ value: 'uuid-123', label: 'From Loader' }])
+    const { container } = render(
+      <ComboboxInput value="uuid-123" onChange={() => {}} loadSuggestions={loadSuggestions} />,
+    )
+    await waitFor(() => expect(getInput(container).value).toBe('From Loader'))
+    expect(loadSuggestions).toHaveBeenCalledWith()
+  })
+
+  it('keeps the resolved label after a blur revert when custom values are disallowed', async () => {
+    const onChange = jest.fn()
+    const { container } = render(
+      <ComboboxInput
+        value="uuid-123"
+        onChange={onChange}
+        allowCustomValues={false}
+        resolveLabel={async () => 'Acme Corp'}
+      />,
+    )
+    await waitFor(() => expect(getInput(container).value).toBe('Acme Corp'))
+    const input = getInput(container)
+    act(() => {
+      fireEvent.change(input, { target: { value: 'partial typing' } })
+      fireEvent.blur(input)
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    })
+    expect(getInput(container).value).toBe('Acme Corp')
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('does not bake a placeholder back into the input on blur while resolution is pending', async () => {
+    let resolve: (label: string) => void = () => {}
+    const resolveLabel = jest.fn(
+      () => new Promise<string>((res) => { resolve = res }),
+    )
+    const { container } = render(
+      <ComboboxInput
+        value="uuid-123"
+        onChange={() => {}}
+        allowCustomValues={false}
+        resolveLabel={resolveLabel}
+      />,
+    )
+    const input = getInput(container)
+    // user clears the field before resolution lands, then blurs
+    act(() => {
+      fireEvent.change(input, { target: { value: '' } })
+      fireEvent.blur(input)
+    })
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 250))
+    })
+    // the raw uuid must not have been written into the visible input
+    expect(getInput(container).value).not.toBe('uuid-123')
+    // once resolution arrives, the label shows up
+    act(() => resolve('Acme Corp'))
+    await waitFor(() => expect(getInput(container).value).toBe('Acme Corp'))
+  })
+
+  it('updates the displayed label when the value changes to one resolvable via resolveLabel', async () => {
+    const resolveLabel = jest.fn(async (value: string) => `Label-${value}`)
+    const { container, rerender } = render(
+      <ComboboxInput value="a" onChange={() => {}} resolveLabel={resolveLabel} />,
+    )
+    await waitFor(() => expect(getInput(container).value).toBe('Label-a'))
+    rerender(<ComboboxInput value="b" onChange={() => {}} resolveLabel={resolveLabel} />)
+    await waitFor(() => expect(getInput(container).value).toBe('Label-b'))
+  })
+})


### PR DESCRIPTION
Fixes #1883.

## Summary
`ComboboxInput` had no interaction-free `value → label` path: `loadSuggestions` is gated on `touched`, and `resolveLabel` (which already exists on `ComboboxInputProps`) was never threaded through `CrudForm`'s `combobox` field config. As a result a field that mounted with a pre-selected FK not covered by the first page of `loadOptions` rendered the raw UUID — most visibly on detail/edit pages and on `Tabs` hosts that remount the form.

- **`packages/ui/src/backend/inputs/ComboboxInput.tsx`**
  - New `seedOptions?: ComboboxOption[]` prop — merged into the static option map so a pre-selected value renders its label up front (typical: a record-detail payload that already carries the linked entity's display fields).
  - `resolveLabel` widened to `(value) => string | Promise<string>` (additive — existing sync consumers unaffected).
  - New effect runs eager resolution once per value on mount when the value isn't covered by static/async/seed options: calls `resolveLabel`, falling back to `loadSuggestions()` (no query) so a remount that lost its option cache can still recover. No `touched`/focus required.
  - `optionMap` now prefers a real label over a `value === label` placeholder; the `!allowCustomValues` blur-revert no longer bakes that placeholder back into the visible input while resolution is still pending (also avoids the spurious `onChange('')` clear on that path).
- **`packages/ui/src/backend/CrudForm.tsx`**
  - `CrudBuiltinField` gains `seedOptions?: CrudFieldOption[]` and `resolveLabel?: (value) => string | Promise<string>` for `type: 'combobox'`, threaded into `<ComboboxInput>`.

This is the eager-resolution half of the problem; it also dampens the #1820/#1825 autofocus→onBlur→revert race. Migration path for hosts that already enrich the record payload: pass `seedOptions: [{ value, label }]`.

## Test plan
- [x] New unit tests in `packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx` (9 tests): seed hydration, sync + async `resolveLabel`, `loadSuggestions()` fallback, no-op when value already covered, blur-revert keeps the resolved label / does not bake the placeholder, value-change re-resolution — all pass.
- [x] Typecheck: no new errors introduced (2 pre-existing `CrudForm.tsx` implicit-any errors unchanged).
- [ ] Manual: open a `CrudForm` combobox on a detail page where the field's FK is not on page 1 of `loadOptions` → confirm the label resolves without focusing the field; repeat inside a `Tabs` host that remounts the form.
- [ ] Manual: pass `seedOptions={[{ value, label }]}` from a record-detail page → confirm instant label, no flicker.

> Note: the full `packages/ui` Jest suite could not be exercised locally — `@radix-ui/react-select` is not installed in this checkout (pre-existing; affects `develop` too). The new `ComboboxInput` test has no such dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)