### PR TITLE
fix(dev): purge Turbopack cache before greenfield rebuilds (#1950)

### DIFF
--- a/scripts/__tests__/dev-cache-purge.test.mjs
+++ b/scripts/__tests__/dev-cache-purge.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  GREENFIELD_PURGE_TARGETS,
+  purgeAppBuildCaches,
+} from '../dev-cache-purge.mjs'
+
+function makeLogger() {
+  const messages = []
+  return {
+    messages,
+    log: (line) => messages.push(line),
+  }
+}
+
+function createTempRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'dev-cache-purge-'))
+}
+
+test('purgeAppBuildCaches: targets cover both .mercato/next and the legacy .next', () => {
+  const segmentsList = GREENFIELD_PURGE_TARGETS.map((segments) => segments.join('/'))
+  assert.deepEqual(segmentsList, [
+    'apps/mercato/.mercato/next',
+    'apps/mercato/.next',
+  ])
+})
+
+test('purgeAppBuildCaches: removes stale Turbopack cache and dev/server manifests under .mercato/next', () => {
+  const rootDir = createTempRoot()
+  const turbopackCache = path.join(rootDir, 'apps', 'mercato', '.mercato', 'next', 'dev', 'cache', 'turbopack')
+  const stalePathsManifest = path.join(rootDir, 'apps', 'mercato', '.mercato', 'next', 'dev', 'server', 'app-paths-manifest.json')
+  fs.mkdirSync(turbopackCache, { recursive: true })
+  fs.writeFileSync(path.join(turbopackCache, 'index.bin'), 'stale')
+  fs.mkdirSync(path.dirname(stalePathsManifest), { recursive: true })
+  fs.writeFileSync(stalePathsManifest, '{"/_not-found/page":"app/_not-found/page.js"}')
+
+  const logger = makeLogger()
+  const result = purgeAppBuildCaches({ rootDir, logger })
+
+  assert.equal(fs.existsSync(turbopackCache), false)
+  assert.equal(fs.existsSync(stalePathsManifest), false)
+  assert.equal(fs.existsSync(path.join(rootDir, 'apps', 'mercato', '.mercato', 'next')), false)
+  assert.deepEqual(result.removed, ['apps/mercato/.mercato/next'])
+  assert.ok(logger.messages.some((line) => line.includes('removed apps/mercato/.mercato/next')))
+
+  fs.rmSync(rootDir, { recursive: true, force: true })
+})
+
+test('purgeAppBuildCaches: removes legacy apps/mercato/.next as well', () => {
+  const rootDir = createTempRoot()
+  const legacyCache = path.join(rootDir, 'apps', 'mercato', '.next', 'cache', 'turbopack')
+  fs.mkdirSync(legacyCache, { recursive: true })
+  fs.writeFileSync(path.join(legacyCache, 'index.bin'), 'legacy')
+
+  const logger = makeLogger()
+  const result = purgeAppBuildCaches({ rootDir, logger })
+
+  assert.equal(fs.existsSync(legacyCache), false)
+  assert.equal(fs.existsSync(path.join(rootDir, 'apps', 'mercato', '.next')), false)
+  assert.deepEqual(result.removed, ['apps/mercato/.next'])
+
+  fs.rmSync(rootDir, { recursive: true, force: true })
+})
+
+test('purgeAppBuildCaches: logs a single "no stale build directories" line when nothing exists', () => {
+  const rootDir = createTempRoot()
+  const logger = makeLogger()
+  const result = purgeAppBuildCaches({ rootDir, logger })
+
+  assert.deepEqual(result.removed, [])
+  assert.equal(logger.messages.length, 1)
+  assert.match(logger.messages[0], /no stale Next\/Turbopack build directories to purge/)
+
+  fs.rmSync(rootDir, { recursive: true, force: true })
+})
+
+test('purgeAppBuildCaches: removes both configured and legacy directories in one call when both exist', () => {
+  const rootDir = createTempRoot()
+  fs.mkdirSync(path.join(rootDir, 'apps', 'mercato', '.mercato', 'next', 'dev'), { recursive: true })
+  fs.mkdirSync(path.join(rootDir, 'apps', 'mercato', '.next', 'cache'), { recursive: true })
+
+  const logger = makeLogger()
+  const result = purgeAppBuildCaches({ rootDir, logger })
+
+  assert.deepEqual(result.removed, [
+    'apps/mercato/.mercato/next',
+    'apps/mercato/.next',
+  ])
+  assert.equal(fs.existsSync(path.join(rootDir, 'apps', 'mercato', '.mercato', 'next')), false)
+  assert.equal(fs.existsSync(path.join(rootDir, 'apps', 'mercato', '.next')), false)
+
+  fs.rmSync(rootDir, { recursive: true, force: true })
+})
+
+test('runGreenfieldDev and runClassicGreenfieldDev: source invokes purgeAppBuildCaches before any build:packages stage', async () => {
+  const here = path.dirname(new URL(import.meta.url).pathname)
+  const devMjs = fs.readFileSync(path.resolve(here, '..', 'dev.mjs'), 'utf8')
+
+  for (const fnName of ['runGreenfieldDev', 'runClassicGreenfieldDev']) {
+    const fnMatch = devMjs.match(new RegExp(`async function ${fnName}\\([^)]*\\) \\{([\\s\\S]*?)\\n\\}`))
+    assert.ok(fnMatch, `expected to find ${fnName}() in scripts/dev.mjs`)
+    const body = fnMatch[1]
+    const purgeIdx = body.indexOf('purgeAppBuildCaches(')
+    const buildIdx = body.indexOf("'build:packages'")
+    assert.notEqual(purgeIdx, -1, `${fnName} must call purgeAppBuildCaches()`)
+    assert.notEqual(buildIdx, -1, `${fnName} must run build:packages`)
+    assert.ok(purgeIdx < buildIdx, `${fnName} must purge caches before build:packages`)
+  }
+
+  assert.match(devMjs, /from '\.\/dev-cache-purge\.mjs'/)
+})

--- a/scripts/dev-cache-purge.mjs
+++ b/scripts/dev-cache-purge.mjs
@@ -1,0 +1,34 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Greenfield must not inherit the prior run's compiler state. Wiping the
+// configured Next.js distDir (`apps/mercato/.mercato/next`) plus the legacy
+// `apps/mercato/.next` location guarantees Turbopack rebuilds the route table
+// and middleware manifest from scratch on the next launch. See issue #1950.
+export const GREENFIELD_PURGE_TARGETS = Object.freeze([
+  Object.freeze(['apps', 'mercato', '.mercato', 'next']),
+  Object.freeze(['apps', 'mercato', '.next']),
+])
+
+export function purgeAppBuildCaches({
+  rootDir = process.cwd(),
+  fsImpl = fs,
+  logger = console,
+  targets = GREENFIELD_PURGE_TARGETS,
+} = {}) {
+  const removed = []
+  for (const segments of targets) {
+    const target = path.join(rootDir, ...segments)
+    if (!fsImpl.existsSync(target)) continue
+    fsImpl.rmSync(target, { recursive: true, force: true })
+    removed.push(segments.join('/'))
+  }
+  if (removed.length === 0) {
+    logger.log('🧹 [dev:greenfield] no stale Next/Turbopack build directories to purge')
+  } else {
+    for (const relPath of removed) {
+      logger.log(`🧹 [dev:greenfield] removed ${relPath}`)
+    }
+  }
+  return { removed }
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -22,6 +22,7 @@ import {
   resolveProgressPercent,
   stripAnsi,
 } from './dev-splash-helpers.mjs'
+import { purgeAppBuildCaches } from './dev-cache-purge.mjs'
 import { resolveSpawnCommand } from './dev-spawn-utils.mjs'
 import { createDevSplashCodingFlow } from './dev-splash-coding-flow.mjs'
 import { createDevSplashGitRepoFlow } from './dev-splash-git-repo-flow.mjs'
@@ -1647,6 +1648,7 @@ async function runClassicStandardDev() {
 }
 
 async function runGreenfieldDev() {
+  purgeAppBuildCaches()
   await runStage('🧱 Greenfield build packages', ['build:packages'], { stageCurrent: 1, stageTotal: 5 })
   await runStage('🧬 Greenfield generate artifacts', ['generate'], { stageCurrent: 2, stageTotal: 5 })
   await runStage('🧱 Greenfield rebuild packages', ['build:packages'], { stageCurrent: 3, stageTotal: 5 })
@@ -1657,6 +1659,7 @@ async function runGreenfieldDev() {
 }
 
 async function runClassicGreenfieldDev() {
+  purgeAppBuildCaches()
   await runRawYarnCommand(['build:packages'])
   await runRawYarnCommand(['generate'])
   await runRawYarnCommand(['build:packages'])


### PR DESCRIPTION
Fixes #1950

## Problem

After `yarn dev:greenfield`, every dynamic route (`/`, `/login`, `/api/*`) returned a framework 404. Static assets under `/_next/static/*` continued to serve normally. Running `yarn dev:reset` printed `✅ Turbopack/webpack cache cleared` without actually clearing anything.

## Root Cause

`runGreenfieldDev()` (and the classic variant) in `scripts/dev.mjs` rebuilt packages, regenerated artifacts, and reseeded the DB — but never wiped the prior run's Turbopack persistent cache at `apps/mercato/.mercato/next/dev/cache/turbopack` (the configured `distDir`). That cache embedded a stale route table; `app-paths-manifest.json` ended up containing only `/_not-found/page` and `/page`, and the middleware manifest was empty despite `proxy.ts` being compiled.

(Bug #2 from the issue — `dev-reset.mjs` targeting wrong paths — was already fixed on `develop`. Earlier `Cezar autofix` runs claimed Bug #1 had been fixed too, citing commit `ef2a7b5b`; that commit does not exist in this repository. The fix in this PR is the actual fix for Bug #1.)

## What Changed

- **New helper** `scripts/dev-cache-purge.mjs` exporting `purgeAppBuildCaches()`. Wipes the entire configured `apps/mercato/.mercato/next` build directory plus the legacy `apps/mercato/.next` path. Designed to be testable: `rootDir`, `fs`, `logger`, and `targets` are all injectable.
- **`scripts/dev.mjs`**: imports the helper and calls it as the very first action of both `runGreenfieldDev()` and `runClassicGreenfieldDev()`, before any `build:packages` / `generate` / `initialize` stage. Stage totals are unchanged (the purge is a sub-second pre-stage cleanup, not a numbered stage).
- Greenfield boots now log e.g. `🧹 [dev:greenfield] removed apps/mercato/.mercato/next` (or `no stale ... build directories to purge` when starting from clean), giving the user explicit confirmation that the prior compiler state was thrown away.

## Tests

- New `scripts/__tests__/dev-cache-purge.test.mjs` (6 unit tests using `node:test`):
  - `GREENFIELD_PURGE_TARGETS` covers `.mercato/next` and the legacy `.next`.
  - The helper removes stale Turbopack cache **and** `dev/server/app-paths-manifest.json` (the exact symptom from the issue).
  - The helper removes legacy `apps/mercato/.next` cache directories.
  - The helper logs a single explanatory line when nothing exists, not a misleading `✅`.
  - The helper removes both directories in one call when both exist.
  - **Source-level regression guard** — parses `scripts/dev.mjs` and asserts both `runGreenfieldDev()` and `runClassicGreenfieldDev()` call `purgeAppBuildCaches()` before any `build:packages` stage. Prevents the import or the call site from silently regressing.
- Full `yarn test:scripts` suite: **118 passing, 0 failing**.

## Backward Compatibility

No contract surface changes. This is a behavior-only fix inside the developer-tooling scripts (`scripts/dev.mjs`, `scripts/dev-cache-purge.mjs`). No types, signatures, import paths, event IDs, ACL features, API routes, DB schema, DI keys, or CLI commands were added or modified. The user-visible behavioral change is: `yarn dev:greenfield` now actually starts from a fresh Next/Turbopack build — which is what its name promises.

## Out of Scope

Suggested fix #3 from the issue (make `dev-reset.mjs` fail loudly when it has nothing to clean *and* a dev server is detected) is a polish item on Bug #2, which is already fixed. Keeping that for a separate PR if reviewers want it — this PR is intentionally minimal and targets the actual remaining defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)