### PR TITLE
fix(sales): enforce sign semantics for non-return adjustment kinds (#1905)

### DIFF
--- a/packages/core/src/modules/sales/api/order-adjustments/route.ts
+++ b/packages/core/src/modules/sales/api/order-adjustments/route.ts
@@ -4,7 +4,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { SalesOrderAdjustment } from '../../data/entities'
 import {
-  enforceReturnAdjustmentSign,
+  enforceAdjustmentSign,
   orderAdjustmentCreateSchema,
 } from '../../data/validators'
 import { createPagedListResponseSchema, createSalesCrudOpenApi, defaultOkResponseSchema } from '../openapi'
@@ -34,7 +34,7 @@ const routeMetadata = {
 
 const upsertSchema = orderAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
-  .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceAdjustmentSign)
 
 const deleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/api/quote-adjustments/route.ts
+++ b/packages/core/src/modules/sales/api/quote-adjustments/route.ts
@@ -4,7 +4,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { SalesQuoteAdjustment } from '../../data/entities'
 import {
-  enforceReturnAdjustmentSign,
+  enforceAdjustmentSign,
   quoteAdjustmentCreateSchema,
 } from '../../data/validators'
 import { createPagedListResponseSchema, createSalesCrudOpenApi, defaultOkResponseSchema } from '../openapi'
@@ -34,7 +34,7 @@ const routeMetadata = {
 
 const upsertSchema = quoteAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
-  .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceAdjustmentSign)
 
 const deleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -66,7 +66,7 @@ import {
   CustomerPersonProfile,
 } from "../../customers/data/entities";
 import {
-  enforceReturnAdjustmentSign,
+  enforceAdjustmentSign,
   quoteCreateSchema,
   quoteLineCreateSchema,
   quoteAdjustmentCreateSchema,
@@ -6304,7 +6304,7 @@ const orderAdjustmentUpsertSchema = orderAdjustmentCreateSchema
   .extend({
     id: z.string().uuid().optional(),
   })
-  .superRefine(enforceReturnAdjustmentSign);
+  .superRefine(enforceAdjustmentSign);
 
 const orderAdjustmentDeleteSchema = z.object({
   id: z.string().uuid(),
@@ -6315,7 +6315,7 @@ const quoteAdjustmentUpsertSchema = quoteAdjustmentCreateSchema
   .extend({
     id: z.string().uuid().optional(),
   })
-  .superRefine(enforceReturnAdjustmentSign);
+  .superRefine(enforceAdjustmentSign);
 
 const quoteAdjustmentDeleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
@@ -1,7 +1,16 @@
 import { z } from 'zod'
 import {
+  DISCOUNT_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
   RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
   RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
+  SHIPPING_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  SHIPPING_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+  SURCHARGE_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  SURCHARGE_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+  TAX_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  TAX_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+  enforceAdjustmentSign,
   enforceReturnAdjustmentSign,
   orderAdjustmentCreateSchema,
   quoteAdjustmentCreateSchema,
@@ -17,13 +26,13 @@ const QUOTE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
 
 const orderUpsertSchema = orderAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
-  .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceAdjustmentSign)
 
 const quoteUpsertSchema = quoteAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
-  .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceAdjustmentSign)
 
-describe('enforceReturnAdjustmentSign — order adjustments', () => {
+describe('enforceAdjustmentSign — return adjustments', () => {
   const base = {
     ...SCOPE,
     orderId: ORDER_ID,
@@ -90,9 +99,135 @@ describe('enforceReturnAdjustmentSign — order adjustments', () => {
     })
     expect(result.success).toBe(true)
   })
+
+  it('keeps backward-compatible enforceReturnAdjustmentSign export pointing at the unified helper', () => {
+    expect(enforceReturnAdjustmentSign).toBe(enforceAdjustmentSign)
+  })
 })
 
-describe('enforceReturnAdjustmentSign — quote adjustments', () => {
+describe('enforceAdjustmentSign — non-return kinds (issue #1905)', () => {
+  const base = {
+    ...SCOPE,
+    orderId: ORDER_ID,
+    scope: 'order' as const,
+    currencyCode: 'USD',
+  }
+
+  const nonNegativeCases: Array<{
+    kind: 'discount' | 'surcharge' | 'shipping' | 'tax'
+    netMessage: string
+    grossMessage: string
+  }> = [
+    {
+      kind: 'discount',
+      netMessage: DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+      grossMessage: DISCOUNT_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+    },
+    {
+      kind: 'surcharge',
+      netMessage: SURCHARGE_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+      grossMessage: SURCHARGE_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+    },
+    {
+      kind: 'shipping',
+      netMessage: SHIPPING_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+      grossMessage: SHIPPING_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+    },
+    {
+      kind: 'tax',
+      netMessage: TAX_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+      grossMessage: TAX_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+    },
+  ]
+
+  for (const { kind, netMessage, grossMessage } of nonNegativeCases) {
+    it(`rejects negative amountNet and amountGross for kind="${kind}"`, () => {
+      const result = orderUpsertSchema.safeParse({
+        ...base,
+        kind,
+        amountNet: -10,
+        amountGross: -10,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const messages = result.error.issues.map((i) => i.message)
+        expect(messages).toContain(netMessage)
+        expect(messages).toContain(grossMessage)
+      }
+    })
+
+    it(`rejects negative-only amountGross for kind="${kind}"`, () => {
+      const result = orderUpsertSchema.safeParse({
+        ...base,
+        kind,
+        amountNet: 5,
+        amountGross: -5,
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const messages = result.error.issues.map((i) => i.message)
+        expect(messages).toContain(grossMessage)
+        expect(messages).not.toContain(netMessage)
+      }
+    })
+
+    it(`accepts zero amounts for kind="${kind}"`, () => {
+      const result = orderUpsertSchema.safeParse({
+        ...base,
+        kind,
+        amountNet: 0,
+        amountGross: 0,
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it(`accepts positive amounts for kind="${kind}"`, () => {
+      const result = orderUpsertSchema.safeParse({
+        ...base,
+        kind,
+        amountNet: 15,
+        amountGross: 18,
+      })
+      expect(result.success).toBe(true)
+    })
+  }
+
+  it('leaves kind="custom" sign unconstrained (operator-controlled)', () => {
+    const positive = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'custom',
+      amountNet: 5,
+      amountGross: 5,
+    })
+    expect(positive.success).toBe(true)
+    const negative = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'custom',
+      amountNet: -5,
+      amountGross: -5,
+    })
+    expect(negative.success).toBe(true)
+  })
+
+  it('rejects negative discount amounts on quote adjustments', () => {
+    const result = quoteUpsertSchema.safeParse({
+      ...SCOPE,
+      quoteId: QUOTE_ID,
+      scope: 'order' as const,
+      currencyCode: 'USD',
+      kind: 'discount',
+      amountNet: -3,
+      amountGross: -3,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages).toContain(DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE)
+    }
+  })
+})
+
+describe('enforceAdjustmentSign — quote adjustments retain return behavior', () => {
   const base = {
     ...SCOPE,
     quoteId: QUOTE_ID,

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -419,13 +419,37 @@ export const quoteLineUpdateSchema = z
   })
   .merge(quoteLineCreateSchema.partial())
 
-// A `return` adjustment must never increase the grand total. The calculation
-// engine is defensively normalized to negative, but the API edge also rejects
-// positive amounts so bad input is caught before it reaches storage. See #1705.
+// Each adjustment kind has an intrinsic sign convention so the grand total
+// stays semantically correct regardless of operator input. The calculation
+// engine normalizes signs defensively, but the API edge rejects values that
+// would invert the kind's meaning so bad data never reaches storage.
+//
+// - `return`: non-positive — returns reduce the total (see #1705).
+// - `discount`: non-negative — discounts reduce the total.
+// - `surcharge`/`shipping`/`tax`: non-negative — they add to the total.
+// - `custom` and unknown kinds: unconstrained (operator-controlled).
+//
+// See #1905.
 export const RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE =
   'Return adjustments must use a non-positive amountNet (returns reduce the total).'
 export const RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE =
   'Return adjustments must use a non-positive amountGross (returns reduce the total).'
+export const DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE =
+  'Discount adjustments must use a non-negative amountNet (discounts reduce the total).'
+export const DISCOUNT_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE =
+  'Discount adjustments must use a non-negative amountGross (discounts reduce the total).'
+export const SURCHARGE_ADJUSTMENT_NEGATIVE_NET_MESSAGE =
+  'Surcharge adjustments must use a non-negative amountNet (surcharges add to the total).'
+export const SURCHARGE_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE =
+  'Surcharge adjustments must use a non-negative amountGross (surcharges add to the total).'
+export const SHIPPING_ADJUSTMENT_NEGATIVE_NET_MESSAGE =
+  'Shipping adjustments must use a non-negative amountNet (shipping adds to the total).'
+export const SHIPPING_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE =
+  'Shipping adjustments must use a non-negative amountGross (shipping adds to the total).'
+export const TAX_ADJUSTMENT_NEGATIVE_NET_MESSAGE =
+  'Tax adjustments must use a non-negative amountNet (taxes add to the total).'
+export const TAX_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE =
+  'Tax adjustments must use a non-negative amountGross (taxes add to the total).'
 
 type AdjustmentSignInput = {
   kind?: string
@@ -433,26 +457,71 @@ type AdjustmentSignInput = {
   amountGross?: number
 }
 
-export const enforceReturnAdjustmentSign = (
+const NON_NEGATIVE_SIGN_MESSAGES: Record<string, { net: string; gross: string }> = {
+  discount: {
+    net: DISCOUNT_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+    gross: DISCOUNT_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  },
+  surcharge: {
+    net: SURCHARGE_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+    gross: SURCHARGE_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  },
+  shipping: {
+    net: SHIPPING_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+    gross: SHIPPING_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  },
+  tax: {
+    net: TAX_ADJUSTMENT_NEGATIVE_NET_MESSAGE,
+    gross: TAX_ADJUSTMENT_NEGATIVE_GROSS_MESSAGE,
+  },
+}
+
+export const enforceAdjustmentSign = (
   value: AdjustmentSignInput,
   ctx: z.RefinementCtx
 ) => {
-  if (value.kind !== 'return') return
-  if (typeof value.amountNet === 'number' && value.amountNet > 0) {
+  if (!value.kind) return
+  if (value.kind === 'return') {
+    if (typeof value.amountNet === 'number' && value.amountNet > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
+        path: ['amountNet'],
+      })
+    }
+    if (typeof value.amountGross === 'number' && value.amountGross > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
+        path: ['amountGross'],
+      })
+    }
+    return
+  }
+  const messages = NON_NEGATIVE_SIGN_MESSAGES[value.kind]
+  if (!messages) return
+  if (typeof value.amountNet === 'number' && value.amountNet < 0) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
+      message: messages.net,
       path: ['amountNet'],
     })
   }
-  if (typeof value.amountGross === 'number' && value.amountGross > 0) {
+  if (typeof value.amountGross === 'number' && value.amountGross < 0) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
+      message: messages.gross,
       path: ['amountGross'],
     })
   }
 }
+
+/**
+ * @deprecated Use `enforceAdjustmentSign` — it enforces the sign convention
+ * for every adjustment kind, not just `return`. Kept for backward compatibility
+ * with third-party code that imported the original helper.
+ */
+export const enforceReturnAdjustmentSign = enforceAdjustmentSign
 
 export const orderAdjustmentCreateSchema = scoped.extend({
   orderId: uuid(),

--- a/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
@@ -273,4 +273,98 @@ describe('calculateDocumentTotals', () => {
     expect(result.totals.grandTotalNetAmount).toBeCloseTo(8, 4)
     expect(result.totals.grandTotalGrossAmount).toBeCloseTo(12, 4)
   })
+
+  it('normalizes signs for discount/surcharge/shipping/tax so negatives never invert the grand total (issue #1905)', async () => {
+    const lines: SalesLineSnapshot[] = [
+      {
+        kind: 'product',
+        quantity: 1,
+        currencyCode: 'USD',
+        unitPriceNet: 100,
+        taxRate: 0,
+      },
+    ]
+    const negativeAdjustments: SalesAdjustmentDraft[] = [
+      {
+        scope: 'order',
+        kind: 'discount',
+        amountNet: -20,
+        amountGross: -20,
+        currencyCode: 'USD',
+      },
+      {
+        scope: 'order',
+        kind: 'surcharge',
+        amountNet: -5,
+        amountGross: -5,
+        currencyCode: 'USD',
+      },
+      {
+        scope: 'order',
+        kind: 'shipping',
+        amountNet: -10,
+        amountGross: -10,
+        currencyCode: 'USD',
+      },
+      {
+        scope: 'order',
+        kind: 'tax',
+        amountNet: -3,
+        amountGross: -3,
+        currencyCode: 'USD',
+      },
+    ]
+
+    const negativeResult = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: negativeAdjustments,
+      context: { ...baseContext, metadata: {} },
+    })
+
+    const positiveAdjustments: SalesAdjustmentDraft[] = negativeAdjustments.map(
+      (adj) => ({ ...adj, amountNet: Math.abs(adj.amountNet!), amountGross: Math.abs(adj.amountGross!) }),
+    )
+    const positiveResult = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: positiveAdjustments,
+      context: { ...baseContext, metadata: {} },
+    })
+
+    // Negative amounts must not flip the semantic effect of any kind.
+    expect(negativeResult.totals.discountTotalAmount).toBeCloseTo(
+      positiveResult.totals.discountTotalAmount,
+      4,
+    )
+    expect(negativeResult.totals.surchargeTotalAmount).toBeCloseTo(
+      positiveResult.totals.surchargeTotalAmount,
+      4,
+    )
+    expect(negativeResult.totals.shippingNetAmount).toBeCloseTo(
+      positiveResult.totals.shippingNetAmount,
+      4,
+    )
+    expect(negativeResult.totals.shippingGrossAmount).toBeCloseTo(
+      positiveResult.totals.shippingGrossAmount,
+      4,
+    )
+    expect(negativeResult.totals.taxTotalAmount).toBeCloseTo(
+      positiveResult.totals.taxTotalAmount,
+      4,
+    )
+    expect(negativeResult.totals.grandTotalNetAmount).toBeCloseTo(
+      positiveResult.totals.grandTotalNetAmount,
+      4,
+    )
+    expect(negativeResult.totals.grandTotalGrossAmount).toBeCloseTo(
+      positiveResult.totals.grandTotalGrossAmount,
+      4,
+    )
+
+    // Sanity: discount reduces, surcharge/shipping/tax increase.
+    // 100 - 20 (discount) + 5 (surcharge net) + 10 (shipping net) = 95 net.
+    expect(positiveResult.totals.subtotalNetAmount).toBeCloseTo(95, 4)
+    expect(positiveResult.totals.discountTotalAmount).toBeCloseTo(20, 4)
+  })
 })

--- a/packages/core/src/modules/sales/lib/calculations.ts
+++ b/packages/core/src/modules/sales/lib/calculations.ts
@@ -151,13 +151,26 @@ function buildBaseDocumentResult(params: {
   )
 
   for (const adj of scopedAdjustments) {
-    const net = toNumber(adj.amountNet, toNumber(adj.amountGross))
-    const gross = toNumber(adj.amountGross, net)
+    const rawNet = toNumber(adj.amountNet, toNumber(adj.amountGross))
+    const rawGross = toNumber(adj.amountGross, rawNet)
+    // Each adjustment kind has an intrinsic sign convention. The API edge
+    // (enforceAdjustmentSign) rejects values that would invert the kind's
+    // semantic effect, but the calculation engine normalizes defensively so
+    // direct DB writes or seeded data can't inflate the grand total either.
+    // See #1905 (mirrors the existing return normalization a few lines below
+    // introduced for #1705).
+    const isNonNegativeKind =
+      adj.kind === 'discount' ||
+      adj.kind === 'surcharge' ||
+      adj.kind === 'shipping' ||
+      adj.kind === 'tax'
+    const net = isNonNegativeKind ? Math.abs(rawNet) : rawNet
+    const gross = isNonNegativeKind ? Math.abs(rawGross) : rawGross
     const taxRate = extractAdjustmentTaxRate(adj)
     const taxPortion = taxRate !== null ? round(gross - net) : 0
     switch (adj.kind) {
       case 'discount':
-        discountTotal += Math.abs(net)
+        discountTotal += net
         subtotalNet = Math.max(subtotalNet - net, 0)
         subtotalGross = Math.max(subtotalGross - gross, 0)
         if (taxPortion) {


### PR DESCRIPTION
Fixes #1905

## Problem

Adjustment kinds with intrinsic sign conventions accepted both positive and negative values, inverting their semantic effect on the grand total:

- discount with `amountNet = -20` increased the total (instead of decreasing it)
- surcharge / shipping / tax with negative values decreased the total

Only the `return` kind enforced sign semantics (added in #1855 for issue #1705). Other kinds had no validation at the API edge or normalization in the calculation engine.

## Root Cause

`enforceReturnAdjustmentSign` only rejected positive amounts for `kind === 'return'`, and the calculation engine in `lib/calculations.ts` only normalized signs (`-Math.abs`) for `return`. Every other kind passed through user-supplied signs untouched, so `subtotalNet - net` (discount) or `subtotalNet + net` (shipping/surcharge/tax) inverted whenever `net` was negative.

## What Changed

- `packages/core/src/modules/sales/data/validators.ts`:
  - Generalized `enforceReturnAdjustmentSign` into `enforceAdjustmentSign`. The new helper rejects positive amounts for `return` (unchanged) and negative amounts for `discount`/`surcharge`/`shipping`/`tax`. `custom` and unknown kinds remain unconstrained (operator-controlled, per the issue note).
  - Added `DISCOUNT_/SURCHARGE_/SHIPPING_/TAX_ADJUSTMENT_NEGATIVE_{NET,GROSS}_MESSAGE` constants.
  - Kept `enforceReturnAdjustmentSign` as a `@deprecated` alias pointing at the new helper for backward compatibility with any third-party importer.
- `packages/core/src/modules/sales/lib/calculations.ts`: defense-in-depth — normalize `net`/`gross` to `Math.abs(...)` for `discount`/`surcharge`/`shipping`/`tax` before the switch statement, mirroring the existing `return` normalization a few lines below.
- Switched the four `superRefine` call sites to `enforceAdjustmentSign`:
  - `api/order-adjustments/route.ts`
  - `api/quote-adjustments/route.ts`
  - `commands/documents.ts` (two nested upsert schemas)

## Tests

- `packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts`:
  - Preserved the original return-kind tests.
  - Added parametrized tests for each non-negative kind (discount/surcharge/shipping/tax) covering: negative amountNet+amountGross rejection, negative-only amountGross rejection, zero acceptance, positive acceptance.
  - Added a `custom` kind test verifying unchanged operator-controlled behavior.
  - Added an assertion that `enforceReturnAdjustmentSign === enforceAdjustmentSign` (BC alias guard).
  - Added a quote-adjustment negative-discount rejection test.
- `packages/core/src/modules/sales/lib/__tests__/calculations.test.ts`: added an issue-#1905 regression test asserting that negative amounts on all four kinds produce the same grand-total totals as their positive counterparts.

### Checks run

- `yarn jest --testPathPatterns="modules/sales"` — 257 / 257 passed
- `yarn typecheck` — passed (18/18 packages)
- `yarn i18n:check-sync` / `yarn i18n:check-usage` — clean
- `yarn test` (full suite) — 3919 / 3919 passed across 456 suites
- `yarn build:app` failed on `/_global-error` prerender (`useContext` null) — unrelated to this PR: the diff touches **zero** files in `apps/` and **zero** UI/Next.js code (only validators + calculations + tests in `packages/core/src/modules/sales/`).

## Backward Compatibility

- Additive: new `enforceAdjustmentSign` export, new message constants. None of the existing exports were removed.
- Stable: `enforceReturnAdjustmentSign` is now a deprecated alias that delegates to `enforceAdjustmentSign`. Behavior for `return` is byte-identical; behavior for other kinds is **new validation** (previously the helper was a no-op for non-return kinds).
- API contract: requests that previously sent negative `amountNet`/`amountGross` for `discount`/`surcharge`/`shipping`/`tax` will now receive 400 validation errors. This is the intended fix per the issue. No fields removed; no event IDs, widget spot IDs, or DI names changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)