### PR TITLE
fix(messages): sent drafts no longer remain in drafts folder (#1940)

### DIFF
--- a/packages/core/src/modules/messages/commands/messages.ts
+++ b/packages/core/src/modules/messages/commands/messages.ts
@@ -368,6 +368,11 @@ const updateDraftCommand: CommandHandler<unknown, { ok: true; id: string }> = {
     if (message.senderUserId !== input.userId) throw new Error('Access denied')
     if (!message.isDraft) throw new Error('Only draft messages can be edited')
 
+    const isSending = input.isDraft === false
+    const preloadedRecipients = isSending && !input.recipients
+      ? await em.find(MessageRecipient, { messageId: message.id, deletedAt: null })
+      : null
+
     const nextMessageType = input.type ?? message.type
     if (input.objects) {
       const objectValidationError = validateMessageObjectsForType(nextMessageType, input.objects)
@@ -454,12 +459,50 @@ const updateDraftCommand: CommandHandler<unknown, { ok: true; id: string }> = {
       )
     }
 
+    if (isSending) {
+      const finalVisibility = input.visibility ?? message.visibility
+      const finalSubject = input.subject ?? message.subject
+      const finalBody = input.body ?? message.body
+      const finalRecipientCount = input.recipients
+        ? input.recipients.length
+        : (preloadedRecipients?.length ?? 0)
+
+      if (finalVisibility !== 'public' && finalRecipientCount === 0) {
+        throw new Error('at least one recipient is required')
+      }
+      if (!finalSubject?.trim()) throw new Error('subject is required')
+      if (!finalBody?.trim()) throw new Error('body is required')
+
+      message.isDraft = false
+      message.status = 'sent'
+      message.sentAt = new Date()
+      if (!message.threadId) message.threadId = message.id
+    }
+
     await em.flush()
     await emitMessageIndexUpsert(ctx.container, {
       messageId: message.id,
       tenantId: input.tenantId,
       organizationId: input.organizationId,
     })
+
+    if (isSending) {
+      const recipientUserIds = input.recipients
+        ? input.recipients.map((r) => r.userId)
+        : (preloadedRecipients ?? []).map((r) => r.recipientUserId)
+      const resolvedVisibility = input.visibility ?? message.visibility
+      const resolvedSendViaEmail = input.sendViaEmail ?? message.sendViaEmail
+      await emitMessageSentEvent(ctx.container, {
+        messageId: message.id,
+        senderUserId: input.userId,
+        recipientUserIds,
+        sendViaEmail: resolvedVisibility === 'public' ? true : resolvedSendViaEmail,
+        externalEmail: message.externalEmail ?? null,
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+      })
+    }
+
     return { ok: true, id: message.id }
   },
   async captureAfter(rawInput, _result, ctx) {
@@ -473,7 +516,7 @@ const updateDraftCommand: CommandHandler<unknown, { ok: true; id: string }> = {
   buildLog: async ({ input, snapshots }) => {
     const parsed = updateDraftCommandSchema.parse(input)
     return {
-      actionLabel: 'Update draft message',
+      actionLabel: parsed.isDraft === false ? 'Send draft message' : 'Update draft message',
       resourceKind: 'messages.message',
       resourceId: parsed.messageId,
       tenantId: parsed.tenantId,

--- a/packages/core/src/modules/messages/data/validators.ts
+++ b/packages/core/src/modules/messages/data/validators.ts
@@ -186,6 +186,7 @@ export const updateDraftSchema = z.object({
   attachmentIds: z.array(z.string().uuid()).optional(),
   actionData: messageActionDataSchema.optional(),
   sendViaEmail: z.boolean().optional(),
+  isDraft: z.literal(false).optional(),
 }).superRefine((value, ctx) => {
   if (value.recipients) {
     const duplicateRecipientIds = collectDuplicateRecipientIds(value.recipients)

--- a/packages/ui/src/backend/messages/useMessageCompose.ts
+++ b/packages/ui/src/backend/messages/useMessageCompose.ts
@@ -16,6 +16,8 @@ import {
   useComposeSendOperation,
   useForwardSubmitOperation,
   useReplySubmitOperation,
+  useSendDraftOperation,
+  useUpdateDraftOperation,
 } from './useMessageComposeOperations'
 
 function toErrorMessage(payload: unknown): string | null {
@@ -514,16 +516,59 @@ export function useMessageCompose({
     sendViaEmail,
   })
 
+  const sendDraftOperation = useSendDraftOperation({
+    t,
+    messageId: messageId ?? '',
+    messageType,
+    priority,
+    visibility,
+    externalEmail,
+    recipientIds,
+    subject,
+    body,
+    bodyFormat,
+    sendViaEmail,
+    contextObject,
+    defaultValues,
+    contextActionOptions,
+    normalizedRequiredActionMode,
+    shouldShowContextActions,
+    contextActionRequired,
+    contextActionType,
+  })
+
+  const updateDraftOperation = useUpdateDraftOperation({
+    t,
+    messageId: messageId ?? '',
+    messageType,
+    priority,
+    visibility,
+    externalEmail,
+    recipientIds,
+    subject,
+    body,
+    bodyFormat,
+    sendViaEmail,
+    contextObject,
+    defaultValues,
+    contextActionOptions,
+    normalizedRequiredActionMode,
+    shouldShowContextActions,
+    contextActionRequired,
+    contextActionType,
+  })
+
   const handleSubmit = React.useCallback(async ({ saveAsDraft = false }: { saveAsDraft?: boolean } = {}) => {
     if (submitting) return false
 
     setSubmitError(null)
 
+    const isEditingExistingDraft = variant === 'compose' && Boolean(messageId)
     const isComposeDraftSubmit = saveAsDraft && variant === 'compose'
     const operation = isComposeDraftSubmit
-      ? composeDraftOperation
+      ? (isEditingExistingDraft ? updateDraftOperation : composeDraftOperation)
       : variant === 'compose'
-        ? composeSendOperation
+        ? (isEditingExistingDraft ? sendDraftOperation : composeSendOperation)
         : variant === 'reply'
           ? replyOperation
           : forwardOperation
@@ -556,10 +601,10 @@ export function useMessageCompose({
       }
 
       if (!shouldReturnFalse) {
-        const { endpoint, payload } = operation.buildRequest({ attachmentIds: nextAttachmentIds })
+        const { endpoint, method, payload } = operation.buildRequest({ attachmentIds: nextAttachmentIds })
 
         const call = await apiCall<{ id?: string }>(endpoint, {
-          method: 'POST',
+          method: method ?? 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         })
@@ -612,11 +657,14 @@ export function useMessageCompose({
     forwardOperation,
     inline,
     loadAttachmentIds,
+    messageId,
     onOpenChange,
     onSuccess,
     replyOperation,
+    sendDraftOperation,
     submitting,
     t,
+    updateDraftOperation,
     variant,
   ])
 

--- a/packages/ui/src/backend/messages/useMessageComposeOperations.ts
+++ b/packages/ui/src/backend/messages/useMessageComposeOperations.ts
@@ -16,6 +16,7 @@ type MessageRecipient = {
 
 type SubmitRequest = {
   endpoint: string
+  method?: 'POST' | 'PATCH'
   payload: Record<string, unknown>
 }
 
@@ -253,6 +254,53 @@ export function useForwardSubmitOperation(params: ForwardOperationParams): BaseO
     }),
     successMessage: params.t('messages.flash.forwardSuccess', 'Message forwarded.'),
     requiresAttachmentRefresh: false,
+  }), [params])
+}
+
+type SendDraftOperationParams = DraftOperationParams & { messageId: string }
+
+export function useSendDraftOperation(params: SendDraftOperationParams): BaseOperation {
+  return React.useMemo(() => ({
+    validate: () => {
+      if (params.visibility !== 'public' && params.recipientIds.length === 0) {
+        return params.t('messages.errors.noRecipients', 'Please add at least one recipient.')
+      }
+      if (params.visibility === 'public' && !isValidEmailAddress(params.externalEmail.trim())) {
+        return params.t('messages.errors.noExternalEmail', 'Please enter a valid external email.')
+      }
+      if (!params.subject.trim()) {
+        return params.t('messages.errors.noSubject', 'Please enter a subject.')
+      }
+      if (!params.body.trim()) {
+        return params.t('messages.errors.noBody', 'Please enter a message.')
+      }
+      return null
+    },
+    buildRequest: ({ attachmentIds }) => ({
+      endpoint: `/api/messages/${encodeURIComponent(params.messageId)}`,
+      method: 'PATCH' as const,
+      payload: buildComposePayload(params, { attachmentIds, isDraft: false }),
+    }),
+    successMessage: params.t('messages.flash.sentSuccess', 'Message sent.'),
+    requiresAttachmentRefresh: true,
+  }), [params])
+}
+
+type UpdateDraftOperationParams = DraftOperationParams & { messageId: string }
+
+export function useUpdateDraftOperation(params: UpdateDraftOperationParams): BaseOperation {
+  return React.useMemo(() => ({
+    validate: () => null,
+    buildRequest: ({ attachmentIds }) => {
+      const { isDraft: _omit, ...payload } = buildComposePayload(params, { attachmentIds, isDraft: true })
+      return {
+        endpoint: `/api/messages/${encodeURIComponent(params.messageId)}`,
+        method: 'PATCH' as const,
+        payload,
+      }
+    },
+    successMessage: params.t('messages.flash.draftSaved', 'Draft saved.'),
+    requiresAttachmentRefresh: true,
   }), [params])
 }
 


### PR DESCRIPTION
When editing an existing draft and clicking Send, the composer called POST /api/messages creating a new sent message instead of transitioning the draft. The original draft stayed in Drafts while a duplicate appeared in Sent.

Rather than adding a new command and route, the fix extends the existing update_draft command with optional send semantics:

- Add `isDraft: false` to `updateDraftSchema` — the only meaningful transition value (draft → sent); passing true is rejected by Zod
- In `updateDraftCommand.execute`: when `isDraft === false`, validate required fields from the message's final state (recipients, subject, body), then atomically set `isDraft=false`, `status='sent'`, `sentAt`, and `threadId` before flush; emit `messages.message.sent` after the flush
- Add `useSendDraftOperation`: calls `PATCH /api/messages/:id` with `isDraft: false` when the user sends an existing draft
- Add `useUpdateDraftOperation`: calls `PATCH /api/messages/:id` (without `isDraft`) when the user saves an existing draft
- Update `useMessageCompose` operation selection: detects `variant='compose' + messageId` (editing existing draft) and routes to the correct operation, fixing both Send and Save Draft

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #1940
