### PR TITLE
fix(shared): singularizeSegment handles irregular plurals (#2072)

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/cache.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/cache.test.ts
@@ -1,0 +1,64 @@
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: async <T>(_tenant: string | null, fn: () => Promise<T> | T) => fn(),
+}))
+
+import { deriveResourceFromCommandId } from '@open-mercato/shared/lib/crud/cache'
+
+describe('deriveResourceFromCommandId — irregular plurals (#2072)', () => {
+  it('singularises "people" to "person"', () => {
+    // Regression for the resourceKind divergence between hand-written literals
+    // ('customers.person') and factory-derived runtime values
+    // ('customers.people') — see issue #2072 and PR #2055.
+    expect(deriveResourceFromCommandId('customers.people.update')).toBe('customers.person')
+    expect(deriveResourceFromCommandId('customers.people.create')).toBe('customers.person')
+    expect(deriveResourceFromCommandId('customers.people.delete')).toBe('customers.person')
+  })
+
+  it('handles the other known irregular plurals', () => {
+    expect(deriveResourceFromCommandId('mod.children.update')).toBe('mod.child')
+    expect(deriveResourceFromCommandId('mod.mice.update')).toBe('mod.mouse')
+    expect(deriveResourceFromCommandId('mod.men.update')).toBe('mod.man')
+    expect(deriveResourceFromCommandId('mod.women.update')).toBe('mod.woman')
+    expect(deriveResourceFromCommandId('mod.geese.update')).toBe('mod.goose')
+    expect(deriveResourceFromCommandId('mod.feet.update')).toBe('mod.foot')
+    expect(deriveResourceFromCommandId('mod.teeth.update')).toBe('mod.tooth')
+    expect(deriveResourceFromCommandId('mod.oxen.update')).toBe('mod.ox')
+  })
+
+  it('lower-cases the entity segment before matching irregular plurals', () => {
+    // Singularizer is case-insensitive (lower-cases input); commandId module
+    // segment casing is preserved by the caller as today.
+    expect(deriveResourceFromCommandId('customers.People.update')).toBe('customers.person')
+  })
+
+  it('still handles each pre-existing regular plural rule', () => {
+    // ies → y (companies → company)
+    expect(deriveResourceFromCommandId('customers.companies.update')).toBe('customers.company')
+    // ses → s (addresses → address)
+    expect(deriveResourceFromCommandId('customers.addresses.update')).toBe('customers.address')
+    // xes → x (boxes → box)
+    expect(deriveResourceFromCommandId('mod.boxes.update')).toBe('mod.box')
+    // zes → z (quizzes → quizze — preserved as today; checking the rule still fires)
+    expect(deriveResourceFromCommandId('mod.buzzes.update')).toBe('mod.buzz')
+    // ches → ch (matches → match)
+    expect(deriveResourceFromCommandId('mod.matches.update')).toBe('mod.match')
+    // shes → sh (dishes → dish)
+    expect(deriveResourceFromCommandId('mod.dishes.update')).toBe('mod.dish')
+    // trailing s → drop (orders → order)
+    expect(deriveResourceFromCommandId('sales.orders.update')).toBe('sales.order')
+    // dashed segments singularise each part (leave-requests → leave-request)
+    expect(deriveResourceFromCommandId('staff.leave-requests.update')).toBe('staff.leave-request')
+  })
+
+  it('leaves already-singular hand-written commandIds unchanged', () => {
+    expect(deriveResourceFromCommandId('mod.person.update')).toBe('mod.person')
+    expect(deriveResourceFromCommandId('mod.box.update')).toBe('mod.box')
+  })
+
+  it('returns null for malformed inputs', () => {
+    expect(deriveResourceFromCommandId(null)).toBeNull()
+    expect(deriveResourceFromCommandId(undefined)).toBeNull()
+    expect(deriveResourceFromCommandId('')).toBeNull()
+    expect(deriveResourceFromCommandId('singletonly')).toBeNull()
+  })
+})

--- a/packages/shared/src/lib/crud/cache.ts
+++ b/packages/shared/src/lib/crud/cache.ts
@@ -110,8 +110,22 @@ export function pickFirstIdentifier(...values: Array<unknown>): string | null {
   return null
 }
 
+const IRREGULAR_PLURALS: Record<string, string> = {
+  people: 'person',
+  children: 'child',
+  mice: 'mouse',
+  men: 'man',
+  women: 'woman',
+  geese: 'goose',
+  feet: 'foot',
+  teeth: 'tooth',
+  oxen: 'ox',
+}
+
 function singularizeSegment(segment: string): string {
   const lower = segment.toLowerCase()
+  const irregular = IRREGULAR_PLURALS[lower]
+  if (irregular) return irregular
   if (lower.endsWith('ies') && lower.length > 3) return lower.slice(0, -3) + 'y'
   if (lower.endsWith('ses') && lower.length > 3) return lower.slice(0, -2)
   if (


### PR DESCRIPTION
Fixes #2072

## Problem

`packages/shared/src/lib/crud/cache.ts:singularizeSegment` handled regular plurals (`companies → company`, `orders → order`, `addresses → address`, `boxes → box`) but did NOT handle the irregular plural `people → person`. The CRUD factory's runtime-derived `resourceKind` for `customers.people.update` therefore resolved to `customers.people`, while every hand-written `resourceKind` literal in the codebase uses `customers.person`. That divergence silently skipped mutation guards, response enrichers, and cache invalidations declared against the singular form (this is what bit us during PR #2055 stabilization, where iter-19 needed a dual-key workaround).

`customers.people` is the only commandId in the codebase whose middle segment is an irregular plural the current singularizer cannot handle, but the contract surface is set up to bite again for any future entity with an irregular plural.

## Root Cause

`singularizeSegment` only checked rule-based endings (`ies → y`, `ses → s`, `xes/zes/ches/shes → x/z/ch/sh`, `s → ∅`). Words like `people`, `children`, `mice`, etc. don't end with any of those patterns and fell through to the identity branch, returning the plural unchanged.

## What Changed

`packages/shared/src/lib/crud/cache.ts` — added an `IRREGULAR_PLURALS` map (`people→person`, `children→child`, `mice→mouse`, `men→man`, `women→woman`, `geese→goose`, `feet→foot`, `teeth→tooth`, `oxen→ox`) and short-circuited `singularizeSegment` on a match before the rule-based branches. Diff: +14 production lines, zero existing rules touched. Every other `resourceKind` continues to resolve exactly as today.

This is Option A from the issue. Options B (flip everything to plural) and D (lean on `events.entity` precedence) were rejected per the analysis in the issue body; Option C (per-route `resourceKind` override) is a nice ergonomic addition but doesn't replace this fix and was deferred.

## Tests

New `packages/shared/src/lib/crud/__tests__/cache.test.ts` (6 tests, all passing here; 3 fail on baseline `cache.ts` — confirmed):

- `customers.people.{update,create,delete}` → `customers.person`
- Each other irregular plural round-trips correctly
- Case-insensitive entity-segment matching
- One assertion per pre-existing regular-plural rule (`companies/addresses/boxes/buzzes/matches/dishes/orders/leave-requests`) — defensive against accidental regressions
- Already-singular hand-written commandIds round-trip
- Malformed inputs return `null`

Test relies on a 2-line `jest.mock('@open-mercato/cache', …)` (covers the `runWithCacheTenant` import in `cache.ts`; nothing in the tested code path actually touches it).

### Validation gate

- `yarn workspace @open-mercato/shared jest` — 92/92 suites, 960/960 tests
- `yarn workspace @open-mercato/core jest src/modules/customers` — 113/113 suites, 593/593 tests
- `yarn workspace @open-mercato/core jest` — 499/499 suites, 4202/4202 tests
- `yarn workspace @open-mercato/ui jest` — 139/139 suites, 1074/1074 tests
- `tsc --noEmit` in `packages/shared` — clean
- `tsc --noEmit` in `packages/core` — only pre-existing `tsconfig.json(7,27): error TS5103: Invalid value for '--ignoreDeprecations'` (TS 6.0 dependabot bump regression, present on develop unchanged; tracked separately)
- `yarn generate` — clean
- `yarn build:packages` — 19/19 cached/built
- `yarn i18n:check-sync` — clean

## Backward Compatibility

`singularizeSegment` is **not exported** — it's an internal helper consumed via the exported `deriveResourceFromCommandId`, which keeps its signature unchanged. The behavior change is purely additive: inputs that previously fell through to the identity branch (and returned the plural) now correctly singularize. A repo-wide grep confirms zero source consumers ever depended on the buggy plural form for `customers.people` (zero hits for `resourceKind: 'customers.people'` and `targetEntity: 'customers.people'`).

Per `BACKWARD_COMPATIBILITY.md`, the change does not touch any of the 13 frozen/stable contract surface categories (no type signatures changed, no exports added or removed, no event IDs / spot IDs / ACL features / API routes / DB schema / generated files modified).

## Acceptance Criteria — issue body

- [x] `singularizeSegment` returns `'person'` for input `'people'`; returns `'child'` for `'children'`; etc. (covered by `deriveResourceFromCommandId` tests through the public surface)
- [x] Unit tests for each irregular plural and at least one regular plural per existing rule
- [x] `deriveResourceFromCommandId('customers.people.update')` returns `'customers.person'`
- [ ] PR #2055's iter-19 dual-key workaround revert — left for PR #2055 to handle on its own next rebase against develop (their branch hasn't merged this fix yet; reverting on their branch is their author's call)
- [ ] BACKWARD_COMPATIBILITY.md note — skipped; the changed function is internal, the public API signature is unchanged, and no source code depended on the previous behavior. Happy to add a paragraph if reviewer disagrees.
- [ ] Spec entry under `.ai/specs/` — skipped per `.ai/specs/AGENTS.md` "Skip specs for small bug fixes, typo-only edits, and isolated one-file refactors with no behavior change." This is a 14-LOC bug fix to a single private function; the issue body itself serves as the analysis doc. Happy to add a short spec if reviewer disagrees.