### PR TITLE
fix(create-app): default DEMO_MODE=false in scaffold template (#1861)

### DIFF
--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -35,7 +35,8 @@ APP_URL=http://localhost:3000
 
 # Enable self-service onboarding (default: false)
 SELF_SERVICE_ONBOARDING_ENABLED=false
-DEMO_MODE=true
+# Enable Open Mercato demo widgets (default: false)
+DEMO_MODE=false
 
 # Enable enterprise-only optional modules (default: false)
 # Developer preview is free for local/dev usage.

--- a/packages/create-app/template/src/app/(backend)/backend/__tests__/layout-route-registry.test.tsx
+++ b/packages/create-app/template/src/app/(backend)/backend/__tests__/layout-route-registry.test.tsx
@@ -9,6 +9,11 @@ const backendRoutes = [
 ]
 
 const mockRegisterBackendRouteManifests = jest.fn()
+const mockParseBooleanWithDefault = jest.fn(() => false)
+const mockCookies = jest.fn()
+const mockHeaders = jest.fn()
+const mockResolveTranslations = jest.fn()
+const mockGetAuthFromCookies = jest.fn()
 
 jest.mock('@/.mercato/generated/backend-routes.generated', () => ({
   backendRoutes,
@@ -20,12 +25,12 @@ jest.mock('@open-mercato/shared/modules/registry', () => ({
 }))
 
 jest.mock('next/headers', () => ({
-  cookies: jest.fn(),
-  headers: jest.fn(),
+  cookies: (...args: unknown[]) => mockCookies(...args),
+  headers: (...args: unknown[]) => mockHeaders(...args),
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
-  getAuthFromCookies: jest.fn(),
+  getAuthFromCookies: (...args: unknown[]) => mockGetAuthFromCookies(...args),
 }))
 
 jest.mock('@open-mercato/ui/backend/AppShell', () => ({
@@ -33,7 +38,7 @@ jest.mock('@open-mercato/ui/backend/AppShell', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
-  resolveTranslations: jest.fn(),
+  resolveTranslations: (...args: unknown[]) => mockResolveTranslations(...args),
 }))
 
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
@@ -49,7 +54,7 @@ jest.mock('@open-mercato/shared/lib/version', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/boolean', () => ({
-  parseBooleanWithDefault: jest.fn(() => true),
+  parseBooleanWithDefault: (...args: unknown[]) => mockParseBooleanWithDefault(...args),
 }))
 
 jest.mock('@open-mercato/ui/backend/injection/PageInjectionBoundary', () => ({
@@ -73,6 +78,11 @@ describe('Backend layout route registry', () => {
   beforeEach(() => {
     jest.resetModules()
     mockRegisterBackendRouteManifests.mockClear()
+    mockParseBooleanWithDefault.mockClear()
+    mockCookies.mockReset()
+    mockHeaders.mockReset()
+    mockResolveTranslations.mockReset()
+    mockGetAuthFromCookies.mockReset()
   })
 
   it('registers backend route manifests at module load', async () => {
@@ -81,5 +91,36 @@ describe('Backend layout route registry', () => {
     })
 
     expect(mockRegisterBackendRouteManifests).toHaveBeenCalledWith(backendRoutes)
+  })
+
+  it('defaults the demo mode flag to false when DEMO_MODE is unset', async () => {
+    const originalDemoMode = process.env.DEMO_MODE
+    delete process.env.DEMO_MODE
+    mockGetAuthFromCookies.mockResolvedValue(null)
+    mockCookies.mockResolvedValue({ get: () => undefined })
+    mockHeaders.mockResolvedValue({ get: () => null })
+    mockResolveTranslations.mockResolvedValue({
+      translate: (_key: string, fallback: string) => fallback,
+      locale: 'en',
+      dict: {},
+    })
+
+    try {
+      await jest.isolateModulesAsync(async () => {
+        const { default: BackendLayout } = await import('../layout')
+        await BackendLayout({
+          children: React.createElement('div'),
+          params: Promise.resolve({}),
+        })
+      })
+
+      expect(mockParseBooleanWithDefault).toHaveBeenCalledWith(undefined, false)
+    } finally {
+      if (originalDemoMode === undefined) {
+        delete process.env.DEMO_MODE
+      } else {
+        process.env.DEMO_MODE = originalDemoMode
+      }
+    }
   })
 })

--- a/packages/create-app/template/src/app/(backend)/backend/layout.tsx
+++ b/packages/create-app/template/src/app/(backend)/backend/layout.tsx
@@ -80,7 +80,7 @@ export default async function BackendLayout({
 
   const collapsedCookie = cookieStore.get('om_sidebar_collapsed')?.value
   const initialCollapsed = collapsedCookie === '1'
-  const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, true)
+  const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, false)
   const deployEnv = process.env.DEPLOY_ENV
   const baseProductName = translate('appShell.productName', 'Open Mercato')
   const productName = deployEnv && deployEnv !== 'local'

--- a/packages/create-app/template/src/app/__tests__/layout.test.tsx
+++ b/packages/create-app/template/src/app/__tests__/layout.test.tsx
@@ -97,4 +97,18 @@ describe('RootLayout', () => {
     expect(appProviders?.props.demoModeEnabled).toBe(false)
     expect(appProviders?.props.noticeBarsEnabled).toBe(true)
   })
+
+  it('defaults demo mode off when DEMO_MODE is unset', async () => {
+    delete process.env.DEMO_MODE
+    delete process.env.OM_INTEGRATION_TEST
+
+    const { default: RootLayout } = await import('../layout')
+    const { AppProviders } = await import('@/components/AppProviders')
+    const tree = await RootLayout({ children: 'child' })
+    const appProviders = findElementByType(tree, AppProviders)
+
+    expect(appProviders).not.toBeNull()
+    expect(appProviders?.props.demoModeEnabled).toBe(false)
+    expect(appProviders?.props.noticeBarsEnabled).toBe(true)
+  })
 })

--- a/packages/create-app/template/src/app/layout.tsx
+++ b/packages/create-app/template/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default async function RootLayout({
 }>) {
   const locale = await detectLocale()
   const dict = await loadDictionary(locale)
-  const demoModeEnabled = process.env.DEMO_MODE !== 'false'
+  const demoModeEnabled = process.env.DEMO_MODE === 'true'
   const noticeBarsEnabled = process.env.OM_INTEGRATION_TEST !== 'true'
   return (
     <html lang={locale} suppressHydrationWarning>


### PR DESCRIPTION
Fixes #1861

## Problem
`packages/create-app/template/` shipped three independent places that all defaulted `DEMO_MODE` "on":

1. `template/.env.example` — `DEMO_MODE=true`
2. `template/src/app/layout.tsx` — `process.env.DEMO_MODE !== 'false'` (default-true when env var absent)
3. `template/src/app/(backend)/backend/layout.tsx` — `parseBooleanWithDefault(process.env.DEMO_MODE, true)`

As a result every `npx create-mercato-app` scaffold opted into the Open Mercato demo widgets by default — the "Talk to Open Mercato team" popup and the amber lead-gen notice bar — until the operator explicitly turned them off. That is appropriate for the OM-hosted showcase but inappropriate as the default for downstream apps building real products on the framework.

## Root Cause
The three default-on paths in the scaffolder template — operators only got the demo widgets disabled if they remembered to set `DEMO_MODE=false` after scaffolding.

## What Changed
- `template/.env.example` — `DEMO_MODE=false` with a new `# Enable Open Mercato demo widgets (default: false)` comment to match the surrounding `(default: ...)` annotations.
- `template/src/app/layout.tsx` — `process.env.DEMO_MODE === 'true'` so an absent env var resolves to `false`.
- `template/src/app/(backend)/backend/layout.tsx` — `parseBooleanWithDefault(process.env.DEMO_MODE, false)`.

`apps/mercato/.env.example` (the OM-hosted showcase) keeps `DEMO_MODE=true` explicitly, so the live demo behaves identically. Existing scaffolded apps with their own `.env` are unaffected — only the `.env.example` template and the in-code fallbacks change, both of which only matter when `DEMO_MODE` is absent.

## Tests
- Added `RootLayout` test case: `defaults demo mode off when DEMO_MODE is unset` — asserts `demoModeEnabled=false` and `noticeBarsEnabled=true` when `DEMO_MODE` is not set.
- Extended backend `layout-route-registry` test: `defaults the demo mode flag to false when DEMO_MODE is unset` — invokes `BackendLayout` with `DEMO_MODE` unset and asserts `parseBooleanWithDefault(undefined, false)` is the actual call.
- Ran the touched template suites plus the `apps/mercato` showcase layout test — all pass.
- Ran `yarn typecheck` and `yarn build:packages` — green.
- `yarn i18n:check-sync` passes; `yarn i18n:check-usage` reports the same pre-existing missing/unused keys that exist on `develop` (none introduced here — diff is template-only and touches no i18n strings).

## Backward Compatibility
- No contract surface changes (template defaults only).
- New behavior only kicks in for newly-scaffolded apps that do not copy `.env.example` to `.env` and do not set `DEMO_MODE`. Existing apps pin the value in their environment and are not affected.
- Operators that want demo behavior opt in with a single `DEMO_MODE=true` line.

## Test plan
- [x] Unit: `packages/create-app/template/src/app/__tests__/layout.test.tsx` (default-off when unset, on when `DEMO_MODE=true`, off when `DEMO_MODE=false`)
- [x] Unit: `packages/create-app/template/src/app/(backend)/backend/__tests__/layout-route-registry.test.tsx` (asserts `parseBooleanWithDefault(process.env.DEMO_MODE, false)` is invoked)
- [x] Regression: `apps/mercato/src/app/__tests__/layout.test.tsx` continues to pass (OM showcase unchanged)
- [ ] Manual: scaffold a fresh app and confirm the demo widget + amber notice are absent by default; set `DEMO_MODE=true` and confirm they come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)