### PR TITLE
fix(sso): allow Entra ID login without email_verified claim

### DIFF
--- a/packages/enterprise/src/modules/sso/lib/oidc-provider.ts
+++ b/packages/enterprise/src/modules/sso/lib/oidc-provider.ts
@@ -74,7 +74,9 @@ export class OidcProvider implements SsoProtocolProvider {
       throw new Error('IdP did not return an email claim (checked: email, upn, unique_name)')
     }
 
-    const emailVerified = mergedClaims.email_verified === true
+    const emailVerified = typeof mergedClaims.email_verified === 'boolean'
+      ? mergedClaims.email_verified
+      : undefined
     const groups = extractIdentityGroups(mergedClaims)
 
   

--- a/packages/enterprise/src/modules/sso/lib/types.ts
+++ b/packages/enterprise/src/modules/sso/lib/types.ts
@@ -35,7 +35,7 @@ export interface SsoProtocolProvider {
 export interface SsoIdentityPayload {
   subject: string
   email: string
-  emailVerified: boolean
+  emailVerified?: boolean
   name?: string
   groups?: string[]
 }


### PR DESCRIPTION
Fixes #2026 

## Summary

Fixes Microsoft Entra ID SSO login when the OIDC ID token omits the `email_verified` claim.

Entra does not include `email_verified` by default, but the SSO flow previously normalized the missing claim to `false`. That caused account linking/provisioning to reject otherwise valid Entra users as if the IdP had explicitly reported an unverified email.

## Changes

- Makes `SsoIdentityPayload.emailVerified` optional.
- Preserves explicit boolean `email_verified` values from the IdP.
- Treats missing or non-boolean `email_verified` as `undefined` instead of `false`, allowing downstream logic to distinguish “not provided” from “explicitly unverified”.

## Testing

- Passed: `node_modules/.bin/jest --config packages/enterprise/jest.config.cjs packages/enterprise/src/modules/sso`
- Passed: `yarn workspace @open-mercato/enterprise build`