### PR TITLE
fix(auth): allow clearing user display name

### DIFF
--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-039.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-039.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createUserFixture, deleteUserIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+/**
+ * TC-AUTH-039: Clear user display name through the API
+ * Verifies that submitting an empty display name removes the stored value instead of preserving the previous one.
+ */
+test.describe('TC-AUTH-039: Clear user display name through the API', () => {
+  test('should persist a blank display name as null', async ({ request, page }) => {
+    test.slow()
+
+    const stamp = Date.now()
+    const email = `qa-auth-039-${stamp}@acme.com`
+    let token: string | null = null
+    let userId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+      const { organizationId } = getTokenContext(token)
+      userId = await createUserFixture(request, token, {
+        email,
+        name: 'Temporary Display Name',
+        password: 'Valid1!Pass',
+        organizationId,
+        roles: ['employee'],
+      })
+
+      const updateResponse = await apiRequest(request, 'PUT', '/api/auth/users', {
+        token,
+        data: {
+          id: userId,
+          name: '',
+        },
+      })
+      expect(updateResponse.status()).toBe(200)
+
+      const readResponse = await apiRequest(request, 'GET', `/api/auth/users?id=${encodeURIComponent(userId)}&page=1&pageSize=1`, {
+        token,
+      })
+      const body = await readJsonSafe<{ items?: Array<{ name?: string | null }> }>(readResponse)
+      expect(body.items?.[0]?.name).toBeNull()
+
+      await login(page, 'admin')
+      await page.goto(`/backend/users/${userId}/edit`, { waitUntil: 'domcontentloaded' })
+      await expect(page).toHaveURL(new RegExp(`/backend/users/${userId}/edit$`, 'i'))
+      await expect(page.locator('[data-crud-field-id="name"] input').first()).toHaveValue('')
+    } finally {
+      await deleteUserIfExists(request, token, userId)
+    }
+  })
+})

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-039.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-039.spec.ts
@@ -41,6 +41,9 @@ test.describe('TC-AUTH-039: Clear user display name through the API', () => {
         token,
       })
       const body = await readJsonSafe<{ items?: Array<{ name?: string | null }> }>(readResponse)
+      if (!body) {
+        throw new Error('Expected user list response body')
+      }
       expect(body.items?.[0]?.name).toBeNull()
 
       await login(page, 'admin')

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-040.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-040.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { createUserFixture, deleteUserIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/authFixtures'
+import { getTokenContext } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
+
+/**
+ * TC-AUTH-040: Remove user display name from the edit form
+ * Verifies the backend edit form can clear the display name and the change survives a refresh/reopen.
+ */
+test.describe('TC-AUTH-040: Remove user display name from the edit form', () => {
+  test('should keep an emptied display name cleared after save and reopen', async ({ page, request }) => {
+    test.slow()
+
+    const stamp = Date.now()
+    const email = `qa-auth-040-${stamp}@acme.com`
+    let token: string | null = null
+    let userId: string | null = null
+
+    try {
+      token = await getAuthToken(request)
+      const { organizationId } = getTokenContext(token)
+      userId = await createUserFixture(request, token, {
+        email,
+        name: 'Name To Remove',
+        password: 'Valid1!Pass',
+        organizationId,
+        roles: ['employee'],
+      })
+
+      await login(page, 'admin')
+      await page.goto(`/backend/users/${userId}/edit`, { waitUntil: 'domcontentloaded' })
+      await expect(page).toHaveURL(new RegExp(`/backend/users/${userId}/edit$`, 'i'))
+
+      const nameInput = page.locator('[data-crud-field-id="name"] input').first()
+      await expect(nameInput).toHaveValue('Name To Remove')
+      await nameInput.fill('')
+      await page.getByRole('button', { name: 'Save' }).first().click()
+
+      await expect(page).toHaveURL(/\/backend\/users(?:\?.*)?$/)
+
+      await page.goto(`/backend/users/${userId}/edit`, { waitUntil: 'domcontentloaded' })
+      await expect(page).toHaveURL(new RegExp(`/backend/users/${userId}/edit$`, 'i'))
+      await expect(page.locator('[data-crud-field-id="name"] input').first()).toHaveValue('')
+    } finally {
+      await deleteUserIfExists(request, token, userId)
+    }
+  })
+})

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -20,6 +20,7 @@ import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { sql } from 'kysely'
+import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 
 const querySchema = z.object({
   id: z.string().uuid().optional(),
@@ -36,12 +37,8 @@ const rawBodySchema = z.object({}).passthrough()
 const passwordSchema = buildPasswordSchema()
 
 const displayNameSchema = z.preprocess(
-  (value) => {
-    if (typeof value !== 'string') return value
-    const trimmed = value.trim()
-    return trimmed.length ? trimmed : undefined
-  },
-  z.string().trim().min(1).max(120).optional(),
+  normalizeDisplayNameInput,
+  z.string().trim().min(1).max(120).nullable().optional(),
 )
 
 const userCreateSchema = z.object({

--- a/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { formatPasswordRequirements, getPasswordPolicy } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { UserConsentsPanel } from '@open-mercato/core/modules/auth/components/UserConsentsPanel'
+import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 
 type EditUserFormValues = {
   email: string
@@ -442,7 +443,7 @@ export default function EditUserPage({ params }: { params?: { id?: string } }) {
             const payload = {
               id: id ? String(id) : '',
               email: values.email,
-              name: typeof values.name === 'string' && values.name.trim().length ? values.name.trim() : undefined,
+              name: normalizeDisplayNameInput(values.name),
               password: values.password && values.password.trim() ? values.password : undefined,
               organizationId: values.organizationId ? values.organizationId : undefined,
               roles: Array.isArray(values.roles) ? values.roles : [],

--- a/packages/core/src/modules/auth/backend/users/create/page.tsx
+++ b/packages/core/src/modules/auth/backend/users/create/page.tsx
@@ -14,6 +14,7 @@ import { RadioGroup } from '@open-mercato/ui/primitives/radio'
 import { RadioField } from '@open-mercato/ui/primitives/radio-field'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { formatPasswordRequirements, getPasswordPolicy } from '@open-mercato/shared/lib/auth/passwordPolicy'
+import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 
 type CreateUserFormValues = {
   email: string
@@ -326,7 +327,7 @@ export default function CreateUserPage() {
             const customFields = collectCustomFieldValues(values)
             const payload: Record<string, unknown> = {
               email: values.email,
-              name: typeof values.name === 'string' && values.name.trim().length ? values.name.trim() : undefined,
+              name: normalizeDisplayNameInput(values.name),
               organizationId: values.organizationId ? values.organizationId : null,
               roles: Array.isArray(values.roles) ? values.roles : [],
               ...(Object.keys(customFields).length ? { customFields } : {}),

--- a/packages/core/src/modules/auth/commands/__tests__/users.display-name-clearing.test.ts
+++ b/packages/core/src/modules/auth/commands/__tests__/users.display-name-clearing.test.ts
@@ -1,0 +1,140 @@
+import '@open-mercato/core/modules/auth/commands/users'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { User } from '../../data/entities'
+
+describe('auth.users.update display name clearing', () => {
+  it('clears the display name when the submitted value is blank', async () => {
+    const handler = commandRegistry.get<Record<string, unknown>, unknown>('auth.users.update') as CommandHandler
+    expect(handler).toBeDefined()
+
+    const updateOrmEntity = jest.fn(async (opts: Parameters<DataEngine['updateOrmEntity']>[0]) => {
+      const entity = {
+        id: '523e4567-e89b-12d3-a456-426614174901',
+        email: 'before@example.com',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        passwordHash: null,
+        name: 'Before',
+        isConfirmed: true,
+        roles: [],
+        acls: [],
+      } as unknown as User
+
+      await (opts.apply as (current: User) => Promise<void> | void)(entity)
+
+      expect(entity.name).toBeNull()
+      return entity
+    }) as DataEngine['updateOrmEntity']
+
+    const dataEngine: Pick<DataEngine, 'updateOrmEntity' | 'setCustomFields' | 'emitOrmEntityEvent' | 'markOrmEntityChange' | 'flushOrmEntityChanges'> = {
+      updateOrmEntity,
+      setCustomFields: jest.fn(async () => undefined) as DataEngine['setCustomFields'],
+      emitOrmEntityEvent: (async () => undefined) as DataEngine['emitOrmEntityEvent'],
+      markOrmEntityChange: jest.fn() as any,
+      flushOrmEntityChanges: (async () => undefined) as DataEngine['flushOrmEntityChanges'],
+    }
+
+    const em = {
+      find: async () => [],
+      remove: () => undefined,
+      persist: () => undefined,
+      flush: async () => undefined,
+      nativeDelete: async () => 0,
+      create: (_entity: unknown, data: unknown) => data,
+      findOne: async () => null,
+    } as unknown as EntityManager
+
+    const container = {
+      resolve: (token: string) => {
+        switch (token) {
+          case 'dataEngine':
+            return dataEngine
+          case 'em':
+            return em
+          case 'rbacService':
+            return { invalidateUserCache: jest.fn(async () => {}) }
+          case 'cache':
+            return { deleteByTags: jest.fn(async () => {}) }
+          default:
+            throw new Error(`Unexpected dependency: ${token}`)
+        }
+      },
+    }
+
+    const ctx: CommandRuntimeContext = {
+      container: container as any,
+      auth: { sub: 'actor-1', tenantId: 'tenant-1', orgId: null } as any,
+      organizationScope: null,
+      selectedOrganizationId: null,
+      organizationIds: null,
+      request: undefined as any,
+    }
+
+    await handler.execute({
+      id: '523e4567-e89b-12d3-a456-426614174901',
+      name: '',
+    }, ctx)
+
+    expect(updateOrmEntity).toHaveBeenCalled()
+  })
+
+  it('rejects non-string display names instead of treating them as omitted', async () => {
+    const handler = commandRegistry.get<Record<string, unknown>, unknown>('auth.users.update') as CommandHandler
+    expect(handler).toBeDefined()
+
+    const updateOrmEntity = jest.fn()
+    const dataEngine: Pick<DataEngine, 'updateOrmEntity' | 'setCustomFields' | 'emitOrmEntityEvent' | 'markOrmEntityChange' | 'flushOrmEntityChanges'> = {
+      updateOrmEntity,
+      setCustomFields: jest.fn(async () => undefined) as DataEngine['setCustomFields'],
+      emitOrmEntityEvent: (async () => undefined) as DataEngine['emitOrmEntityEvent'],
+      markOrmEntityChange: jest.fn() as any,
+      flushOrmEntityChanges: (async () => undefined) as DataEngine['flushOrmEntityChanges'],
+    }
+
+    const em = {
+      find: async () => [],
+      remove: () => undefined,
+      persist: () => undefined,
+      flush: async () => undefined,
+      nativeDelete: async () => 0,
+      create: (_entity: unknown, data: unknown) => data,
+      findOne: async () => null,
+    } as unknown as EntityManager
+
+    const container = {
+      resolve: (token: string) => {
+        switch (token) {
+          case 'dataEngine':
+            return dataEngine
+          case 'em':
+            return em
+          case 'rbacService':
+            return { invalidateUserCache: jest.fn(async () => {}) }
+          case 'cache':
+            return { deleteByTags: jest.fn(async () => {}) }
+          default:
+            throw new Error(`Unexpected dependency: ${token}`)
+        }
+      },
+    }
+
+    const ctx: CommandRuntimeContext = {
+      container: container as any,
+      auth: { sub: 'actor-1', tenantId: 'tenant-1', orgId: null } as any,
+      organizationScope: null,
+      selectedOrganizationId: null,
+      organizationIds: null,
+      request: undefined as any,
+    }
+
+    await expect(handler.execute({
+      id: '523e4567-e89b-12d3-a456-426614174901',
+      name: 123,
+    }, ctx)).rejects.toThrow()
+
+    expect(updateOrmEntity).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/auth/commands/users.ts
+++ b/packages/core/src/modules/auth/commands/users.ts
@@ -37,6 +37,7 @@ import InviteUserEmail from '@open-mercato/core/modules/auth/emails/InviteUserEm
 import { INVITE_TOKEN_TTL_MS } from '@open-mercato/core/modules/auth/lib/inviteToken'
 import { getSecurityEmailBaseUrl } from '@open-mercato/shared/lib/url'
 import { generateAuthToken, hashAuthToken } from '@open-mercato/core/modules/auth/lib/tokenHash'
+import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 
 type SerializedUser = {
   email: string
@@ -76,12 +77,8 @@ type UserSnapshots = {
 const passwordSchema = buildPasswordSchema()
 
 const displayNameSchema = z.preprocess(
-  (value) => {
-    if (typeof value !== 'string') return value
-    const trimmed = value.trim()
-    return trimmed.length ? trimmed : undefined
-  },
-  z.string().trim().min(1).max(120).optional(),
+  normalizeDisplayNameInput,
+  z.string().trim().min(1).max(120).nullable().optional(),
 )
 
 const createSchema = z.object({

--- a/packages/core/src/modules/auth/data/entities.ts
+++ b/packages/core/src/modules/auth/data/entities.ts
@@ -19,7 +19,7 @@ export class User {
   emailHash?: string | null
 
   @Property({ type: 'text', nullable: true })
-  name?: string
+  name?: string | null
 
   @Property({ name: 'password_hash', type: 'text', nullable: true })
   passwordHash?: string | null

--- a/packages/core/src/modules/auth/lib/__tests__/displayName.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/displayName.test.ts
@@ -1,0 +1,18 @@
+import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
+
+describe('normalizeDisplayNameInput', () => {
+  it('returns null for blank strings', () => {
+    expect(normalizeDisplayNameInput('')).toBeNull()
+    expect(normalizeDisplayNameInput('   ')).toBeNull()
+  })
+
+  it('trims non-empty strings and preserves null', () => {
+    expect(normalizeDisplayNameInput('  Ada Lovelace  ')).toBe('Ada Lovelace')
+    expect(normalizeDisplayNameInput(null)).toBeNull()
+  })
+
+  it('preserves non-string values so validation can reject them', () => {
+    expect(normalizeDisplayNameInput(123)).toBe(123)
+    expect(normalizeDisplayNameInput({})).toEqual({})
+  })
+})

--- a/packages/core/src/modules/auth/lib/displayName.ts
+++ b/packages/core/src/modules/auth/lib/displayName.ts
@@ -1,0 +1,6 @@
+export function normalizeDisplayNameInput(value: unknown): unknown {
+  if (value === null) return null
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}


### PR DESCRIPTION
## Summary

Fix user display name clearing so the last remaining character can be removed and saved correctly. Empty values are now normalized to `null` instead of silently preserving the previous name, and invalid non-string input is still rejected by validation.

## Changes

- Added a shared `normalizeDisplayNameInput()` helper for auth user display names.
- Updated auth user create/edit forms to send `null` when the display name is cleared.
- Updated the auth users API schema and command layer to accept `null` for `name`.
- Adjusted the `User` entity typing to allow `null` display names.
- Added regression tests for blank input normalization and non-string validation.
- Added command-level coverage for clearing the display name.
- Added module integration coverage for the display-name removal flow.

## Specification

**Does a spec exist for this feature/module?**
- [x] No (minor change, no spec needed)

**Spec file path:**
- N/A

## Testing

- `yarn install`
- `node --check scripts/dev.mjs`
- `node --check scripts/dev-spawn-utils.mjs`
- `yarn test` / relevant auth test subset
- Verified `yarn dev` after fixing local workspace dependency resolution

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements