### PR TITLE
fix(ui): raiseCrudError extracts message from structured { error: { code, message } } envelopes (#1912)

### DIFF
--- a/packages/ui/src/backend/__tests__/serverErrors.test.ts
+++ b/packages/ui/src/backend/__tests__/serverErrors.test.ts
@@ -1,4 +1,9 @@
-import { mapCrudServerErrorToFormErrors, raiseCrudError, readJsonSafe } from '../utils/serverErrors'
+import {
+  mapCrudServerErrorToFormErrors,
+  normalizeCrudServerError,
+  raiseCrudError,
+  readJsonSafe,
+} from '../utils/serverErrors'
 
 describe('serverErrors helpers', () => {
   it('maps details array into field errors and message', () => {
@@ -57,6 +62,79 @@ describe('serverErrors helpers', () => {
       expect(err).toMatchObject({ status: 400, message: 'Invalid input' })
       expect(err).toHaveProperty('details')
     }
+  })
+
+  it('raiseCrudError extracts message from structured { error: { code, message } } envelope', async () => {
+    expect.assertions(4)
+    const response = new Response(
+      JSON.stringify({
+        ok: false,
+        error: {
+          code: 'invite_cooldown_active',
+          message: 'A recent invite for this email is still pending — please wait before re-inviting.',
+          details: { retryAfterSeconds: 60 },
+        },
+      }),
+      { status: 429, headers: { 'content-type': 'application/json' } },
+    )
+
+    try {
+      await raiseCrudError(response, 'Fallback message')
+    } catch (err) {
+      expect(err).toMatchObject({
+        status: 429,
+        message:
+          'A recent invite for this email is still pending — please wait before re-inviting.',
+      })
+      const errorField = (err as { error?: unknown }).error as
+        | { code?: unknown; details?: unknown }
+        | undefined
+      expect(errorField?.code).toBe('invite_cooldown_active')
+      expect(errorField?.details).toEqual({ retryAfterSeconds: 60 })
+      expect((err as { ok?: unknown }).ok).toBe(false)
+    }
+  })
+
+  it('normalizeCrudServerError reads message from nested { error: { message } } envelope', () => {
+    const normalized = normalizeCrudServerError({
+      ok: false,
+      error: {
+        code: 'invite_cooldown_active',
+        message: 'A recent invite for this email is still pending — please wait before re-inviting.',
+      },
+    })
+    expect(normalized.message).toBe(
+      'A recent invite for this email is still pending — please wait before re-inviting.',
+    )
+  })
+
+  it('raiseCrudError prefers top-level string error over nested error.message', async () => {
+    expect.assertions(1)
+    const response = new Response(
+      JSON.stringify({
+        error: 'Top-level message',
+        message: 'Top-level message',
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    )
+
+    await expect(raiseCrudError(response, 'Fallback message')).rejects.toMatchObject({
+      status: 400,
+      message: 'Top-level message',
+    })
+  })
+
+  it('raiseCrudError falls back when structured envelope has empty nested message', async () => {
+    expect.assertions(1)
+    const response = new Response(
+      JSON.stringify({ ok: false, error: { code: 'oops', message: '   ' } }),
+      { status: 500, headers: { 'content-type': 'application/json' } },
+    )
+
+    await expect(raiseCrudError(response, 'Fallback message')).rejects.toMatchObject({
+      status: 500,
+      message: 'Fallback message',
+    })
   })
 
   it('raiseCrudError falls back to message when body is plain text', async () => {

--- a/packages/ui/src/backend/utils/serverErrors.ts
+++ b/packages/ui/src/backend/utils/serverErrors.ts
@@ -124,12 +124,19 @@ export function normalizeCrudServerError(err: unknown): NormalizedCrudServerErro
 
     if (typeof current !== 'object') continue
 
+    const errorField = (current as any).error
+    const nestedErrorMessage =
+      errorField && typeof errorField === 'object' &&
+      typeof (errorField as any).message === 'string' &&
+      (errorField as any).message.trim()
+        ? ((errorField as any).message as string)
+        : undefined
     const candidateMessage =
-      typeof (current as any).error === 'string'
-        ? (current as any).error
+      typeof errorField === 'string'
+        ? errorField
         : typeof (current as any).message === 'string'
           ? (current as any).message
-          : undefined
+          : nestedErrorMessage
     if (candidateMessage && !message) message = candidateMessage
 
     for (const key of JSON_FIELD_KEYS) {
@@ -266,12 +273,12 @@ export async function raiseCrudError(res: Response, fallbackMessage?: string): P
 
   if (parsed && typeof parsed === 'object') {
     const data = parsed as Record<string, unknown>
+    const normalized = normalizeCrudServerError(data)
+    const normalizedMessage = normalized.message?.trim()
     const rawMessage =
-      typeof data.error === 'string' && data.error.trim()
-        ? data.error.trim()
-        : typeof data.message === 'string' && data.message.trim()
-          ? data.message.trim()
-          : fallbackMessage ?? `Request failed (${res.status})`
+      normalizedMessage && normalizedMessage.length > 0
+        ? normalizedMessage
+        : fallbackMessage ?? `Request failed (${res.status})`
     const message = parseServerMessage(rawMessage)
     throw buildHttpError(message, {
       ...data,


### PR DESCRIPTION
Fixes #1912

## Problem
When a UI page calls `apiCallOrThrow` + `flash(err.message, 'error')` and the API returns a structured error envelope of the shape

```json
{ "ok": false, "error": { "code": "invite_cooldown_active", "message": "A recent invite...", "details": { "retryAfterSeconds": 60 } } }
```

`raiseCrudError` previously surfaced the generic placeholder `Request failed (NNN)` instead of the backend's `error.message`, because it only inspected `data.error` when it was a string. The actionable copy and any `details` hints were dropped from the toast.

## Root Cause
`packages/ui/src/backend/utils/serverErrors.ts → raiseCrudError` checked `typeof data.error === 'string'`; with the structured envelope `data.error` is an object, so the chain fell through to the fallback. The sibling helper `normalizeCrudServerError` already handled nested form-error shapes but didn't inspect `error.message` either, so it could not be reused as-is.

## What Changed
- Extend `normalizeCrudServerError` to read `error.message` when `error` is an object with a non-empty string message. Top-level string `error`/`message` continue to take precedence.
- Refactor `raiseCrudError` to use `normalizeCrudServerError` for human-readable message extraction. The thrown `Error` still spreads `...data`, so `error.code`, `error.details`, and other fields remain available to advanced consumers.

## Tests
Added regression tests in `packages/ui/src/backend/__tests__/serverErrors.test.ts`:
- `raiseCrudError extracts message from structured { error: { code, message } } envelope` — proves the bug fix, also asserts `error.code` / `error.details` / top-level `ok` are still exposed on the thrown error.
- `normalizeCrudServerError reads message from nested { error: { message } } envelope` — direct unit test for the helper extension.
- `raiseCrudError prefers top-level string error over nested error.message` — pins precedence so legacy callers don't regress.
- `raiseCrudError falls back when structured envelope has empty nested message` — covers whitespace/empty `error.message`.

Validation gate run on this branch:
- `yarn build:packages` — pass
- `yarn generate` — pass
- `yarn i18n:check-sync` — pass (all locales in sync)
- `yarn i18n:check-usage` — pass (advisory; pre-existing missing/unused keys unchanged by this PR)
- `yarn typecheck` — pass (18/18 packages)
- `yarn test` — pass (full monorepo; UI package alone: 876/876 tests)

`yarn build:app` fails on `/_global-error` prerender (`TypeError: Cannot read properties of null (reading 'useContext')`) but the failure reproduces on clean `origin/develop` without this PR's diff — it is a pre-existing Next.js prerender issue on a page this PR does not touch. Filing/tracking that build failure is out of scope for this fix.

## Backward Compatibility
No contract surface changes:
- `raiseCrudError` / `normalizeCrudServerError` signatures unchanged.
- Thrown `Error` still spreads `...data` (so `error.code` / `error.details` / top-level fields remain accessible).
- Top-level string `error` and `message` still take precedence — only previously-unhandled structured envelopes are affected.
- No DB, ORM, encryption, ACL, event ID, widget spot ID, DI key, or generated-file changes.