### PR TITLE
fix: stabilize sync_excel integration runtime reuse

### DIFF
--- a/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
+++ b/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
@@ -57,15 +57,15 @@ Non-goals:
 
 ### Phase 1: Diagnose Import Start Failure
 
-- [ ] 1.1 Reproduce or capture the import route failure locally
-- [ ] 1.2 Inspect the sync_excel import/data_sync bootstrap path
-- [ ] 1.3 Identify the root cause layer
+- [x] 1.1 Reproduce or capture the import route failure locally — 5ab04ab30
+- [x] 1.2 Inspect the sync_excel import/data_sync bootstrap path — 5ab04ab30
+- [x] 1.3 Identify the root cause layer — 5ab04ab30
 
 ### Phase 2: Apply Minimal Stabilization
 
-- [ ] 2.1 Implement the minimal root-cause fix
-- [ ] 2.2 Add or update regression coverage
-- [ ] 2.3 Re-run targeted unit and integration tests
+- [x] 2.1 Implement the minimal root-cause fix — 5ab04ab30
+- [x] 2.2 Add or update regression coverage — 5ab04ab30
+- [x] 2.3 Re-run targeted unit and integration tests — 5ab04ab30
 
 ### Phase 3: Validate and Ship
 

--- a/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
+++ b/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
@@ -1,0 +1,74 @@
+# Stabilize sync_excel Import Integration Test
+
+## Overview
+
+Goal: stabilize `TC-SX-001` so `POST /api/sync_excel/import` reliably returns `201` when starting a customer person import from an uploaded CSV.
+
+Scope:
+- Investigate the `500` returned by `packages/core/src/modules/sync_excel/__integration__/TC-SX-001.spec.ts` at import start.
+- Apply the smallest production or test-harness fix that removes the flaky failure.
+- Add or update unit coverage for the root cause.
+- Re-run the focused sync_excel integration test and relevant package checks.
+
+Affected modules/packages:
+- `packages/core/src/modules/sync_excel`
+- `packages/core/src/modules/data_sync` only if the root cause is provider/run bootstrap behavior.
+- Integration test harness only if the root cause is nondeterministic fixture/runtime setup.
+
+Source spec:
+- `.ai/specs/2026-03-29-sync-excel-customers-import-foundation.md`
+- `.ai/specs/implemented/SPEC-045b-data-sync-hub.md`
+
+Non-goals:
+- Do not redesign sync_excel mapping or customer import behavior.
+- Do not change public API contracts for `/api/sync_excel/*`.
+- Do not relax the integration test assertions unless the assertion is proven to be incorrect.
+- Do not add broad retries or longer timeouts as the primary fix.
+
+## Implementation Plan
+
+### Phase 1: Diagnose Import Start Failure
+
+1. Reproduce or capture the import route failure locally with focused unit/integration commands.
+2. Inspect the failing `500` path in `sync_excel` import start, `data_sync` run creation, and provider registration/bootstrap.
+3. Identify whether the failure is production logic, test fixture setup, or integration runtime ordering.
+
+### Phase 2: Apply Minimal Stabilization
+
+1. Implement the smallest fix in the root-cause layer.
+2. Add or update unit coverage that fails before the fix and passes after it.
+3. Re-run targeted unit tests and the focused `TC-SX-001` integration test.
+
+### Phase 3: Validate and Ship
+
+1. Run affected package checks and required full gates where feasible.
+2. Perform code-review and backward-compatibility self-review.
+3. Open a PR against `develop`, label it, and run the required auto-review pass.
+
+## Risks
+
+- The integration failure may depend on ephemeral CI runtime ordering and be hard to reproduce locally.
+- The import route touches data sync, integrations, attachments, custom fields, customers, and queue-driven workers, so root-cause fixes must preserve tenant/organization scoping.
+- Full integration and full CI gates are expensive; if they cannot complete in one turn, the PR must remain resumable through this plan.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Diagnose Import Start Failure
+
+- [ ] 1.1 Reproduce or capture the import route failure locally
+- [ ] 1.2 Inspect the sync_excel import/data_sync bootstrap path
+- [ ] 1.3 Identify the root cause layer
+
+### Phase 2: Apply Minimal Stabilization
+
+- [ ] 2.1 Implement the minimal root-cause fix
+- [ ] 2.2 Add or update regression coverage
+- [ ] 2.3 Re-run targeted unit and integration tests
+
+### Phase 3: Validate and Ship
+
+- [ ] 3.1 Run affected package and required validation gates
+- [ ] 3.2 Complete code-review and backward-compatibility self-review
+- [ ] 3.3 Open PR, label it, and complete auto-review pass

--- a/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
+++ b/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
@@ -90,4 +90,4 @@ Non-goals:
 
 - [x] 3.1 Run affected package and required validation gates — a531b0211
 - [x] 3.2 Complete code-review and backward-compatibility self-review — a531b0211
-- [ ] 3.3 Open PR, label it, and complete auto-review pass
+- [x] 3.3 Open PR, label it, and complete auto-review pass — 247421c8b

--- a/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
+++ b/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
@@ -68,7 +68,7 @@ Non-goals:
 
 - Backward compatibility: no public API route, event ID, widget spot, ACL feature, DI service, database schema, or public import path was removed or renamed.
 - Security/tenant isolation: no production database queries or auth/tenant-scoped data paths were changed.
-- Scope: the production behavior change is limited to integration test runtime state reuse; data_sync locale additions are additive keys required by the i18n gate.
+- Scope: the production behavior change is limited to integration test runtime state reuse; the data_sync locale gate drift was resolved by rebasing onto `develop`, which already contained the missing localized keys.
 
 ## Progress
 
@@ -76,18 +76,18 @@ Non-goals:
 
 ### Phase 1: Diagnose Import Start Failure
 
-- [x] 1.1 Reproduce or capture the import route failure locally — 5ab04ab30
-- [x] 1.2 Inspect the sync_excel import/data_sync bootstrap path — 5ab04ab30
-- [x] 1.3 Identify the root cause layer — 5ab04ab30
+- [x] 1.1 Reproduce or capture the import route failure locally — 62fead5f9
+- [x] 1.2 Inspect the sync_excel import/data_sync bootstrap path — 62fead5f9
+- [x] 1.3 Identify the root cause layer — 62fead5f9
 
 ### Phase 2: Apply Minimal Stabilization
 
-- [x] 2.1 Implement the minimal root-cause fix — 5ab04ab30
-- [x] 2.2 Add or update regression coverage — 5ab04ab30
-- [x] 2.3 Re-run targeted unit and integration tests — 5ab04ab30
+- [x] 2.1 Implement the minimal root-cause fix — 62fead5f9
+- [x] 2.2 Add or update regression coverage — 62fead5f9
+- [x] 2.3 Re-run targeted unit and integration tests — 62fead5f9
 
 ### Phase 3: Validate and Ship
 
-- [x] 3.1 Run affected package and required validation gates — 5188e0d26
-- [x] 3.2 Complete code-review and backward-compatibility self-review — 5188e0d26
+- [x] 3.1 Run affected package and required validation gates — a531b0211
+- [x] 3.2 Complete code-review and backward-compatibility self-review — a531b0211
 - [ ] 3.3 Open PR, label it, and complete auto-review pass

--- a/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
+++ b/.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md
@@ -51,6 +51,25 @@ Non-goals:
 - The import route touches data sync, integrations, attachments, custom fields, customers, and queue-driven workers, so root-cause fixes must preserve tenant/organization scoping.
 - Full integration and full CI gates are expensive; if they cannot complete in one turn, the PR must remain resumable through this plan.
 
+## Validation Notes
+
+- `yarn workspace @open-mercato/cli test packages/cli/src/lib/testing/__tests__/integration.test.ts --runInBand` passed.
+- `yarn workspace @open-mercato/cli typecheck` passed.
+- `yarn workspace @open-mercato/core test packages/core/src/modules/sync_excel/api/import/__tests__/route.test.ts --runInBand` passed.
+- `BASE_URL=http://127.0.0.1:5001 DATABASE_URL=postgres://mercato:secret@localhost:55004/mercato_test npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/sync_excel/__integration__/TC-SX-001.spec.ts --retries=0` passed against ephemeral.
+- `yarn build:packages`, `yarn generate`, and post-generate `yarn build:packages` passed.
+- `yarn i18n:check-sync` passed.
+- `yarn i18n:check-usage` passed with unused-key advisory output only.
+- `yarn build:app` passed with existing Turbopack dynamic import/NFT warnings.
+- `yarn typecheck` was stopped after 19m16s because `@open-mercato/core#typecheck` stayed CPU-bound with no diagnostics; 18/19 tasks completed.
+- `yarn test` failed in `create-mercato-app#test` due three CLI scaffold subprocess `ETIMEDOUT` failures while unrelated package tests were still passing; targeted changed-package tests passed.
+
+## Self-Review Notes
+
+- Backward compatibility: no public API route, event ID, widget spot, ACL feature, DI service, database schema, or public import path was removed or renamed.
+- Security/tenant isolation: no production database queries or auth/tenant-scoped data paths were changed.
+- Scope: the production behavior change is limited to integration test runtime state reuse; data_sync locale additions are additive keys required by the i18n gate.
+
 ## Progress
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
@@ -69,6 +88,6 @@ Non-goals:
 
 ### Phase 3: Validate and Ship
 
-- [ ] 3.1 Run affected package and required validation gates
-- [ ] 3.2 Complete code-review and backward-compatibility self-review
+- [x] 3.1 Run affected package and required validation gates — 5188e0d26
+- [x] 3.2 Complete code-review and backward-compatibility self-review — 5188e0d26
 - [ ] 3.3 Open PR, label it, and complete auto-review pass

--- a/packages/cli/src/lib/testing/__tests__/integration.test.ts
+++ b/packages/cli/src/lib/testing/__tests__/integration.test.ts
@@ -24,6 +24,19 @@ const APP_READY_TIMEOUT_ENV_VAR = 'OM_INTEGRATION_APP_READY_TIMEOUT_SECONDS'
 const CHECKOUT_TEST_INJECTION_FLAG = 'NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED'
 const resolver = createResolver()
 const projectRootDirectory = resolver.getRootDir()
+const TEST_DATABASE_URL = 'postgres://mercato:secret@127.0.0.1:55001/mercato_test'
+const TEST_QUEUE_BASE_DIR = path.join(projectRootDirectory, '.ai', 'qa', 'tmp-queue')
+
+const writeTestEphemeralEnvironmentState = (input: {
+  baseUrl: string
+  port: number
+  logPrefix: string
+  captureScreenshots: boolean
+}) => writeEphemeralEnvironmentState({
+  ...input,
+  databaseUrl: TEST_DATABASE_URL,
+  queueBaseDir: TEST_QUEUE_BASE_DIR,
+})
 
 const mockHealthyReadinessFetch = (
   overrides: {
@@ -127,7 +140,7 @@ describe('integration cache and options', () => {
     const fetchSpy = mockHealthyReadinessFetch()
 
     try {
-      await writeEphemeralEnvironmentState({
+      await writeTestEphemeralEnvironmentState({
         baseUrl,
         port: 5001,
         logPrefix: 'integration',
@@ -135,7 +148,13 @@ describe('integration cache and options', () => {
       })
 
       const state = await readEphemeralEnvironmentState()
-      expect(state).toMatchObject({ baseUrl, port: 5001, captureScreenshots: true })
+      expect(state).toMatchObject({
+        baseUrl,
+        port: 5001,
+        databaseUrl: TEST_DATABASE_URL,
+        queueBaseDir: TEST_QUEUE_BASE_DIR,
+        captureScreenshots: true,
+      })
 
       const environment = await tryReuseExistingEnvironment({
         verbose: false,
@@ -151,6 +170,8 @@ describe('integration cache and options', () => {
         ownedByCurrentProcess: false,
       })
       expect(environment?.commandEnvironment.OM_INTEGRATION_TEST).toBe('true')
+      expect(environment?.commandEnvironment.DATABASE_URL).toBe(TEST_DATABASE_URL)
+      expect(environment?.commandEnvironment.QUEUE_BASE_DIR).toBe(TEST_QUEUE_BASE_DIR)
       expect(environment?.commandEnvironment.PW_CAPTURE_SCREENSHOTS).toBe('1')
       expect(environment?.commandEnvironment.NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED).toBeUndefined()
     } finally {
@@ -164,7 +185,7 @@ describe('integration cache and options', () => {
     const fetchSpy = mockHealthyReadinessFetch()
 
     try {
-      await writeEphemeralEnvironmentState({
+      await writeTestEphemeralEnvironmentState({
         baseUrl,
         port: 5001,
         logPrefix: 'integration',
@@ -193,7 +214,7 @@ describe('integration cache and options', () => {
     })
 
     try {
-      await writeEphemeralEnvironmentState({
+      await writeTestEphemeralEnvironmentState({
         baseUrl,
         port: 5001,
         logPrefix: 'integration',
@@ -228,7 +249,7 @@ describe('integration cache and options', () => {
     })
 
     try {
-      await writeEphemeralEnvironmentState({
+      await writeTestEphemeralEnvironmentState({
         baseUrl,
         port: 5001,
         logPrefix: 'integration',
@@ -258,7 +279,7 @@ describe('integration cache and options', () => {
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ status: 500 } as unknown as Response)
 
     try {
-      await writeEphemeralEnvironmentState({
+      await writeTestEphemeralEnvironmentState({
         baseUrl,
         port: 5001,
         logPrefix: 'integration',
@@ -281,12 +302,40 @@ describe('integration cache and options', () => {
     }
   })
 
+  it('does not reuse legacy ephemeral state without runtime database and queue settings', async () => {
+    const baseUrl = 'http://127.0.0.1:5001'
+    const fetchSpy = mockHealthyReadinessFetch()
+
+    try {
+      await writeFile(ephemeralEnvFilePath, `${JSON.stringify({
+        status: 'running',
+        baseUrl,
+        port: 5001,
+        source: 'integration',
+        captureScreenshots: true,
+        startedAt: new Date().toISOString(),
+      }, null, 2)}\n`, 'utf8')
+
+      const environment = await tryReuseExistingEnvironment({
+        verbose: false,
+        captureScreenshots: true,
+        logPrefix: 'integration',
+        forceRebuild: false,
+      })
+
+      expect(environment).toBeNull()
+      await expect(readEphemeralEnvironmentState()).resolves.toBeNull()
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  }, 20000)
+
   it('does not reuse an existing ephemeral environment when source requirement does not match', async () => {
     const baseUrl = 'http://127.0.0.1:5001'
     const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({ status: 200 } as unknown as Response)
 
     try {
-      await writeEphemeralEnvironmentState({
+      await writeTestEphemeralEnvironmentState({
         baseUrl,
         port: 5001,
         logPrefix: 'integration',
@@ -322,6 +371,8 @@ describe('integration cache and options', () => {
       status: 'running' as const,
       baseUrl: 'http://127.0.0.1:5001',
       port: 5001,
+      databaseUrl: TEST_DATABASE_URL,
+      queueBaseDir: TEST_QUEUE_BASE_DIR,
       source: 'integration',
       captureScreenshots: true,
       startedAt: new Date().toISOString(),

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -138,6 +138,8 @@ type EphemeralEnvironmentState = {
   status: 'running'
   baseUrl: string
   port: number
+  databaseUrl: string
+  queueBaseDir: string
   source: string
   captureScreenshots: boolean
   startedAt: string
@@ -1168,6 +1170,8 @@ async function getPreferredPort(preferredPort: number): Promise<number> {
 export async function writeEphemeralEnvironmentState(input: {
   baseUrl: string
   port: number
+  databaseUrl: string
+  queueBaseDir: string
   logPrefix: string
   captureScreenshots: boolean
 }): Promise<void> {
@@ -1175,6 +1179,8 @@ export async function writeEphemeralEnvironmentState(input: {
     status: 'running',
     baseUrl: input.baseUrl,
     port: input.port,
+    databaseUrl: input.databaseUrl,
+    queueBaseDir: input.queueBaseDir,
     source: input.logPrefix,
     captureScreenshots: input.captureScreenshots,
     startedAt: new Date().toISOString(),
@@ -1219,6 +1225,12 @@ export async function readEphemeralEnvironmentState(): Promise<EphemeralEnvironm
   if (typeof record.port !== 'number' || !Number.isFinite(record.port) || record.port < 1) {
     return null
   }
+  if (typeof record.databaseUrl !== 'string' || record.databaseUrl.length === 0) {
+    return null
+  }
+  if (typeof record.queueBaseDir !== 'string' || record.queueBaseDir.length === 0) {
+    return null
+  }
   if (typeof record.source !== 'string' || record.source.length === 0) {
     return null
   }
@@ -1233,6 +1245,8 @@ export async function readEphemeralEnvironmentState(): Promise<EphemeralEnvironm
     status: 'running',
     baseUrl: record.baseUrl,
     port: record.port,
+    databaseUrl: record.databaseUrl,
+    queueBaseDir: record.queueBaseDir,
     source: record.source,
     captureScreenshots: record.captureScreenshots,
     startedAt: record.startedAt,
@@ -1614,12 +1628,19 @@ export async function acquireEphemeralRuntimeLock(
   }
 }
 
-function buildReusableEnvironment(baseUrl: string, captureScreenshots: boolean): NodeJS.ProcessEnv {
+function buildReusableEnvironment(input: {
+  baseUrl: string
+  databaseUrl: string
+  queueBaseDir: string
+  captureScreenshots: boolean
+}): NodeJS.ProcessEnv {
   const enterpriseModulesFlag = process.env.OM_ENABLE_ENTERPRISE_MODULES ?? 'false'
   return buildEnvironment({
-    BASE_URL: baseUrl,
-    APP_URL: baseUrl,
-    NEXT_PUBLIC_APP_URL: baseUrl,
+    DATABASE_URL: input.databaseUrl,
+    QUEUE_BASE_DIR: input.queueBaseDir,
+    BASE_URL: input.baseUrl,
+    APP_URL: input.baseUrl,
+    NEXT_PUBLIC_APP_URL: input.baseUrl,
     NODE_ENV: 'production',
     JWT_SECRET: process.env.JWT_SECRET ?? 'om-ephemeral-integration-jwt-secret',
     OM_SECURITY_MFA_SETUP_SECRET: process.env.OM_SECURITY_MFA_SETUP_SECRET ?? 'om-ephemeral-integration-mfa-setup-secret',
@@ -1640,13 +1661,19 @@ function buildReusableEnvironment(baseUrl: string, captureScreenshots: boolean):
     OM_CLI_QUIET: '1',
     MERCATO_QUIET: '1',
     NODE_NO_WARNINGS: '1',
-    PW_CAPTURE_SCREENSHOTS: captureScreenshots ? '1' : '0',
+    PW_CAPTURE_SCREENSHOTS: input.captureScreenshots ? '1' : '0',
   })
 }
 
 export async function tryReuseExistingEnvironment(options: EphemeralRuntimeOptions): Promise<EphemeralEnvironmentHandle | null> {
   const state = await readEphemeralEnvironmentState()
   if (!state) {
+    return null
+  }
+
+  if (!state.databaseUrl || !state.queueBaseDir) {
+    console.log(`[${options.logPrefix}] Existing ephemeral environment state is missing runtime database or queue settings. Clearing ${EPHEMERAL_ENV_FILE_PATH}.`)
+    await clearEphemeralEnvironmentState()
     return null
   }
 
@@ -1695,8 +1722,13 @@ export async function tryReuseExistingEnvironment(options: EphemeralRuntimeOptio
   return {
     baseUrl: state.baseUrl,
     port: state.port,
-    databaseUrl: '',
-    commandEnvironment: buildReusableEnvironment(state.baseUrl, state.captureScreenshots),
+    databaseUrl: state.databaseUrl,
+    commandEnvironment: buildReusableEnvironment({
+      baseUrl: state.baseUrl,
+      databaseUrl: state.databaseUrl,
+      queueBaseDir: state.queueBaseDir,
+      captureScreenshots: state.captureScreenshots,
+    }),
     ownedByCurrentProcess: false,
     stop: async () => {},
   }
@@ -3030,6 +3062,8 @@ export async function startEphemeralEnvironment(options: EphemeralRuntimeOptions
       await writeEphemeralEnvironmentState({
         baseUrl: applicationBaseUrl,
         port: applicationPort,
+        databaseUrl,
+        queueBaseDir: EPHEMERAL_QUEUE_BASE_DIR,
         logPrefix: options.logPrefix,
         captureScreenshots: options.captureScreenshots,
       })


### PR DESCRIPTION
"## Summary\n\nStabilizes the sync_excel integration test runtime by persisting the ephemeral database URL and queue directory in `.ai/qa/ephemeral-env.json`, then restoring those settings when Playwright reuses an existing ephemeral app. This prevents reused test processes from draining queues or reading direct DB assertions against the wrong database.\n\nTracking plan: `.ai/runs/2026-05-20-stabilize-sync-excel-import-integration.md`\n\n## Validation\n\n- PASS: `yarn workspace @open-mercato/cli test packages/cli/src/lib/testing/__tests__/integration.test.ts --runInBand`\n- PASS: `yarn workspace @open-mercato/cli typecheck`\n- PASS: `yarn workspace @open-mercato/core test packages/core/src/modules/sync_excel/api/import/__tests__/route.test.ts --runInBand`\n- PASS: `BASE_URL=http://127.0.0.1:5001 DATABASE_URL=postgres://mercato:secret@localhost:55004/mercato_test npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/sync_excel/__integration__/TC-SX-001.spec.ts --retries=0`\n- PASS: `yarn build:packages`\n- PASS: `yarn generate`\n- PASS: `yarn build:packages` after generate\n- PASS: `yarn i18n:check-sync`\n- PASS: `yarn i18n:check-usage` with unused-key advisory only\n- PASS: `yarn build:app` with existing Turbopack warnings\n- INCOMPLETE: `yarn typecheck` stopped after 19m16s; `@open-mercato/core#typecheck` stayed CPU-bound with no diagnostics, 18/19 tasks completed.\n- FAIL: `yarn test` failed in unrelated `create-mercato-app#test` scaffold subprocesses with `spawnSync ... ETIMEDOUT`; targeted changed-package tests passed.\n\n## Notes\n\nNo public API, schema, event, ACL, DI, widget, or import-path contract is changed.\n"