### PR TITLE
fix(customer-accounts): implement search tokens for encrypted customer user search (#2034)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/__tests__/users.route.test.ts
@@ -16,6 +16,24 @@ const mockEmNativeUpdate = jest.fn()
 const mockFindByEmail = jest.fn()
 const mockCreateUser = jest.fn()
 
+const mockSearchTokenExecute = jest.fn()
+const mockSearchTokenWhere = jest.fn().mockImplementation(() => searchTokenQueryBuilder)
+const mockSearchTokenHaving = jest.fn().mockImplementation(() => searchTokenQueryBuilder)
+const mockSearchTokenGroupBy = jest.fn().mockImplementation(() => searchTokenQueryBuilder)
+const mockSearchTokenSelect = jest.fn().mockImplementation(() => searchTokenQueryBuilder)
+const searchTokenQueryBuilder: any = {
+  select: mockSearchTokenSelect,
+  where: mockSearchTokenWhere,
+  groupBy: mockSearchTokenGroupBy,
+  having: mockSearchTokenHaving,
+  execute: mockSearchTokenExecute,
+}
+const mockSelectFrom = jest.fn((table: string) => {
+  if (table === 'search_tokens') return searchTokenQueryBuilder
+  throw new Error(`Unexpected selectFrom ${table}`)
+})
+const mockKysely = { selectFrom: mockSelectFrom }
+
 const mockEm = {
   find: mockEmFind,
   findAndCount: mockEmFindAndCount,
@@ -24,6 +42,7 @@ const mockEm = {
   persist: mockEmPersist,
   flush: mockEmFlush,
   nativeUpdate: mockEmNativeUpdate,
+  getKysely: jest.fn(() => mockKysely),
 }
 
 const mockContainer = {
@@ -148,6 +167,92 @@ describe('admin /api/customer_accounts/admin/users — GET listing', () => {
       (call) => call[0] === CustomerUserRole,
     )
     expect(customerUserRoleCalls).toHaveLength(0)
+  })
+})
+
+describe('admin /api/customer_accounts/admin/users — GET search', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuth.mockResolvedValue({ sub: adminId, tenantId, orgId })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockSearchTokenExecute.mockResolvedValue([])
+  })
+
+  it('queries search_tokens with the generated entity id (E.customer_accounts.customer_user) and scopes by tenant', async () => {
+    const matchedId = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+    mockSearchTokenExecute.mockResolvedValueOnce([{ entity_id: matchedId }])
+    mockEmFindAndCount.mockResolvedValueOnce([[makeUser(matchedId)], 1])
+
+    const res = await GET(buildRequest('http://localhost/api/customer_accounts/admin/users?search=alice'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(mockSelectFrom).toHaveBeenCalledWith('search_tokens')
+    const entityTypeCall = mockSearchTokenWhere.mock.calls.find(
+      (call) => call[0] === 'entity_type' && call[1] === '=' && call[2] === 'customer_accounts:customer_user',
+    )
+    expect(entityTypeCall).toBeDefined()
+    const tenantScopeCall = mockSearchTokenWhere.mock.calls.find((call) => {
+      const clause = call[0] as { toOperationNode?: () => { sqlFragments?: string[]; parameters?: Array<{ value?: unknown }> } } | undefined
+      const node = clause && typeof clause === 'object' && typeof clause.toOperationNode === 'function'
+        ? clause.toOperationNode()
+        : null
+      if (!node || !Array.isArray(node.sqlFragments)) return false
+      const joined = node.sqlFragments.join('?')
+      if (!joined.includes('tenant_id is not distinct from')) return false
+      const params = Array.isArray(node.parameters) ? node.parameters : []
+      return params.some((p) => p && typeof p === 'object' && 'value' in p && p.value === tenantId)
+    })
+    expect(tenantScopeCall).toBeDefined()
+
+    const whereArg = mockEmFindAndCount.mock.calls[0][1] as Record<string, any>
+    expect(whereArg.$or).toEqual(expect.arrayContaining([
+      { id: { $in: [matchedId] } },
+    ]))
+    expect(body.total).toBe(1)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).toMatchObject({ id: matchedId })
+  })
+
+  it('combines emailHash lookup with search_tokens matches when the query looks like an email', async () => {
+    const tokenId = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb'
+    mockSearchTokenExecute.mockResolvedValueOnce([{ entity_id: tokenId }])
+    mockEmFindAndCount.mockResolvedValueOnce([[makeUser(tokenId)], 1])
+
+    const res = await GET(buildRequest('http://localhost/api/customer_accounts/admin/users?search=alice%40example.com'))
+
+    expect(res.status).toBe(200)
+    const whereArg = mockEmFindAndCount.mock.calls[0][1] as Record<string, any>
+    expect(Array.isArray(whereArg.$or)).toBe(true)
+    expect(whereArg.$or).toEqual(expect.arrayContaining([
+      { id: { $in: [tokenId] } },
+      expect.objectContaining({ emailHash: expect.any(String) }),
+    ]))
+  })
+
+  it('returns an empty page when neither search_tokens nor the email-hash fallback match', async () => {
+    mockSearchTokenExecute.mockResolvedValueOnce([])
+
+    const res = await GET(buildRequest('http://localhost/api/customer_accounts/admin/users?search=nobody'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true, items: [], total: 0, totalPages: 1, page: 1 })
+    expect(mockEmFindAndCount).not.toHaveBeenCalled()
+  })
+
+  it('falls back to emailHash-only search when search_tokens yield no match but the query is email-like', async () => {
+    mockSearchTokenExecute.mockResolvedValueOnce([])
+    mockEmFindAndCount.mockResolvedValueOnce([[], 0])
+
+    const res = await GET(buildRequest('http://localhost/api/customer_accounts/admin/users?search=ghost%40example.com'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(mockEmFindAndCount).toHaveBeenCalled()
+    const whereArg = mockEmFindAndCount.mock.calls[0][1] as Record<string, any>
+    expect(whereArg.$or).toEqual([expect.objectContaining({ emailHash: expect.any(String) })])
+    expect(body.total).toBe(0)
   })
 })
 

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -75,7 +75,7 @@ export async function GET(req: Request) {
     const searchFilter: Record<string, unknown>[] = []
 
     // Search encrypted fields via search_tokens
-    const matchedIds = await findCustomerUserIdsBySearchTokens(em, 'customer_accounts:customer_user', trimmedSearch, auth.tenantId)
+    const matchedIds = await findCustomerUserIdsBySearchTokens(em, E.customer_accounts.customer_user, trimmedSearch, auth.tenantId)
     if (matchedIds && matchedIds.length > 0) {
       searchFilter.push({ id: { $in: matchedIds } })
     }

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -11,6 +11,10 @@ import { adminCreateUserSchema } from '@open-mercato/core/modules/customer_accou
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { findAndCountWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { hashForLookup } from '@open-mercato/shared/lib/encryption/aes'
+import { E } from '#generated/entities.ids.generated'
+import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
+import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import { sql } from 'kysely'
 
 const EMAIL_LIKE_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -64,23 +68,39 @@ export async function GET(req: Request) {
   }
 
   if (search) {
-    const escapedSearch = search.replace(/[%_\\]/g, '\\$&')
+    const trimmedSearch = search.trim()
     // email/displayName are stored encrypted, so SQL ILIKE on the ciphertext
-    // never matches a plaintext search term. Match the deterministic emailHash
-    // (used by CustomerUser as a blind index) when the query looks like an
-    // email so administrators can still look users up by exact address.
-    const searchFilter: Record<string, unknown>[] = [
-      { email: { $ilike: `%${escapedSearch}%` } },
-      { displayName: { $ilike: `%${escapedSearch}%` } },
-    ]
+    // never matches a plaintext search term. Use search_tokens table for partial
+    // matches and emailHash for exact email lookups.
+    const searchFilter: Record<string, unknown>[] = []
+
+    // Search encrypted fields via search_tokens
+    const matchedIds = await findCustomerUserIdsBySearchTokens(em, 'customer_accounts:customer_user', trimmedSearch, auth.tenantId)
+    if (matchedIds && matchedIds.length) {
+      searchFilter.push({ id: { $in: matchedIds } })
+    }
+
+    // Also support exact email lookup via emailHash
     if (EMAIL_LIKE_PATTERN.test(search)) {
       searchFilter.push({ emailHash: hashForLookup(search) })
     }
-    if (where.$or) {
-      where.$and = [{ $or: where.$or }, { $or: searchFilter }]
-      delete where.$or
+
+    if (searchFilter.length > 0) {
+      if (where.$or) {
+        where.$and = [{ $or: where.$or }, { $or: searchFilter }]
+        delete where.$or
+      } else {
+        where.$or = searchFilter
+      }
     } else {
-      where.$or = searchFilter
+      // No search results found, return empty
+      return NextResponse.json({
+        ok: true,
+        items: [],
+        total: 0,
+        totalPages: 1,
+        page,
+      })
     }
   }
 
@@ -269,6 +289,40 @@ const successSchema = z.object({
   user: z.object({ id: z.string().uuid(), email: z.string(), displayName: z.string() }),
 })
 const errorSchema = z.object({ ok: z.literal(false), error: z.string() })
+
+async function findCustomerUserIdsBySearchTokens(
+  em: EntityManager,
+  entityType: string,
+  search: string,
+  tenantScope: string | null | undefined,
+  field?: string,
+): Promise<string[] | null> {
+  const trimmed = search.trim()
+  if (!trimmed) return null
+  const searchConfig = resolveSearchConfig()
+  if (!searchConfig.enabled) return []
+  const { hashes } = tokenizeText(trimmed, searchConfig)
+  if (!hashes.length) return []
+
+  const db = (em as any).getKysely() as any
+  let query = db
+    .selectFrom('search_tokens')
+    .select('entity_id')
+    .where('entity_type', '=', entityType)
+    .where('token_hash', 'in', hashes)
+    .groupBy('entity_id')
+    .having(sql<boolean>`count(distinct token_hash) >= ${hashes.length}`)
+  if (field) {
+    query = query.where('field', '=', field)
+  }
+  if (tenantScope !== undefined) {
+    query = query.where(sql<boolean>`tenant_id is not distinct from ${tenantScope}`)
+  }
+  const rows = (await query.execute()) as Array<{ entity_id?: unknown }>
+  return rows
+    .map((row) => (typeof row.entity_id === 'string' ? row.entity_id : null))
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
 
 const getMethodDoc: OpenApiMethodDoc = {
   summary: 'List customer users (admin)',

--- a/packages/core/src/modules/customer_accounts/api/admin/users.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users.ts
@@ -76,7 +76,7 @@ export async function GET(req: Request) {
 
     // Search encrypted fields via search_tokens
     const matchedIds = await findCustomerUserIdsBySearchTokens(em, 'customer_accounts:customer_user', trimmedSearch, auth.tenantId)
-    if (matchedIds && matchedIds.length) {
+    if (matchedIds && matchedIds.length > 0) {
       searchFilter.push({ id: { $in: matchedIds } })
     }
 


### PR DESCRIPTION
## Summary
Fixes issue #2034 by implementing proper search functionality for customer users with encrypted email and displayName fields.

## Problem
The existing search implementation attempted to use SQL ILIKE queries directly on encrypted fields (email, displayName), which would never match plaintext search terms since it was comparing against ciphertext.

## Solution
- Replaced direct ILIKE queries on encrypted fields with search token-based lookups
- Added `findCustomerUserIdsBySearchTokens` function to query the `search_tokens` table
- Maintains support for exact email lookups via `emailHash` for backward compatibility
- Handles empty search results gracefully by returning empty response when no tokens match

## Changes
- **packages/core/src/modules/customer_accounts/api/admin/users.ts**:
  - Added imports for search token functionality
  - Replaced encrypted field ILIKE searches with token-based search
  - Added `findCustomerUserIdsBySearchTokens` helper function
  - Improved search logic to handle multiple search strategies (tokens + email hash)

## Test Plan
- [ ] Test search functionality with partial names/emails on encrypted customer data
- [ ] Verify exact email lookup still works via emailHash
- [ ] Test search with special characters and edge cases
- [ ] Verify pagination works correctly with search results
- [ ] Test empty search queries return appropriate results

Closes #2034

🤖 Generated with [Claude Code](https://claude.com/claude-code)