### PR TITLE
fix(sales): prevent negative discount adjustments (#1704)

### DIFF
--- a/packages/core/src/modules/sales/api/order-adjustments/route.ts
+++ b/packages/core/src/modules/sales/api/order-adjustments/route.ts
@@ -5,6 +5,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { SalesOrderAdjustment } from '../../data/entities'
 import {
   enforceReturnAdjustmentSign,
+  enforceNonReturnAdjustmentSign,
   orderAdjustmentCreateSchema,
 } from '../../data/validators'
 import { createPagedListResponseSchema, createSalesCrudOpenApi, defaultOkResponseSchema } from '../openapi'
@@ -35,6 +36,7 @@ const routeMetadata = {
 const upsertSchema = orderAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
   .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceNonReturnAdjustmentSign)
 
 const deleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/api/quote-adjustments/route.ts
+++ b/packages/core/src/modules/sales/api/quote-adjustments/route.ts
@@ -5,6 +5,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { SalesQuoteAdjustment } from '../../data/entities'
 import {
   enforceReturnAdjustmentSign,
+  enforceNonReturnAdjustmentSign,
   quoteAdjustmentCreateSchema,
 } from '../../data/validators'
 import { createPagedListResponseSchema, createSalesCrudOpenApi, defaultOkResponseSchema } from '../openapi'
@@ -35,6 +36,7 @@ const routeMetadata = {
 const upsertSchema = quoteAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
   .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceNonReturnAdjustmentSign)
 
 const deleteSchema = z.object({
   id: z.string().uuid(),

--- a/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
+++ b/packages/core/src/modules/sales/data/__tests__/validators.adjustment-sign.test.ts
@@ -3,6 +3,7 @@ import {
   RETURN_ADJUSTMENT_POSITIVE_GROSS_MESSAGE,
   RETURN_ADJUSTMENT_POSITIVE_NET_MESSAGE,
   enforceReturnAdjustmentSign,
+  enforceNonReturnAdjustmentSign,
   orderAdjustmentCreateSchema,
   quoteAdjustmentCreateSchema,
 } from '../validators'
@@ -18,10 +19,12 @@ const QUOTE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
 const orderUpsertSchema = orderAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
   .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceNonReturnAdjustmentSign)
 
 const quoteUpsertSchema = quoteAdjustmentCreateSchema
   .extend({ id: z.string().uuid().optional() })
   .superRefine(enforceReturnAdjustmentSign)
+  .superRefine(enforceNonReturnAdjustmentSign)
 
 describe('enforceReturnAdjustmentSign — order adjustments', () => {
   const base = {
@@ -90,6 +93,20 @@ describe('enforceReturnAdjustmentSign — order adjustments', () => {
     })
     expect(result.success).toBe(true)
   })
+
+  it('rejects negative amounts for discount adjustments', () => {
+    const result = orderUpsertSchema.safeParse({
+      ...base,
+      kind: 'discount',
+      amountNet: -1,
+      amountGross: -1,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages.some(m => m.includes('Non-return adjustments must use non-negative amounts.'))).toBe(true)
+    }
+  })
 })
 
 describe('enforceReturnAdjustmentSign — quote adjustments', () => {
@@ -122,5 +139,19 @@ describe('enforceReturnAdjustmentSign — quote adjustments', () => {
       amountGross: -7.5,
     })
     expect(result.success).toBe(true)
+  })
+
+  it('rejects negative amounts for discount adjustments on quotes', () => {
+    const result = quoteUpsertSchema.safeParse({
+      ...base,
+      kind: 'discount',
+      amountNet: -2,
+      amountGross: -2,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message)
+      expect(messages.some(m => m.includes('Non-return adjustments must use non-negative amounts.'))).toBe(true)
+    }
   })
 })

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -454,6 +454,27 @@ export const enforceReturnAdjustmentSign = (
   }
 }
 
+export const enforceNonReturnAdjustmentSign = (
+  value: AdjustmentSignInput,
+  ctx: z.RefinementCtx
+) => {
+  if (value.kind === 'return') return
+  if (typeof value.amountNet === 'number' && value.amountNet < 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Non-return adjustments must use non-negative amounts.',
+      path: ['amountNet'],
+    })
+  }
+  if (typeof value.amountGross === 'number' && value.amountGross < 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Non-return adjustments must use non-negative amounts.',
+      path: ['amountGross'],
+    })
+  }
+}
+
 export const orderAdjustmentCreateSchema = scoped.extend({
   orderId: uuid(),
   orderLineId: uuid().optional(),


### PR DESCRIPTION
Fixes #1704

## Problem
Negative discount amounts in order and quote adjustments cause incorrect calculations where the discount increases the total instead of decreasing it. This happens because the calculation logic subtracts the discount amount, so a negative discount becomes subtraction of a negative number (addition).

## Root Cause
The adjustment validation only enforced positive amounts for `return` kind adjustments but allowed negative amounts for all other adjustment types including `discount`. This allowed semantically invalid data where discount amounts could be negative.

## What Changed
- Added `enforceNonReturnAdjustmentSign` validator function that rejects negative amounts for all adjustment kinds except 'return'
- Applied the new validator to both order and quote adjustment API routes alongside existing `enforceReturnAdjustmentSign`
- Updated validation tests to verify discount adjustments with negative amounts are properly rejected

## Tests
- Added regression tests for both order and quote adjustments to verify negative discount amounts are rejected
- Verified existing return adjustment tests continue to pass (preserving negative amount support for returns)
- Ran full validation gate: build:packages, generate, typecheck - all steps passed successfully

## Backward Compatibility
No contract changes. This change tightens input validation to reject semantically invalid data (negative discount amounts) but does not modify any API response schemas, event structures, or stable interfaces. All existing valid use cases continue to work unchanged.

🤖 Generated by autofix.