### PR TITLE
fix(customer_accounts): add search indexing subscribers for customer users (#2060)

### DIFF
--- a/packages/core/src/modules/customer_accounts/subscribers/__tests__/search-reindex-created.test.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/__tests__/search-reindex-created.test.ts
@@ -1,0 +1,89 @@
+import handle from '../search-reindex-created'
+
+const emitEventMock = jest.fn(async () => undefined)
+
+describe('customer_accounts search reindex created subscriber', () => {
+  const ctx = { resolve: jest.fn(() => ({ emitEvent: emitEventMock })) }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('emits query_index.upsert_one event for valid payload', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      createdBy: 'admin-1',
+    }, ctx)
+
+    expect(ctx.resolve).toHaveBeenCalledWith('eventBus')
+    expect(emitEventMock).toHaveBeenCalledWith(
+      'query_index.upsert_one',
+      {
+        entityType: 'customer_accounts:customer_user',
+        recordId: 'user-123',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        crudAction: 'created',
+        coverageBaseDelta: 1,
+      },
+      {
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      },
+    )
+  })
+
+  it('skips event when userId is missing', async () => {
+    await handle({
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    }, ctx)
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('skips event when tenantId is missing', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      organizationId: 'org-1',
+    }, ctx)
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('handles missing organizationId gracefully', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: null,
+    }, ctx)
+
+    expect(emitEventMock).toHaveBeenCalledWith(
+      'query_index.upsert_one',
+      expect.objectContaining({
+        organizationId: null,
+      }),
+      expect.objectContaining({
+        organizationId: null,
+      }),
+    )
+  })
+
+  it('handles eventBus resolution failure gracefully', async () => {
+    const failureCtx = { resolve: jest.fn(() => { throw new Error('Resolution failed') }) }
+
+    await expect(handle({
+      id: 'user-123',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    }, failureCtx)).resolves.toBeUndefined()
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/subscribers/__tests__/search-reindex-deleted.test.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/__tests__/search-reindex-deleted.test.ts
@@ -1,0 +1,87 @@
+import handle from '../search-reindex-deleted'
+
+const emitEventMock = jest.fn(async () => undefined)
+
+describe('customer_accounts search reindex deleted subscriber', () => {
+  const ctx = { resolve: jest.fn(() => ({ emitEvent: emitEventMock })) }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('emits query_index.delete_one event for valid payload', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      deletedBy: 'admin-1',
+    }, ctx)
+
+    expect(ctx.resolve).toHaveBeenCalledWith('eventBus')
+    expect(emitEventMock).toHaveBeenCalledWith(
+      'query_index.delete_one',
+      {
+        entityType: 'customer_accounts:customer_user',
+        recordId: 'user-123',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+      },
+      {
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      },
+    )
+  })
+
+  it('skips event when userId is missing', async () => {
+    await handle({
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    }, ctx)
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('skips event when tenantId is missing', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      organizationId: 'org-1',
+    }, ctx)
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('handles missing organizationId gracefully', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: null,
+    }, ctx)
+
+    expect(emitEventMock).toHaveBeenCalledWith(
+      'query_index.delete_one',
+      expect.objectContaining({
+        organizationId: null,
+      }),
+      expect.objectContaining({
+        organizationId: null,
+      }),
+    )
+  })
+
+  it('handles eventBus resolution failure gracefully', async () => {
+    const failureCtx = { resolve: jest.fn(() => { throw new Error('Resolution failed') }) }
+
+    await expect(handle({
+      id: 'user-123',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    }, failureCtx)).resolves.toBeUndefined()
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/subscribers/__tests__/search-reindex-updated.test.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/__tests__/search-reindex-updated.test.ts
@@ -1,0 +1,89 @@
+import handle from '../search-reindex-updated'
+
+const emitEventMock = jest.fn(async () => undefined)
+
+describe('customer_accounts search reindex updated subscriber', () => {
+  const ctx = { resolve: jest.fn(() => ({ emitEvent: emitEventMock })) }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('emits query_index.upsert_one event for valid payload', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      updatedBy: 'admin-1',
+    }, ctx)
+
+    expect(ctx.resolve).toHaveBeenCalledWith('eventBus')
+    expect(emitEventMock).toHaveBeenCalledWith(
+      'query_index.upsert_one',
+      {
+        entityType: 'customer_accounts:customer_user',
+        recordId: 'user-123',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        crudAction: 'updated',
+        coverageBaseDelta: 0,
+      },
+      {
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+      },
+    )
+  })
+
+  it('skips event when userId is missing', async () => {
+    await handle({
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    }, ctx)
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('skips event when tenantId is missing', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      organizationId: 'org-1',
+    }, ctx)
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('handles missing organizationId gracefully', async () => {
+    await handle({
+      id: 'user-123',
+      email: 'test@example.com',
+      tenantId: 'tenant-1',
+      organizationId: null,
+    }, ctx)
+
+    expect(emitEventMock).toHaveBeenCalledWith(
+      'query_index.upsert_one',
+      expect.objectContaining({
+        organizationId: null,
+      }),
+      expect.objectContaining({
+        organizationId: null,
+      }),
+    )
+  })
+
+  it('handles eventBus resolution failure gracefully', async () => {
+    const failureCtx = { resolve: jest.fn(() => { throw new Error('Resolution failed') }) }
+
+    await expect(handle({
+      id: 'user-123',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    }, failureCtx)).resolves.toBeUndefined()
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/subscribers/search-reindex-created.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/search-reindex-created.ts
@@ -1,0 +1,42 @@
+export const metadata = {
+  event: 'customer_accounts.user.created',
+  persistent: false,
+  id: 'customer_accounts:query-index-reindex-created',
+}
+
+type Payload = {
+  id?: string
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+type EventBus = { emitEvent: (name: string, body: unknown, options?: unknown) => Promise<void> }
+type HandlerContext = { resolve: <T = unknown>(name: string) => T }
+
+export default async function handle(payload: Payload, ctx: HandlerContext) {
+  const userId = typeof payload?.id === 'string' ? payload.id : null
+  const tenantId = typeof payload?.tenantId === 'string' ? payload.tenantId : null
+  if (!userId || !tenantId) return
+  let bus: EventBus | null = null
+  try {
+    bus = ctx.resolve<EventBus>('eventBus')
+  } catch {
+    bus = null
+  }
+  if (!bus) return
+  await bus.emitEvent(
+    'query_index.upsert_one',
+    {
+      entityType: 'customer_accounts:customer_user',
+      recordId: userId,
+      organizationId: payload.organizationId ?? null,
+      tenantId,
+      crudAction: 'created',
+      coverageBaseDelta: 1,
+    },
+    {
+      tenantId,
+      organizationId: payload.organizationId ?? null,
+    },
+  ).catch(() => undefined)
+}

--- a/packages/core/src/modules/customer_accounts/subscribers/search-reindex-deleted.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/search-reindex-deleted.ts
@@ -1,0 +1,40 @@
+export const metadata = {
+  event: 'customer_accounts.user.deleted',
+  persistent: false,
+  id: 'customer_accounts:query-index-reindex-deleted',
+}
+
+type Payload = {
+  id?: string
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+type EventBus = { emitEvent: (name: string, body: unknown, options?: unknown) => Promise<void> }
+type HandlerContext = { resolve: <T = unknown>(name: string) => T }
+
+export default async function handle(payload: Payload, ctx: HandlerContext) {
+  const userId = typeof payload?.id === 'string' ? payload.id : null
+  const tenantId = typeof payload?.tenantId === 'string' ? payload.tenantId : null
+  if (!userId || !tenantId) return
+  let bus: EventBus | null = null
+  try {
+    bus = ctx.resolve<EventBus>('eventBus')
+  } catch {
+    bus = null
+  }
+  if (!bus) return
+  await bus.emitEvent(
+    'query_index.delete_one',
+    {
+      entityType: 'customer_accounts:customer_user',
+      recordId: userId,
+      organizationId: payload.organizationId ?? null,
+      tenantId,
+    },
+    {
+      tenantId,
+      organizationId: payload.organizationId ?? null,
+    },
+  ).catch(() => undefined)
+}

--- a/packages/core/src/modules/customer_accounts/subscribers/search-reindex-updated.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/search-reindex-updated.ts
@@ -1,0 +1,42 @@
+export const metadata = {
+  event: 'customer_accounts.user.updated',
+  persistent: false,
+  id: 'customer_accounts:query-index-reindex-updated',
+}
+
+type Payload = {
+  id?: string
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+type EventBus = { emitEvent: (name: string, body: unknown, options?: unknown) => Promise<void> }
+type HandlerContext = { resolve: <T = unknown>(name: string) => T }
+
+export default async function handle(payload: Payload, ctx: HandlerContext) {
+  const userId = typeof payload?.id === 'string' ? payload.id : null
+  const tenantId = typeof payload?.tenantId === 'string' ? payload.tenantId : null
+  if (!userId || !tenantId) return
+  let bus: EventBus | null = null
+  try {
+    bus = ctx.resolve<EventBus>('eventBus')
+  } catch {
+    bus = null
+  }
+  if (!bus) return
+  await bus.emitEvent(
+    'query_index.upsert_one',
+    {
+      entityType: 'customer_accounts:customer_user',
+      recordId: userId,
+      organizationId: payload.organizationId ?? null,
+      tenantId,
+      crudAction: 'updated',
+      coverageBaseDelta: 0,
+    },
+    {
+      tenantId,
+      organizationId: payload.organizationId ?? null,
+    },
+  ).catch(() => undefined)
+}


### PR DESCRIPTION
Fixes #2060

## Problem
Customer users are not findable by search due to missing search indexing. When customer users are created, updated, or deleted, no search tokens are generated, making them unsearchable by display name and other fields.

## Root Cause
The customer_accounts module lacks event subscribers to trigger search indexing. While other modules like messages have subscribers that emit query_index events for search functionality, customer_accounts was missing these critical subscribers.

## What Changed
- Added search-reindex-created.ts subscriber for customer user creation events
- Added search-reindex-updated.ts subscriber for customer user update events  
- Added search-reindex-deleted.ts subscriber for customer user deletion events
- Added comprehensive unit tests for all three subscribers

## Tests
- Added 15 unit tests covering valid payloads, missing parameters, error handling, and event emission verification
- All 281 existing customer_accounts module tests continue to pass
- TypeScript compilation passes successfully

## Backward Compatibility
No contract changes - this is a pure addition of internal event subscribers that enables existing search functionality to work correctly for customer users without modifying any public APIs or changing existing behavior.

🤖 Generated by autofix.