### PR TITLE
fix(customers): keep deal analyzer stage approval tool available

### DIFF
--- a/.ai/runs/2026-05-22-deal-analyzer-stage-approval-tool.md
+++ b/.ai/runs/2026-05-22-deal-analyzer-stage-approval-tool.md
@@ -1,0 +1,48 @@
+# Fix Deal Analyzer Stage Approval Tool Availability
+
+## Goal
+
+Ensure the `customers.deal_analyzer` agent can create a pending deal stage-change approval when the operator asks for that action directly, instead of reporting that `customers.update_deal_stage` is unavailable.
+
+## Scope
+
+- Customers module AI agent definition.
+- Customers module AI agent unit coverage.
+
+## Non-goals
+
+- No new AI tools.
+- No changes to mutation approval persistence or approval-card rendering.
+- No changes to customer deal write APIs.
+
+## Implementation Plan
+
+### Phase 1: Root Cause And Patch
+
+1. Update the deal analyzer loop `prepareStep` tool narrowing so `customers.update_deal_stage` remains available on the first step while the prompt still instructs the agent to analyze first.
+2. Update unit coverage to assert the mutation tool is available in step 0 and step 1.
+
+### Phase 2: Validation And PR
+
+1. Run targeted customers AI-agent tests.
+2. Run package-level typecheck if practical.
+3. Push the branch and open a PR against `develop`.
+
+## Risks
+
+- Exposing the mutation tool in step 0 could let the model call it before `customers.analyze_deals`; the agent prompt still requires analysis first, and the mutation remains gated by `prepareMutation` + `confirm-required`.
+- Tenant policy overrides can still make the mutation unavailable when the tenant is read-only; that behavior is intentional and not changed.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append `— <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Root Cause And Patch
+
+- [ ] 1.1 Update deal analyzer first-step active tools
+- [ ] 1.2 Update unit coverage
+
+### Phase 2: Validation And PR
+
+- [ ] 2.1 Run targeted validation
+- [ ] 2.2 Open PR

--- a/.ai/runs/2026-05-22-deal-analyzer-stage-approval-tool.md
+++ b/.ai/runs/2026-05-22-deal-analyzer-stage-approval-tool.md
@@ -39,10 +39,20 @@ Ensure the `customers.deal_analyzer` agent can create a pending deal stage-chang
 
 ### Phase 1: Root Cause And Patch
 
-- [ ] 1.1 Update deal analyzer first-step active tools
-- [ ] 1.2 Update unit coverage
+- [x] 1.1 Update deal analyzer first-step active tools — da26125f5
+- [x] 1.2 Update unit coverage — da26125f5
 
 ### Phase 2: Validation And PR
 
-- [ ] 2.1 Run targeted validation
+- [x] 2.1 Run targeted validation — da26125f5
 - [ ] 2.2 Open PR
+
+## Validation
+
+- `yarn workspace @open-mercato/core test src/modules/customers/__tests__/ai-agents.test.ts --runInBand`
+- `yarn workspace @open-mercato/core test src/modules/customers/__tests__/ai-tools/deals-pack.mutation.test.ts --runInBand`
+
+## Notes
+
+- `yarn workspace @open-mercato/core typecheck` could not run in this fresh worktree because the workspace script could not find `tsc`.
+- `yarn exec tsc -p packages/core/tsconfig.json --noEmit` was blocked by missing generated `#generated/entities...` shims in the fresh worktree.

--- a/packages/core/src/modules/customers/__tests__/ai-agents.test.ts
+++ b/packages/core/src/modules/customers/__tests__/ai-agents.test.ts
@@ -454,7 +454,7 @@ describe('customers.deal_analyzer demo agents', () => {
     expect((stepZero as any).activeTools).toContain('meta.update_task_plan')
     expect((stepZero as any).activeTools).toContain('customers.analyze_deals')
     expect((stepZero as any).activeTools).toContain('customers.list_pipeline_stages')
-    expect((stepZero as any).activeTools).not.toContain('customers.update_deal_stage')
+    expect((stepZero as any).activeTools).toContain('customers.update_deal_stage')
     expect((stepOne as any).activeTools).toContain('customers.update_deal_stage')
     expect((stepOne as any).activeTools).toContain('customers.list_pipeline_stages')
   })

--- a/packages/core/src/modules/customers/ai-agents.ts
+++ b/packages/core/src/modules/customers/ai-agents.ts
@@ -452,6 +452,7 @@ function buildDealAnalyzerPrepareStep() {
       return {
         activeTools: [
           'customers.analyze_deals',
+          'customers.update_deal_stage',
           'customers.list_deals',
           'customers.get_deal',
           'customers.list_activities',


### PR DESCRIPTION
Tracking plan: `.ai/runs/2026-05-22-deal-analyzer-stage-approval-tool.md`
Status: ready for review

## Goal
Fix Deal Analyzer so direct stage-change approval requests can create a pending approval card instead of reporting `customers.update_deal_stage` is unavailable.

## Summary
- Kept `customers.update_deal_stage` in the deal analyzer first-step active tool set.
- Preserved the existing prompt contract that tells the model to analyze deals first.
- Updated the agent unit test to lock the mutation tool availability on step 0 and step 1.

## Testing
- `yarn workspace @open-mercato/core test src/modules/customers/__tests__/ai-agents.test.ts --runInBand`
- `yarn workspace @open-mercato/core test src/modules/customers/__tests__/ai-tools/deals-pack.mutation.test.ts --runInBand`

## Validation notes
- `yarn workspace @open-mercato/core typecheck` could not run in this fresh worktree because the workspace script could not find `tsc`.
- `yarn exec tsc -p packages/core/tsconfig.json --noEmit` was blocked by missing generated `#generated/entities...` shims in the fresh worktree.

## Backward Compatibility
- No API, DB schema, event, ACL, DI, widget spot, import path, or generated contract changes.
- Mutation execution remains behind `prepareMutation` and `confirm-required`.
