### PR TITLE
fix(staff): team delete shows success toast despite 409 rejection (#2049)

### DIFF
--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md
@@ -1,0 +1,27 @@
+# Handoff — 2026-05-25-fix-staff-team-delete-success-toast
+
+**Last updated:** 2026-05-25T00:00:00Z
+**Branch:** fix/fix-staff-team-delete-success-toast
+**PR:** not yet opened
+**Current phase/step:** Phase 1 Step 1.1
+**Last commit:** — (run folder not yet committed)
+
+## What just happened
+- Run folder created with PLAN.md, HANDOFF.md, NOTIFY.md
+- Root cause confirmed: `handleDelete` in edit page swallows 409 error, CrudForm sees resolved promise, fires success toast
+- Double-toast risk resolved in plan: remove flash from success path too, keep router.push
+
+## Next concrete action
+- Step 1.1: Edit `packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx` — replace `handleDelete` (lines 283–297)
+
+## Blockers / open questions
+- None
+
+## Environment caveats
+- Dev runtime runnable: unknown
+- Playwright / browser checks: skipped (no UI path changed structurally — logic-only fix)
+- Database/migration state: clean (no schema changes)
+
+## Worktree
+- Path: TBD (worktree being created)
+- Created this run: yes

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md
@@ -1,10 +1,10 @@
 # Handoff — 2026-05-25-fix-staff-team-delete-success-toast
 
-**Last updated:** 2026-05-25T09:36:00Z
+**Last updated:** 2026-05-25T09:46:00Z
 **Branch:** fix/fix-staff-team-delete-success-toast
-**PR:** not yet opened
-**Current phase/step:** All steps complete (1.1 ✅, 2.1 ✅) — opening PR
-**Last commit:** 42abcb811 — test(staff): add 409 integration test for team delete with assigned members
+**PR:** https://github.com/open-mercato/open-mercato/pull/2051
+**Current phase/step:** DONE — PR opened, run complete
+**Last commit:** d38f687ad — docs(runs): checkpoint 1 — steps 1.1..2.1 verified
 
 ## What just happened
 - Step 1.1: Removed try/catch and success flash from `handleDelete` in `staff/teams/[id]/edit/page.tsx`. CrudForm now owns the error flow for 409 rejections.
@@ -12,7 +12,7 @@
 - Checkpoint 1 passed.
 
 ## Next concrete action
-- Open PR against develop, claim with three-signal in-progress lock
+- None — run is complete. PR #2051 is open and awaiting review.
 
 ## Blockers / open questions
 - None

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md
@@ -1,27 +1,27 @@
 # Handoff — 2026-05-25-fix-staff-team-delete-success-toast
 
-**Last updated:** 2026-05-25T00:00:00Z
+**Last updated:** 2026-05-25T09:36:00Z
 **Branch:** fix/fix-staff-team-delete-success-toast
 **PR:** not yet opened
-**Current phase/step:** Phase 1 Step 1.1
-**Last commit:** — (run folder not yet committed)
+**Current phase/step:** All steps complete (1.1 ✅, 2.1 ✅) — opening PR
+**Last commit:** 42abcb811 — test(staff): add 409 integration test for team delete with assigned members
 
 ## What just happened
-- Run folder created with PLAN.md, HANDOFF.md, NOTIFY.md
-- Root cause confirmed: `handleDelete` in edit page swallows 409 error, CrudForm sees resolved promise, fires success toast
-- Double-toast risk resolved in plan: remove flash from success path too, keep router.push
+- Step 1.1: Removed try/catch and success flash from `handleDelete` in `staff/teams/[id]/edit/page.tsx`. CrudForm now owns the error flow for 409 rejections.
+- Step 2.1: Added 409 test case to TC-STAFF-002. Creates team + member, asserts DELETE returns 409, teardown deletes member then team.
+- Checkpoint 1 passed.
 
 ## Next concrete action
-- Step 1.1: Edit `packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx` — replace `handleDelete` (lines 283–297)
+- Open PR against develop, claim with three-signal in-progress lock
 
 ## Blockers / open questions
 - None
 
 ## Environment caveats
-- Dev runtime runnable: unknown
-- Playwright / browser checks: skipped (no UI path changed structurally — logic-only fix)
+- Dev runtime runnable: unknown (no dev server started)
+- Playwright / browser checks: skipped (logic-only fix, no structural UI change)
 - Database/migration state: clean (no schema changes)
 
 ## Worktree
-- Path: TBD (worktree being created)
+- Path: /home/bernard/workspace/OpenMercatoTest/.ai/tmp/auto-create-pr/fix-staff-team-delete-success-toast-20260525-093133
 - Created this run: yes

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md
@@ -1,0 +1,10 @@
+# Notify — 2026-05-25-fix-staff-team-delete-success-toast
+
+> Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
+
+## 2026-05-25T00:00:00Z — run started
+- Brief: Fix staff team delete success toast on 409 rejection (issue #2049)
+- External skill URLs: none
+- Source spec: .ai/specs/2026-05-25-fix-staff-team-delete-success-toast.md
+- Steps: 2 (1.1 fix handleDelete, 2.1 add 409 integration test)
+- Decision: remove try/catch AND success flash from handleDelete to avoid double-toast on happy path. CrudForm's generic "Item deleted successfully." flash is sufficient.

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md
@@ -2,6 +2,12 @@
 
 > Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
 
+## 2026-05-25T09:46:00Z — run complete
+- PR #2051 opened: https://github.com/open-mercato/open-mercato/pull/2051
+- Completion comment posted on PR
+- All tracking files finalized
+- Labels (bug, skip-qa, review) require maintainer to apply (no label-write access to upstream)
+
 ## 2026-05-25T09:36:00Z — checkpoint 1 complete
 - Steps covered: 1.1 (1aa45ad89) → 2.1 (42abcb811)
 - handleDelete structure verified (no try/catch, no flash in success path)

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md
@@ -2,6 +2,13 @@
 
 > Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
 
+## 2026-05-25T09:36:00Z — checkpoint 1 complete
+- Steps covered: 1.1 (1aa45ad89) → 2.1 (42abcb811)
+- handleDelete structure verified (no try/catch, no flash in success path)
+- Integration test shape verified
+- Pre-existing typecheck errors in unrelated packages (sync-akeneo, attachments) — not introduced by this run
+- Opening PR next
+
 ## 2026-05-25T00:00:00Z — run started
 - Brief: Fix staff team delete success toast on 409 rejection (issue #2049)
 - External skill URLs: none

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
@@ -8,7 +8,7 @@ Source spec: .ai/specs/2026-05-25-fix-staff-team-delete-success-toast.md
 
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
-| 1 | 1.1 | Fix handleDelete — remove try/catch and redundant flash | todo | — |
+| 1 | 1.1 | Fix handleDelete — remove try/catch and redundant flash | done | 6ea19dc98 |
 | 2 | 2.1 | Add 409 integration test for delete-with-members | todo | — |
 
 ## Goal

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
@@ -8,8 +8,8 @@ Source spec: .ai/specs/2026-05-25-fix-staff-team-delete-success-toast.md
 
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
-| 1 | 1.1 | Fix handleDelete — remove try/catch and redundant flash | done | 6ea19dc98 |
-| 2 | 2.1 | Add 409 integration test for delete-with-members | todo | — |
+| 1 | 1.1 | Fix handleDelete — remove try/catch and redundant flash | done | 1aa45ad89 |
+| 2 | 2.1 | Add 409 integration test for delete-with-members | done | 3a1d285cd |
 
 ## Goal
 

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
@@ -1,0 +1,93 @@
+# fix-staff-team-delete-success-toast
+
+Source spec: .ai/specs/2026-05-25-fix-staff-team-delete-success-toast.md
+
+## Tasks
+
+> Authoritative status table. `Status` is one of `todo` or `done`. On landing a Step, flip `Status` to `done` and fill the `Commit` column with the short SHA. The first row whose `Status` is not `done` is the resume point for `auto-continue-pr`. Step ids are immutable once a Step has a commit.
+
+| Phase | Step | Title | Status | Commit |
+|-------|------|-------|--------|--------|
+| 1 | 1.1 | Fix handleDelete — remove try/catch and redundant flash | todo | — |
+| 2 | 2.1 | Add 409 integration test for delete-with-members | todo | — |
+
+## Goal
+
+Fix the staff team delete UX bug (issue #2049): when a team with assigned members is deleted via the edit page, the backend returns 409 but the UI shows a success toast. Root cause: the edit page's `handleDelete` swallows the thrown error and returns normally, causing `CrudForm` to call its own success flash.
+
+## Scope
+
+- `packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx` — fix `handleDelete`
+- `packages/core/src/modules/staff/__integration__/TC-STAFF-002.spec.ts` — add 409 test case
+
+## Non-Goals
+
+- Hiding the delete button on the edit page when members exist (follow-up UX improvement)
+- Changing CrudForm error handling
+- Any other staff module changes
+
+## Risks
+
+- **Double toast on happy path**: after removing try/catch, `handleDelete`'s `flash('Team deleted.', 'success')` would show alongside CrudForm's own `flash('Item deleted successfully.', 'success')`. Fix: remove the module-specific `flash` from `handleDelete`'s success path too; CrudForm's generic flash is sufficient. The `router.push` stays.
+- **Integration test fixture**: uses `/api/staff/team-members` POST with `{ teamId, displayName }` — confirmed from `staffTeamMemberCreateSchema`.
+
+## Implementation Plan
+
+### Phase 1: Fix handleDelete
+
+#### Step 1.1 — Fix handleDelete — remove try/catch and redundant flash
+
+File: `packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx`
+
+Replace the `handleDelete` callback (lines 283–297):
+
+**Before:**
+```tsx
+const handleDelete = React.useCallback(async () => {
+  if (!teamId) return
+  try {
+    await deleteCrud('staff/teams', teamId, {
+      errorMessage: t('staff.teams.errors.delete', 'Failed to delete team.'),
+    })
+    flash(t('staff.teams.messages.deleted', 'Team deleted.'), 'success')
+    router.push('/backend/staff/teams')
+  } catch (error) {
+    const message = error instanceof Error
+      ? error.message
+      : t('staff.teams.errors.delete', 'Failed to delete team.')
+    flash(message, 'error')
+  }
+}, [teamId, router, t])
+```
+
+**After:**
+```tsx
+const handleDelete = React.useCallback(async () => {
+  if (!teamId) return
+  await deleteCrud('staff/teams', teamId, {
+    errorMessage: t('staff.teams.errors.delete', 'Failed to delete team.'),
+  })
+  router.push('/backend/staff/teams')
+}, [teamId, router, t])
+```
+
+Rationale:
+- Removing try/catch lets `deleteCrud` throw on 409. `CrudForm`'s outer `catch (err)` (CrudForm.tsx:1206) handles the error flash.
+- Removing the success `flash` avoids a double toast (edit page + CrudForm both flash). `CrudForm` shows `t('ui.forms.flash.deleteSuccess')` = "Item deleted successfully." after `await onDelete()` resolves.
+- Removing `t` from the dependency array since it's no longer used (if `t` is still used by other callbacks it stays — verify during implementation).
+
+### Phase 2: Integration test
+
+#### Step 2.1 — Add 409 integration test for delete-with-members
+
+File: `packages/core/src/modules/staff/__integration__/TC-STAFF-002.spec.ts`
+
+Add a second test to the existing `test.describe` block. The test:
+1. Creates a team
+2. POSTs a team member to `/api/staff/team-members` with `{ teamId, displayName }`
+3. Attempts DELETE `/api/staff/teams?id=<teamId>`
+4. Expects 409 with error message matching `/assigned member/i`
+5. Teardown: deletes member first (unblocks team), then team
+
+Member creation endpoint: `POST /api/staff/team-members` with body `{ teamId: <uuid>, displayName: 'QA Member ...' }`
+Member deletion endpoint: `DELETE /api/staff/team-members?id=<memberId>` (mirrors team pattern)

--- a/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/checkpoint-1-checks.md
+++ b/.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/checkpoint-1-checks.md
@@ -1,0 +1,24 @@
+# Checkpoint 1 — Steps 1.1..2.1
+
+**Checkpoint index:** 1
+**Steps covered:** 1.1 (1aa45ad89) → 2.1 (42abcb811)
+**Touched packages:** `packages/core` (staff module edit page + integration test)
+
+## Checks
+
+| Check | Result | Notes |
+|-------|--------|-------|
+| handleDelete structure (AST parse) | ✅ Pass | No try/catch, no flash in success path confirmed via node script |
+| `flash` import still present | ✅ Pass | Used by other callbacks in the same file |
+| `t` dep in useCallback | ✅ Pass | Still needed for `errorMessage` in deleteCrud call |
+| TypeCheck root | ⚠️ Skip | Pre-existing `#generated/entities.ids.generated` errors in unrelated modules (attachments, sync-akeneo); worker unable to run `yarn generate` without dev DB |
+| Integration test structure | ✅ Pass | TC-STAFF-002 second test: creates team + member, asserts 409, teardown deletes member then team |
+| `createStaffTeamFixture` import added | ✅ Pass | Import updated from staffFixtures |
+| Teardown order | ✅ Pass | Member deleted before team (unblocks team deletion) |
+
+## UI verification
+Skipped — this is a logic-only fix in an async callback. No structural UI change. No new pages, routes, or widgets added. No Playwright session needed at this checkpoint.
+
+## Notes
+- Double-toast risk resolved: removed both `try/catch` AND the success `flash` from `handleDelete`. CrudForm shows "Item deleted successfully." on success, handles error flash on 409.
+- Pre-existing typecheck errors in `sync-akeneo` and `attachments` (missing generated shims) are unrelated to this run.

--- a/packages/core/src/modules/staff/__integration__/TC-STAFF-002.spec.ts
+++ b/packages/core/src/modules/staff/__integration__/TC-STAFF-002.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
-import { deleteStaffEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/staffFixtures';
+import { createStaffTeamFixture, deleteStaffEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/staffFixtures';
 
 /**
  * TC-STAFF-002: Staff Team CRUD via API
@@ -51,6 +51,42 @@ test.describe('TC-STAFF-002: Staff Team CRUD via API', () => {
       expect(deleteResponse.status(), 'DELETE /api/staff/teams should return 200').toBe(200);
       teamId = null;
     } finally {
+      await deleteStaffEntityIfExists(request, token, '/api/staff/teams', teamId);
+    }
+  });
+
+  test('should reject deletion of a team that has assigned members (409)', async ({ request }) => {
+    let token: string | null = null;
+    let teamId: string | null = null;
+    let memberId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+
+      teamId = await createStaffTeamFixture(request, token);
+
+      const memberResponse = await apiRequest(request, 'POST', '/api/staff/team-members', {
+        token,
+        data: { teamId, displayName: `QA TC-STAFF-002-409 ${Date.now()}` },
+      });
+      expect(memberResponse.status(), 'POST /api/staff/team-members should return 201').toBe(201);
+      const memberBody = (await memberResponse.json()) as { id?: string };
+      memberId = memberBody.id ?? null;
+
+      const deleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `/api/staff/teams?id=${encodeURIComponent(teamId)}`,
+        { token },
+      );
+      expect(
+        deleteResponse.status(),
+        'DELETE /api/staff/teams with assigned members should return 409',
+      ).toBe(409);
+      const deleteBody = (await deleteResponse.json()) as { error?: string };
+      expect(deleteBody.error, 'Error body should mention assigned members').toMatch(/assigned member/i);
+    } finally {
+      await deleteStaffEntityIfExists(request, token, '/api/staff/team-members', memberId);
       await deleteStaffEntityIfExists(request, token, '/api/staff/teams', teamId);
     }
   });

--- a/packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx
@@ -282,18 +282,10 @@ export default function StaffTeamEditPage({ params }: { params?: { id?: string }
 
   const handleDelete = React.useCallback(async () => {
     if (!teamId) return
-    try {
-      await deleteCrud('staff/teams', teamId, {
-        errorMessage: t('staff.teams.errors.delete', 'Failed to delete team.'),
-      })
-      flash(t('staff.teams.messages.deleted', 'Team deleted.'), 'success')
-      router.push('/backend/staff/teams')
-    } catch (error) {
-      const message = error instanceof Error
-        ? error.message
-        : t('staff.teams.errors.delete', 'Failed to delete team.')
-      flash(message, 'error')
-    }
+    await deleteCrud('staff/teams', teamId, {
+      errorMessage: t('staff.teams.errors.delete', 'Failed to delete team.'),
+    })
+    router.push('/backend/staff/teams')
   }, [teamId, router, t])
 
   return (


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md
Tracking run folder: .ai/runs/2026-05-25-fix-staff-team-delete-success-toast/
Status: complete

Fixes #2049

## Goal
- Fix staff team delete UX bug: editing a team with assigned members and clicking Delete shows a success toast ("Item deleted successfully.") even though the backend returns 409 ("Team has assigned members and cannot be deleted.")

## What Changed
- **Phase 1** — `packages/core/src/modules/staff/backend/staff/teams/[id]/edit/page.tsx`: removed the try/catch wrapper from `handleDelete`. The local catch block was swallowing the 409 error and returning normally, causing `CrudForm` to interpret the delete as successful and fire its success toast. With the try/catch gone, `deleteCrud` throws on 409 and `CrudForm`'s outer catch handles the error flash. Also removed the module-specific success flash to avoid a double toast on the happy path.
- **Phase 2** — `packages/core/src/modules/staff/__integration__/TC-STAFF-002.spec.ts`: added a second test case that creates a team, assigns a member, and asserts `DELETE /api/staff/teams` returns 409 with an error referencing assigned members. Teardown deletes the member first to unblock team cleanup.

## Tests
- New integration test: TC-STAFF-002 second case — 409 for delete-with-members
- Existing TC-STAFF-002 happy path unchanged

## Backward Compatibility
- No contract surface changes. The 409 response from the backend is unchanged. Only the frontend error-handling path is fixed.

## Progress
See the [Tasks table in the plan](.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/PLAN.md#tasks) — that is the authoritative Step-status source.

## Handoff & Notifications
- Live handoff: `.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/HANDOFF.md`
- Notifications log: `.ai/runs/2026-05-25-fix-staff-team-delete-success-toast/NOTIFY.md`