### PR TITLE
fix(ui): dedupe portal nav by pattern to prevent duplicate React keys (#1851)

### DIFF
--- a/packages/ui/src/portal/utils/__tests__/nav.test.ts
+++ b/packages/ui/src/portal/utils/__tests__/nav.test.ts
@@ -135,6 +135,86 @@ describe('buildPortalNav', () => {
     expect(buildPortalNav({ routes, orgSlug: 'my-org', grantedFeatures: [] })).toEqual([])
   })
 
+  it('dedupes manifest entries that share the same portal pattern', () => {
+    const routes: FrontendRouteManifestEntry[] = [
+      makeRoute({
+        moduleId: 'core',
+        pattern: '/[orgSlug]/portal/dashboard',
+        nav: { label: 'Dashboard', group: 'main', order: 10 },
+      }),
+      makeRoute({
+        moduleId: 'app',
+        pattern: '/[orgSlug]/portal/dashboard',
+        nav: { label: 'Dashboard', group: 'main', order: 10 },
+      }),
+    ]
+
+    const groups = buildPortalNav({ routes, orgSlug: 'my-org', grantedFeatures: [] })
+    const main = groups.find((g) => g.id === 'main')!
+    expect(main.items).toHaveLength(1)
+    const ids = main.items.map((i) => i.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('prefers the override with non-empty requireCustomerFeatures over a broad fallback', () => {
+    const routes: FrontendRouteManifestEntry[] = [
+      makeRoute({
+        moduleId: 'core',
+        pattern: '/[orgSlug]/portal/dashboard',
+        nav: { label: 'Dashboard', group: 'main' },
+      }),
+      makeRoute({
+        moduleId: 'app',
+        pattern: '/[orgSlug]/portal/dashboard',
+        requireCustomerFeatures: ['portal.dashboard.view'],
+        nav: { label: 'Dashboard', group: 'main' },
+      }),
+    ]
+
+    const without = buildPortalNav({ routes, orgSlug: 'my-org', grantedFeatures: [] })
+    expect(without).toEqual([])
+
+    const withGrant = buildPortalNav({
+      routes,
+      orgSlug: 'my-org',
+      grantedFeatures: ['portal.dashboard.view'],
+    })
+    expect(withGrant).toEqual([
+      { id: 'main', items: [expect.objectContaining({ label: 'Dashboard' })] },
+    ])
+  })
+
+  it('prefers the override with the longer requireCustomerFeatures list', () => {
+    const routes: FrontendRouteManifestEntry[] = [
+      makeRoute({
+        moduleId: 'core',
+        pattern: '/[orgSlug]/portal/orders',
+        requireCustomerFeatures: ['portal.orders.view'],
+        nav: { label: 'Orders', group: 'main' },
+      }),
+      makeRoute({
+        moduleId: 'app',
+        pattern: '/[orgSlug]/portal/orders',
+        requireCustomerFeatures: ['portal.orders.view', 'portal.orders.manage'],
+        nav: { label: 'Orders', group: 'main' },
+      }),
+    ]
+
+    const partial = buildPortalNav({
+      routes,
+      orgSlug: 'my-org',
+      grantedFeatures: ['portal.orders.view'],
+    })
+    expect(partial).toEqual([])
+
+    const full = buildPortalNav({
+      routes,
+      orgSlug: 'my-org',
+      grantedFeatures: ['portal.orders.view', 'portal.orders.manage'],
+    })
+    expect(full[0].items[0].label).toBe('Orders')
+  })
+
   it('sorts items by order then label', () => {
     const routes: FrontendRouteManifestEntry[] = [
       makeRoute({

--- a/packages/ui/src/portal/utils/nav.ts
+++ b/packages/ui/src/portal/utils/nav.ts
@@ -46,6 +46,20 @@ function pickGroup(group: unknown): PortalNavGroupId {
   return 'main'
 }
 
+function pickPreferredRoute(
+  existing: FrontendRouteManifestEntry,
+  candidate: FrontendRouteManifestEntry,
+): FrontendRouteManifestEntry {
+  const existingFeatures = existing.requireCustomerFeatures ?? []
+  const candidateFeatures = candidate.requireCustomerFeatures ?? []
+  if (existingFeatures.length === 0 && candidateFeatures.length > 0) return candidate
+  if (candidateFeatures.length === 0 && existingFeatures.length > 0) return existing
+  if (existingFeatures.length !== candidateFeatures.length) {
+    return candidateFeatures.length > existingFeatures.length ? candidate : existing
+  }
+  return existing
+}
+
 /**
  * Build the portal sidebar from the frontend route manifest.
  *
@@ -66,19 +80,27 @@ export function buildPortalNav({
   const mainItems: PortalNavItem[] = []
   const accountItems: PortalNavItem[] = []
 
+  const dedupedByPattern = new Map<string, FrontendRouteManifestEntry>()
   for (const route of routes) {
     const pattern = route.pattern ?? route.path
     if (!isPortalPattern(pattern)) continue
     if (route.navHidden) continue
     const nav = route.nav
     if (!nav || typeof nav.label !== 'string' || nav.label.length === 0) continue
+    const existing = dedupedByPattern.get(pattern)
+    dedupedByPattern.set(pattern, existing ? pickPreferredRoute(existing, route) : route)
+  }
+
+  for (const route of dedupedByPattern.values()) {
+    const pattern = (route.pattern ?? route.path) as string
+    const nav = route.nav!
 
     const requireFeatures = route.requireCustomerFeatures ?? []
     if (!isPortalAdmin && requireFeatures.length) {
       if (!hasAllFeatures(grantedFeatures as string[], requireFeatures as string[])) continue
     }
 
-    const href = resolveHref(pattern as string, orgSlug)
+    const href = resolveHref(pattern, orgSlug)
     if (!hasNoUnresolvedParams(href)) continue
 
     const group = pickGroup(nav.group)


### PR DESCRIPTION
Fixes #1851

## Problem

`buildPortalNav` (in `packages/ui/src/portal/utils/nav.ts`) iterates the frontend route manifest and emits one nav item per discovered `page.meta.ts` `nav` block, keyed as `portal-nav:${pattern}`. When two modules ship a `page.meta.ts` at the same logical route — e.g. a downstream module overriding `frontend/[orgSlug]/portal/dashboard/` — both metas land in the manifest, both nav items are emitted with the same `id`, and React logs `Encountered two children with the same key, \`portal-nav:/[orgSlug]/portal/dashboard\`. Keys should be unique...`

The page-level routing collision is already resolved by module precedence, but the nav builder had no equivalent dedup.

## Root Cause

The `id` is a pure function of `pattern`, so any two manifest entries with the same pattern produce the same id. `mergePortalSidebarGroupsWithInjected` already dedupes injected items against discovered items by id and href; the discovered set itself was never deduped.

## What Changed

- `buildPortalNav` now dedupes manifest entries by portal pattern before emitting nav items.
- When two entries share a pattern, the more restrictive override wins, in this order:
  1. Entry with non-empty `requireCustomerFeatures` over entry with empty `requireCustomerFeatures`.
  2. Entry with the longer `requireCustomerFeatures` array.
  3. First-seen wins (stable fallback).
- This matches Next.js routing precedence (downstream/app modules override core) and lets downstream apps cleanly override portal nav entries by shipping a same-route `page.meta.ts` with a `nav` block.

## Tests

Added 3 new unit tests in `packages/ui/src/portal/utils/__tests__/nav.test.ts`:

- dedupes manifest entries that share the same portal pattern
- prefers the override with non-empty `requireCustomerFeatures` over a broad fallback
- prefers the override with the longer `requireCustomerFeatures` list

All 13 nav tests pass; full UI suite (875 tests) green; `yarn typecheck` clean; `yarn i18n:check-sync` clean.

## Backward Compatibility

No contract surface changes. `buildPortalNav`'s signature, options, and return shape are unchanged. The behavior change is strictly narrowing: callers that previously got two duplicate items now get one — the same result authors of override-style `page.meta.ts` already expect from page-level routing precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)