### PR TITLE
fix(cli): accept third-party npm package specifiers in generator (#1998)

### DIFF
--- a/packages/cli/src/lib/generators/__tests__/module-subset.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/module-subset.test.ts
@@ -768,6 +768,148 @@ export function GET() {
     )
   })
 
+  it('emits imports for third-party scoped npm packages registered via src/modules.ts', async () => {
+    // Simulate a third-party module package published at @dainamite/cpq
+    // (see issue #1998). The generator must accept @<vendor>/<package> specifiers
+    // and emit imports that point at the package's modules/<id> subtree.
+    const pkgModuleBase = path.join(
+      tmpDir,
+      'packages',
+      'thirdparty',
+      'src',
+      'modules',
+      'cpq',
+    )
+    touchFile(
+      path.join(pkgModuleBase, 'subscribers', 'on-event.ts'),
+      `export const metadata = { event: 'cpq.quote.created' }\nexport default async function handler() {}\n`,
+    )
+
+    const baseResolver = createMockResolver(tmpDir, [
+      { id: 'cpq', from: '@dainamite/cpq' },
+    ])
+    const resolver: PackageResolver = {
+      ...baseResolver,
+      getModulePaths: (entry: ModuleEntry) => ({
+        appBase: path.join(tmpDir, 'app', 'src', 'modules', entry.id),
+        pkgBase: pkgModuleBase,
+      }),
+      getModuleImportBase: (entry: ModuleEntry) => ({
+        appBase: `@/modules/${entry.id}`,
+        pkgBase: `@dainamite/cpq/modules/${entry.id}`,
+      }),
+    }
+
+    const result = await generateModuleRegistry({ resolver, quiet: true })
+    expect(result.errors).toEqual([])
+
+    const output = readGenerated(tmpDir, 'modules.generated.ts')!
+    expect(output).toContain('id: "cpq"')
+    expect(output).toContain('@dainamite/cpq/modules/cpq/subscribers/on-event')
+  })
+
+  it('emits imports for bare (unscoped) third-party npm packages', async () => {
+    const pkgModuleBase = path.join(
+      tmpDir,
+      'packages',
+      'thirdparty-bare',
+      'src',
+      'modules',
+      'foo',
+    )
+    touchFile(
+      path.join(pkgModuleBase, 'subscribers', 'on-event.ts'),
+      `export const metadata = { event: 'foo.thing.created' }\nexport default async function handler() {}\n`,
+    )
+
+    const baseResolver = createMockResolver(tmpDir, [
+      { id: 'foo', from: 'acme-modules' },
+    ])
+    const resolver: PackageResolver = {
+      ...baseResolver,
+      getModulePaths: (entry: ModuleEntry) => ({
+        appBase: path.join(tmpDir, 'app', 'src', 'modules', entry.id),
+        pkgBase: pkgModuleBase,
+      }),
+      getModuleImportBase: (entry: ModuleEntry) => ({
+        appBase: `@/modules/${entry.id}`,
+        pkgBase: `acme-modules/modules/${entry.id}`,
+      }),
+    }
+
+    const result = await generateModuleRegistry({ resolver, quiet: true })
+    expect(result.errors).toEqual([])
+
+    const output = readGenerated(tmpDir, 'modules.generated.ts')!
+    expect(output).toContain('id: "foo"')
+    expect(output).toContain('acme-modules/modules/foo/subscribers/on-event')
+  })
+
+  it('fails fast when a third-party module entry points at a package without the expected OM module shape', async () => {
+    // No files scaffolded — the package directory does not exist, so the
+    // entry is almost certainly not an Open Mercato module.
+    const enabled: ModuleEntry[] = [{ id: 'cpq', from: '@dainamite/cpq' }]
+    const baseResolver = createMockResolver(tmpDir, enabled)
+    const resolver: PackageResolver = {
+      ...baseResolver,
+      getModulePaths: (entry: ModuleEntry) => ({
+        appBase: path.join(tmpDir, 'app', 'src', 'modules', entry.id),
+        pkgBase: path.join(
+          tmpDir,
+          'node_modules',
+          '@dainamite',
+          'cpq',
+          'dist',
+          'modules',
+          entry.id,
+        ),
+      }),
+      getModuleImportBase: (entry: ModuleEntry) => ({
+        appBase: `@/modules/${entry.id}`,
+        pkgBase: `@dainamite/cpq/modules/${entry.id}`,
+      }),
+    }
+
+    await expect(generateModuleRegistry({ resolver, quiet: true })).rejects.toThrow(
+      /no Open Mercato module shape was found/,
+    )
+  })
+
+  it('rejects third-party specifiers with path-traversal segments', async () => {
+    const pkgModuleBase = path.join(
+      tmpDir,
+      'packages',
+      'thirdparty-traversal',
+      'src',
+      'modules',
+      'evil',
+    )
+    touchFile(
+      path.join(pkgModuleBase, 'subscribers', 'on-event.ts'),
+      `export const metadata = { event: 'evil.x' }\nexport default async function handler() {}\n`,
+    )
+
+    const baseResolver = createMockResolver(tmpDir, [
+      { id: 'evil', from: '@vendor/pkg' },
+    ])
+    const resolver: PackageResolver = {
+      ...baseResolver,
+      getModulePaths: (entry: ModuleEntry) => ({
+        appBase: path.join(tmpDir, 'app', 'src', 'modules', entry.id),
+        pkgBase: pkgModuleBase,
+      }),
+      // Inject a malicious specifier with a ".." segment.
+      getModuleImportBase: (entry: ModuleEntry) => ({
+        appBase: `@/modules/${entry.id}`,
+        pkgBase: `@vendor/pkg/../escape/modules/${entry.id}`,
+      }),
+    }
+
+    await expect(generateModuleRegistry({ resolver, quiet: true })).rejects.toThrow(
+      /Unsafe generated module specifier/,
+    )
+  })
+
   it('mixed subset: core module + app module, then remove core module', async () => {
     scaffoldModule(tmpDir, 'core_mod', 'pkg', [
       'backend/page.tsx',

--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -925,8 +925,12 @@ function toLiteral(value: unknown): string {
     .replace(/\u2029/g, '\\u2029')
 }
 
-const GENERATED_MODULE_SPECIFIER_PREFIXES = ['@/', '@open-mercato/', '../../src/modules/', './'] as const
+const GENERATED_MODULE_RELATIVE_PREFIXES = ['@/', '../../src/modules/', './'] as const
 const GENERATED_MODULE_SPECIFIER_SEGMENT = /^[A-Za-z0-9_.\-[\]()']+$/
+// Lenient npm package name matcher. Accepts legacy uppercase packages and
+// tilde-prefixed names, bans leading "." / "_", and reserves "@" for scope
+// markers so the dispatcher below can split scope-vs-bare unambiguously.
+const NPM_PACKAGE_NAME_SEGMENT = /^[A-Za-z0-9~][A-Za-z0-9_.~-]*$/
 
 function sanitizeGeneratedModuleSpecifierSegment(segment: string, importPath: string): string {
   const match = GENERATED_MODULE_SPECIFIER_SEGMENT.exec(segment)
@@ -936,22 +940,83 @@ function sanitizeGeneratedModuleSpecifierSegment(segment: string, importPath: st
   return match[0]
 }
 
-function sanitizeGeneratedModuleSpecifier(importPath: string): string {
-  const prefix = GENERATED_MODULE_SPECIFIER_PREFIXES.find((candidate) => importPath.startsWith(candidate))
-  if (!prefix) {
-    throw new Error(`Unsafe generated module specifier prefix: ${importPath}`)
+function sanitizeNpmPackageNameSegment(segment: string, importPath: string): void {
+  if (!NPM_PACKAGE_NAME_SEGMENT.test(segment) || segment === '.' || segment === '..') {
+    throw new Error(`Unsafe generated module specifier: ${importPath}`)
   }
+}
 
-  const suffix = importPath.slice(prefix.length)
-  if (!suffix) {
+function sanitizeGeneratedModuleSpecifier(importPath: string): string {
+  if (!importPath) {
     throw new Error(`Unsafe generated module specifier: ${importPath}`)
   }
 
-  const segments = suffix
+  const relativePrefix = GENERATED_MODULE_RELATIVE_PREFIXES.find((candidate) =>
+    importPath.startsWith(candidate),
+  )
+  if (relativePrefix) {
+    const suffix = importPath.slice(relativePrefix.length)
+    if (!suffix) {
+      throw new Error(`Unsafe generated module specifier: ${importPath}`)
+    }
+    const segments = suffix
+      .split('/')
+      .map((segment) => sanitizeGeneratedModuleSpecifierSegment(segment, importPath))
+    return `${relativePrefix}${segments.join('/')}`
+  }
+
+  if (importPath.startsWith('@')) {
+    // Scoped npm package: @scope/name[/subpath]
+    const firstSlash = importPath.indexOf('/')
+    if (firstSlash < 2) {
+      throw new Error(`Unsafe generated module specifier prefix: ${importPath}`)
+    }
+    const scope = importPath.slice(1, firstSlash)
+    sanitizeNpmPackageNameSegment(scope, importPath)
+    const rest = importPath.slice(firstSlash + 1)
+    if (!rest) {
+      throw new Error(`Unsafe generated module specifier: ${importPath}`)
+    }
+    const secondSlash = rest.indexOf('/')
+    const name = secondSlash >= 0 ? rest.slice(0, secondSlash) : rest
+    sanitizeNpmPackageNameSegment(name, importPath)
+    const subpath = secondSlash >= 0 ? rest.slice(secondSlash + 1) : ''
+    if (!subpath) {
+      return `@${scope}/${name}`
+    }
+    const segments = subpath
+      .split('/')
+      .map((segment) => sanitizeGeneratedModuleSpecifierSegment(segment, importPath))
+    return `@${scope}/${name}/${segments.join('/')}`
+  }
+
+  // Bare npm package: name[/subpath]
+  const firstSlash = importPath.indexOf('/')
+  const name = firstSlash >= 0 ? importPath.slice(0, firstSlash) : importPath
+  sanitizeNpmPackageNameSegment(name, importPath)
+  const subpath = firstSlash >= 0 ? importPath.slice(firstSlash + 1) : ''
+  if (!subpath) {
+    return name
+  }
+  const segments = subpath
     .split('/')
     .map((segment) => sanitizeGeneratedModuleSpecifierSegment(segment, importPath))
+  return `${name}/${segments.join('/')}`
+}
 
-  return `${prefix}${segments.join('/')}`
+// Defense in depth: when src/modules.ts registers a module from a third-party
+// npm scope (anything outside @app / @open-mercato/*), verify the resolved
+// pkgBase directory exists. If it doesn't, the package referenced via `from:`
+// is almost certainly not an Open Mercato module (or the id is wrong), and
+// silently emitting an empty module registration would hide the misconfig.
+function verifyThirdPartyModuleShape(entry: { id: string; from?: string }, pkgBase: string): void {
+  const from = entry.from
+  if (!from || from === '@app' || from.startsWith('@open-mercato/')) return
+  if (fs.existsSync(pkgBase)) return
+  throw new Error(
+    `Module '${entry.id}' is registered with from: '${from}' but no Open Mercato module shape was found at '${pkgBase}'. ` +
+      `Ensure the package ships a 'modules/${entry.id}' subtree (either under 'dist/modules/' or 'src/modules/'), or correct the 'from' value in src/modules.ts.`,
+  )
 }
 
 function buildImportStatement(importClause: string, importPath: string): string {
@@ -2502,6 +2567,9 @@ export async function generateModuleRegistry(options: ModuleRegistryOptions): Pr
   const legacySubscribersChecksumFile = path.join(outputDir, 'subscribers.generated.checksum')
 
   const enabled = resolver.loadEnabledModules()
+  for (const entry of enabled) {
+    verifyThirdPartyModuleShape(entry, resolver.getModulePaths(entry).pkgBase)
+  }
   const extensions = loadGeneratorExtensions()
 
   // Pre-pass: collect generator plugins from each enabled module's generators.ts
@@ -3118,6 +3186,9 @@ export async function generateModuleRegistryApp(options: ModuleRegistryOptions):
   const enabledIdsChecksumFile = path.join(outputDir, 'enabled-module-ids.generated.checksum')
 
   const enabled = resolver.loadEnabledModules()
+  for (const entry of enabled) {
+    verifyThirdPartyModuleShape(entry, resolver.getModulePaths(entry).pkgBase)
+  }
   const imports: string[] = []
   const moduleDecls: WriterFunction[] = []
   const importIdRef = { value: 0 }
@@ -3449,6 +3520,9 @@ export async function generateModuleRegistryCli(options: ModuleRegistryOptions):
   const legacyChecksumFile = path.join(outputDir, 'cli-modules.generated.checksum')
 
   const enabled = resolver.loadEnabledModules()
+  for (const entry of enabled) {
+    verifyThirdPartyModuleShape(entry, resolver.getModulePaths(entry).pkgBase)
+  }
   const imports: string[] = []
   const moduleDecls: WriterFunction[] = []
   // Mutable ref so extracted helper functions can increment the shared counter


### PR DESCRIPTION
Fixes #1998

## Problem

`@open-mercato/cli`'s module-registry generator rejects every `from:` entry in
`src/modules.ts` that is not `@app` or `@open-mercato/*`. Concretely, `yarn generate`
in a standalone app fails with:

```
💥 Failed: Unsafe generated module specifier prefix: @dainamite/cpq/modules/cpq/index
```

This breaks the documented marketplace/extensibility model — third parties cannot
ship Open Mercato modules under their own npm scopes.

## Root Cause

`sanitizeGeneratedModuleSpecifier` in `packages/cli/src/lib/generators/module-registry.ts`
held a hard-coded allow-list of import-specifier prefixes:

```ts
const GENERATED_MODULE_SPECIFIER_PREFIXES = ['@/', '@open-mercato/', '../../src/modules/', './'] as const
```

Anything outside that list threw. The discovery layer was already scope-agnostic
(entity scanning already worked for third-party packages); only the sanitizer gate
blocked emission.

## What Changed

- **Widen the sanitizer** to accept any well-formed npm package specifier — scoped
  (`@scope/name[/subpath]`) or bare (`name[/subpath]`) — while keeping per-segment
  validation and the explicit `.` / `..` rejection.
- **Add a defense-in-depth structural check** that runs once per enabled module at
  generation start. For any `from:` entry outside `@app` / `@open-mercato/*`, the
  generator now verifies the resolved `pkgBase` directory actually exists on disk
  and fails fast with an actionable message:
  > `Module 'cpq' is registered with from: '@dainamite/cpq' but no Open Mercato
  > module shape was found at '...'. Ensure the package ships a 'modules/cpq'
  > subtree (either under 'dist/modules/' or 'src/modules/'), or correct the
  > 'from' value in src/modules.ts.`

  This addresses the user's "check if it's really an Open Mercato module maybe?"
  follow-up on the issue — a typo in `from:` or pointing at a non-OM package no
  longer silently produces empty module registrations.

## Tests

Added four regression tests in `packages/cli/src/lib/generators/__tests__/module-subset.test.ts`:

- emits imports for a scoped third-party package (`@dainamite/cpq`)
- emits imports for a bare (unscoped) third-party package (`acme-modules`)
- fails fast when a third-party `from:` resolves to a missing module shape
- still rejects path-traversal segments in third-party specifiers

`yarn test` in `packages/cli` (39 suites, 876 tests) and `yarn typecheck` both
pass green.

## Backward Compatibility

No contract surface changes. The relative/app-alias prefixes (`@/`, `./`,
`../../src/modules/`) are preserved verbatim, `@open-mercato/*` specifiers still
sanitize identically (they're now handled by the generalized scoped branch),
and the bad-spec rejection path (`Unsafe generated module specifier`) is
unchanged.

The new structural check only fires for non-`@app` / non-`@open-mercato/*`
entries, so existing apps and tests are unaffected.