### PR TITLE
feat(api_docs): expose deployed version via GET /api/version (#1718)

### DIFF
--- a/packages/core/src/modules/api_docs/api/__tests__/version.route.test.ts
+++ b/packages/core/src/modules/api_docs/api/__tests__/version.route.test.ts
@@ -1,0 +1,34 @@
+import { GET, metadata } from '../get/version'
+
+describe('api_docs /api/version route', () => {
+  it('is served at /api/version without auth', () => {
+    expect(metadata.path).toBe('/version')
+    expect(metadata.GET.requireAuth).toBe(false)
+  })
+
+  it('returns the deployed version', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(typeof body.version).toBe('string')
+    expect(body.version.length).toBeGreaterThan(0)
+    expect(Object.keys(body)).toEqual(['version'])
+  })
+
+  it('prefers an explicit OM_VERSION / OPEN_MERCATO_VERSION override', async () => {
+    const originalOm = process.env.OM_VERSION
+    process.env.OM_VERSION = '9.9.9-test'
+    try {
+      let body: { version: string } | undefined
+      await jest.isolateModulesAsync(async () => {
+        const mod = await import('../get/version')
+        const res = await mod.GET()
+        body = await res.json()
+      })
+      expect(body?.version).toBe('9.9.9-test')
+    } finally {
+      if (originalOm === undefined) delete process.env.OM_VERSION
+      else process.env.OM_VERSION = originalOm
+    }
+  })
+})

--- a/packages/core/src/modules/api_docs/api/get/version.ts
+++ b/packages/core/src/modules/api_docs/api/get/version.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+const versionResponseSchema = z.object({
+  version: z.string(),
+})
+
+type VersionResponse = z.infer<typeof versionResponseSchema>
+
+function readDeployedVersion(): string {
+  // Explicit override wins: deployments that bundle a different version than the
+  // running app's package.json (or want to pin the Open Mercato platform version)
+  // set OM_VERSION / OPEN_MERCATO_VERSION.
+  const explicit = process.env.OM_VERSION || process.env.OPEN_MERCATO_VERSION
+  if (explicit && explicit.length > 0) return explicit
+  try {
+    const packageJsonPath = path.join(process.cwd(), 'package.json')
+    const parsed = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { version?: string }
+    if (typeof parsed.version === 'string' && parsed.version.length > 0) return parsed.version
+  } catch {
+    // Fall through to the development sentinel below.
+  }
+  return '0.0.0-dev'
+}
+
+const deployedVersion = readDeployedVersion()
+
+export const metadata = {
+  path: '/version',
+  GET: {
+    requireAuth: false,
+    rateLimit: { points: 30, duration: 60, keyPrefix: 'api_version' },
+  },
+}
+
+export async function GET() {
+  const body: VersionResponse = { version: deployedVersion }
+  return NextResponse.json(body)
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'API Documentation',
+  summary: 'Deployed Open Mercato version',
+  methods: {
+    GET: {
+      summary: 'Return the deployed Open Mercato version',
+      tags: ['API Documentation'],
+      responses: [
+        {
+          status: 200,
+          description: 'Current deployment version metadata',
+          schema: versionResponseSchema,
+        },
+      ],
+    },
+  },
+}

--- a/packages/core/src/modules/api_docs/api/get/version.ts
+++ b/packages/core/src/modules/api_docs/api/get/version.ts
@@ -41,6 +41,8 @@ export async function GET() {
   return NextResponse.json(body)
 }
 
+export default GET
+
 export const openApi: OpenApiRouteDoc = {
   tag: 'API Documentation',
   summary: 'Deployed Open Mercato version',


### PR DESCRIPTION
## Summary
- Adds an unauthenticated, rate-limited `GET /api/version` endpoint to the `api_docs` module, returning `{ version }`.
- Version resolves from `OM_VERSION` / `OPEN_MERCATO_VERSION` env override, then `package.json`, then a `0.0.0-dev` sentinel.
- Closes #1718 — gives API consumers a programmatic way to detect the deployed Open Mercato version (implements option 2 from the issue: the `/api/version` endpoint).

## Details
- Route: `packages/core/src/modules/api_docs/api/get/version.ts` (auto-discovered at `/api/version` via `metadata.path`).
- `requireAuth: false` (intentional — reachable for failure-mode diagnostics, per the issue) and rate-limited to 30 req / 60 s via the dispatcher's `metadata.rateLimit` contract.
- Exports `openApi` for documentation generation.

## Test plan
- [x] Unit tests (`api/__tests__/version.route.test.ts`): served at `/version`, `requireAuth: false`, returns non-empty `version`, `OM_VERSION` override wins.
- [x] `yarn generate` registers the route at `/api/version`.
- [x] `@open-mercato/core` typecheck passes.
- [x] Manual: `curl -i http://localhost:3000/api/version` -> `200 {"version":"0.6.2"}` after dev restart.

## Follow-up (optional)
- `openApi` doc could document the `429` rate-limit response for completeness.