### PR TITLE
docs(core): document auth locale API route

### DIFF
--- a/packages/core/src/modules/auth/api/locale/route.ts
+++ b/packages/core/src/modules/auth/api/locale/route.ts
@@ -1,8 +1,16 @@
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
 const supportedLocales = new Set<Locale>(locales)
+const localeSchema = z.object({ locale: z.enum(locales as [Locale, ...Locale[]]) })
+const localeQuerySchema = localeSchema.extend({
+  redirect: z.string().optional(),
+})
+const localeResponseSchema = z.object({ ok: z.boolean() })
+const localeErrorSchema = z.object({ error: z.string() })
 
 export const metadata = {
   GET: { requireAuth: false },
@@ -46,4 +54,32 @@ export async function GET(req: Request) {
   const res = NextResponse.redirect(new URL(safePath, url.origin))
   res.cookies.set('locale', locale as Locale, { path: '/', maxAge: 60 * 60 * 24 * 365 })
   return res
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Authentication & Accounts',
+  summary: 'Locale preference',
+  methods: {
+    GET: {
+      summary: 'Set locale and redirect',
+      description: 'Stores the selected locale in a cookie and redirects to a safe local path.',
+      query: localeQuerySchema,
+      responses: [
+        { status: 302, description: 'Locale cookie set and request redirected' },
+        { status: 400, description: 'Invalid locale', schema: localeErrorSchema },
+      ],
+    },
+    POST: {
+      summary: 'Set locale',
+      description: 'Stores the selected locale in a cookie and returns a JSON success response.',
+      requestBody: {
+        contentType: 'application/json',
+        schema: localeSchema,
+      },
+      responses: [
+        { status: 200, description: 'Locale cookie set', schema: localeResponseSchema },
+        { status: 400, description: 'Invalid locale or malformed request body', schema: localeErrorSchema },
+      ],
+    },
+  },
 }


### PR DESCRIPTION
## Summary

Adds missing OpenAPI documentation for `/api/auth/locale`.

Documents:
- `GET /api/auth/locale` with `locale` and optional `redirect` query parameters
- `POST /api/auth/locale` with JSON body `{ locale }`
- `400` error responses for invalid locale or malformed request payload

## Validation

- `git diff --check`
- Attempted core typecheck; blocked by missing generated `#generated/*` files in this checkout