### PR TITLE
fix(shared): mergeIdFilter must fail closed on unknown id filter shapes (#1736)

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/ids.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/ids.test.ts
@@ -28,6 +28,13 @@ describe('crud ids helpers', () => {
     expect(parseIdsParam(ids.join(','))).toHaveLength(MAX_IDS_PER_REQUEST)
   })
 
+  it('parseIdsParam accepts RFC 9562 UUID v6, v7, v8', () => {
+    const v6 = '1ec9414c-232a-6b00-b3c8-9e6bdeced846'
+    const v7 = '017f22e2-79b0-7cc3-98c4-dc0c0c07398f'
+    const v8 = '320c3d4d-cc00-875b-8ec9-32363a3c8c4f'
+    expect(parseIdsParam(`${v6},${v7},${v8}`)).toEqual([v6, v7, v8])
+  })
+
   it('mergeIdFilter adds id filter when none exists', () => {
     expect(mergeIdFilter({}, [idA, idB])).toEqual({
       id: { $in: [idA, idB] },
@@ -52,11 +59,54 @@ describe('crud ids helpers', () => {
     })
   })
 
-  it('mergeIdFilter falls back to parsed ids for unknown filter shape', () => {
+  it('mergeIdFilter intersects existing plain-array narrowing', () => {
+    expect(mergeIdFilter({ id: [idA, idC] as any }, [idA, idB])).toEqual({
+      id: { $in: [idA] },
+    })
+    expect(mergeIdFilter({ id: [idC] as any }, [idA, idB])).toEqual({
+      id: { $in: [] },
+    })
+  })
+
+  it('mergeIdFilter intersects existing $eq with UUID v6/v7/v8', () => {
+    const v6 = '1ec9414c-232a-6b00-b3c8-9e6bdeced846'
+    const v7 = '017f22e2-79b0-7cc3-98c4-dc0c0c07398f'
+    const v8 = '320c3d4d-cc00-875b-8ec9-32363a3c8c4f'
+    expect(mergeIdFilter({ id: { $eq: v6 } as any }, [v6, idA])).toEqual({
+      id: { $in: [v6] },
+    })
+    expect(mergeIdFilter({ id: { $eq: v7 } as any }, [idA])).toEqual({
+      id: { $in: [] },
+    })
+    expect(mergeIdFilter({ id: { $in: [v7, v8] } as any }, [v7, idB])).toEqual({
+      id: { $in: [v7] },
+    })
+  })
+
+  it('mergeIdFilter preserves existing filter for unknown filter shape (fail closed)', () => {
+    // Regression: previously the unrecognised shape was silently discarded and
+    // replaced with `{ id: { $in: parsedIds } }`, widening access. The contract
+    // is "intersect with existing id filters — never widen" — so unknown shapes
+    // must degrade closed.
     expect(
-      mergeIdFilter({ id: { $ne: idA } }, [idA, idB]),
-    ).toEqual({
-      id: { $in: [idA, idB] },
+      mergeIdFilter({ id: { $ne: idA } as any }, [idA, idB]),
+    ).toEqual({ id: { $ne: idA } })
+  })
+
+  it('mergeIdFilter preserves existing $eq with unsupported value (fail closed)', () => {
+    // An `$eq` with a non-UUID payload is also an unrecognised narrowing — we
+    // must not drop it and substitute `parsedIds`.
+    expect(
+      mergeIdFilter({ id: { $eq: 'not-a-uuid' } as any }, [idA]),
+    ).toEqual({ id: { $eq: 'not-a-uuid' } })
+  })
+
+  it('mergeIdFilter treats undefined/null id as no existing narrowing', () => {
+    expect(mergeIdFilter({ id: undefined } as any, [idA])).toEqual({
+      id: { $in: [idA] },
+    })
+    expect(mergeIdFilter({ id: null } as any, [idA])).toEqual({
+      id: { $in: [idA] },
     })
   })
 })

--- a/packages/shared/src/lib/crud/ids.ts
+++ b/packages/shared/src/lib/crud/ids.ts
@@ -2,7 +2,7 @@ import type { Where } from '@open-mercato/shared/lib/query/types'
 
 export const MAX_IDS_PER_REQUEST = 200
 
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 function isUuid(value: unknown): value is string {
   return typeof value === 'string' && UUID_REGEX.test(value)
@@ -23,16 +23,20 @@ function readExistingIds(filter: unknown): string[] | null {
   if (typeof filter === 'string') {
     return isUuid(filter) ? [filter] : null
   }
+  if (Array.isArray(filter)) {
+    return normalizeIdList(
+      filter.filter((value): value is string => typeof value === 'string'),
+    )
+  }
   if (!filter || typeof filter !== 'object') return null
 
   const operators = filter as Record<string, unknown>
   if (isUuid(operators.$eq)) return [operators.$eq]
 
   if (Array.isArray(operators.$in)) {
-    const parsed = normalizeIdList(
+    return normalizeIdList(
       operators.$in.filter((value): value is string => typeof value === 'string'),
     )
-    return parsed
   }
 
   return null
@@ -51,14 +55,22 @@ export function mergeIdFilter<Fields extends Record<string, unknown>>(
 ): Where<Fields> {
   if (parsedIds.length === 0) return existingFilters
 
-  const allowed = new Set(parsedIds)
   const existingFilter = (existingFilters as Record<string, unknown>).id
   const existingIds = readExistingIds(existingFilter)
 
   if (!existingIds) {
-    return { ...existingFilters, id: { $in: parsedIds } }
+    // No existing narrowing — safe to install the user-supplied `$in`.
+    if (existingFilter === undefined || existingFilter === null) {
+      return { ...existingFilters, id: { $in: parsedIds } }
+    }
+    // Existing `id` filter is in a shape we do not recognise. Fail closed:
+    // preserve the existing filter instead of widening to `parsedIds`. Adding
+    // a new recognised shape to `readExistingIds` is preferable to silently
+    // dropping a narrowing that another caller put in place.
+    return existingFilters
   }
 
+  const allowed = new Set(parsedIds)
   const intersection = existingIds.filter((id) => allowed.has(id))
   return {
     ...existingFilters,


### PR DESCRIPTION
Fixes #1736

## Problem
`mergeIdFilter()` in `packages/shared/src/lib/crud/ids.ts` is responsible for narrowing CRUD list results by `?ids=...`. When the existing `id` filter is in a shape that `readExistingIds()` does not recognise, the helper silently discards the existing filter and replaces it with `{ id: { $in: parsedIds } }`. The result is a one-sided merge that can widen access beyond what an interceptor intended to allow.

Two reported triggers:
- Plain-array narrowing (`{ id: ['uuid', ...] }`) was unrecognised and silently dropped.
- UUID v6/v7/v8 in `$eq` was unrecognised because `UUID_REGEX` only accepted versions 1–5, so the narrowing was silently dropped.

## Root Cause
- `readExistingIds()` recognised only three shapes (bare UUID string, `{ $eq: <v1-5 uuid> }`, `{ $in: [...] }`); every other shape returned `null`.
- The `if (!existingIds)` branch in `mergeIdFilter` then fell open: it set `{ id: { $in: parsedIds } }`, overwriting whatever the caller had put in place.
- That violates the documented contract from `packages/shared/AGENTS.md`: "intersect with existing `id` filters — never widen".

## What Changed
- `UUID_REGEX` now accepts RFC 9562 UUID v1–v8 (`[1-8]` in the version nibble), so `$eq`/`$in`/plain-array narrowings using v6, v7, or v8 IDs are recognised.
- `readExistingIds()` now recognises plain-array notation (`{ id: ['uuid', ...] }`) and intersects with it.
- When the existing `id` filter is still in a shape we do not recognise, `mergeIdFilter` now preserves the existing filter instead of overwriting it. Unknown shapes degrade closed — they never widen.
- The fast path for "no existing `id` filter at all" (undefined/null) still installs `{ id: { $in: parsedIds } }` as before.

## Tests
Updated `packages/shared/src/lib/crud/__tests__/ids.test.ts`:
- New: `parseIdsParam` accepts UUID v6/v7/v8.
- New: `mergeIdFilter` intersects plain-array narrowing.
- New: `mergeIdFilter` intersects `$eq`/`$in` with v6/v7/v8 UUIDs.
- Updated: the previous "falls back to parsed ids for unknown filter shape" expectation was the bug — replaced with a regression test asserting the existing filter is preserved.
- New: `$eq` with a non-UUID payload is preserved (fail closed).
- New: `id: undefined` / `id: null` are treated as "no existing narrowing" and the parsed `$in` is installed.

Validation run locally:
- `yarn workspace @open-mercato/shared jest src/lib/crud/__tests__/ids.test.ts` — 13/13 pass.
- `yarn workspace @open-mercato/shared jest src/lib/crud --testPathIgnorePatterns=crud-factory` — 86/86 pass.
- `yarn workspace @open-mercato/shared typecheck` — clean.
- The `crud-factory.test.ts` suite has one pre-existing failure (`POST is blocked by interceptor before hook`) on `develop` (verified by reverting `ids.ts`/`ids.test.ts`); not caused by this change.

## Backward Compatibility
- `UUID_REGEX` change is additive — previously valid IDs continue to validate.
- Plain-array recognition is additive — a shape that previously fail-open'd now intersects per the documented contract.
- The fail-closed change for unrecognised shapes is the intended behavioural fix; the previous fail-open behaviour was the security defect. No in-repo caller relies on it; the only test that asserted it (`mergeIdFilter falls back to parsed ids for unknown filter shape`) was asserting the bug and has been updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)