### PR TITLE
fix(ui): hide stale AppShell sidebar nav until chrome resolves (#1828)

### DIFF
--- a/packages/core/src/modules/portal/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/portal/__integration__/TC-AUTH-033.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { getTokenContext } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+/**
+ * TC-AUTH-033: Portal dashboard waits for nav bootstrap before asserting sidebar content
+ *
+ * Regression coverage for the portal-shell loading-state fix:
+ *   - customer portal login succeeds for a real customer user
+ *   - the dashboard waits for `portal-nav-ready[data-ready="true"]`
+ *   - sidebar nav is asserted only after the bootstrap payload has hydrated
+ */
+test.describe('TC-AUTH-033: portal dashboard waits for nav bootstrap', () => {
+  test('dashboard sidebar is asserted only after the nav ready marker flips to true', async ({ page, request }) => {
+    const stamp = Date.now()
+    const customerEmail = `qa-auth-033-${stamp}@test.local`
+    const password = `Password${stamp}!`
+
+    let adminToken: string | null = null
+    let organizationId: string | null = null
+    let orgSlug: string | null = null
+    let customerId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      const { tenantId } = getTokenContext(adminToken)
+
+      const createOrgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: adminToken,
+        data: {
+          name: `QA Portal Org ${stamp}`,
+          tenantId,
+        },
+      })
+      expect(createOrgRes.status(), 'organization should be created').toBe(201)
+      const createOrgBody = (await createOrgRes.json()) as { id?: string }
+      organizationId = createOrgBody.id ?? null
+      expect(organizationId, 'organization id should be returned').toBeTruthy()
+
+      const orgDetailsRes = await apiRequest(
+        request,
+        'GET',
+        `/api/directory/organizations?view=manage&ids=${encodeURIComponent(organizationId!)}&tenantId=${encodeURIComponent(tenantId)}`,
+        { token: adminToken },
+      )
+      expect(orgDetailsRes.ok(), 'organization lookup should succeed').toBeTruthy()
+      const orgDetailsBody = (await orgDetailsRes.json()) as { items?: Array<{ slug?: string | null }> }
+      orgSlug = orgDetailsBody.items?.[0]?.slug ?? null
+      expect(orgSlug, 'organization slug should be returned').toBeTruthy()
+
+      const createRes = await apiRequest(request, 'POST', '/api/customer_accounts/admin/users', {
+        token: adminToken,
+        data: {
+          email: customerEmail,
+          password,
+          displayName: `QA Auth 033 ${stamp}`,
+          organizationId,
+        },
+      })
+      expect(createRes.status(), 'customer user should be created').toBe(201)
+      const createBody = (await createRes.json()) as { user?: { id?: string } }
+      customerId = createBody.user?.id ?? null
+      expect(customerId, 'created user id should be returned').toBeTruthy()
+
+      const loginRes = await request.post('/api/customer_accounts/login', {
+        data: { email: customerEmail, password, tenantId },
+        headers: { 'Content-Type': 'application/json' },
+      })
+      expect(loginRes.ok(), 'portal login should succeed').toBeTruthy()
+
+      const setCookieHeader = loginRes.headers()['set-cookie'] ?? ''
+      const authCookieMatch = setCookieHeader.match(/customer_auth_token=([^;]+)/)
+      const sessionCookieMatch = setCookieHeader.match(/customer_session_token=([^;]+)/)
+      expect(authCookieMatch, 'customer_auth_token cookie must be set').toBeTruthy()
+      expect(sessionCookieMatch, 'customer_session_token cookie must be set').toBeTruthy()
+
+      const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+      await page.context().addCookies([
+        {
+          name: 'customer_auth_token',
+          value: authCookieMatch![1],
+          url: baseUrl,
+          sameSite: 'Lax',
+        },
+        {
+          name: 'customer_session_token',
+          value: sessionCookieMatch![1],
+          url: baseUrl,
+          sameSite: 'Lax',
+        },
+      ])
+
+      await page.goto(`/${orgSlug}/portal/dashboard`, { waitUntil: 'domcontentloaded' })
+      await page.waitForURL(new RegExp(`/${orgSlug}/portal/dashboard$`), { timeout: 15_000 })
+
+      await expect(page.getByTestId('portal-nav-ready')).toHaveAttribute('data-ready', 'true', { timeout: 15_000 })
+      await expect(page.getByRole('link', { name: 'Dashboard' })).toBeVisible()
+      await expect(page.getByRole('link', { name: 'Profile' })).toBeVisible()
+    } finally {
+      if (adminToken && customerId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/customer_accounts/admin/users/${customerId}`,
+          { token: adminToken },
+        ).catch(() => {})
+      }
+      if (adminToken && organizationId) {
+        await apiRequest(
+          request,
+          'DELETE',
+          `/api/directory/organizations?id=${encodeURIComponent(organizationId)}`,
+          { token: adminToken },
+        ).catch(() => {})
+      }
+    }
+  })
+})

--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -808,7 +808,7 @@ function AppShellBody({ productName, logo, email, groups, rightHeaderSlot, child
   }
 
   function renderSidebar(compact: boolean, hideHeader?: boolean, forceMainOnly?: boolean) {
-    if (!isChromeReady && isChromeLoading && resolvedGroups.length === 0) {
+    if (!isChromeReady && isChromeLoading) {
       return (
         <div className="flex flex-col min-h-full gap-3" data-testid="backend-chrome-loading">
           {!hideHeader ? (

--- a/packages/ui/src/backend/__tests__/AppShell.test.tsx
+++ b/packages/ui/src/backend/__tests__/AppShell.test.tsx
@@ -610,4 +610,90 @@ describe('AppShell', () => {
       ;(window as Window & { __omOriginalFetch?: typeof fetch }).__omOriginalFetch = previousOriginalFetch
     }
   })
+
+  // Regression: #1828 — skeleton must hide stale SSR groups until chrome resolves
+  it('shows skeleton (not stale SSR groups) while chrome API is loading', async () => {
+    const previousFetch = global.fetch
+    const previousWindowFetch = window.fetch
+    const previousOriginalFetch = (window as Window & { __omOriginalFetch?: typeof fetch }).__omOriginalFetch
+    let resolveFetch: ((response: Response) => void) | null = null
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchMock = jest.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof Request
+          ? input.url
+          : input.toString()
+      if (url.includes('/api/auth/admin/nav-flicker-regression')) {
+        return fetchPromise
+      }
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as unknown as typeof fetch
+    global.fetch = fetchMock
+    window.fetch = fetchMock
+    ;(window as Window & { __omOriginalFetch?: typeof fetch }).__omOriginalFetch = fetchMock
+
+    const staleGroups = [
+      {
+        id: 'core',
+        name: 'Stale Core',
+        items: [{ href: '/backend/stale-link', title: 'Stale Link' }],
+      },
+    ]
+
+    try {
+      renderWithProviders(
+        <AppShell
+          email="demo@example.com"
+          groups={staleGroups}
+          adminNavApi="/api/auth/admin/nav-flicker-regression"
+        >
+          <div>Hydrated content</div>
+        </AppShell>,
+        { dict },
+      )
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId('backend-chrome-loading').length).toBeGreaterThan(0)
+      })
+      expect(screen.queryByText('Stale Link')).toBeNull()
+      expect(screen.getByTestId('backend-chrome-ready')).toHaveAttribute('data-ready', 'false')
+
+      resolveFetch?.(new Response(JSON.stringify({
+        groups: [
+          {
+            id: 'core',
+            name: 'Core',
+            defaultName: 'Core',
+            items: [
+              {
+                href: '/backend/users',
+                title: 'Fresh Link',
+                defaultTitle: 'Fresh Link',
+                enabled: true,
+              },
+            ],
+          },
+        ],
+        settingsSections: [],
+        settingsPathPrefixes: [],
+        profileSections: [],
+        profilePathPrefixes: ['/backend/profile/'],
+        grantedFeatures: ['auth.*'],
+        roles: ['admin'],
+      }), { status: 200, headers: { 'content-type': 'application/json' } }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Fresh Link')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('backend-chrome-loading')).toBeNull()
+      expect(screen.queryByText('Stale Link')).toBeNull()
+    } finally {
+      global.fetch = previousFetch
+      window.fetch = previousWindowFetch
+      ;(window as Window & { __omOriginalFetch?: typeof fetch }).__omOriginalFetch = previousOriginalFetch
+    }
+  })
 })

--- a/packages/ui/src/portal/PortalShell.tsx
+++ b/packages/ui/src/portal/PortalShell.tsx
@@ -1,11 +1,12 @@
 "use client"
-import { type ReactNode, useEffect, useState, useCallback, useMemo, useContext } from 'react'
+import { type ReactNode, useEffect, useState, useCallback, useMemo } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '../primitives/button'
 import { IconButton } from '../primitives/icon-button'
+import { Skeleton } from '../primitives/skeleton'
 import { usePortalInjectedMenuItems } from './hooks/usePortalInjectedMenuItems'
 import { usePortalEventBridge } from './hooks/usePortalEventBridge'
 import { mergeMenuItems } from '../backend/injection/mergeMenuItems'
@@ -117,6 +118,17 @@ function SidebarNavItem({
   return null
 }
 
+function SidebarNavSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 px-3 py-1" data-testid="portal-nav-loading">
+      <Skeleton className="h-9 w-full rounded-lg" />
+      <Skeleton className="h-9 w-11/12 rounded-lg" />
+      <Skeleton className="h-9 w-5/6 rounded-lg" />
+      <Skeleton className="h-9 w-10/12 rounded-lg" />
+    </div>
+  )
+}
+
 /* ---- User initials avatar ---- */
 
 function UserAvatar({ name, className }: { name?: string; className?: string }) {
@@ -191,12 +203,15 @@ export function PortalShell({
   const closeMobile = useCallback(() => setMobileOpen(false), [])
 
   const [autoNavGroups, setAutoNavGroups] = useState<PortalNavGroup[]>([])
+  const [isNavLoading, setIsNavLoading] = useState(authenticated)
   useEffect(() => {
     if (!authenticated) {
       setAutoNavGroups([])
+      setIsNavLoading(false)
       return
     }
     let cancelled = false
+    setIsNavLoading(true)
     const load = async () => {
       try {
         const { ok, result } = await apiCall<{ ok: boolean; groups?: PortalNavGroup[] }>(
@@ -206,6 +221,8 @@ export function PortalShell({
         setAutoNavGroups(Array.isArray(result.groups) ? result.groups : [])
       } catch {
         if (!cancelled) setAutoNavGroups([])
+      } finally {
+        if (!cancelled) setIsNavLoading(false)
       }
     }
     void load()
@@ -237,6 +254,10 @@ export function PortalShell({
     }))
     return mergeMenuItems(builtIn, injectedAccountItems)
   }, [authenticated, autoNavGroups, injectedAccountItems])
+
+  const shouldRenderMainNav = isNavLoading || mergedNavItems.length > 0
+  const shouldRenderAccountNav = mergedAccountItems.length > 0
+  const shouldRenderNav = shouldRenderMainNav || shouldRenderAccountNav
 
   /* ---- PUBLIC LAYOUT ---- */
   if (!authenticated) {
@@ -291,41 +312,58 @@ export function PortalShell({
         </Link>
       </div>
 
-      <nav aria-label="Portal navigation" className="flex-1 overflow-y-auto px-3 py-5">
-        <p className="mb-2 px-3 text-overline font-semibold uppercase tracking-widest text-muted-foreground/50">
-          {t('portal.nav.home', 'Portal')}
-        </p>
-        <div className="flex flex-col gap-0.5">
-          {mergedNavItems.map((item) => (
-            <SidebarNavItem
-              key={item.id}
-              item={item}
-              active={!!item.href && pathname.startsWith(item.href)}
-              t={t}
-              onClick={closeMobile}
-            />
-          ))}
-        </div>
+      <div
+        className="hidden"
+        data-testid="portal-nav-ready"
+        data-ready={isNavLoading ? 'false' : 'true'}
+        aria-hidden="true"
+      />
 
-        {mergedAccountItems.length > 0 ? (
-          <div className="mt-8">
-            <p className="mb-2 px-3 text-overline font-semibold uppercase tracking-widest text-muted-foreground/50">
-              {t('portal.nav.account', 'Account')}
-            </p>
-            <div className="flex flex-col gap-0.5">
-              {mergedAccountItems.map((item) => (
-                <SidebarNavItem
-                  key={item.id}
-                  item={item}
-                  active={!!item.href && pathname.startsWith(item.href)}
-                  t={t}
-                  onClick={closeMobile}
-                />
-              ))}
+      {shouldRenderNav ? (
+        <nav aria-label="Portal navigation" className="flex-1 overflow-y-auto px-3 py-5">
+          {shouldRenderMainNav ? (
+            <>
+              <p className="mb-2 px-3 text-overline font-semibold uppercase tracking-widest text-muted-foreground/50">
+                {t('portal.nav.home', 'Portal')}
+              </p>
+              {isNavLoading ? (
+                <SidebarNavSkeleton />
+              ) : (
+                <div className="flex flex-col gap-0.5">
+                  {mergedNavItems.map((item) => (
+                    <SidebarNavItem
+                      key={item.id}
+                      item={item}
+                      active={!!item.href && pathname.startsWith(item.href)}
+                      t={t}
+                      onClick={closeMobile}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
+          ) : null}
+
+          {shouldRenderAccountNav ? (
+            <div className={shouldRenderMainNav ? 'mt-8' : ''}>
+              <p className="mb-2 px-3 text-overline font-semibold uppercase tracking-widest text-muted-foreground/50">
+                {t('portal.nav.account', 'Account')}
+              </p>
+              <div className="flex flex-col gap-0.5">
+                {mergedAccountItems.map((item) => (
+                  <SidebarNavItem
+                    key={item.id}
+                    item={item}
+                    active={!!item.href && pathname.startsWith(item.href)}
+                    t={t}
+                    onClick={closeMobile}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
-        ) : null}
-      </nav>
+          ) : null}
+        </nav>
+      ) : null}
 
       <div className="border-t px-3 py-3">
         <div className="flex items-center gap-2.5 rounded-lg px-3 py-2">

--- a/packages/ui/src/portal/__tests__/PortalShell.test.tsx
+++ b/packages/ui/src/portal/__tests__/PortalShell.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { PortalShell } from '../PortalShell'
+
+const apiCallMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('next/link', () => {
+  const React = require('react')
+  return React.forwardRef(({ children, href, ...rest }: any, ref: React.ForwardedRef<HTMLAnchorElement>) => (
+    <a href={typeof href === 'string' ? href : href?.toString?.()} ref={ref} {...rest}>
+      {children}
+    </a>
+  ))
+})
+
+jest.mock('next/image', () => (props: any) => <img alt={props.alt} {...props} />)
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/acme/portal/orders',
+}))
+
+jest.mock('../../backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('../hooks/usePortalInjectedMenuItems', () => ({
+  usePortalInjectedMenuItems: () => ({
+    items: [],
+    isLoading: false,
+  }),
+}))
+
+jest.mock('../hooks/usePortalEventBridge', () => ({
+  usePortalEventBridge: jest.fn(),
+}))
+
+jest.mock('../components/PortalNotificationBell', () => ({
+  PortalNotificationBell: () => null,
+}))
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+beforeEach(() => {
+  apiCallMock.mockReset()
+})
+
+describe('PortalShell', () => {
+  it('shows a loading skeleton until the portal nav payload arrives', async () => {
+    const deferred = createDeferred<{
+      ok: boolean
+      result: {
+        ok: boolean
+        groups: Array<{
+          id: string
+          items: Array<{ id: string; label: string; href: string }>
+        }>
+      }
+    }>()
+
+    apiCallMock.mockReturnValueOnce(deferred.promise)
+
+    render(
+      <PortalShell
+        authenticated
+        orgSlug="acme"
+        organizationName="Acme"
+        userName="Ada Lovelace"
+        userEmail="ada@example.com"
+        onLogout={jest.fn()}
+      >
+        <div>Portal content</div>
+      </PortalShell>,
+    )
+
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalledWith('/api/customer_accounts/portal/nav')
+    })
+
+    expect(screen.getByTestId('portal-nav-loading')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Orders' })).not.toBeInTheDocument()
+
+    await act(async () => {
+      deferred.resolve({
+        ok: true,
+        result: {
+          ok: true,
+          groups: [
+            {
+              id: 'main',
+              items: [
+                {
+                  id: 'orders',
+                  label: 'Orders',
+                  href: '/acme/portal/orders',
+                },
+              ],
+            },
+          ],
+        },
+      })
+      await deferred.promise
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('portal-nav-loading')).not.toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Orders' })).toHaveAttribute('href', '/acme/portal/orders')
+    })
+  })
+
+  it('does not keep an empty nav section visible when the payload has no items', async () => {
+    apiCallMock.mockResolvedValueOnce({
+      ok: true,
+      result: {
+        ok: true,
+        groups: [],
+      },
+    })
+
+    render(
+      <PortalShell
+        authenticated
+        orgSlug="acme"
+        organizationName="Acme"
+        onLogout={jest.fn()}
+      >
+        <div>Portal content</div>
+      </PortalShell>,
+    )
+
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalledWith('/api/customer_accounts/portal/nav')
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('portal-nav-loading')).not.toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('navigation', { name: 'Portal navigation' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #1828 and #1829 — closes #2032 by folding it into this PR.

## What this PR does

This PR bundles **two parallel nav-flicker fixes** addressing the same UX problem in the two different shells of Open Mercato:
- The **backend admin sidebar** (`AppShell.tsx`) flickered briefly because the skeleton guard didn't activate when SSR `groups` were passed.
- The **customer portal sidebar** (`PortalShell.tsx`) flashed an empty nav block on every login until the portal nav bootstrap completed.

The two fixes touch different files (`packages/ui/src/backend/AppShell.tsx` vs `packages/ui/src/portal/PortalShell.tsx`) and there are no merge conflicts between them. They are bundled together because they solve the same UX class (nav flicker on first load) using the same conceptual pattern (render skeleton until bootstrap finishes, hide nav while empty). Reviewers benefit from seeing both shells handled consistently in one place.

### 1. Backend AppShell sidebar flicker (#1828) — by @pkarw

After login, the backend sidebar briefly rendered stale or default navigation groups, then swapped to the final groups once `BackendChromeProvider` resolved — producing a visible flicker on every login.

**Root cause.** The skeleton guard in `renderSidebar` (`packages/ui/src/backend/AppShell.tsx:811`) required `resolvedGroups.length === 0` to activate. Any app that passed `groups` via SSR props bypassed the skeleton entirely and rendered the stale groups until the chrome API resolved and the sync effect replaced them.

**Changes**
- `packages/ui/src/backend/AppShell.tsx` — drop the `resolvedGroups.length === 0` clause. The skeleton now renders whenever `!isChromeReady && isChromeLoading`, regardless of whether SSR `groups` were passed.
- Behavior preserved for other paths:
  - No `adminNavApi` configured → `isReady = true`, `isLoading = false` → skeleton not shown; `groups` prop drives nav as before.
  - Subsequent navigation with chrome cache hit → `isReady = true`, `isLoading = false` → skeleton not shown.
  - Focus refresh (cache exists, refresh in-flight) → `isReady = true` (payload kept), so the currently-rendered nav stays visible during the in-flight refresh.

### 2. Portal PortalShell nav loading flash (#1829) — by @PawelSydorow (folded from #2032)

After login, the portal shell briefly showed an empty nav section while `/api/customer_accounts/portal/nav` was in flight. This PR (folded from #2032) introduces a sidebar skeleton mirroring the AppShell pattern.

**Changes (preserving original PR #2032 by @PawelSydorow)**
- `packages/ui/src/portal/PortalShell.tsx`:
  - Added `isNavLoading` state and tracked the portal nav bootstrap request lifecycle.
  - Rendered a sidebar `Skeleton` while `/api/customer_accounts/portal/nav` is in flight (`portal-nav-loading` testid).
  - Suppressed the nav section entirely when there are no nav items to show.
  - Added a hidden `data-testid="portal-nav-ready" data-ready` sentinel mirroring the existing `backend-chrome-ready` pattern so integration tests can wait for nav hydration deterministically.
- `packages/ui/src/portal/__tests__/PortalShell.test.tsx` — unit test for the loading skeleton / empty-nav behavior.
- `packages/core/src/modules/portal/__integration__/TC-AUTH-033.spec.ts` — integration test covering the portal dashboard nav bootstrap flow (creates org + customer user, logs in, asserts the dashboard waits for `portal-nav-ready[data-ready="true"]` before checking sidebar items, and tears down fixtures in a `finally` block).

Credit for the portal-side work goes to @PawelSydorow (original PR #2032). The original commit is preserved with author attribution.

## Why both fixes ship together

They solve the same conceptual UX problem (nav flicker on initial load) in the two shells the product ships. The portal fix follows the AppShell pattern intentionally — the `portal-nav-ready` sentinel mirrors `backend-chrome-ready`. Shipping them as one PR keeps the cross-shell symmetry visible to reviewers and avoids inconsistent UX between admin and portal.

## Tests

**Backend AppShell**
- Added regression test `shows skeleton (not stale SSR groups) while chrome API is loading` in `packages/ui/src/backend/__tests__/AppShell.test.tsx`:
  - Passes `groups=[stale...]` and `adminNavApi=...` with a manually-resolved fetch promise.
  - Asserts the `backend-chrome-loading` skeleton renders and the stale link is not visible.
  - Resolves the fetch, then asserts the fresh link replaces the skeleton.
- All 13 tests in `AppShell.test.tsx` pass.

**Portal PortalShell**
- `packages/ui/src/portal/__tests__/PortalShell.test.tsx` — 2 cases:
  - `shows a loading skeleton until the portal nav payload arrives` (deferred promise resolved mid-test).
  - `does not keep an empty nav section visible when the payload has no items`.
- Integration spec `TC-AUTH-033` creates fixtures (org + customer user) and tears them down on `finally`.

**Suite-wide**
- Full `packages/ui` Jest suite: **138 suites / 1052 tests pass**.
- `yarn workspace @open-mercato/ui exec tsc --noEmit`: clean.

## Backward Compatibility

- **AppShell** — no contract surface changes. The `backend-chrome-loading` test id and the skeleton markup are preserved. No props, events, ACL features, or API responses changed. Apps that don't pass `adminNavApi` see no behavior change.
- **PortalShell** — the new `portal-nav-loading` and `portal-nav-ready` testids are additive. No props, events, ACL features, or API responses changed.
