### PR TITLE
fix(ui): gate upgrade action banner by ACL (#2057)

### DIFF
--- a/apps/mercato/src/app/(backend)/backend/layout.tsx
+++ b/apps/mercato/src/app/(backend)/backend/layout.tsx
@@ -5,6 +5,7 @@ import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
 import { AppShell } from '@open-mercato/ui/backend/AppShell'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 import { profilePathPrefixes } from '@open-mercato/core/modules/auth/lib/profile-sections'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
@@ -82,6 +83,10 @@ export default async function BackendLayout({
   const initialCollapsed = collapsedCookie === '1'
   const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, true)
   const deployEnv = process.env.DEPLOY_ENV
+  const grantedFeatures = Array.isArray(auth?.features)
+    ? auth.features.filter((feature): feature is string => typeof feature === 'string')
+    : []
+  const canManageUpgradeActions = auth?.isSuperAdmin === true || hasAllFeatures(['configs.manage'], grantedFeatures)
   const baseProductName = translate('appShell.productName', 'Open Mercato')
   const productName = deployEnv && deployEnv !== 'local'
     ? `${baseProductName} (${deployEnv.charAt(0).toUpperCase() + deployEnv.slice(1)})`
@@ -99,6 +104,7 @@ export default async function BackendLayout({
       <AppShell
         productName={productName}
         email={auth?.email}
+        canManageUpgradeActions={canManageUpgradeActions}
         groups={[]}
         currentTitle={currentTitle}
         breadcrumb={breadcrumb}

--- a/packages/create-app/template/src/app/(backend)/backend/layout.tsx
+++ b/packages/create-app/template/src/app/(backend)/backend/layout.tsx
@@ -5,6 +5,7 @@ import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
 import { AppShell } from '@open-mercato/ui/backend/AppShell'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
 import { profilePathPrefixes } from '@open-mercato/core/modules/auth/lib/profile-sections'
 import { APP_VERSION } from '@open-mercato/shared/lib/version'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
@@ -82,6 +83,10 @@ export default async function BackendLayout({
   const initialCollapsed = collapsedCookie === '1'
   const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, true)
   const deployEnv = process.env.DEPLOY_ENV
+  const grantedFeatures = Array.isArray(auth?.features)
+    ? auth.features.filter((feature): feature is string => typeof feature === 'string')
+    : []
+  const canManageUpgradeActions = auth?.isSuperAdmin === true || hasAllFeatures(['configs.manage'], grantedFeatures)
   const baseProductName = translate('appShell.productName', 'Open Mercato')
   const productName = deployEnv && deployEnv !== 'local'
     ? `${baseProductName} (${deployEnv.charAt(0).toUpperCase() + deployEnv.slice(1)})`
@@ -99,6 +104,7 @@ export default async function BackendLayout({
       <AppShell
         productName={productName}
         email={auth?.email}
+        canManageUpgradeActions={canManageUpgradeActions}
         groups={[]}
         currentTitle={currentTitle}
         breadcrumb={breadcrumb}

--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -66,6 +66,7 @@ export type AppShellProps = {
   productName?: string
   logo?: ShellLogo
   email?: string
+  canManageUpgradeActions?: boolean
   groups: {
     id?: string
     name: string
@@ -416,7 +417,7 @@ export function AppShell(props: AppShellProps) {
   )
 }
 
-function AppShellBody({ productName, logo, email, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot }: AppShellProps) {
+function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot }: AppShellProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const t = useT()
@@ -1341,7 +1342,7 @@ function AppShellBody({ productName, logo, email, groups, rightHeaderSlot, child
           <InjectionSpot spotId={BACKEND_LAYOUT_TOP_INJECTION_SPOT_ID} context={injectionContext} />
           <FlashMessages />
           <PartialIndexBanner />
-          <UpgradeActionBanner />
+          {canManageUpgradeActions ? <UpgradeActionBanner /> : null}
           <LastOperationBanner />
           <InjectionSpot spotId={BACKEND_RECORD_CURRENT_INJECTION_SPOT_ID} context={injectionContext} />
           <InjectionSpot

--- a/packages/ui/src/backend/__tests__/AppShell.test.tsx
+++ b/packages/ui/src/backend/__tests__/AppShell.test.tsx
@@ -243,6 +243,33 @@ describe('AppShell', () => {
     })
   })
 
+  it('renders the upgrade action banner only for users who can manage upgrade actions', () => {
+    const { rerender } = renderWithProviders(
+      <AppShell
+        email="demo@example.com"
+        groups={groups}
+        canManageUpgradeActions={false}
+      >
+        <div>Child content</div>
+      </AppShell>,
+      { dict },
+    )
+
+    expect(screen.queryByTestId('upgrade-action-banner')).not.toBeInTheDocument()
+
+    rerender(
+      <AppShell
+        email="demo@example.com"
+        groups={groups}
+        canManageUpgradeActions
+      >
+        <div>Child content</div>
+      </AppShell>,
+    )
+
+    expect(screen.getByTestId('upgrade-action-banner')).toBeInTheDocument()
+  })
+
   it('resets breadcrumb to server-provided values when pathname changes', async () => {
     mockPathname = '/backend/users'
 

--- a/packages/ui/src/backend/upgrades/UpgradeActionBanner.tsx
+++ b/packages/ui/src/backend/upgrades/UpgradeActionBanner.tsx
@@ -31,6 +31,8 @@ type RunActionResponse = {
   error?: string
 }
 
+const forbiddenRedirectOptOutHeader = { 'x-om-forbidden-redirect': '0' } as const
+
 export function UpgradeActionBanner() {
   const t = useT()
   const [action, setAction] = React.useState<UpgradeActionPayload | null>(null)
@@ -40,7 +42,9 @@ export function UpgradeActionBanner() {
   const loadNextAction = React.useCallback(async () => {
     if (!upgradeActionsEnabled) return
     if (typeof window === 'undefined' || typeof fetch === 'undefined') return
-    const call = await apiCall<UpgradeActionResponse>('/api/configs/upgrade-actions')
+    const call = await apiCall<UpgradeActionResponse>('/api/configs/upgrade-actions', {
+      headers: forbiddenRedirectOptOutHeader,
+    })
     if (cancelledRef.current) return
     if (!call.ok || !call.result || !Array.isArray(call.result.actions) || !call.result.actions.length) {
       setAction(null)
@@ -65,7 +69,7 @@ export function UpgradeActionBanner() {
     try {
       const response = await apiCall<RunActionResponse>('/api/configs/upgrade-actions', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...forbiddenRedirectOptOutHeader, 'Content-Type': 'application/json' },
         body: JSON.stringify({ actionId: action.id }),
       })
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- render the upgrade action banner only for users who can manage the configs.manage feature
- opt the banner API calls out of forbidden-login redirects as a safety net
- cover the gating behavior in the AppShell test and sync the standalone template layout

## Testing
- yarn jest --config "packages/ui/jest.config.cjs" "packages/ui/src/backend/__tests__/AppShell.test.tsx"
- ./node_modules/typescript/bin/tsc -p "packages/ui/tsconfig.json" --noEmit

Fixes #2057