### PR TITLE
fix(cli): clear MikroORM MetadataStorage between db:generate iterations (#1911)

### DIFF
--- a/packages/cli/src/lib/db/__tests__/commands.test.ts
+++ b/packages/cli/src/lib/db/__tests__/commands.test.ts
@@ -5,11 +5,14 @@ import {
   getMigrationSnapshotName,
   shouldCreateInitialModuleMigration,
   resolveGeneratedMigrationPath,
+  dbGenerate,
   dbGreenfield,
 } from '../commands'
+import { MetadataStorage } from '@mikro-orm/core'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import type { ModuleEntry, PackageResolver } from '../../resolver'
 
 describe('db commands security', () => {
   describe('sanitizeModuleId', () => {
@@ -243,5 +246,104 @@ describe('db commands', () => {
         expect(() => validateTableName(tableName)).not.toThrow()
       })
     })
+  })
+})
+
+describe('dbGenerate metadata isolation (issue #1911)', () => {
+  // Regression test for https://github.com/open-mercato/open-mercato/issues/1911.
+  // Without per-iteration MetadataStorage.clear(), every module's migration
+  // accumulated the @Entity() decorator registrations from previously-loaded
+  // modules and therefore produced polluted CREATE TABLE statements. The fix
+  // is a single MetadataStorage.clear() call at the top of every iteration of
+  // the dbGenerate loop. The test verifies that the clear is invoked once per
+  // iteration and that it actually wipes any pre-existing global metadata
+  // entries (the practical pollution vector that caused the bug).
+
+  const tempDirs: string[] = []
+  let clearSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://noop@localhost:5432/test'
+    MetadataStorage.clear()
+    clearSpy = jest.spyOn(MetadataStorage, 'clear')
+  })
+
+  afterEach(() => {
+    clearSpy.mockRestore()
+    for (const dir of tempDirs.splice(0)) {
+      try { fs.rmSync(dir, { recursive: true, force: true }) } catch {}
+    }
+    MetadataStorage.clear()
+  })
+
+  function createTempModule(id: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `mercato-mod-${id}-`))
+    tempDirs.push(dir)
+    fs.mkdirSync(path.join(dir, 'data'), { recursive: true })
+    fs.mkdirSync(path.join(dir, 'migrations'), { recursive: true })
+    fs.writeFileSync(path.join(dir, 'migrations', '.snapshot-open-mercato.json'), '{}', 'utf8')
+    fs.writeFileSync(
+      path.join(dir, 'data', 'entities.ts'),
+      `export class TestEntity_${id} {}\n`,
+      'utf8',
+    )
+    return dir
+  }
+
+  function createMockResolver(modules: { id: string; dir: string }[]): PackageResolver {
+    const entries: ModuleEntry[] = modules.map((m) => ({ id: m.id, from: '@app' as const }))
+    const byId = new Map(modules.map((m) => [m.id, m.dir]))
+    return {
+      isMonorepo: () => true,
+      getRootDir: () => '/tmp/test-root',
+      getAppDir: () => '/tmp/test-app',
+      getOutputDir: () => '/tmp/test-out',
+      getModulesConfigPath: () => '/tmp/test-root/modules.ts',
+      discoverPackages: () => [],
+      loadEnabledModules: () => entries,
+      getModulePaths: (entry: ModuleEntry) => {
+        const dir = byId.get(entry.id) ?? '/nonexistent'
+        return { appBase: dir, pkgBase: dir }
+      },
+      getModuleImportBase: (entry: ModuleEntry) => ({
+        appBase: `@/modules/${entry.id}`,
+        pkgBase: `@open-mercato/core/modules/${entry.id}`,
+      }),
+      getPackageOutputDir: () => '/tmp/test-out',
+      getPackageRoot: () => '/tmp/test-root',
+    }
+  }
+
+  it('calls MetadataStorage.clear() at the start of every module iteration', async () => {
+    const moduleA = { id: 'modulealpha', dir: createTempModule('modulealpha') }
+    const moduleB = { id: 'modulebeta', dir: createTempModule('modulebeta') }
+    const resolver = createMockResolver([moduleA, moduleB])
+
+    await dbGenerate(resolver)
+
+    // The fix adds one MetadataStorage.clear() at the top of every iteration of
+    // the dbGenerate loop. With two modules, clear must be invoked at least
+    // twice. Without the fix (the regression introduced by 3b0b8eb6a), clear is
+    // never invoked from dbGenerate at all.
+    expect(clearSpy.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('wipes pre-existing global metadata entries before processing each module', async () => {
+    // Simulate the @Entity decorator side effect from a previously-loaded
+    // module by manually registering a metadata entry. Without the fix, this
+    // entry would persist into the next module's MikroORM.init() and end up
+    // in its generated migration as an unrelated CREATE TABLE statement.
+    MetadataStorage.getMetadata('LingeringEntity', '/stale/path/lingering')
+    expect(Object.keys(MetadataStorage.getMetadata())).toHaveLength(1)
+
+    const moduleA = { id: 'modulealpha', dir: createTempModule('modulealpha') }
+    const resolver = createMockResolver([moduleA])
+
+    await dbGenerate(resolver)
+
+    // After dbGenerate runs, the clear must have wiped the stale entry. We
+    // observe the registry state at clear time AND after dbGenerate exits.
+    expect(clearSpy.mock.calls.length).toBeGreaterThanOrEqual(1)
+    expect(Object.keys(MetadataStorage.getMetadata())).toHaveLength(0)
   })
 })

--- a/packages/cli/src/lib/db/commands.ts
+++ b/packages/cli/src/lib/db/commands.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import fs from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import ts from 'typescript'
-import { MikroORM, type Logger } from '@mikro-orm/core'
+import { MikroORM, MetadataStorage, type Logger } from '@mikro-orm/core'
 import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy'
 import { Migrator } from '@mikro-orm/migrations'
 import { PostgreSqlDriver } from '@mikro-orm/postgresql'
@@ -234,18 +234,19 @@ export async function dbGenerate(resolver: PackageResolver, options: DbOptions =
   const ordered = sortModules(modules)
   const results: string[] = []
 
-  const moduleClasses = new Map<string, any[]>()
-  for (const entry of ordered) {
-    moduleClasses.set(entry.id, await loadModuleEntities(entry, resolver))
-  }
-
   const sslConfig = getSslConfig()
   const usedFileNames = new Set<string>()
 
   for (const entry of ordered) {
+    // Clear the global @Entity() decorator registry before loading this module's
+    // entities. MikroORM's migrator reads MetadataStorage at createMigration()
+    // time, so without this clear, every module's migration would include every
+    // previously-loaded module's tables (see issue #1911).
+    MetadataStorage.clear()
+
     const modId = entry.id
     const sanitizedModId = sanitizeModuleId(modId)
-    const entities = moduleClasses.get(modId) ?? []
+    const entities = await loadModuleEntities(entry, resolver)
     if (!entities.length) {
       if (entry.from === '@app') {
         results.push(formatResult(modId, 'no entities discovered', ''))


### PR DESCRIPTION
Fixes #1911

## Problem
`yarn db:generate` could produce polluted migrations for new modules — a migration for one new module could contain `CREATE TABLE` statements for unrelated core-module tables (per the issue report: ~200 tables, 1,000+ lines), making the migration destructive on apply.

## Root Cause
Commit `f2f43dbc3` previously fixed this by calling `MetadataStorage.clear()` between module iterations in `dbGenerate`. Commit `3b0b8eb6a` (the MikroORM v7 polish stage) then restructured `dbGenerate` to **pre-load every module's entity classes into a `Map` before the iteration loop**, dropping both the `MetadataStorage.clear()` call and the `MetadataStorage` import. After the refactor, the pre-load fires every module's `@Entity()` decorator side effects into MikroORM's global metadata registry up-front, and the migrator reads from that registry at `createMigration()` time.

## What Changed
`packages/cli/src/lib/db/commands.ts`:
- Re-import `MetadataStorage` from `@mikro-orm/core`.
- Remove the pre-load `moduleClasses` `Map`; move `loadModuleEntities()` back inside the per-module loop.
- Call `MetadataStorage.clear()` as the first statement of every iteration so each module's migration is generated against its own metadata only.

## Tests
`packages/cli/src/lib/db/__tests__/commands.test.ts` — new `dbGenerate metadata isolation (issue #1911)` describe block:
- `calls MetadataStorage.clear() at the start of every module iteration` — spies on `MetadataStorage.clear` and asserts at least one call per iterated module. Fails on the buggy branch (0 calls).
- `wipes pre-existing global metadata entries before processing each module` — pre-plants a synthetic metadata entry to simulate the @Entity decorator side effect from a previously-loaded module, runs `dbGenerate`, and asserts the entry is gone. Fails on the buggy branch (entry persists).

Other verification run:
- `yarn typecheck` — 18/18 packages clean.
- `yarn build:packages` — 18/18 packages built.
- `yarn test` — 19/19 packages green (854 CLI tests, 3744 core tests).
- `yarn i18n:check-sync` — clean.
- `yarn i18n:check-usage` — 20 pre-existing missing keys in `ai_assistant` files (unrelated to this PR).
- End-to-end reproduction: created a throwaway app module with two entities (`issue1911_widgets`, `issue1911_gizmos`), enabled it in `apps/mercato/src/modules.ts`, ran `yarn db:generate` against a fresh DB — generated migration contained exactly those two `CREATE TABLE` statements and nothing else.

## Backward Compatibility
- No frozen / stable contract surface changes. `dbGenerate` signature, imports, and behavior on the happy path are preserved.
- No API response, event ID, widget spot ID, ACL feature, DI key, or DB schema changes.
- The `MetadataStorage` import is added to an existing import statement; no new public re-exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)