### PR TITLE
fix(docker): make bundled Traefik an opt-in overlay

### DIFF
--- a/docker-compose.fullapp.dev.yml
+++ b/docker-compose.fullapp.dev.yml
@@ -23,31 +23,12 @@ services:
     networks:
       - mercato-network-fullapp
 
-  traefik:
-    image: traefik:v3.2
-    container_name: mercato-traefik-${DEPLOY_ENV:-local}
-    restart: unless-stopped
-    command:
-      - "--configFile=/etc/traefik/traefik.yml"
-    ports:
-      - "${TRAEFIK_HTTP_PORT:-80}:80"
-      - "${TRAEFIK_HTTPS_PORT:-443}:443"
-      - "${TRAEFIK_DASHBOARD_PORT:-8081}:8080"
-    volumes:
-      - ./docker/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-      - traefik_acme:/letsencrypt
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      ACME_EMAIL: ${ACME_EMAIL:-admin@example.com}
-      TRAEFIK_LOG_LEVEL: ${TRAEFIK_LOG_LEVEL:-INFO}
-      # Default to LE staging in dev so we don't burn rate limits while
-      # iterating. Set TRAEFIK_CA_SERVER to the prod URL to flip to real certs.
-      TRAEFIK_CA_SERVER: ${TRAEFIK_CA_SERVER:-https://acme-staging-v02.api.letsencrypt.org/directory}
-      TRAEFIK_DOCKER_NETWORK: mercato-network-${DEPLOY_ENV:-local}
-    depends_on:
-      - app
-    networks:
-      - mercato-network-fullapp
+  # Traefik (TLS termination, on-demand ACME, custom-domain ForwardAuth gate)
+  # is now an opt-in overlay so this base file works behind an external reverse
+  # proxy (Dokploy, Caddy, nginx, Cloudflare Tunnel, etc.) without conflict.
+  # To run the bundled Traefik in dev (staging ACME by default):
+  #   docker compose -f docker-compose.fullapp.dev.yml \
+  #     -f docker-compose.fullapp.traefik.yml up --build
 
   app:
     build:
@@ -56,29 +37,7 @@ services:
     image: open-mercato/app:${DEPLOY_ENV:-local}-dev
     user: "0"
     command: ["/bin/sh", "/app/docker/scripts/dev-entrypoint.sh"]
-    labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=mercato-network-${DEPLOY_ENV:-local}"
-      - "traefik.http.routers.platform.rule=Host(`${PLATFORM_PRIMARY_HOST:-openmercato.com}`)"
-      - "traefik.http.routers.platform.priority=100"
-      - "traefik.http.routers.platform.entrypoints=websecure"
-      - "traefik.http.routers.platform.tls=true"
-      - "traefik.http.routers.platform.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.platform.service=app-upstream"
-      - "traefik.http.routers.customer.rule=HostRegexp(`{any:.+}`)"
-      - "traefik.http.routers.customer.priority=1"
-      - "traefik.http.routers.customer.entrypoints=websecure"
-      - "traefik.http.routers.customer.tls=true"
-      - "traefik.http.routers.customer.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.customer.service=app-upstream"
-      - "traefik.http.routers.customer.middlewares=inject-domain-check-secret,domain-check"
-      - "traefik.http.middlewares.inject-domain-check-secret.headers.customrequestheaders.X-Domain-Check-Secret=${DOMAIN_CHECK_SECRET}"
-      - "traefik.http.middlewares.domain-check.forwardauth.address=http://app:3000/api/customer_accounts/domain-check"
-      - "traefik.http.middlewares.domain-check.forwardauth.authrequestheaders=X-Domain-Check-Secret,X-Forwarded-Host,X-Forwarded-Proto,X-Forwarded-Uri"
-      - "traefik.http.middlewares.domain-check.forwardauth.authresponseheaders=X-Open-Mercato-Origin"
-      - "traefik.http.middlewares.domain-check.forwardauth.trustforwardheader=false"
-      - "traefik.http.services.app-upstream.loadbalancer.server.port=3000"
-      - "traefik.http.services.app-upstream.loadbalancer.passhostheader=true"
+    # Traefik labels live in docker-compose.fullapp.traefik.yml — opt-in only.
     volumes:
       - .:/app
       - app_node_modules:/app/node_modules
@@ -278,8 +237,6 @@ volumes:
     name: mercato-pkg-ai-assistant-dist-${DEPLOY_ENV:-local}
   pkg_create_app_dist:
     name: mercato-pkg-create-app-dist-${DEPLOY_ENV:-local}
-  traefik_acme:
-    name: mercato-traefik-acme-${DEPLOY_ENV:-local}
 
 networks:
   mercato-network-fullapp:

--- a/docker-compose.fullapp.traefik.yml
+++ b/docker-compose.fullapp.traefik.yml
@@ -1,0 +1,88 @@
+# Optional Traefik overlay for the Open Mercato fullapp stack.
+#
+# Use this overlay when you want the bundled Traefik to terminate TLS,
+# auto-issue Let's Encrypt certificates, and run the custom-domain
+# ForwardAuth gate (Phase 3 of `.ai/specs/2026-04-08-portal-custom-domain-routing.md`).
+#
+# Skip this overlay when an external reverse proxy already terminates TLS
+# (Dokploy, Caddy, nginx, Cloudflare Tunnel, etc.) — point that proxy at
+# the app container's port and replicate the two routers + ForwardAuth
+# middleware in its own config. See docker/traefik/README.md.
+#
+# Usage:
+#   # Production:
+#   docker compose -f docker-compose.fullapp.yml \
+#     -f docker-compose.fullapp.traefik.yml up -d
+#
+#   # Dev (LE staging is the default in dev — override TRAEFIK_CA_SERVER for prod):
+#   docker compose -f docker-compose.fullapp.dev.yml \
+#     -f docker-compose.fullapp.traefik.yml up --build
+
+services:
+  traefik:
+    image: traefik:v3.2
+    container_name: mercato-traefik-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    command:
+      - "--configFile=/etc/traefik/traefik.yml"
+    ports:
+      - "${TRAEFIK_HTTP_PORT:-80}:80"
+      - "${TRAEFIK_HTTPS_PORT:-443}:443"
+      # Dashboard is NOT published by default. The Traefik dashboard exposes
+      # routers/services/cert metadata to anyone who can reach the published
+      # port. Set TRAEFIK_DASHBOARD_PORT to publish it (operator opt-in) and
+      # restrict access via firewall/VPN; otherwise keep it private.
+      # - "${TRAEFIK_DASHBOARD_PORT}:8080"
+    volumes:
+      - ./docker/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - traefik_acme:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      ACME_EMAIL: ${ACME_EMAIL:-admin@example.com}
+      TRAEFIK_LOG_LEVEL: ${TRAEFIK_LOG_LEVEL:-INFO}
+      TRAEFIK_CA_SERVER: ${TRAEFIK_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
+      TRAEFIK_DOCKER_NETWORK: mercato-network-${DEPLOY_ENV:-local}
+    depends_on:
+      - app
+    networks:
+      - mercato-network-fullapp
+
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=mercato-network-${DEPLOY_ENV:-local}"
+      # Platform router — known operator hostnames bypass the domain-check
+      # middleware. Configure PLATFORM_PRIMARY_HOST in the deployment env.
+      - "traefik.http.routers.platform.rule=Host(`${PLATFORM_PRIMARY_HOST:-openmercato.com}`)"
+      - "traefik.http.routers.platform.priority=100"
+      - "traefik.http.routers.platform.entrypoints=websecure"
+      - "traefik.http.routers.platform.tls=true"
+      - "traefik.http.routers.platform.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.platform.service=app-upstream"
+      # Catch-all router for custom customer domains. Goes through the
+      # inject-secret + domain-check middlewares so unmapped hostnames are
+      # rejected at the edge.
+      - "traefik.http.routers.customer.rule=HostRegexp(`{any:.+}`)"
+      - "traefik.http.routers.customer.priority=1"
+      - "traefik.http.routers.customer.entrypoints=websecure"
+      - "traefik.http.routers.customer.tls=true"
+      - "traefik.http.routers.customer.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.customer.service=app-upstream"
+      - "traefik.http.routers.customer.middlewares=inject-domain-check-secret,domain-check"
+      # Inject the shared secret onto the request so ForwardAuth can forward
+      # it to the app. The header is also delivered to the upstream app, but
+      # the app ignores X-Domain-Check-Secret outside the domain-check route.
+      - "traefik.http.middlewares.inject-domain-check-secret.headers.customrequestheaders.X-Domain-Check-Secret=${DOMAIN_CHECK_SECRET}"
+      # Verification endpoint — Traefik forwards X-Forwarded-Host (the
+      # original Host) which the app's domain-check route accepts.
+      - "traefik.http.middlewares.domain-check.forwardauth.address=http://app:3000/api/customer_accounts/domain-check"
+      - "traefik.http.middlewares.domain-check.forwardauth.authrequestheaders=X-Domain-Check-Secret,X-Forwarded-Host,X-Forwarded-Proto,X-Forwarded-Uri"
+      - "traefik.http.middlewares.domain-check.forwardauth.authresponseheaders=X-Open-Mercato-Origin"
+      - "traefik.http.middlewares.domain-check.forwardauth.trustforwardheader=false"
+      # Service definition: route to the app on its container port.
+      - "traefik.http.services.app-upstream.loadbalancer.server.port=${CONTAINER_PORT:-3000}"
+      - "traefik.http.services.app-upstream.loadbalancer.passhostheader=true"
+
+volumes:
+  traefik_acme:
+    name: mercato-traefik-acme-${DEPLOY_ENV:-local}

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -22,33 +22,10 @@ services:
     networks:
       - mercato-network-fullapp
 
-  traefik:
-    image: traefik:v3.2
-    container_name: mercato-traefik-${DEPLOY_ENV:-local}
-    restart: unless-stopped
-    command:
-      - "--configFile=/etc/traefik/traefik.yml"
-    ports:
-      - "${TRAEFIK_HTTP_PORT:-80}:80"
-      - "${TRAEFIK_HTTPS_PORT:-443}:443"
-      # Dashboard is NOT published by default. The Traefik dashboard exposes
-      # routers/services/cert metadata to anyone who can reach the published
-      # port. Set TRAEFIK_DASHBOARD_PORT to publish it (operator opt-in) and
-      # restrict access via firewall/VPN; otherwise keep it private.
-      # - "${TRAEFIK_DASHBOARD_PORT}:8080"
-    volumes:
-      - ./docker/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-      - traefik_acme:/letsencrypt
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    environment:
-      ACME_EMAIL: ${ACME_EMAIL:-admin@example.com}
-      TRAEFIK_LOG_LEVEL: ${TRAEFIK_LOG_LEVEL:-INFO}
-      TRAEFIK_CA_SERVER: ${TRAEFIK_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
-      TRAEFIK_DOCKER_NETWORK: mercato-network-${DEPLOY_ENV:-local}
-    depends_on:
-      - app
-    networks:
-      - mercato-network-fullapp
+  # Traefik (TLS termination, on-demand ACME, custom-domain ForwardAuth gate)
+  # is now an opt-in overlay so this base file works behind an external reverse
+  # proxy (Dokploy, Caddy, nginx, Cloudflare Tunnel, etc.) without conflict.
+  # To run the bundled Traefik, add `-f docker-compose.fullapp.traefik.yml`.
 
   app:
     build:
@@ -73,40 +50,9 @@ services:
     working_dir: /app/apps/mercato
     ports:
       - "${APP_PORT:-3000}:${CONTAINER_PORT:-3000}"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=mercato-network-${DEPLOY_ENV:-local}"
-      # Platform router — known operator hostnames bypass the domain-check
-      # middleware. Configure PLATFORM_PRIMARY_HOST in the deployment env.
-      - "traefik.http.routers.platform.rule=Host(`${PLATFORM_PRIMARY_HOST:-openmercato.com}`)"
-      - "traefik.http.routers.platform.priority=100"
-      - "traefik.http.routers.platform.entrypoints=websecure"
-      - "traefik.http.routers.platform.tls=true"
-      - "traefik.http.routers.platform.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.platform.service=app-upstream"
-      # Catch-all router for custom customer domains. Goes through the
-      # inject-secret + domain-check middlewares so unmapped hostnames are
-      # rejected at the edge.
-      - "traefik.http.routers.customer.rule=HostRegexp(`{any:.+}`)"
-      - "traefik.http.routers.customer.priority=1"
-      - "traefik.http.routers.customer.entrypoints=websecure"
-      - "traefik.http.routers.customer.tls=true"
-      - "traefik.http.routers.customer.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.customer.service=app-upstream"
-      - "traefik.http.routers.customer.middlewares=inject-domain-check-secret,domain-check"
-      # Inject the shared secret onto the request so ForwardAuth can forward
-      # it to the app. The header is also delivered to the upstream app, but
-      # the app ignores X-Domain-Check-Secret outside the domain-check route.
-      - "traefik.http.middlewares.inject-domain-check-secret.headers.customrequestheaders.X-Domain-Check-Secret=${DOMAIN_CHECK_SECRET}"
-      # Verification endpoint — Traefik forwards X-Forwarded-Host (the
-      # original Host) which the app's domain-check route accepts.
-      - "traefik.http.middlewares.domain-check.forwardauth.address=http://app:3000/api/customer_accounts/domain-check"
-      - "traefik.http.middlewares.domain-check.forwardauth.authrequestheaders=X-Domain-Check-Secret,X-Forwarded-Host,X-Forwarded-Proto,X-Forwarded-Uri"
-      - "traefik.http.middlewares.domain-check.forwardauth.authresponseheaders=X-Open-Mercato-Origin"
-      - "traefik.http.middlewares.domain-check.forwardauth.trustforwardheader=false"
-      # Service definition: route to the app on its container port.
-      - "traefik.http.services.app-upstream.loadbalancer.server.port=${CONTAINER_PORT:-3000}"
-      - "traefik.http.services.app-upstream.loadbalancer.passhostheader=true"
+    # Traefik labels are declared in docker-compose.fullapp.traefik.yml so
+    # external reverse proxies (Dokploy, etc.) that also watch the Docker
+    # socket don't accidentally pick them up.
     environment:
       TENANT_DATA_ENCRYPTION: ${TENANT_DATA_ENCRYPTION:-true}
       TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
@@ -222,8 +168,6 @@ volumes:
     name: mercato-init-marker-${DEPLOY_ENV:-local}
   attachments_storage:
     name: mercato-attachments-storage-${DEPLOY_ENV:-local}
-  traefik_acme:
-    name: mercato-traefik-acme-${DEPLOY_ENV:-local}
 
 networks:
   mercato-network-fullapp:

--- a/docker/traefik/README.md
+++ b/docker/traefik/README.md
@@ -14,10 +14,38 @@ issues Let's Encrypt certificates on demand via TLS-ALPN-01.
 | `traefik.yml` | Static config: entrypoints (`web`/`websecure`), HTTP→HTTPS redirect, ACME resolver (Let's Encrypt + TLS-ALPN-01), Docker provider. |
 | `dynamic.example.yml` | Reference dynamic config for non-Docker deployments. Replace placeholders before mounting at `/etc/traefik/dynamic.yml`. |
 
-In Docker, routers/services/middlewares are declared as **labels** on the
-`app` service in `docker-compose.fullapp.yml` and `docker-compose.fullapp.dev.yml`,
-which lets compose-level `${ENV}` substitution inject `DOMAIN_CHECK_SECRET`
-and `PLATFORM_PRIMARY_HOST`.
+The bundled Traefik service and the routers/services/middlewares it reads
+live in **`docker-compose.fullapp.traefik.yml`** — an **opt-in overlay**.
+The base compose files (`docker-compose.fullapp.yml` / `…dev.yml`) ship
+without Traefik so the stack runs cleanly behind an external reverse proxy
+(Dokploy, Caddy, nginx, Cloudflare Tunnel, ELB, …) without port or label
+conflicts. Skip the overlay when something upstream already terminates TLS
+and replicate the routers + ForwardAuth middleware in *that* proxy's config.
+
+## When to use the bundled Traefik
+
+| Scenario | Bundled Traefik (this overlay)? |
+|----------|--------------------------------|
+| Self-hosted VPS, you own port 80/443 | Yes |
+| Behind Dokploy / Coolify / managed PaaS that already runs Traefik | **No** — register the routers + ForwardAuth middleware in the PaaS Traefik instead |
+| Cloudflare Tunnel / ngrok / external L7 load balancer terminates TLS | No |
+| Local dev without TLS (use `X-Force-Host` test bypass) | No |
+
+## Usage with the overlay
+
+```bash
+# Production:
+docker compose -f docker-compose.fullapp.yml \
+  -f docker-compose.fullapp.traefik.yml up -d
+
+# Dev (LE staging is the default — override TRAEFIK_CA_SERVER for prod):
+docker compose -f docker-compose.fullapp.dev.yml \
+  -f docker-compose.fullapp.traefik.yml up --build
+```
+
+Routers/services/middlewares are declared as **labels on the `app` service**
+inside the overlay so compose-level `${ENV}` substitution can inject
+`DOMAIN_CHECK_SECRET` and `PLATFORM_PRIMARY_HOST`.
 
 ## Required environment
 


### PR DESCRIPTION
## Summary

Hotfix port of #1928 against `main`.

- Splits the bundled Traefik service + `traefik.*` labels + ACME volume out of `docker-compose.fullapp.yml` / `…dev.yml` into a new opt-in overlay `docker-compose.fullapp.traefik.yml`.
- Base compose files now run cleanly behind an external reverse proxy (Dokploy, Caddy, nginx, Cloudflare Tunnel, …). No port 80/443 conflict, no orphan `traefik.*` labels for a foreign Traefik to materialise against an unknown certresolver.
- Operators on bare VPS still get the bundled Traefik by adding `-f docker-compose.fullapp.traefik.yml`.

### Why

Reported by a Dokploy operator: the Traefik service shipped in `docker-compose.fullapp.yml` collides with Dokploy's own Traefik (port binding + label discovery), breaking previously-configured domains. There's no way to host the stack behind any external reverse proxy without manually editing compose files.

### Usage

```bash
# External reverse proxy (Dokploy / Caddy / nginx / Cloudflare Tunnel):
docker compose -f docker-compose.fullapp.yml up -d

# Bundled Traefik (self-hosted VPS, prod):
docker compose -f docker-compose.fullapp.yml \
  -f docker-compose.fullapp.traefik.yml up -d

# Bundled Traefik (dev — LE staging by default):
docker compose -f docker-compose.fullapp.dev.yml \
  -f docker-compose.fullapp.traefik.yml up --build
```

`docker/traefik/README.md` documents both modes and a "when to use bundled Traefik" matrix.

## Test plan

- [x] `docker compose -f docker-compose.fullapp.yml config -q` — parses clean, no Traefik service.
- [x] `docker compose -f docker-compose.fullapp.yml -f docker-compose.fullapp.traefik.yml config -q` — parses clean, Traefik service present, `traefik.*` labels on `app`.
- [x] `docker compose -f docker-compose.fullapp.dev.yml -f docker-compose.fullapp.traefik.yml config -q` — parses clean.
- [ ] Manual: deploy base compose behind Dokploy → previously-configured domains work again; bundled Traefik does not start, no port conflict.
- [ ] Manual: deploy base + overlay on a self-hosted VPS → ACME issuance + ForwardAuth gate behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)