### PR TITLE
feat(storage_s3): env-based preconfiguration CLI + docs (#1968)

### DIFF
--- a/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
+++ b/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
@@ -112,3 +112,12 @@ Bring `packages/storage-s3` up to the bar set by `gateway_stripe` / `sync_akeneo
 ### Phase 6: Pull request
 
 - [x] 6.1 Open PR + labels + summary comment — PR #1999, labels `review` / `feature` / `documentation` / `needs-qa`.
+
+### Phase 7: Deploy-hook ergonomics (`--all-tenants`)
+
+> Added after initial PR opened. User asked whether the preset auto-applies on Dokploy redeploy; the honest answer was no, so we extended the CLI with a single command that iterates every active scope so a single deploy hook applies the preset without baking UUIDs into the deploy config.
+
+- [x] 7.1 Add `--all-tenants` flag, lib helper `runConfigureFromEnvForScopes`, per-scope summary + exit semantics — 2a92f84db
+- [x] 7.2 Unit-test coverage for the multi-scope flow (mixed configured+skipped, one-tenant-errors, all-skip, `--force` per scope) — 2a92f84db
+- [x] 7.3 Document `--all-tenants` in storage-hub.mdx and both `.env.example` files — 2a92f84db
+- [x] 7.4 Manual smoke verified against three real tenants: skip-all (creds present), configure-all (after wipe), incomplete-env → exit 1, mode-conflict → exit 1.

--- a/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
+++ b/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
@@ -4,7 +4,7 @@
 >
 > Source spec: `.ai/specs/implemented/SPEC-045i-storage-hub.md` (this run is a follow-up addendum, not a new spec)
 >
-> Status: in-progress
+> Status: complete — PR #1999
 
 ## Goal
 
@@ -111,4 +111,4 @@ Bring `packages/storage-s3` up to the bar set by `gateway_stripe` / `sync_akeneo
 
 ### Phase 6: Pull request
 
-- [ ] 6.1 Open PR + labels + summary comment
+- [x] 6.1 Open PR + labels + summary comment — PR #1999, labels `review` / `feature` / `documentation` / `needs-qa`.

--- a/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
+++ b/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
@@ -87,19 +87,19 @@ Bring `packages/storage-s3` up to the bar set by `gateway_stripe` / `sync_akeneo
 
 ### Phase 1: Provider CLI + setup hardening
 
-- [ ] 1.1 Add storage_s3 configure-from-env CLI
-- [ ] 1.2 Surface tenant-setup preset failures via IntegrationLogService
+- [x] 1.1 Add storage_s3 configure-from-env CLI — 44827dd6d
+- [x] 1.2 Surface tenant-setup preset failures via IntegrationLogService — 44827dd6d
 
 ### Phase 2: Documentation
 
-- [ ] 2.1 Document env block in apps/mercato/.env
-- [ ] 2.2 Document env block in packages/create-app/template/.env.example
-- [ ] 2.3 Expand storage-hub.mdx with rerunnable CLI + force semantics
+- [x] 2.1 Document env block in apps/mercato/.env — dd9bb63c5
+- [x] 2.2 Document env block in packages/create-app/template/.env.example — dd9bb63c5
+- [x] 2.3 Expand storage-hub.mdx with rerunnable CLI + force semantics — dd9bb63c5
 
 ### Phase 3: Tests
 
-- [ ] 3.1 Add preset.test.ts
-- [ ] 3.2 Add cli.test.ts
+- [x] 3.1 Add preset.test.ts — 44827dd6d
+- [x] 3.2 Add cli.test.ts — 44827dd6d
 
 ### Phase 4: Validation gate
 

--- a/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
+++ b/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
@@ -103,11 +103,11 @@ Bring `packages/storage-s3` up to the bar set by `gateway_stripe` / `sync_akeneo
 
 ### Phase 4: Validation gate
 
-- [ ] 4.1 Run full validation gate
+- [x] 4.1 Run full validation gate — typecheck, tests, generate, build:packages, build:app green; lint blocked by a pre-existing eslint-plugin-react/`next.config.ts` incompatibility (also reproduces on `origin/develop`); i18n usage check is advisory (no new keys added).
 
 ### Phase 5: Manual smoke verification
 
-- [ ] 5.1 Exercise CLI in running app, confirm logs in Integration UI
+- [x] 5.1 Exercise CLI in running app, confirm logs in Integration UI — verified five scenarios (missing env / full env / existing creds no-force / `--force` / incomplete env), info log persisted in `integration_logs`. Incomplete env exits 1 via the dispatcher's catch path (post-04753e982 fix).
 
 ### Phase 6: Pull request
 

--- a/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
+++ b/.ai/runs/2026-05-20-storage-s3-env-preconfigure.md
@@ -1,0 +1,114 @@
+# Execution Plan: env-based preconfiguration for `storage_s3`
+
+> Tracking GitHub issue: [#1968](https://github.com/open-mercato/open-mercato/issues/1968)
+>
+> Source spec: `.ai/specs/implemented/SPEC-045i-storage-hub.md` (this run is a follow-up addendum, not a new spec)
+>
+> Status: in-progress
+
+## Goal
+
+Bring `packages/storage-s3` up to the bar set by `gateway_stripe` / `sync_akeneo` for env-based preconfiguration: rerunnable CLI, hardened error logging, fully documented env block, doc page section, and unit coverage. Do this without changing the S3 driver, health check, or standalone API surfaces from #1617.
+
+## Scope
+
+- `packages/storage-s3/src/modules/storage_s3/cli.ts` (new)
+- `packages/storage-s3/src/modules/storage_s3/setup.ts` (log preset errors via `IntegrationLogService` instead of `console.warn`)
+- `packages/storage-s3/src/modules/storage_s3/lib/preset.ts` (no behavior change expected; only refactor if needed to support test wiring)
+- `packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts` (new)
+- `packages/storage-s3/src/modules/storage_s3/__tests__/preset.test.ts` (new — orthogonal coverage for preset reader)
+- `apps/mercato/.env` — add `OM_INTEGRATION_STORAGE_S3_*` block matching Stripe/Akeneo precedent
+- `packages/create-app/template/.env.example` — mirror the block for new apps
+- `apps/docs/docs/user-guide/storage-hub.mdx` — expand the existing env-preconfig section with the rerunnable CLI command and `--force` semantics
+- README of nothing else; we keep the changes narrow.
+
+### Non-goals
+
+- Do not touch the S3 driver, health check, or standalone S3 API routes.
+- Do not change credential storage format.
+- Do not rework `credentialsEnvPrefix` on attachment partitions (orthogonal, per the issue).
+- Do not introduce a new `OM_ENABLE_STORAGE_S3` flag rename. The flag already exists in `apps/mercato/src/modules.ts:141` and `packages/create-app/template/src/modules.ts:141` — we just clarify it in docs and ensure the .env block keeps it.
+
+## Implementation Plan
+
+### Phase 1: Provider CLI + setup hardening
+
+1.1 Add `packages/storage-s3/src/modules/storage_s3/cli.ts` that:
+- exports `[configureFromEnvCommand, helpCommand]` as the module's CLI surface (same shape as Stripe/Akeneo);
+- parses `--tenant`, `--org`, `--force`, plus aliases `--tenantId`, `--orgId`, `--organizationId`;
+- prints a help block listing the required and optional `OM_INTEGRATION_STORAGE_S3_*` env vars;
+- calls `applyS3EnvPreset(...)` with services resolved via `createRequestContainer()` (DI names: `integrationCredentialsService`, `integrationLogService`); — falls back to `createCredentialsService(em)` / `createIntegrationLogService(em)` if the DI keys are missing in some apps;
+- exits with `process.exitCode = 1` on `Incomplete S3 env preset` or any thrown error.
+
+1.2 Update `packages/storage-s3/src/modules/storage_s3/setup.ts` so that preset failures during `onTenantCreated` are surfaced through `IntegrationLogService.error(...)` (scope-aware) instead of `console.warn`. The CLI path already propagates errors via thrown exception.
+
+### Phase 2: Documentation
+
+2.1 Add the `# S3 Storage Preconfiguration` block to `apps/mercato/.env` matching the Stripe/Akeneo blocks (including a comment that the CLI command is rerunnable).
+
+2.2 Mirror the same block in `packages/create-app/template/.env.example` so freshly scaffolded apps get it.
+
+2.3 Expand the `Environment-based preconfiguration` section in `apps/docs/docs/user-guide/storage-hub.mdx` to (a) call out the rerunnable CLI `yarn mercato storage_s3 configure-from-env ...`, (b) document `--force` + `OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE`, (c) clarify the relationship with `OM_ENABLE_STORAGE_S3` (the module-enablement gate consumed in `modules.ts`).
+
+### Phase 3: Tests
+
+3.1 Add `packages/storage-s3/src/modules/storage_s3/__tests__/preset.test.ts` covering: missing env → null, full env → typed preset, optional fields preserved, `FORCE_PRECONFIGURE` parsing.
+
+3.2 Add `packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts` covering the CLI handler behavior with stub services: (a) missing env → skip, (b) full env → configure, (c) existing creds + no force → skip, (d) `--force` flag → overwrite, (e) malformed env (missing region) → non-zero exit code.
+
+### Phase 4: Validation gate
+
+4.1 Run `yarn build:packages`, `yarn generate`, `yarn build:packages` (post-generate), `yarn typecheck`, `yarn test`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn build:app`.
+
+### Phase 5: Manual smoke verification
+
+5.1 Spin up the running app (`yarn dev`), set the env vars, exercise the rerunnable CLI (configured + skipped paths), and confirm the Integration logs UI shows the structured info/error log entry.
+
+### Phase 6: Pull request
+
+6.1 Open a PR against `develop`, apply `review`, `feature`, `documentation` labels, and post the comprehensive summary comment.
+
+## Risks
+
+- **DI key drift**: `integrationCredentialsService` / `integrationLogService` are the registered keys in the host app; the storage-s3 module's own `di.ts` does not register them. Mirror the gateway_stripe CLI exactly to avoid binding surprises. If host registry is missing, fall back to `createCredentialsService(em)`/`createIntegrationLogService(em)` to remain self-contained.
+- **Container disposal**: Follow gateway_stripe's `finally { dispose }` pattern so DB connections close on exit.
+- **Setup.ts swallowed errors**: When `IntegrationLogService.error(...)` itself throws (e.g. DB not ready during a partial tenant create), fall back to `console.error(...)` so we never crash tenant provisioning.
+- **Env block bloat**: Keep the new block commented out by default so existing deployments are not impacted.
+
+## Backward Compatibility
+
+- All new behavior is additive. No existing import path, env var, or DI registration is renamed.
+- `applyS3EnvPreset` already supports the `force?: boolean` parameter — we reuse it.
+- The existing `onTenantCreated` flow is preserved; only the error-handling branch changes from `console.warn` to `IntegrationLogService.error`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Provider CLI + setup hardening
+
+- [ ] 1.1 Add storage_s3 configure-from-env CLI
+- [ ] 1.2 Surface tenant-setup preset failures via IntegrationLogService
+
+### Phase 2: Documentation
+
+- [ ] 2.1 Document env block in apps/mercato/.env
+- [ ] 2.2 Document env block in packages/create-app/template/.env.example
+- [ ] 2.3 Expand storage-hub.mdx with rerunnable CLI + force semantics
+
+### Phase 3: Tests
+
+- [ ] 3.1 Add preset.test.ts
+- [ ] 3.2 Add cli.test.ts
+
+### Phase 4: Validation gate
+
+- [ ] 4.1 Run full validation gate
+
+### Phase 5: Manual smoke verification
+
+- [ ] 5.1 Exercise CLI in running app, confirm logs in Integration UI
+
+### Phase 6: Pull request
+
+- [ ] 6.1 Open PR + labels + summary comment

--- a/apps/docs/docs/user-guide/storage-hub.mdx
+++ b/apps/docs/docs/user-guide/storage-hub.mdx
@@ -97,12 +97,40 @@ OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 OM_INTEGRATION_STORAGE_S3_REGION=us-east-1
 OM_INTEGRATION_STORAGE_S3_BUCKET=my-mercato-bucket
-# Optional for MinIO / DO Spaces / R2:
+# Optional:
+# OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN=
 # OM_INTEGRATION_STORAGE_S3_ENDPOINT=https://nyc3.digitaloceanspaces.com
 # OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE=true
+# OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=false
 ```
 
-On first startup the module reads these vars and pre-populates the Integration Marketplace credentials so no manual configuration step is needed.
+`OM_ENABLE_STORAGE_S3=true` is the module-enablement gate: without it the `storage_s3` module is not registered in `enabledModules` and the rest of the `OM_INTEGRATION_STORAGE_S3_*` block is ignored. The two layers are intentionally separate so you can preview the integration card in the UI without preconfiguring credentials.
+
+On new tenant setup the module reads `OM_INTEGRATION_STORAGE_S3_*` and pre-populates the Integration Marketplace credentials so no manual configuration step is needed. Setup failures (for example a partial env block) are surfaced through the **Integrations → Logs** UI under the `storage_s3` filter, so operators can see them alongside other integration activity.
+
+### Preconfigure existing tenants from the CLI
+
+`onTenantCreated` only runs once per tenant. If you upgrade an existing deployment after setting the `OM_INTEGRATION_STORAGE_S3_*` block, rerun the provider CLI to apply the preset to a tenant that was provisioned before the variables were available:
+
+```bash
+yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId>
+```
+
+Behavior:
+
+- No env vars set → the command prints `Skipped: No S3 env preset was found.` and exits `0`. Safe to call from a startup hook.
+- Required vars partially set → exits `1` with `Incomplete S3 env preset` so CI/automation can detect misconfiguration.
+- Tenant already has stored credentials → prints `Skipped: S3 credentials already exist.` and exits `0` unless you pass `--force` or set `OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=true`.
+- Full env + (no existing creds OR `--force`) → writes the credentials and adds an entry to the integration logs.
+
+Use `--force` when you want to roll keys without going through the Integrations UI:
+
+```bash
+yarn mercato storage_s3 configure-from-env \
+  --tenant <tenantId> \
+  --org <organizationId> \
+  --force
+```
 
 ## Local development with LocalStack
 

--- a/apps/docs/docs/user-guide/storage-hub.mdx
+++ b/apps/docs/docs/user-guide/storage-hub.mdx
@@ -132,6 +132,30 @@ yarn mercato storage_s3 configure-from-env \
   --force
 ```
 
+### Apply to every tenant from a deploy hook (`--all-tenants`)
+
+For unattended deploys — Dokploy, Coolify, Kamal, plain `docker run`, etc. — you usually do not want to track tenant and organization UUIDs in your deploy configuration. Use `--all-tenants` instead: the CLI iterates every active organization in the database and applies the preset to each `(tenantId, organizationId)` pair.
+
+```bash
+yarn mercato storage_s3 configure-from-env --all-tenants
+```
+
+Use it as a post-deploy / release hook in your platform (e.g. a Dokploy "deploy command", a Kamal `accessory` post-deploy, a Coolify "after deployment" step). On every redeploy, the command:
+
+- Reads the `OM_INTEGRATION_STORAGE_S3_*` block from the process environment once.
+- Enumerates every active organization (excludes soft-deleted ones).
+- Calls the same `applyS3EnvPreset` per-scope, with the same per-tenant skip / `--force` semantics — already-configured tenants are skipped automatically, fresh tenants get the preset.
+- Prints a summary line at the end (configured / skipped / errored counts).
+
+Exit code semantics:
+
+- All scopes succeed or skip → exit `0`. Safe to wire into every release hook.
+- Env preset is incomplete (a required `OM_INTEGRATION_STORAGE_S3_*` var is missing) → every scope errors → exit `1`. CI/automation can detect misconfiguration without parsing stdout.
+- At least one scope errors while others succeed → exit `1`. The summary line reports the breakdown.
+- No active organizations exist yet (fresh DB, before `mercato init`) → exit `0` with a "Nothing to do" message.
+
+`--all-tenants` cannot be combined with `--tenant` / `--org`. Pick one mode per invocation.
+
 ## Local development with LocalStack
 
 For local development and integration testing you can run a local S3 stub using **LocalStack**. Start it alongside the other infrastructure services by enabling the `storage-s3` compose profile:

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -55,6 +55,13 @@ OM_ENABLE_ENTERPRISE_MODULES_SSO=false
 # Requires OM_ENABLE_ENTERPRISE_MODULES=true
 OM_ENABLE_ENTERPRISE_MODULES_SECURITY=false
 
+# Enable the S3-compatible storage provider module (default: false).
+# When true, `storage_s3` is added to enabledModules in modules.ts and the
+# Integration Marketplace exposes the "S3 Object Storage" card.
+# The provider can also be preconfigured from env vars — see the
+# "S3 Storage Preconfiguration" block at the bottom of this file.
+OM_ENABLE_STORAGE_S3=false
+
 OM_SECURITY_TOTP_ISSUER="Open Mercato"
 OM_SECURITY_TOTP_WINDOW=1
 OM_SECURITY_OTP_EXPIRY_SECONDS=600
@@ -464,6 +471,47 @@ OCR_MODEL=gpt-4o
 # OM_INTEGRATION_AKENEO_PRODUCTS_SETTINGS_JSON=
 # OM_INTEGRATION_AKENEO_CATEGORIES_SETTINGS_JSON=
 # OM_INTEGRATION_AKENEO_ATTRIBUTES_SETTINGS_JSON=
+
+# ============================================================================
+# S3 Storage Preconfiguration
+# ============================================================================
+# If these credentials are set, the storage_s3 provider preconfigures itself
+# during tenant setup and can be rerun later (for existing tenants) with:
+# yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId>
+#
+# The CLI exits non-zero on an incomplete preset so CI/automation can detect
+# misconfiguration. Pass --force (or set OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=true)
+# to overwrite credentials that have already been stored for the tenant.
+#
+# The module itself is only loaded when OM_ENABLE_STORAGE_S3=true (see above)
+# — without that flag the preconfiguration block below is ignored.
+#
+# Required for auto-preconfiguration:
+# OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+# OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+# OM_INTEGRATION_STORAGE_S3_REGION=eu-central-1
+# OM_INTEGRATION_STORAGE_S3_BUCKET=my-mercato-attachments
+#
+# Optional behavior:
+# OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN=
+# OM_INTEGRATION_STORAGE_S3_ENDPOINT=https://fra1.digitaloceanspaces.com
+# OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE=false
+# OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=false
+#
+# Notes:
+# - SESSION_TOKEN is only needed for short-lived STS credentials.
+# - Leave ENDPOINT blank for AWS S3. Set it for MinIO, DigitalOcean Spaces,
+#   Cloudflare R2, Backblaze B2, etc.
+# - FORCE_PATH_STYLE must be true for MinIO and most self-hosted S3 services.
+# - Leave the block commented out when S3 should not be preconfigured.
+# OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID=
+# OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY=
+# OM_INTEGRATION_STORAGE_S3_REGION=
+# OM_INTEGRATION_STORAGE_S3_BUCKET=
+# OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN=
+# OM_INTEGRATION_STORAGE_S3_ENDPOINT=
+# OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE=false
+# OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=false
 
 # ============================================================================
 # Customer Portal Sessions

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -479,6 +479,11 @@ OCR_MODEL=gpt-4o
 # during tenant setup and can be rerun later (for existing tenants) with:
 # yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId>
 #
+# For unattended deploys (Dokploy, Coolify, Kamal, etc.), use --all-tenants
+# as a post-deploy hook to apply the preset to every active organization
+# without tracking UUIDs in your deploy config:
+# yarn mercato storage_s3 configure-from-env --all-tenants
+#
 # The CLI exits non-zero on an incomplete preset so CI/automation can detect
 # misconfiguration. Pass --force (or set OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=true)
 # to overwrite credentials that have already been stored for the tenant.

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-004.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-004.spec.ts
@@ -49,11 +49,13 @@ test.describe('TC-CUR-004: Set Base Currency from UI', () => {
       await login(page, 'admin');
       await page.goto('/backend/currencies');
 
-      // Wait for the table to load and find our fixture row.
-      // Word boundaries avoid matching the code as a substring of a seeded
-      // currency name (e.g. random code "BRI" inside "British Pound").
-      const codePattern = new RegExp(`\\b${code}\\b`);
-      const row = page.getByRole('row').filter({ hasText: codePattern });
+      // Wait for the table to load and find our fixture row. Match the
+      // code cell exactly — substring matching on the whole row collides
+      // when a random code (e.g. "BRI") appears inside a seeded currency
+      // name (e.g. "British Pound").
+      const row = page.getByRole('row').filter({
+        has: page.getByRole('cell', { name: code, exact: true }),
+      });
       await expect(row).toBeVisible({ timeout: 10_000 });
 
       // Open row actions menu (focus + Enter, same pattern as TC-ADMIN-002)

--- a/packages/core/src/modules/currencies/__integration__/TC-CUR-004.spec.ts
+++ b/packages/core/src/modules/currencies/__integration__/TC-CUR-004.spec.ts
@@ -49,8 +49,11 @@ test.describe('TC-CUR-004: Set Base Currency from UI', () => {
       await login(page, 'admin');
       await page.goto('/backend/currencies');
 
-      // Wait for the table to load and find our fixture row
-      const row = page.getByRole('row').filter({ hasText: code });
+      // Wait for the table to load and find our fixture row.
+      // Word boundaries avoid matching the code as a substring of a seeded
+      // currency name (e.g. random code "BRI" inside "British Pound").
+      const codePattern = new RegExp(`\\b${code}\\b`);
+      const row = page.getByRole('row').filter({ hasText: codePattern });
       await expect(row).toBeVisible({ timeout: 10_000 });
 
       // Open row actions menu (focus + Enter, same pattern as TC-ADMIN-002)

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -55,6 +55,13 @@ OM_ENABLE_ENTERPRISE_MODULES_SSO=false
 # Requires OM_ENABLE_ENTERPRISE_MODULES=true
 OM_ENABLE_ENTERPRISE_MODULES_SECURITY=false
 
+# Enable the S3-compatible storage provider module (default: false).
+# When true, `storage_s3` is added to enabledModules in modules.ts and the
+# Integration Marketplace exposes the "S3 Object Storage" card.
+# The provider can also be preconfigured from env vars — see the
+# "S3 Storage Preconfiguration" block at the bottom of this file.
+OM_ENABLE_STORAGE_S3=false
+
 # OM_SECURITY_MFA_SETUP_SECRET=change-me-mfa-setup-secret
 OM_SECURITY_TOTP_ISSUER=Open Mercato
 OM_SECURITY_TOTP_WINDOW=1
@@ -450,6 +457,47 @@ OCR_MODEL=gpt-4o
 # OM_INTEGRATION_AKENEO_PRODUCTS_SETTINGS_JSON=
 # OM_INTEGRATION_AKENEO_CATEGORIES_SETTINGS_JSON=
 # OM_INTEGRATION_AKENEO_ATTRIBUTES_SETTINGS_JSON=
+
+# ============================================================================
+# S3 Storage Preconfiguration
+# ============================================================================
+# If these credentials are set, the storage_s3 provider preconfigures itself
+# during tenant setup and can be rerun later (for existing tenants) with:
+# yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId>
+#
+# The CLI exits non-zero on an incomplete preset so CI/automation can detect
+# misconfiguration. Pass --force (or set OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=true)
+# to overwrite credentials that have already been stored for the tenant.
+#
+# The module itself is only loaded when OM_ENABLE_STORAGE_S3=true (see above)
+# — without that flag the preconfiguration block below is ignored.
+#
+# Required for auto-preconfiguration:
+# OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+# OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+# OM_INTEGRATION_STORAGE_S3_REGION=eu-central-1
+# OM_INTEGRATION_STORAGE_S3_BUCKET=my-mercato-attachments
+#
+# Optional behavior:
+# OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN=
+# OM_INTEGRATION_STORAGE_S3_ENDPOINT=https://fra1.digitaloceanspaces.com
+# OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE=false
+# OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=false
+#
+# Notes:
+# - SESSION_TOKEN is only needed for short-lived STS credentials.
+# - Leave ENDPOINT blank for AWS S3. Set it for MinIO, DigitalOcean Spaces,
+#   Cloudflare R2, Backblaze B2, etc.
+# - FORCE_PATH_STYLE must be true for MinIO and most self-hosted S3 services.
+# - Leave the block commented out when S3 should not be preconfigured.
+# OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID=
+# OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY=
+# OM_INTEGRATION_STORAGE_S3_REGION=
+# OM_INTEGRATION_STORAGE_S3_BUCKET=
+# OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN=
+# OM_INTEGRATION_STORAGE_S3_ENDPOINT=
+# OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE=false
+# OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=false
 
 # ============================================================================
 # InboxOps Configuration (email-to-ERP agent)

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -465,6 +465,11 @@ OCR_MODEL=gpt-4o
 # during tenant setup and can be rerun later (for existing tenants) with:
 # yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId>
 #
+# For unattended deploys (Dokploy, Coolify, Kamal, etc.), use --all-tenants
+# as a post-deploy hook to apply the preset to every active organization
+# without tracking UUIDs in your deploy config:
+# yarn mercato storage_s3 configure-from-env --all-tenants
+#
 # The CLI exits non-zero on an incomplete preset so CI/automation can detect
 # misconfiguration. Pass --force (or set OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=true)
 # to overwrite credentials that have already been stored for the tenant.

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts
@@ -1,6 +1,9 @@
 import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
 import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
-import { runConfigureFromEnv } from '../lib/configure-from-env'
+import {
+  runConfigureFromEnv,
+  runConfigureFromEnvForScopes,
+} from '../lib/configure-from-env'
 
 function buildLogService() {
   const info = jest.fn()
@@ -139,5 +142,121 @@ describe('storage_s3 configure-from-env CLI handler', () => {
     expect(outcome.status).toBe('error')
     expect(outcome.message).toMatch(/Incomplete S3 env preset/)
     expect(credentialsService.save).not.toHaveBeenCalled()
+  })
+})
+
+describe('storage_s3 configure-from-env --all-tenants helper', () => {
+  function buildFullEnv() {
+    return {
+      OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+      OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+      OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+      OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+    }
+  }
+
+  it('iterates every scope and reports per-scope outcomes', async () => {
+    const existing = new Set(['org-existing'])
+    const saved: Array<{ tenantId: string; organizationId: string }> = []
+
+    const credentialsService = {
+      getRaw: jest.fn(async (_id: string, scope: { tenantId: string; organizationId: string }) =>
+        existing.has(scope.organizationId) ? { accessKeyId: 'existing' } : null,
+      ),
+      save: jest.fn(async (_id: string, _creds: unknown, scope: { tenantId: string; organizationId: string }) => {
+        saved.push(scope)
+      }),
+    } as unknown as CredentialsService
+
+    const { integrationLogService } = buildLogService()
+
+    const summary = await runConfigureFromEnvForScopes(
+      { credentialsService, integrationLogService, env: buildFullEnv() },
+      [
+        { tenantId: 't1', organizationId: 'org-fresh' },
+        { tenantId: 't2', organizationId: 'org-existing' },
+      ],
+    )
+
+    expect(summary).toMatchObject({ code: 0, configured: 1, skipped: 1, errored: 0 })
+    expect(summary.perScope).toHaveLength(2)
+    expect(summary.perScope[0].outcome.status).toBe('configured')
+    expect(summary.perScope[1].outcome.status).toBe('skipped')
+    expect(saved).toEqual([{ tenantId: 't1', organizationId: 'org-fresh' }])
+  })
+
+  it('returns exit code 1 when at least one scope errors', async () => {
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue(null),
+      save: jest.fn(async (_id, _creds, scope) => {
+        if ((scope as { organizationId: string }).organizationId === 'broken') {
+          throw new Error('boom')
+        }
+      }),
+    } as unknown as CredentialsService
+
+    const { integrationLogService } = buildLogService()
+
+    const summary = await runConfigureFromEnvForScopes(
+      { credentialsService, integrationLogService, env: buildFullEnv() },
+      [
+        { tenantId: 't1', organizationId: 'ok' },
+        { tenantId: 't2', organizationId: 'broken' },
+      ],
+    )
+
+    expect(summary.code).toBe(1)
+    expect(summary.configured).toBe(1)
+    expect(summary.errored).toBe(1)
+    expect(summary.perScope[1].outcome.status).toBe('error')
+    expect((summary.perScope[1].outcome as { message: string }).message).toMatch(/boom/)
+  })
+
+  it('returns exit code 0 with skip-only outcomes when env is unset', async () => {
+    const credentialsService = {
+      getRaw: jest.fn(),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+
+    const { integrationLogService } = buildLogService()
+
+    const summary = await runConfigureFromEnvForScopes(
+      { credentialsService, integrationLogService, env: {} },
+      [
+        { tenantId: 't1', organizationId: 'a' },
+        { tenantId: 't2', organizationId: 'b' },
+      ],
+    )
+
+    expect(summary.code).toBe(0)
+    expect(summary.skipped).toBe(2)
+    expect(summary.configured).toBe(0)
+    expect(summary.errored).toBe(0)
+    expect(credentialsService.save).not.toHaveBeenCalled()
+  })
+
+  it('propagates --force to every scope', async () => {
+    const saveCalls: Array<{ scope: { tenantId: string; organizationId: string } }> = []
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue({ accessKeyId: 'existing' }),
+      save: jest.fn(async (_id, _creds, scope) => {
+        saveCalls.push({ scope: scope as { tenantId: string; organizationId: string } })
+      }),
+    } as unknown as CredentialsService
+
+    const { integrationLogService } = buildLogService()
+
+    const summary = await runConfigureFromEnvForScopes(
+      { credentialsService, integrationLogService, env: buildFullEnv() },
+      [
+        { tenantId: 't1', organizationId: 'a' },
+        { tenantId: 't2', organizationId: 'b' },
+      ],
+      { force: true },
+    )
+
+    expect(summary.code).toBe(0)
+    expect(summary.configured).toBe(2)
+    expect(saveCalls).toHaveLength(2)
   })
 })

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts
@@ -1,6 +1,9 @@
 import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
 import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
 import {
+  mapOrganizationsToScopes,
+  parseCliArgs,
+  resolveCliMode,
   runConfigureFromEnv,
   runConfigureFromEnvForScopes,
 } from '../lib/configure-from-env'
@@ -258,5 +261,158 @@ describe('storage_s3 configure-from-env --all-tenants helper', () => {
     expect(summary.code).toBe(0)
     expect(summary.configured).toBe(2)
     expect(saveCalls).toHaveLength(2)
+  })
+})
+
+describe('storage_s3 parseCliArgs', () => {
+  it('parses standalone flags as boolean true', () => {
+    expect(parseCliArgs(['--all-tenants'])).toEqual({ 'all-tenants': true })
+    expect(parseCliArgs(['--force'])).toEqual({ force: true })
+  })
+
+  it('parses --key value pairs', () => {
+    expect(parseCliArgs(['--tenant', 'abc', '--org', 'def'])).toEqual({
+      tenant: 'abc',
+      org: 'def',
+    })
+  })
+
+  it('parses --key=value form', () => {
+    expect(parseCliArgs(['--tenant=abc', '--org=def'])).toEqual({
+      tenant: 'abc',
+      org: 'def',
+    })
+  })
+
+  it('treats the next --flag as a separate flag, not a value', () => {
+    expect(parseCliArgs(['--all-tenants', '--force'])).toEqual({
+      'all-tenants': true,
+      force: true,
+    })
+  })
+
+  it('ignores positional arguments without a leading --', () => {
+    expect(parseCliArgs(['ignored', '--tenant', 'abc', 'also-ignored'])).toEqual({
+      tenant: 'abc',
+    })
+  })
+})
+
+describe('storage_s3 resolveCliMode', () => {
+  it('returns help when no tenant/org and no --all-tenants is provided', () => {
+    expect(resolveCliMode({})).toEqual({ kind: 'help' })
+    expect(resolveCliMode({ force: true })).toEqual({ kind: 'help' })
+  })
+
+  it('returns help when only --tenant is provided without --org', () => {
+    expect(resolveCliMode({ tenant: 'abc' })).toEqual({ kind: 'help' })
+  })
+
+  it('returns help when only --org is provided without --tenant', () => {
+    expect(resolveCliMode({ org: 'def' })).toEqual({ kind: 'help' })
+  })
+
+  it('returns single mode when both --tenant and --org are provided', () => {
+    expect(resolveCliMode({ tenant: 'abc', org: 'def' })).toEqual({
+      kind: 'single',
+      tenantId: 'abc',
+      organizationId: 'def',
+      force: undefined,
+    })
+  })
+
+  it('accepts the alias forms --tenantId / --organizationId / --orgId', () => {
+    expect(resolveCliMode({ tenantId: 'abc', organizationId: 'def' })).toEqual({
+      kind: 'single',
+      tenantId: 'abc',
+      organizationId: 'def',
+      force: undefined,
+    })
+    expect(resolveCliMode({ tenant: 'abc', orgId: 'def' })).toEqual({
+      kind: 'single',
+      tenantId: 'abc',
+      organizationId: 'def',
+      force: undefined,
+    })
+  })
+
+  it('propagates --force to single mode', () => {
+    expect(resolveCliMode({ tenant: 'abc', org: 'def', force: true })).toEqual({
+      kind: 'single',
+      tenantId: 'abc',
+      organizationId: 'def',
+      force: true,
+    })
+  })
+
+  it('returns all mode when --all-tenants is provided alone', () => {
+    expect(resolveCliMode({ 'all-tenants': true })).toEqual({
+      kind: 'all',
+      force: undefined,
+    })
+  })
+
+  it('accepts --allTenants as a camelCase alias for --all-tenants', () => {
+    expect(resolveCliMode({ allTenants: true })).toEqual({
+      kind: 'all',
+      force: undefined,
+    })
+  })
+
+  it('propagates --force to all mode', () => {
+    expect(resolveCliMode({ 'all-tenants': true, force: true })).toEqual({
+      kind: 'all',
+      force: true,
+    })
+  })
+
+  it('returns conflict when --all-tenants is combined with --tenant', () => {
+    const mode = resolveCliMode({ 'all-tenants': true, tenant: 'abc' })
+    expect(mode.kind).toBe('conflict')
+    if (mode.kind === 'conflict') {
+      expect(mode.message).toMatch(/cannot be combined/i)
+    }
+  })
+
+  it('returns conflict when --all-tenants is combined with --org', () => {
+    const mode = resolveCliMode({ 'all-tenants': true, org: 'def' })
+    expect(mode.kind).toBe('conflict')
+  })
+
+  it('returns conflict when --all-tenants is combined with both --tenant and --org', () => {
+    expect(resolveCliMode({ 'all-tenants': true, tenant: 'abc', org: 'def' }).kind).toBe('conflict')
+  })
+})
+
+describe('storage_s3 mapOrganizationsToScopes', () => {
+  it('returns an empty array when there are no organizations', () => {
+    expect(mapOrganizationsToScopes([])).toEqual([])
+  })
+
+  it('returns a scope per organization with its tenant id', () => {
+    const orgs = [
+      { id: 'org-1', tenant: { id: 'tenant-1' } },
+      { id: 'org-2', tenant: { id: 'tenant-1' } },
+      { id: 'org-3', tenant: { id: 'tenant-2' } },
+    ]
+    expect(mapOrganizationsToScopes(orgs)).toEqual([
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+      { tenantId: 'tenant-1', organizationId: 'org-2' },
+      { tenantId: 'tenant-2', organizationId: 'org-3' },
+    ])
+  })
+
+  it('skips organizations without a populated tenant (defensive guard)', () => {
+    const orgs = [
+      { id: 'org-1', tenant: { id: 'tenant-1' } },
+      { id: 'org-2', tenant: null },
+      { id: 'org-3' },
+      { id: 'org-4', tenant: { id: null } },
+      { id: 'org-5', tenant: { id: 'tenant-2' } },
+    ]
+    expect(mapOrganizationsToScopes(orgs)).toEqual([
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+      { tenantId: 'tenant-2', organizationId: 'org-5' },
+    ])
   })
 })

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts
@@ -1,0 +1,143 @@
+import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
+import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
+import { runConfigureFromEnv } from '../lib/configure-from-env'
+
+function buildLogService() {
+  const info = jest.fn()
+  const integrationLogService = {
+    scoped: jest.fn(() => ({ info })),
+  } as unknown as IntegrationLogService
+  return { integrationLogService, info }
+}
+
+describe('storage_s3 configure-from-env CLI handler', () => {
+  it('skips when no env vars are set', async () => {
+    const credentialsService = {
+      getRaw: jest.fn(),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+    const { integrationLogService } = buildLogService()
+
+    const outcome = await runConfigureFromEnv(
+      { credentialsService, integrationLogService, env: {} },
+      { tenantId: 't', organizationId: 'o' },
+    )
+
+    expect(outcome).toEqual({
+      code: 0,
+      status: 'skipped',
+      message: expect.stringMatching(/No S3 env preset/),
+    })
+    expect(credentialsService.save).not.toHaveBeenCalled()
+  })
+
+  it('configures credentials with a complete env preset', async () => {
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue(null),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+    const { integrationLogService, info } = buildLogService()
+
+    const outcome = await runConfigureFromEnv(
+      {
+        credentialsService,
+        integrationLogService,
+        env: {
+          OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+          OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+          OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+          OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+        },
+      },
+      { tenantId: 't', organizationId: 'o' },
+    )
+
+    expect(outcome).toEqual({
+      code: 0,
+      status: 'configured',
+      message: expect.stringMatching(/configured from env/i),
+    })
+    expect(credentialsService.save).toHaveBeenCalledTimes(1)
+    expect(info).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips when credentials already exist and --force is not set', async () => {
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue({ accessKeyId: 'existing' }),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+    const { integrationLogService } = buildLogService()
+
+    const outcome = await runConfigureFromEnv(
+      {
+        credentialsService,
+        integrationLogService,
+        env: {
+          OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+          OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+          OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+          OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+        },
+      },
+      { tenantId: 't', organizationId: 'o' },
+    )
+
+    expect(outcome).toEqual({
+      code: 0,
+      status: 'skipped',
+      message: expect.stringMatching(/already exist/i),
+    })
+    expect(credentialsService.save).not.toHaveBeenCalled()
+  })
+
+  it('overwrites credentials when --force is true', async () => {
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue({ accessKeyId: 'existing' }),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+    const { integrationLogService } = buildLogService()
+
+    const outcome = await runConfigureFromEnv(
+      {
+        credentialsService,
+        integrationLogService,
+        env: {
+          OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+          OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+          OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+          OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+        },
+      },
+      { tenantId: 't', organizationId: 'o', force: true },
+    )
+
+    expect(outcome.code).toBe(0)
+    expect(outcome.status).toBe('configured')
+    expect(credentialsService.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns code 1 with a clear message for incomplete env presets', async () => {
+    const credentialsService = {
+      getRaw: jest.fn(),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+    const { integrationLogService } = buildLogService()
+
+    const outcome = await runConfigureFromEnv(
+      {
+        credentialsService,
+        integrationLogService,
+        env: {
+          OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+          OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+        },
+      },
+      { tenantId: 't', organizationId: 'o' },
+    )
+
+    expect(outcome.code).toBe(1)
+    expect(outcome.status).toBe('error')
+    expect(outcome.message).toMatch(/Incomplete S3 env preset/)
+    expect(credentialsService.save).not.toHaveBeenCalled()
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/preset.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/preset.test.ts
@@ -1,0 +1,175 @@
+import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
+import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
+import { applyS3EnvPreset, readS3EnvPreset } from '../lib/preset'
+
+describe('storage_s3 preset', () => {
+  it('returns null when no env vars are provided', () => {
+    expect(readS3EnvPreset({})).toBeNull()
+  })
+
+  it('reads required credentials from env and applies optional fields', () => {
+    const preset = readS3EnvPreset({
+      OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+      OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+      OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+      OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+      OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN: 'session',
+      OM_INTEGRATION_STORAGE_S3_ENDPOINT: 'https://example.com',
+      OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE: 'true',
+      OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE: 'true',
+    })
+
+    expect(preset).not.toBeNull()
+    expect(preset?.credentials).toEqual({
+      authMode: 'access_keys',
+      accessKeyId: 'AKIAEXAMPLE',
+      secretAccessKey: 'secret',
+      sessionToken: 'session',
+      region: 'eu-central-1',
+      bucket: 'om-bucket',
+      endpoint: 'https://example.com',
+      forcePathStyle: true,
+    })
+    expect(preset?.force).toBe(true)
+  })
+
+  it('throws when any required env value is missing', () => {
+    expect(() =>
+      readS3EnvPreset({
+        OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+        OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+      }),
+    ).toThrow(/Incomplete S3 env preset/)
+  })
+
+  it('saves credentials and writes an info log when applied for the first time', async () => {
+    const saved: Array<Record<string, unknown>> = []
+    const logCalls: Array<{ message: string; payload?: Record<string, unknown> }> = []
+
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue(null),
+      save: jest.fn(async (_integrationId, credentials) => {
+        saved.push(credentials as Record<string, unknown>)
+      }),
+    } as unknown as CredentialsService
+
+    const integrationLogService = {
+      scoped: jest.fn(() => ({
+        info: async (message: string, payload?: Record<string, unknown>) => {
+          logCalls.push({ message, payload })
+        },
+      })),
+    } as unknown as IntegrationLogService
+
+    const result = await applyS3EnvPreset({
+      credentialsService,
+      integrationLogService,
+      scope: { tenantId: 'tenant-1', organizationId: 'org-1' },
+      env: {
+        OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+        OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+        OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+        OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+      },
+    })
+
+    expect(result).toEqual({ status: 'configured' })
+    expect(saved).toEqual([
+      {
+        authMode: 'access_keys',
+        accessKeyId: 'AKIAEXAMPLE',
+        secretAccessKey: 'secret',
+        region: 'eu-central-1',
+        bucket: 'om-bucket',
+      },
+    ])
+    expect(logCalls).toHaveLength(1)
+    expect(logCalls[0].payload).toMatchObject({
+      region: 'eu-central-1',
+      bucket: 'om-bucket',
+      endpoint: null,
+    })
+  })
+
+  it('skips when credentials already exist and force is not set', async () => {
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue({ accessKeyId: 'existing' }),
+      save: jest.fn(),
+    } as unknown as CredentialsService
+
+    const integrationLogService = {
+      scoped: jest.fn(() => ({ info: jest.fn() })),
+    } as unknown as IntegrationLogService
+
+    const result = await applyS3EnvPreset({
+      credentialsService,
+      integrationLogService,
+      scope: { tenantId: 't', organizationId: 'o' },
+      env: {
+        OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+        OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+        OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+        OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+      },
+    })
+
+    expect(result.status).toBe('skipped')
+    expect(credentialsService.save).not.toHaveBeenCalled()
+  })
+
+  it('overwrites existing credentials when force is true', async () => {
+    const saveSpy = jest.fn()
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue({ accessKeyId: 'existing' }),
+      save: saveSpy,
+    } as unknown as CredentialsService
+
+    const integrationLogService = {
+      scoped: jest.fn(() => ({ info: jest.fn() })),
+    } as unknown as IntegrationLogService
+
+    const result = await applyS3EnvPreset({
+      credentialsService,
+      integrationLogService,
+      scope: { tenantId: 't', organizationId: 'o' },
+      force: true,
+      env: {
+        OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+        OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+        OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+        OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+      },
+    })
+
+    expect(result.status).toBe('configured')
+    expect(saveSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('honors OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE when no explicit force is passed', async () => {
+    const saveSpy = jest.fn()
+    const credentialsService = {
+      getRaw: jest.fn().mockResolvedValue({ accessKeyId: 'existing' }),
+      save: saveSpy,
+    } as unknown as CredentialsService
+
+    const integrationLogService = {
+      scoped: jest.fn(() => ({ info: jest.fn() })),
+    } as unknown as IntegrationLogService
+
+    const result = await applyS3EnvPreset({
+      credentialsService,
+      integrationLogService,
+      scope: { tenantId: 't', organizationId: 'o' },
+      env: {
+        OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID: 'AKIAEXAMPLE',
+        OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY: 'secret',
+        OM_INTEGRATION_STORAGE_S3_REGION: 'eu-central-1',
+        OM_INTEGRATION_STORAGE_S3_BUCKET: 'om-bucket',
+        OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE: 'true',
+      },
+    })
+
+    expect(result.status).toBe('configured')
+    expect(saveSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/cli.ts
+++ b/packages/storage-s3/src/modules/storage_s3/cli.ts
@@ -1,8 +1,14 @@
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import type { ModuleCli } from '@open-mercato/shared/modules/registry'
 import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
 import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
-import { runConfigureFromEnv } from './lib/configure-from-env'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
+import type { IntegrationScope } from '@open-mercato/shared/modules/integrations/types'
+import {
+  runConfigureFromEnv,
+  runConfigureFromEnvForScopes,
+} from './lib/configure-from-env'
 
 function parseArgs(args: string[]): Record<string, string | boolean> {
   const result: Record<string, string | boolean> = {}
@@ -32,7 +38,12 @@ function parseArgs(args: string[]): Record<string, string | boolean> {
 }
 
 function printHelp(): void {
-  console.log('Usage: yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId> [--force]')
+  console.log('Usage: yarn mercato storage_s3 configure-from-env [--tenant <tenantId> --org <organizationId> | --all-tenants] [--force]')
+  console.log('')
+  console.log('Modes:')
+  console.log('  --tenant <id> --org <id>   Apply the preset to a single tenant + organization pair.')
+  console.log('  --all-tenants              Apply the preset to every active (tenant, organization) pair.')
+  console.log('                             Designed for unattended deploy hooks; per-tenant skip/force semantics still apply.')
   console.log('')
   console.log('Required env vars:')
   console.log('  OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID')
@@ -47,23 +58,84 @@ function printHelp(): void {
   console.log('  OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE')
 }
 
+async function listActiveScopes(em: EntityManager): Promise<IntegrationScope[]> {
+  const organizations = await em.find(
+    Organization,
+    { deletedAt: null, isActive: true },
+    { populate: ['tenant'] },
+  )
+
+  const scopes: IntegrationScope[] = []
+  for (const organization of organizations) {
+    const tenantId = organization.tenant?.id
+    if (!tenantId) continue
+    scopes.push({ tenantId, organizationId: organization.id })
+  }
+  return scopes
+}
+
 const configureFromEnvCommand: ModuleCli = {
   command: 'configure-from-env',
   async run(rest) {
     const args = parseArgs(rest)
+    const allTenants = args['all-tenants'] === true || args.allTenants === true
     const tenantId = String(args.tenantId ?? args.tenant ?? '')
     const organizationId = String(args.organizationId ?? args.orgId ?? args.org ?? '')
     const force = args.force === true ? true : undefined
 
-    if (!tenantId || !organizationId) {
+    if (!allTenants && (!tenantId || !organizationId)) {
       printHelp()
       return
+    }
+
+    if (allTenants && (tenantId || organizationId)) {
+      console.error('[storage_s3] --all-tenants cannot be combined with --tenant or --org. Pick one mode.')
+      throw new Error('Conflicting CLI arguments: --all-tenants vs --tenant/--org')
     }
 
     const container = await createRequestContainer()
     try {
       const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
       const integrationLogService = container.resolve('integrationLogService') as IntegrationLogService
+
+      if (allTenants) {
+        const em = container.resolve('em') as EntityManager
+        const scopes = await listActiveScopes(em)
+
+        if (scopes.length === 0) {
+          console.log('[storage_s3] --all-tenants: no active organizations found. Nothing to do.')
+          return
+        }
+
+        const summary = await runConfigureFromEnvForScopes(
+          { credentialsService, integrationLogService },
+          scopes,
+          { force },
+        )
+
+        for (const entry of summary.perScope) {
+          const prefix = `[storage_s3] tenant=${entry.scope.tenantId} org=${entry.scope.organizationId}`
+          if (entry.outcome.code === 1) {
+            console.error(`${prefix} ERROR: ${entry.outcome.message}`)
+          } else if (entry.outcome.status === 'skipped') {
+            console.log(`${prefix} skipped: ${entry.outcome.message}`)
+          } else {
+            console.log(`${prefix} configured: ${entry.outcome.message}`)
+          }
+        }
+
+        console.log(
+          `[storage_s3] --all-tenants summary: ${summary.configured} configured, ` +
+            `${summary.skipped} skipped, ${summary.errored} error(s).`,
+        )
+
+        if (summary.code === 1) {
+          throw new Error(
+            `--all-tenants completed with ${summary.errored} error(s) across ${scopes.length} scope(s). See per-scope errors above.`,
+          )
+        }
+        return
+      }
 
       const outcome = await runConfigureFromEnv(
         { credentialsService, integrationLogService },

--- a/packages/storage-s3/src/modules/storage_s3/cli.ts
+++ b/packages/storage-s3/src/modules/storage_s3/cli.ts
@@ -1,0 +1,100 @@
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { ModuleCli } from '@open-mercato/shared/modules/registry'
+import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
+import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
+import { runConfigureFromEnv } from './lib/configure-from-env'
+
+function parseArgs(args: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {}
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (!arg.startsWith('--')) continue
+
+    const key = arg.slice(2)
+    if (key.includes('=')) {
+      const [name, value] = key.split('=')
+      result[name] = value
+      continue
+    }
+
+    const next = args[i + 1]
+    if (next && !next.startsWith('--')) {
+      result[key] = next
+      i += 1
+      continue
+    }
+
+    result[key] = true
+  }
+
+  return result
+}
+
+function printHelp(): void {
+  console.log('Usage: yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId> [--force]')
+  console.log('')
+  console.log('Required env vars:')
+  console.log('  OM_INTEGRATION_STORAGE_S3_ACCESS_KEY_ID')
+  console.log('  OM_INTEGRATION_STORAGE_S3_SECRET_ACCESS_KEY')
+  console.log('  OM_INTEGRATION_STORAGE_S3_REGION')
+  console.log('  OM_INTEGRATION_STORAGE_S3_BUCKET')
+  console.log('')
+  console.log('Optional env vars:')
+  console.log('  OM_INTEGRATION_STORAGE_S3_SESSION_TOKEN')
+  console.log('  OM_INTEGRATION_STORAGE_S3_ENDPOINT')
+  console.log('  OM_INTEGRATION_STORAGE_S3_FORCE_PATH_STYLE')
+  console.log('  OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE')
+}
+
+const configureFromEnvCommand: ModuleCli = {
+  command: 'configure-from-env',
+  async run(rest) {
+    const args = parseArgs(rest)
+    const tenantId = String(args.tenantId ?? args.tenant ?? '')
+    const organizationId = String(args.organizationId ?? args.orgId ?? args.org ?? '')
+    const force = args.force === true ? true : undefined
+
+    if (!tenantId || !organizationId) {
+      printHelp()
+      return
+    }
+
+    const container = await createRequestContainer()
+    try {
+      const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
+      const integrationLogService = container.resolve('integrationLogService') as IntegrationLogService
+
+      const outcome = await runConfigureFromEnv(
+        { credentialsService, integrationLogService },
+        { tenantId, organizationId, force },
+      )
+
+      if (outcome.code === 0) {
+        if (outcome.status === 'skipped') {
+          console.log(`[storage_s3] Skipped: ${outcome.message}`)
+        } else {
+          console.log(`[storage_s3] ${outcome.message}`)
+        }
+        return
+      }
+
+      console.error(`[storage_s3] ${outcome.message}`)
+      process.exitCode = 1
+    } finally {
+      const disposable = container as unknown as { dispose?: () => Promise<void> }
+      if (typeof disposable.dispose === 'function') {
+        await disposable.dispose()
+      }
+    }
+  },
+}
+
+const helpCommand: ModuleCli = {
+  command: 'help',
+  async run() {
+    printHelp()
+  },
+}
+
+export default [configureFromEnvCommand, helpCommand]

--- a/packages/storage-s3/src/modules/storage_s3/cli.ts
+++ b/packages/storage-s3/src/modules/storage_s3/cli.ts
@@ -5,6 +5,7 @@ import type { CredentialsService } from '@open-mercato/core/modules/integrations
 import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import type { IntegrationScope } from '@open-mercato/shared/modules/integrations/types'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import {
   mapOrganizationsToScopes,
   parseCliArgs,
@@ -35,7 +36,8 @@ function printHelp(): void {
 }
 
 async function listActiveScopes(em: EntityManager): Promise<IntegrationScope[]> {
-  const organizations = await em.find(
+  const organizations = await findWithDecryption(
+    em,
     Organization,
     { deletedAt: null, isActive: true },
     { populate: ['tenant'] },

--- a/packages/storage-s3/src/modules/storage_s3/cli.ts
+++ b/packages/storage-s3/src/modules/storage_s3/cli.ts
@@ -79,8 +79,7 @@ const configureFromEnvCommand: ModuleCli = {
         return
       }
 
-      console.error(`[storage_s3] ${outcome.message}`)
-      process.exitCode = 1
+      throw new Error(outcome.message)
     } finally {
       const disposable = container as unknown as { dispose?: () => Promise<void> }
       if (typeof disposable.dispose === 'function') {

--- a/packages/storage-s3/src/modules/storage_s3/cli.ts
+++ b/packages/storage-s3/src/modules/storage_s3/cli.ts
@@ -6,36 +6,12 @@ import type { IntegrationLogService } from '@open-mercato/core/modules/integrati
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import type { IntegrationScope } from '@open-mercato/shared/modules/integrations/types'
 import {
+  mapOrganizationsToScopes,
+  parseCliArgs,
+  resolveCliMode,
   runConfigureFromEnv,
   runConfigureFromEnvForScopes,
 } from './lib/configure-from-env'
-
-function parseArgs(args: string[]): Record<string, string | boolean> {
-  const result: Record<string, string | boolean> = {}
-
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i]
-    if (!arg.startsWith('--')) continue
-
-    const key = arg.slice(2)
-    if (key.includes('=')) {
-      const [name, value] = key.split('=')
-      result[name] = value
-      continue
-    }
-
-    const next = args[i + 1]
-    if (next && !next.startsWith('--')) {
-      result[key] = next
-      i += 1
-      continue
-    }
-
-    result[key] = true
-  }
-
-  return result
-}
 
 function printHelp(): void {
   console.log('Usage: yarn mercato storage_s3 configure-from-env [--tenant <tenantId> --org <organizationId> | --all-tenants] [--force]')
@@ -64,33 +40,22 @@ async function listActiveScopes(em: EntityManager): Promise<IntegrationScope[]> 
     { deletedAt: null, isActive: true },
     { populate: ['tenant'] },
   )
-
-  const scopes: IntegrationScope[] = []
-  for (const organization of organizations) {
-    const tenantId = organization.tenant?.id
-    if (!tenantId) continue
-    scopes.push({ tenantId, organizationId: organization.id })
-  }
-  return scopes
+  return mapOrganizationsToScopes(organizations)
 }
 
 const configureFromEnvCommand: ModuleCli = {
   command: 'configure-from-env',
   async run(rest) {
-    const args = parseArgs(rest)
-    const allTenants = args['all-tenants'] === true || args.allTenants === true
-    const tenantId = String(args.tenantId ?? args.tenant ?? '')
-    const organizationId = String(args.organizationId ?? args.orgId ?? args.org ?? '')
-    const force = args.force === true ? true : undefined
+    const mode = resolveCliMode(parseCliArgs(rest))
 
-    if (!allTenants && (!tenantId || !organizationId)) {
+    if (mode.kind === 'help') {
       printHelp()
       return
     }
 
-    if (allTenants && (tenantId || organizationId)) {
-      console.error('[storage_s3] --all-tenants cannot be combined with --tenant or --org. Pick one mode.')
-      throw new Error('Conflicting CLI arguments: --all-tenants vs --tenant/--org')
+    if (mode.kind === 'conflict') {
+      console.error(`[storage_s3] ${mode.message}`)
+      throw new Error(`Conflicting CLI arguments: ${mode.message}`)
     }
 
     const container = await createRequestContainer()
@@ -98,7 +63,7 @@ const configureFromEnvCommand: ModuleCli = {
       const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
       const integrationLogService = container.resolve('integrationLogService') as IntegrationLogService
 
-      if (allTenants) {
+      if (mode.kind === 'all') {
         const em = container.resolve('em') as EntityManager
         const scopes = await listActiveScopes(em)
 
@@ -110,7 +75,7 @@ const configureFromEnvCommand: ModuleCli = {
         const summary = await runConfigureFromEnvForScopes(
           { credentialsService, integrationLogService },
           scopes,
-          { force },
+          { force: mode.force },
         )
 
         for (const entry of summary.perScope) {
@@ -139,7 +104,11 @@ const configureFromEnvCommand: ModuleCli = {
 
       const outcome = await runConfigureFromEnv(
         { credentialsService, integrationLogService },
-        { tenantId, organizationId, force },
+        {
+          tenantId: mode.tenantId,
+          organizationId: mode.organizationId,
+          force: mode.force,
+        },
       )
 
       if (outcome.code === 0) {

--- a/packages/storage-s3/src/modules/storage_s3/lib/configure-from-env.ts
+++ b/packages/storage-s3/src/modules/storage_s3/lib/configure-from-env.ts
@@ -1,5 +1,6 @@
 import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
 import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
+import type { IntegrationScope } from '@open-mercato/shared/modules/integrations/types'
 import { applyS3EnvPreset, readS3EnvPreset } from './preset'
 
 export type ConfigureFromEnvDeps = {
@@ -49,4 +50,43 @@ export async function runConfigureFromEnv(
     const message = error instanceof Error ? error.message : 'Unknown S3 preset error'
     return { code: 1, status: 'error', message }
   }
+}
+
+export type ConfigureFromEnvScopeOutcome = {
+  scope: IntegrationScope
+  outcome: ConfigureFromEnvOutcome
+}
+
+export type ConfigureFromEnvAllOutcome = {
+  code: 0 | 1
+  configured: number
+  skipped: number
+  errored: number
+  perScope: ConfigureFromEnvScopeOutcome[]
+}
+
+export async function runConfigureFromEnvForScopes(
+  deps: ConfigureFromEnvDeps,
+  scopes: IntegrationScope[],
+  options: { force?: boolean } = {},
+): Promise<ConfigureFromEnvAllOutcome> {
+  const perScope: ConfigureFromEnvScopeOutcome[] = []
+  let configured = 0
+  let skipped = 0
+  let errored = 0
+
+  for (const scope of scopes) {
+    const outcome = await runConfigureFromEnv(deps, {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      force: options.force,
+    })
+    perScope.push({ scope, outcome })
+    if (outcome.code === 1) errored += 1
+    else if (outcome.status === 'configured') configured += 1
+    else skipped += 1
+  }
+
+  const code: 0 | 1 = errored > 0 ? 1 : 0
+  return { code, configured, skipped, errored, perScope }
 }

--- a/packages/storage-s3/src/modules/storage_s3/lib/configure-from-env.ts
+++ b/packages/storage-s3/src/modules/storage_s3/lib/configure-from-env.ts
@@ -1,0 +1,52 @@
+import type { CredentialsService } from '@open-mercato/core/modules/integrations/lib/credentials-service'
+import type { IntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
+import { applyS3EnvPreset, readS3EnvPreset } from './preset'
+
+export type ConfigureFromEnvDeps = {
+  credentialsService: CredentialsService
+  integrationLogService: IntegrationLogService
+  env?: NodeJS.ProcessEnv
+}
+
+export type ConfigureFromEnvOptions = {
+  tenantId: string
+  organizationId: string
+  force?: boolean
+}
+
+export type ConfigureFromEnvOutcome =
+  | { code: 0; status: 'configured' | 'skipped'; message: string }
+  | { code: 1; status: 'error'; message: string }
+
+export async function runConfigureFromEnv(
+  deps: ConfigureFromEnvDeps,
+  options: ConfigureFromEnvOptions,
+): Promise<ConfigureFromEnvOutcome> {
+  try {
+    const preset = readS3EnvPreset(deps.env ?? process.env)
+    if (!preset) {
+      return {
+        code: 0,
+        status: 'skipped',
+        message: 'No S3 env preset was found. Set OM_INTEGRATION_STORAGE_S3_* variables to enable preconfiguration.',
+      }
+    }
+
+    const result = await applyS3EnvPreset({
+      credentialsService: deps.credentialsService,
+      integrationLogService: deps.integrationLogService,
+      scope: { tenantId: options.tenantId, organizationId: options.organizationId },
+      force: options.force,
+      env: deps.env ?? process.env,
+    })
+
+    if (result.status === 'skipped') {
+      return { code: 0, status: 'skipped', message: result.reason }
+    }
+
+    return { code: 0, status: 'configured', message: 'S3 credentials were configured from env.' }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown S3 preset error'
+    return { code: 1, status: 'error', message }
+  }
+}

--- a/packages/storage-s3/src/modules/storage_s3/lib/configure-from-env.ts
+++ b/packages/storage-s3/src/modules/storage_s3/lib/configure-from-env.ts
@@ -90,3 +90,75 @@ export async function runConfigureFromEnvForScopes(
   const code: 0 | 1 = errored > 0 ? 1 : 0
   return { code, configured, skipped, errored, perScope }
 }
+
+export function parseCliArgs(args: string[]): Record<string, string | boolean> {
+  const result: Record<string, string | boolean> = {}
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (!arg.startsWith('--')) continue
+
+    const key = arg.slice(2)
+    if (key.includes('=')) {
+      const [name, value] = key.split('=')
+      result[name] = value
+      continue
+    }
+
+    const next = args[i + 1]
+    if (next && !next.startsWith('--')) {
+      result[key] = next
+      i += 1
+      continue
+    }
+
+    result[key] = true
+  }
+
+  return result
+}
+
+export type ConfigureFromEnvCliMode =
+  | { kind: 'help' }
+  | { kind: 'conflict'; message: string }
+  | { kind: 'all'; force?: boolean }
+  | { kind: 'single'; tenantId: string; organizationId: string; force?: boolean }
+
+export function resolveCliMode(args: Record<string, string | boolean>): ConfigureFromEnvCliMode {
+  const allTenants = args['all-tenants'] === true || args.allTenants === true
+  const tenantId = String(args.tenantId ?? args.tenant ?? '')
+  const organizationId = String(args.organizationId ?? args.orgId ?? args.org ?? '')
+  const force = args.force === true ? true : undefined
+
+  if (allTenants && (tenantId || organizationId)) {
+    return {
+      kind: 'conflict',
+      message: '--all-tenants cannot be combined with --tenant or --org. Pick one mode.',
+    }
+  }
+
+  if (allTenants) {
+    return { kind: 'all', force }
+  }
+
+  if (!tenantId || !organizationId) {
+    return { kind: 'help' }
+  }
+
+  return { kind: 'single', tenantId, organizationId, force }
+}
+
+type OrganizationRow = {
+  id: string
+  tenant?: { id?: string | null } | null
+}
+
+export function mapOrganizationsToScopes(organizations: OrganizationRow[]): IntegrationScope[] {
+  const scopes: IntegrationScope[] = []
+  for (const organization of organizations) {
+    const tenantId = organization.tenant?.id
+    if (!tenantId) continue
+    scopes.push({ tenantId, organizationId: organization.id })
+  }
+  return scopes
+}

--- a/packages/storage-s3/src/modules/storage_s3/setup.ts
+++ b/packages/storage-s3/src/modules/storage_s3/setup.ts
@@ -3,6 +3,8 @@ import { createCredentialsService } from '@open-mercato/core/modules/integration
 import { createIntegrationLogService } from '@open-mercato/core/modules/integrations/lib/log-service'
 import { applyS3EnvPreset } from './lib/preset'
 
+const S3_INTEGRATION_ID = 'storage_s3'
+
 export const setup: ModuleSetupConfig = {
   defaultRoleFeatures: {
     superadmin: ['storage_providers.manage'],
@@ -10,15 +12,26 @@ export const setup: ModuleSetupConfig = {
   },
 
   async onTenantCreated({ em, organizationId, tenantId }) {
+    const integrationLogService = createIntegrationLogService(em)
     try {
       await applyS3EnvPreset({
         credentialsService: createCredentialsService(em),
-        integrationLogService: createIntegrationLogService(em),
+        integrationLogService,
         scope: { tenantId, organizationId },
       })
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown S3 preset error'
-      console.warn(`[storage_s3] Failed to apply env preset during tenant setup: ${message}`)
+      try {
+        await integrationLogService
+          .scoped(S3_INTEGRATION_ID, { tenantId, organizationId })
+          .error(`Failed to apply S3 env preset during tenant setup: ${message}`)
+      } catch (logError) {
+        const logMessage = logError instanceof Error ? logError.message : 'Unknown integration log error'
+        console.error(
+          `[storage_s3] Failed to apply env preset during tenant setup: ${message}. ` +
+            `Also failed to persist the error to integration logs: ${logMessage}`,
+        )
+      }
     }
   },
 }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-20-storage-s3-env-preconfigure.md
Status: complete

Fixes #1968.

## Goal

Bring `packages/storage-s3` to parity with `gateway_stripe` / `sync_akeneo` for env-based preconfiguration: a rerunnable provider CLI, hardened error logging via `IntegrationLogService`, fully documented env block, user-guide section, and unit coverage.

## What Changed

- **CLI (`packages/storage-s3/src/modules/storage_s3/cli.ts`).** New `yarn mercato storage_s3 configure-from-env --tenant <tenantId> --org <organizationId> [--force]` command, mirroring the Stripe/Akeneo command shape (argv parser, help block, DI resolution, disposable container). Throws on error so the mercato dispatcher returns a non-zero exit code on `Incomplete S3 env preset`.
- **Logic helper (`lib/configure-from-env.ts`).** Pure helper that wraps `readS3EnvPreset` + `applyS3EnvPreset` and returns a typed outcome — kept out of `cli.ts` so the unit tests don't need to boot the DI container or pull in MikroORM ESM.
- **`setup.ts` hardening.** Preset failures during `onTenantCreated` now go through `IntegrationLogService.error(...)` (visible in the Integration Marketplace logs UI) instead of `console.warn`; falls back to `console.error` only if the log write itself fails so tenant provisioning is never crashed by a logging issue.
- **`.env.example` blocks.** Added matching `# S3 Storage Preconfiguration` blocks in `apps/mercato/.env.example` and `packages/create-app/template/.env.example`, plus an `OM_ENABLE_STORAGE_S3` entry next to the other `OM_ENABLE_*` flags so the gate is no longer "implicit, only mentioned at the bottom".
- **User guide.** Expanded `apps/docs/docs/user-guide/storage-hub.mdx` "Environment-based preconfiguration" section with the rerunnable CLI, `--force` semantics, the relationship between `OM_ENABLE_STORAGE_S3` and `OM_INTEGRATION_STORAGE_S3_*`, and the Integration logs surface for setup failures.

## Tests

- `packages/storage-s3/src/modules/storage_s3/__tests__/cli.test.ts` (new): missing env → skip, full env → configured, existing creds + no force → skip, `--force` overwrite, incomplete env → `{ code: 1, status: 'error' }`.
- `packages/storage-s3/src/modules/storage_s3/__tests__/preset.test.ts` (new): null when env unset, typed preset from full env, throws on incomplete, configure / skip / `--force` / env-var-driven force flows through `applyS3EnvPreset`.
- `yarn workspace @open-mercato/storage-s3 test` → 30/30 pass.
- `yarn test`, `yarn typecheck`, `yarn generate`, `yarn build:packages`, `yarn build:app` all green.
- `yarn lint` blocked by a pre-existing `eslint-plugin-react` / `next.config.ts` incompatibility that also reproduces on `origin/develop` (unrelated to this PR).

### Manual smoke

Exercised end-to-end against a freshly provisioned tenant (`yarn mercato auth setup ... && yarn mercato storage_s3 configure-from-env ...`):

| Scenario | Result |
|---|---|
| (a) No `OM_INTEGRATION_STORAGE_S3_*` env vars set | `[storage_s3] Skipped: No S3 env preset was found.` — exit 0 |
| (b) Full env, no existing creds | `[storage_s3] S3 credentials were configured from env.` — exit 0, encrypted row in `integration_credentials`, info log in `integration_logs` |
| (c) Full env, existing creds, no `--force` | `[storage_s3] Skipped: S3 credentials already exist. Use OM_INTEGRATION_STORAGE_S3_FORCE_PRECONFIGURE=true to overwrite.` — exit 0 |
| (d) Full env, existing creds, `--force` | `[storage_s3] S3 credentials were configured from env.` — exit 0, second info log appended |
| (e) Partial env (`OM_INTEGRATION_STORAGE_S3_BUCKET=` empty) | `💥 Failed: [storage_s3] Incomplete S3 env preset. Set ...` — exit 1 |

## Backward Compatibility

- All changes are additive. No env var rename, no DI key rename, no DB schema change, no breaking signature change.
- `OM_ENABLE_STORAGE_S3` already existed in `apps/mercato/src/modules.ts:141` and `packages/create-app/template/src/modules.ts:141`; the `.env.example` blocks just make it discoverable. The flag remains gated to `false` by default.
- The existing `onTenantCreated` flow is preserved — only the error-handling branch changes from `console.warn` to `IntegrationLogService.error` (with a fall-through to `console.error` if the log write itself fails).

## Progress

See [Progress section in the plan](.ai/runs/2026-05-20-storage-s3-env-preconfigure.md#progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)