### PR TITLE
fix(widgets): correct injection context keys for AI Deal Analyzer (#2053)

### DIFF
--- a/packages/core/src/modules/catalog/widgets/injection/merchandising-assistant-trigger/widget.client.tsx
+++ b/packages/core/src/modules/catalog/widgets/injection/merchandising-assistant-trigger/widget.client.tsx
@@ -32,8 +32,8 @@ interface HostInjectionContext {
   total?: number | string
   totalMatching?: number | string
   /** Selected row IDs from DataTable (auto-enriched when bulk actions are present). */
-  _selectedRowIds?: string[]
-  _selectedCount?: number
+  selectedRowIds?: string[]
+  selectedCount?: number
 }
 
 interface MerchandisingAssistantTriggerProps {
@@ -83,8 +83,8 @@ export function computeCatalogMerchandisingPageContext(
   context: HostInjectionContext | undefined,
 ): MerchandisingPageContext {
   const totalMatching = readNumber(context?.totalMatching ?? context?.total)
-  const selectedRowIds = Array.isArray(context?._selectedRowIds) ? context._selectedRowIds : []
-  const selectedCount = selectedRowIds.length > 0 ? selectedRowIds.length : readNumber(context?._selectedCount)
+  const selectedRowIds = Array.isArray(context?.selectedRowIds) ? context.selectedRowIds : []
+  const selectedCount = selectedRowIds.length > 0 ? selectedRowIds.length : readNumber(context?.selectedCount)
   return {
     view: 'catalog.products.list',
     entityType: 'catalog.products.list',

--- a/packages/core/src/modules/customers/widgets/injection/ai-deal-analyzer-trigger/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/customers/widgets/injection/ai-deal-analyzer-trigger/__tests__/widget.client.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Unit tests for the AI Deal Analyzer widget injection context handling.
+ *
+ * Covers:
+ *  - `buildDealAnalyzerPageContext` produces correct recordId and selectedCount
+ *    from the host injection context
+ *  - Widget correctly handles selectedRowIds and selectedCount from DataTable
+ *  - Regression test for issue #2053: ensures DataTable key names match widget expectations
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import AiDealAnalyzerTriggerWidget from '../widget.client'
+
+// Mock the buildDealAnalyzerPageContext function to test it directly
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/ui/ai/AiChat', () => ({
+  AiChat: () => <div data-testid="mock-ai-chat" />,
+}))
+
+describe('AI Deal Analyzer injection context', () => {
+  it('builds correct recordId from selectedRowIds', () => {
+    const mockContext = {
+      selectedRowIds: ['deal-1', 'deal-2', 'deal-3'],
+      selectedCount: 3,
+      totalMatching: 10,
+    }
+
+    render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
+
+    // The widget should render (not return null) when valid selectedRowIds are provided
+    // This indirectly tests that buildDealAnalyzerPageContext works correctly
+  })
+
+  it('handles empty selection gracefully', () => {
+    const mockContext = {
+      selectedRowIds: [],
+      selectedCount: 0,
+      totalMatching: 10,
+    }
+
+    const { container } = render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
+
+    // Widget should still render but with null recordId
+    expect(container.firstChild).not.toBeNull()
+  })
+
+  it('handles missing injection context gracefully', () => {
+    const { container } = render(<AiDealAnalyzerTriggerWidget context={{}} />)
+
+    // Widget should render but with default values
+    expect(container.firstChild).not.toBeNull()
+  })
+
+  // Regression test for issue #2053 - ensure DataTable and widget use same key names
+  it('uses correct key names for injection context', () => {
+    // This test documents the expected key names to prevent future mismatches
+    const expectedKeys = {
+      selectedRowIds: 'selectedRowIds',
+      selectedCount: 'selectedCount',
+      totalMatching: 'totalMatching',
+    }
+
+    const mockContext = {
+      [expectedKeys.selectedRowIds]: ['deal-1', 'deal-2'],
+      [expectedKeys.selectedCount]: 2,
+      [expectedKeys.totalMatching]: 5,
+    }
+
+    render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
+
+    // If this test passes, it confirms the widget expects these exact key names
+    // Any change to DataTable injection keys must match these expectations
+  })
+
+  it('prioritizes selectedRowIds length over selectedCount when both provided', () => {
+    const mockContext = {
+      selectedRowIds: ['deal-1', 'deal-2', 'deal-3'],
+      selectedCount: 999, // Wrong count, should be ignored
+      totalMatching: 10,
+    }
+
+    render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
+
+    // Widget should use selectedRowIds.length (3) not selectedCount (999)
+    // This tests the priority logic in buildDealAnalyzerPageContext
+  })
+})

--- a/packages/core/src/modules/customers/widgets/injection/ai-deal-analyzer-trigger/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/customers/widgets/injection/ai-deal-analyzer-trigger/__tests__/widget.client.test.tsx
@@ -1,92 +1,111 @@
 /**
- * @jest-environment jsdom
- *
- * Unit tests for the AI Deal Analyzer widget injection context handling.
- *
- * Covers:
- *  - `buildDealAnalyzerPageContext` produces correct recordId and selectedCount
- *    from the host injection context
- *  - Widget correctly handles selectedRowIds and selectedCount from DataTable
- *  - Regression test for issue #2053: ensures DataTable key names match widget expectations
+ * Regression tests for issue #2053. The DataTable host emits selection state
+ * into the injection context under bare keys (`selectedRowIds` /
+ * `selectedCount`); the AI Deal Analyzer widget must consume the same keys.
+ * Each test asserts on the resolved `DealAnalyzerPageContext` so a future
+ * renaming on either side (for example re-introducing `_selectedRowIds` on
+ * the DataTable while the widget still reads bare keys) breaks the build.
  */
-import * as React from 'react'
-import { render } from '@testing-library/react'
-import AiDealAnalyzerTriggerWidget from '../widget.client'
+import { buildDealAnalyzerPageContext } from '../widget.client'
 
-// Mock the buildDealAnalyzerPageContext function to test it directly
-jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
-  useT: () => (_key: string, fallback: string) => fallback ?? _key,
-}))
-
-jest.mock('@open-mercato/ui/ai/AiChat', () => ({
-  AiChat: () => <div data-testid="mock-ai-chat" />,
-}))
-
-describe('AI Deal Analyzer injection context', () => {
-  it('builds correct recordId from selectedRowIds', () => {
-    const mockContext = {
+describe('buildDealAnalyzerPageContext (regression for #2053)', () => {
+  it('joins selectedRowIds into a comma-separated recordId and reports the selection count', () => {
+    const ctx = buildDealAnalyzerPageContext({
       selectedRowIds: ['deal-1', 'deal-2', 'deal-3'],
       selectedCount: 3,
       totalMatching: 10,
-    }
+    })
 
-    render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
-
-    // The widget should render (not return null) when valid selectedRowIds are provided
-    // This indirectly tests that buildDealAnalyzerPageContext works correctly
+    expect(ctx.view).toBe('customers.deals.list')
+    expect(ctx.recordType).toBeNull()
+    expect(ctx.recordId).toBe('deal-1,deal-2,deal-3')
+    expect(ctx.extra.selectedCount).toBe(3)
+    expect(ctx.extra.totalMatching).toBe(10)
   })
 
-  it('handles empty selection gracefully', () => {
-    const mockContext = {
+  it('returns null recordId and zero selection count when the host has no selection', () => {
+    const ctx = buildDealAnalyzerPageContext({
       selectedRowIds: [],
       selectedCount: 0,
       totalMatching: 10,
-    }
+    })
 
-    const { container } = render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
-
-    // Widget should still render but with null recordId
-    expect(container.firstChild).not.toBeNull()
+    expect(ctx.recordId).toBeNull()
+    expect(ctx.extra.selectedCount).toBe(0)
+    expect(ctx.extra.totalMatching).toBe(10)
   })
 
-  it('handles missing injection context gracefully', () => {
-    const { container } = render(<AiDealAnalyzerTriggerWidget context={{}} />)
+  it('returns null recordId and zero counts when the injection context is empty', () => {
+    const ctx = buildDealAnalyzerPageContext({})
 
-    // Widget should render but with default values
-    expect(container.firstChild).not.toBeNull()
+    expect(ctx.recordId).toBeNull()
+    expect(ctx.extra.selectedCount).toBe(0)
+    expect(ctx.extra.totalMatching).toBe(0)
   })
 
-  // Regression test for issue #2053 - ensure DataTable and widget use same key names
-  it('uses correct key names for injection context', () => {
-    // This test documents the expected key names to prevent future mismatches
-    const expectedKeys = {
-      selectedRowIds: 'selectedRowIds',
-      selectedCount: 'selectedCount',
-      totalMatching: 'totalMatching',
-    }
+  it('returns null recordId and zero counts when no injection context is supplied at all', () => {
+    const ctx = buildDealAnalyzerPageContext(undefined)
 
-    const mockContext = {
-      [expectedKeys.selectedRowIds]: ['deal-1', 'deal-2'],
-      [expectedKeys.selectedCount]: 2,
-      [expectedKeys.totalMatching]: 5,
-    }
-
-    render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
-
-    // If this test passes, it confirms the widget expects these exact key names
-    // Any change to DataTable injection keys must match these expectations
+    expect(ctx.recordId).toBeNull()
+    expect(ctx.extra.selectedCount).toBe(0)
+    expect(ctx.extra.totalMatching).toBe(0)
   })
 
-  it('prioritizes selectedRowIds length over selectedCount when both provided', () => {
-    const mockContext = {
+  it('prefers selectedRowIds.length over selectedCount when both are supplied', () => {
+    const ctx = buildDealAnalyzerPageContext({
       selectedRowIds: ['deal-1', 'deal-2', 'deal-3'],
-      selectedCount: 999, // Wrong count, should be ignored
+      selectedCount: 999,
       totalMatching: 10,
-    }
+    })
 
-    render(<AiDealAnalyzerTriggerWidget context={mockContext} />)
+    expect(ctx.extra.selectedCount).toBe(3)
+    expect(ctx.recordId).toBe('deal-1,deal-2,deal-3')
+  })
 
-    // Widget should use selectedRowIds.length (3) not selectedCount (999)
-    // This tests the priority logic in buildDealAnalyzerPageContext
+  it('falls back to selectedCount when selectedRowIds is missing', () => {
+    const ctx = buildDealAnalyzerPageContext({
+      selectedCount: 7,
+      totalMatching: 12,
+    })
+
+    expect(ctx.recordId).toBeNull()
+    expect(ctx.extra.selectedCount).toBe(7)
+    expect(ctx.extra.totalMatching).toBe(12)
+  })
+
+  it('ignores `_selectedRowIds` / `_selectedCount` — the underscore-prefixed shape from before #2053', () => {
+    const legacyContext = {
+      _selectedRowIds: ['deal-1', 'deal-2'],
+      _selectedCount: 2,
+      totalMatching: 9,
+    } as unknown as Parameters<typeof buildDealAnalyzerPageContext>[0]
+
+    const ctx = buildDealAnalyzerPageContext(legacyContext)
+
+    expect(ctx.recordId).toBeNull()
+    expect(ctx.extra.selectedCount).toBe(0)
+    expect(ctx.extra.totalMatching).toBe(9)
+  })
+
+  it('coerces a stringy selectedCount to a number when selectedRowIds is empty', () => {
+    const ctx = buildDealAnalyzerPageContext({
+      selectedRowIds: [],
+      selectedCount: '4' as unknown as number,
+      totalMatching: 20,
+    })
+
+    expect(ctx.extra.selectedCount).toBe(4)
+  })
+
+  it('falls back to `total` and then `rowCount` for totalMatching', () => {
+    const ctxFromTotal = buildDealAnalyzerPageContext({
+      total: 17,
+    } as unknown as Parameters<typeof buildDealAnalyzerPageContext>[0])
+    expect(ctxFromTotal.extra.totalMatching).toBe(17)
+
+    const ctxFromRowCount = buildDealAnalyzerPageContext({
+      rowCount: 5,
+    } as unknown as Parameters<typeof buildDealAnalyzerPageContext>[0])
+    expect(ctxFromRowCount.extra.totalMatching).toBe(5)
   })
 })

--- a/packages/core/src/modules/customers/widgets/injection/ai-deal-analyzer-trigger/widget.client.tsx
+++ b/packages/core/src/modules/customers/widgets/injection/ai-deal-analyzer-trigger/widget.client.tsx
@@ -57,7 +57,7 @@ function readString(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
-function buildDealAnalyzerPageContext(context: HostInjectionContext | undefined): DealAnalyzerPageContext {
+export function buildDealAnalyzerPageContext(context: HostInjectionContext | undefined): DealAnalyzerPageContext {
   const selectedIdsRaw = Array.isArray(context?.selectedRowIds) ? context?.selectedRowIds ?? [] : []
   const selectedIds = selectedIdsRaw.map(readString).filter((id) => id.length > 0)
   const selectedCount = selectedIds.length > 0

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -1471,7 +1471,7 @@ export function DataTable<T>({
       if (!hasInjectedBulkActions) return baseInjectionContext
       const selectedIds = Object.keys(rowSelection).filter((key) => rowSelection[key])
       if (selectedIds.length === 0) return baseInjectionContext
-      return { ...baseInjectionContext, _selectedRowIds: selectedIds, _selectedCount: selectedIds.length }
+      return { ...baseInjectionContext, selectedRowIds: selectedIds, selectedCount: selectedIds.length }
     },
     [baseInjectionContext, hasInjectedBulkActions, rowSelection],
   )


### PR DESCRIPTION
Fixes #2053

## Problem
The AI Deal Analyzer widget's recordId and selectedCount are always null/0 because of a key naming mismatch in the DataTable injection context.

## Root Cause
The DataTable was providing injection context keys with underscore prefixes (_selectedRowIds, _selectedCount) but the AI Deal Analyzer widget expected them without underscores (selectedRowIds, selectedCount).

## What Changed
- Updated DataTable.tsx to use correct key names (selectedRowIds, selectedCount) in injection context
- Updated merchandising assistant widget to use consistent key names
- Added comprehensive unit tests for AI Deal Analyzer widget injection context handling

## Tests
- Added regression test for AI Deal Analyzer widget injection context
- Verified existing widget tests still pass
- Full build and typecheck validation completed successfully

## Backward Compatibility
No contract changes - this is a bug fix that aligns internal key naming conventions.

🤖 Generated by autofix.