### PR TITLE
fix(auth): only validate role grant deltas on user update (#1938)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 
 import { GET, POST, PUT } from '@open-mercato/core/modules/auth/api/users/route'
-import { Role, RoleAcl, User } from '@open-mercato/core/modules/auth/data/entities'
+import { Role, RoleAcl, User, UserRole } from '@open-mercato/core/modules/auth/data/entities'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 
 const mockGetAuthFromRequest = jest.fn()
@@ -569,5 +569,126 @@ describe('GET /api/auth/users', () => {
 
     expect(response.status).toBe(403)
     expect(body.error).toContain('Cannot grant feature api_keys.create')
+  })
+
+  test('allows limited users to save non-role fields on a more-privileged user when role set is unchanged (regression for #1938)', async () => {
+    const targetUserId = '523e4567-e89b-12d3-a456-426614174601'
+    const superadminRoleId = '323e4567-e89b-12d3-a456-426614174501'
+    mockLoadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.users.edit'],
+      organizations: null,
+    })
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === User) return { id: targetUserId, tenantId, organizationId }
+      return null
+    })
+    mockFindWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === UserRole) {
+        return [
+          {
+            user: { id: targetUserId },
+            role: { id: superadminRoleId, name: 'Superadmin', tenantId },
+          },
+        ]
+      }
+      return []
+    })
+
+    const response = await PUT(new Request('http://localhost/api/auth/users', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: targetUserId,
+        name: 'Updated Display Name',
+        roles: [superadminRoleId],
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockFindOneWithDecryption).not.toHaveBeenCalledWith(expect.anything(), RoleAcl, expect.anything(), expect.anything(), expect.anything())
+  })
+
+  test('allows limited users to keep the same role set when sent by role name on update', async () => {
+    const targetUserId = '523e4567-e89b-12d3-a456-426614174602'
+    const superadminRoleId = '323e4567-e89b-12d3-a456-426614174502'
+    mockLoadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.users.edit'],
+      organizations: null,
+    })
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === User) return { id: targetUserId, tenantId, organizationId }
+      return null
+    })
+    mockFindWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === UserRole) {
+        return [
+          {
+            user: { id: targetUserId },
+            role: { id: superadminRoleId, name: 'superadmin', tenantId },
+          },
+        ]
+      }
+      return []
+    })
+
+    const response = await PUT(new Request('http://localhost/api/auth/users', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: targetUserId,
+        name: 'New Name',
+        roles: ['superadmin'],
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+  })
+
+  test('rejects limited users attempting to revoke a privileged role they cannot grant (privilege de-escalation guard)', async () => {
+    const targetUserId = '523e4567-e89b-12d3-a456-426614174603'
+    const superadminRoleId = '323e4567-e89b-12d3-a456-426614174503'
+    mockLoadAcl.mockResolvedValueOnce({
+      isSuperAdmin: false,
+      features: ['auth.users.edit'],
+      organizations: null,
+    })
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === User) return { id: targetUserId, tenantId, organizationId }
+      if (entity === RoleAcl) {
+        return {
+          isSuperAdmin: true,
+          featuresJson: [],
+          organizationsJson: null,
+          tenantId,
+        }
+      }
+      return null
+    })
+    mockFindWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === UserRole) {
+        return [
+          {
+            user: { id: targetUserId },
+            role: { id: superadminRoleId, name: 'Superadmin', tenantId },
+          },
+        ]
+      }
+      return []
+    })
+
+    const response = await PUT(new Request('http://localhost/api/auth/users', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: targetUserId,
+        roles: [],
+      }),
+    }))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body.error).toContain('Only super administrators can grant super admin access')
   })
 })

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -13,7 +13,10 @@ import { E } from '#generated/entities.ids.generated'
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { userCrudEvents, userCrudIndexer } from '@open-mercato/core/modules/auth/commands/users'
-import { assertActorCanGrantRoleTokens } from '@open-mercato/core/modules/auth/lib/grantChecks'
+import {
+  assertActorCanGrantRoleTokens,
+  assertActorCanGrantRoles,
+} from '@open-mercato/core/modules/auth/lib/grantChecks'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
@@ -430,21 +433,114 @@ async function findUserIdsBySearchTokens(
     .filter((id): id is string => typeof id === 'string' && id.length > 0)
 }
 
+const ROLE_TOKEN_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 async function assertCanAssignRoles(req: Request, roles: unknown, payload: Record<string, unknown>) {
   if (!Array.isArray(roles)) return
   const auth = await getAuthFromRequest(req)
   if (!auth?.sub) throw new CrudHttpError(401, { error: 'Unauthorized' })
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+  const rbacService = container.resolve('rbacService') as RbacService
   const tenantId = await resolveTargetTenantIdForRoleGrant(em, payload, auth.tenantId ?? null)
-  await assertActorCanGrantRoleTokens({
-    em,
-    rbacService: container.resolve('rbacService') as RbacService,
-    actorUserId: auth.sub,
-    tenantId,
-    organizationId: auth.orgId ?? null,
-    roleTokens: roles,
+  const organizationId = auth.orgId ?? null
+
+  const userId = typeof payload.id === 'string' ? payload.id : null
+  if (!userId) {
+    await assertActorCanGrantRoleTokens({
+      em,
+      rbacService,
+      actorUserId: auth.sub,
+      tenantId,
+      organizationId,
+      roleTokens: roles,
+    })
+    return
+  }
+
+  // On update, only validate the role assignment *diff* — roles being added or
+  // removed. Re-checking unchanged assignments would block a limited admin from
+  // saving non-role fields on a more-privileged user whose existing roles they
+  // could never grant in the first place (issue #1938). Both halves of the diff
+  // are still gated: the actor must have the privilege to grant any added role
+  // and to revoke any removed role.
+  const existingRoles = await loadExistingRolesForUser(em, userId)
+  const existingRoleIds = new Set(existingRoles.map((role) => String(role.id)))
+  const existingRoleNames = new Set(
+    existingRoles
+      .map((role) => (typeof role.name === 'string' ? role.name.trim() : ''))
+      .filter((name): name is string => name.length > 0),
+  )
+
+  const requestedRoleIds = new Set<string>()
+  const requestedRoleNames = new Set<string>()
+  const addedRoleTokens: string[] = []
+  for (const token of roles) {
+    if (typeof token !== 'string') {
+      addedRoleTokens.push(token as unknown as string)
+      continue
+    }
+    const trimmed = token.trim()
+    if (!trimmed) continue
+    if (ROLE_TOKEN_UUID_RE.test(trimmed)) {
+      requestedRoleIds.add(trimmed)
+      if (!existingRoleIds.has(trimmed)) addedRoleTokens.push(trimmed)
+    } else {
+      requestedRoleNames.add(trimmed)
+      if (!existingRoleNames.has(trimmed)) addedRoleTokens.push(trimmed)
+    }
+  }
+
+  if (addedRoleTokens.length) {
+    await assertActorCanGrantRoleTokens({
+      em,
+      rbacService,
+      actorUserId: auth.sub,
+      tenantId,
+      organizationId,
+      roleTokens: addedRoleTokens,
+    })
+  }
+
+  const removedRoles = existingRoles.filter((role) => {
+    const id = String(role.id)
+    const name = typeof role.name === 'string' ? role.name.trim() : ''
+    if (requestedRoleIds.has(id)) return false
+    if (name && requestedRoleNames.has(name)) return false
+    return true
   })
+
+  if (removedRoles.length) {
+    await assertActorCanGrantRoles({
+      em,
+      rbacService,
+      actorUserId: auth.sub,
+      tenantId,
+      organizationId,
+      roles: removedRoles,
+    })
+  }
+}
+
+async function loadExistingRolesForUser(em: EntityManager, userId: string): Promise<Role[]> {
+  const links = await findWithDecryption(
+    em,
+    UserRole,
+    { user: userId as unknown as User } as any,
+    { populate: ['role'] },
+    { tenantId: null, organizationId: null },
+  )
+  const roles: Role[] = []
+  const seen = new Set<string>()
+  for (const link of links) {
+    const role = (link as any).role as Role | undefined
+    if (!role?.id) continue
+    const id = String(role.id)
+    if (seen.has(id)) continue
+    seen.add(id)
+    roles.push(role)
+  }
+  return roles
 }
 
 async function resolveTargetTenantIdForRoleGrant(


### PR DESCRIPTION
Fixes #1938

## Problem
A limited admin (carrying `auth.users.edit` but not `auth.users.*`/superadmin) could open the edit modal for a Superadmin user and modify non-sensitive fields like Display Name, but saving was rejected with `Only super administrators can grant super admin access.` — even when no role changes were submitted. The form became read-only in practice for any user the admin could not have created in the first place.

## Root Cause
`PUT /api/auth/users` runs `assertActorCanGrantRoleTokens(...)` on every role token in the incoming payload. Because the standard edit form re-sends the user's current role assignments alongside any unrelated field change, the grant check evaluated the target user's pre-existing Superadmin role on every save and rejected the actor — even though the role assignment was not actually changing.

## What Changed
- `packages/core/src/modules/auth/api/users/route.ts`
  - On update, `assertCanAssignRoles` now loads the target user's existing role assignments (`UserRole` join, both IDs and names) and validates only the diff:
    - Added roles (requested but not currently held) go through the existing `assertActorCanGrantRoleTokens` check.
    - Removed roles (currently held but not requested) are validated with `assertActorCanGrantRoles` against the resolved `Role` entities. This preserves the privilege contract: an actor who cannot grant a privileged role still cannot revoke it from another user (preventing a limited admin from demoting a Superadmin).
  - Create operations (no `id` in payload) keep the existing behavior — every requested role is a new grant.
  - Adds a local `loadExistingRolesForUser` helper that uses `findWithDecryption` against `UserRole` populated with `role`.

## Tests
- `packages/core/src/modules/auth/api/__tests__/users.route.test.ts`
  - New regression: limited admin saves non-role fields on a more-privileged user when the role set is unchanged (id-token form) → 200.
  - New regression: same scenario but with the role sent by name → 200.
  - New regression: limited admin attempting to remove a Superadmin role is rejected with the same forbidden error → 403.
  - Existing tests for create/update privilege escalation (`rejects limited users reassigning an existing user to a privileged role on update`, `rejects limited users assigning a role whose ACL grants features outside the actor ACL`, etc.) continue to pass.
- Full `yarn test` and `yarn typecheck` pass.
- `yarn i18n:check-sync` clean; `yarn i18n:check-usage` advisory only (no change).
- `yarn build:app` fails on develop today with Turbopack/NFT tracing diagnostics in `packages/shared/dist/lib/bootstrap/dynamicLoader.js` and `apps/mercato/next.config.ts` paths that are unrelated to this fix; verified identical failure on a clean `origin/develop` checkout.

## Backward Compatibility
- No change to public types, route shapes, or grant API. `assertActorCanGrantRoleTokens` / `assertActorCanGrantRoles` are reused, not modified.
- Wire format unchanged — the API still accepts `roles: string[]` for both create and update.
- Security posture is strengthened, not weakened: previously a limited admin could submit `roles: []` and silently demote a Superadmin (because `assertActorCanGrantRoleTokens` only checked the *requested* list); revocation is now gated symmetrically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)